### PR TITLE
Generated submenu proof of concept

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{json,yml,yaml}]
+[*.{json,yml,yaml,rb}]
 indent_size = 2
 
 [*.md]

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,5 +1,3 @@
 <!-- JS Libs -->
 <script src="//cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-<script src="{{ "/assets/js/build-menu.js" | relative_url }}"></script>
-<script src="{{ "/assets/js/main.js" | relative_url }}"></script>
 {% include js-search.html %}

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -14,7 +14,13 @@
                 <div class="grid--cell order-last">
                     <aside class="ps-sticky stacks-menu">
                         <h5 class="mx16 px8 py4 mb4 stacks-nav--category fc-orange-500" style="margin-left: -1px;">Sections</h5>
-                        <ul class="grid gs4 gsy fd-column stacks-nav__secondary js-secondary-nav"></ul>
+                        <ul class="grid gs4 gsy fd-column stacks-nav__secondary">
+                            {% for item in page.subnav %}
+                                <li class="stacks-nav--item grid fd-column">
+                                    <a class="grid--cell stacks-nav--link fs-body1" href="{{ item.url }}">{{ item.title }}</a>
+                                </li>
+                            {% endfor %}
+                        </ul>
                     </aside>
                 </div>
                 <div class="grid--cell stacks-content">

--- a/docs/_plugins/submenu.rb
+++ b/docs/_plugins/submenu.rb
@@ -1,0 +1,15 @@
+require "nokogiri"
+
+class SubMenuGenerator < Jekyll::Generator
+  def generate(site)
+    parser = Jekyll::Converters::Markdown.new(site.config)
+
+    site.pages.each do |page|
+      doc = Nokogiri::HTML(parser.convert(page['content']))
+        page.data["subnav"] = []
+        doc.css('h2').each do |heading|
+          page.data["subnav"] << { "title" => heading.text, "url" => [page.url, heading['id']].join("#") }
+        end
+    end
+  end
+end

--- a/docs/_plugins/submenu.rb
+++ b/docs/_plugins/submenu.rb
@@ -2,10 +2,9 @@ require "nokogiri"
 
 class SubMenuGenerator < Jekyll::Generator
   def generate(site)
-    parser = Jekyll::Converters::Markdown.new(site.config)
 
     site.pages.each do |page|
-      doc = Nokogiri::HTML(parser.convert(page['content']))
+      doc = Nokogiri::HTML(page['content'])
         page.data["subnav"] = []
         doc.css('h2').each do |heading|
           page.data["subnav"] << { "title" => heading.text, "url" => [page.url, heading['id']].join("#") }

--- a/docs/base/colors.html
+++ b/docs/base/colors.html
@@ -6,55 +6,55 @@ description: To avoid specifying color values by hand, we’ve included a robust
 
 
 <section class="stacks-section">
-    <h2 class="grid jc-space-between ai-center stacks-h2"><div class="grid--cell fl1">Primary Colors</div></h2>
+    <h2 class="grid jc-space-between ai-center stacks-h2" id="primary-colors"><div class="grid--cell fl1">Primary Colors</div></h2>
     <div class="grid gs16 grid__allcells4">
-        <a class="grid--cell fw-wrap p12 bg-orange-400 fc-dark mb12 bar-sm" href="#orange">
-            <h2 class="fs-subheading mb4">Orange</h2>
+        <a class="grid--cell p12 bg-orange-400 fc-dark mb12 bar-sm" href="#orange">
+            <p class="fs-subheading mb4">Orange</p>
             <p class="ff-mono mb0">@orange-400</p>
         </a>
 
         <a class="grid--cell p12 bg-black-900 mb12 fc-white bar-sm" href="#black">
-            <h2 class="fs-subheading mb4">Black</h2>
+            <p class="fs-subheading mb4">Black</p>
             <p class="ff-mono mb0">@black-900</p>
         </a>
 
         <a class="grid--cell p12 bg-blue-600 mb12 fc-white bar-sm" href="#blue">
-            <h2 class="fs-subheading mb4">Blue</h2>
+            <p class="fs-subheading mb4">Blue</p>
             <p class="ff-mono mb0">@blue-600</p>
         </a>
     </div>
 </section>
 
 <section class="stacks-section">
-    <h2 class="grid jc-space-between ai-center stacks-h2"><div class="grid--cell fl1">Accent Colors</div></h2>
+    <h2 class="grid jc-space-between ai-center stacks-h2" id="accent-colors"><div class="grid--cell fl1">Accent Colors</div></h2>
     <div class="grid fw-wrap gs16 grid__allcells3">
         <a class="grid--cell p12 bg-powder-100 mb12 fc-powder-900 bar-sm" href="#powder">
-            <h2 class="fs-subheading mb4">Powder</h2>
+            <p class="fs-subheading mb4">Powder</p>
             <p class="ff-mono mb0">@powder-100</p>
         </a>
 
         <a class="grid--cell p12 bg-green-400 mb12 fc-green-900 bar-sm" href="#green">
-            <h2 class="fs-subheading mb4">Green</h2>
+            <p class="fs-subheading mb4">Green</p>
             <p class="ff-mono mb0">@green-400</p>
         </a>
 
         <a class="grid--cell p12 bg-yellow-100 mb12 fc-yellow-900 bar-sm" href="#yellow">
-            <h2 class="fs-subheading mb4">Yellow</h2>
+            <p class="fs-subheading mb4">Yellow</p>
             <p class="ff-mono mb0">@yellow-100</p>
         </a>
 
         <a class="grid--cell p12 bg-red-500 mb12 fc-white bar-sm" href="#red">
-            <h2 class="fs-subheading mb4">Red</h2>
+            <p class="fs-subheading mb4">Red</p>
             <p class="ff-mono mb0">@red-500</p>
         </a>
     </div>
 </section>
 
 <section class="stacks-section">
-    <h2 class="grid jc-space-between ai-center stacks-h2"><div class="grid--cell fl1">Color Stops</div></h2>
+    <h2 class="grid jc-space-between ai-center stacks-h2" id="color-stops"><div class="grid--cell fl1">Color Stops</div></h2>
     {% for color in site.data.color-stops %}
         {% assign color_stops = color.stops %}
-        <h3 class="grid jc-space-between ai-center stacks-h3"><div class="grid--cell fl1">{{ color.name | capitalize }}</div></h3>
+        <h3 class="grid jc-space-between ai-center stacks-h3" id="{{ color.name }}"><div class="grid--cell fl1">{{ color.name | capitalize }}</div></h3>
         <table class="s-table s-table__hover s-table__condensed va-middle mb48 fs-caption">
             <thead>
                 <tr>


### PR DESCRIPTION
This PR is an attempt to have Jekyll generate our submenus and header links, instead of relying on Javascript. I've hit a wall:

1. Generator plugins run in Jekyll _before_ page rendering. Liquid tags aren't rendered yet, so when our main page's content is generated in a for loop, our submenu will render the raw tags, not the output.
2. So far, I've only been able to implement a single level of headers. We can make this happen, but Ruby's new for me.
3. Replacing headers with a syntax like `{% header Color Stops %}` would be amazing to generate the proper markup and anchor on the jekyll side, but we'd have to then filter out those liquid tags.

Question: How annoying is it if our submenus only have a single layer of navigation?