### PR TITLE
support LESS 2.5 (for now)

### DIFF
--- a/lib/src/atomic/_stacks-flex.less
+++ b/lib/src/atomic/_stacks-flex.less
@@ -73,7 +73,7 @@
     responsive,
     '.ai',
     {
-        .template(@value) when (@value=start) or (@value=end) { align-items: ~"flex-@{value}" !important; }
+        .template(@value) when (@value=start), (@value=end) { align-items: ~"flex-@{value}" !important; }
         .template(@value) when (default()) { align-items: @value !important; };
     },
     baseline center end start stretch
@@ -93,7 +93,7 @@
     responsive,
     '.as',
     {
-        .template(@value) when (@value=start) or (@value=end) { align-self: ~"flex-@{value}" !important; }
+        .template(@value) when (@value=start), (@value=end) { align-self: ~"flex-@{value}" !important; }
         .template(@value) when (default()) { align-self: @value !important; };
     },
     auto baseline center end start stretch


### PR DESCRIPTION
The `or` syntax for mixin guards was only added in 2.6.