### PR TITLE
Clarify Team Identification usage

### DIFF
--- a/docs/email/components/team-identification.html
+++ b/docs/email/components/team-identification.html
@@ -1,18 +1,12 @@
 ---
 layout: page
 title: Team Identification
-description: Emails coming from a private Team should be clearly labeled.
+description: Emails sent from a Team on <a href="https://stackoverflow.com/teams">Stack Overflow for Teams</a> should be clearly labeled.
 ---
 <section class="stacks-section">
-    <div class="grid ai-start s-notice s-notice__info mb24">
-        <div class="grid--cell mr8">{% icon Alert %}</div>
-        <div class="grid--cell lh-lg">
-            <p><strong>Note:</strong> An email should only contain content from <strong>one</strong> Team. A Team’s content should never appear mixed alongside with content from another Team or public content in a single email.</p>
-            <p class="m0">Additionally, the color should match the Team’s <strong>Theme Color</strong> as defined in their display settings (eg. <code class="stacks-code bg-powder-200">https://stackoverflow.com/c/team-name/admin/settings/theme</code>) on Stack Overflow or Stack Overflow for Enterprise.</p>
-        </div>
-    </div>
+    <p class="stacks-copy">Team icon and name should be in a prominent, noticeable location in the email. The icon color should match the Team’s <strong>theme color</strong> as defined in their display settings (eg. <code class="stacks-code">https://stackoverflow.com/c/team-name/admin/settings/theme</code>) on Stack Overflow or Stack Overflow for Enterprise.</p>
+    <p class="stacks-copy">If space is tight, an icon-only version can be used.</p>
     {% header h2 | Example %}
-    <p class="stacks-copy">Team Icon and Names should be placed in a prominent place to identify the private Team an email is referencing. If spacing is tight, an icon-only version is also available.</p>
     <div class="stacks-preview mb24">
 {% highlight html linenos %}
 <table border="0" cellpadding="0" cellspacing="0" role="presentation" align="left">
@@ -32,10 +26,10 @@ description: Emails coming from a private Team should be clearly labeled.
             <table border="0" cellpadding="0" cellspacing="0" role="presentation">
                 <tr>
                     <td valign="middle" height="19" width="19" style="font-family: arial, sans-serif; font-size: 13px; line-height: 13px; color: #ffffff; background-color: #EB5757; font-weight: bold; text-align: center; border-radius: 3px;">
-                        T
+                        S
                     </td>
                     <td valign="middle" style="padding-left: 5px; font-family: arial, sans-serif; font-size: 13px; line-height: 13px; color: #242729; text-align: left;">
-                        Team Name
+                        SO for Teams Name
                     </td>
                 </tr>
             </table>
@@ -43,10 +37,16 @@ description: Emails coming from a private Team should be clearly labeled.
             <table border="0" cellpadding="0" cellspacing="0" role="presentation">
                 <tr>
                     <td valign="middle" height="19" width="19" style="font-family: arial, sans-serif; font-size: 13px; line-height: 13px; color: #ffffff; background-color: #EB5757; font-weight: bold; text-align: center; border-radius: 3px;">
-                        I
+                        S
                     </td>
                 </tr>
             </table>
+        </div>
+    </div>
+    <div class="grid ai-start s-notice s-notice__info mt24">
+        <div class="grid--cell mr8">{% icon Alert %}</div>
+        <div class="grid--cell lh-lg">
+            <p><strong>Note:</strong> An email should only contain content from <strong>one</strong> Team. A Team’s content should never appear mixed alongside with content from another Team or public content in a single email.</p>
         </div>
     </div>
 </section>

--- a/docs/email/templates/code/transactional-long.html
+++ b/docs/email/templates/code/transactional-long.html
@@ -313,10 +313,10 @@
                                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation" align="left">
                                                         <tr>
                                                             <td valign="middle" height="19" width="19" style="font-family: arial, sans-serif; font-size: 13px; line-height: 13px; color: #ffffff; background-color: #EB5757; font-weight: bold; text-align: center; border-radius: 3px;">
-                                                                T
+                                                                S
                                                             </td>
                                                             <td valign="middle" style="padding-left: 5px; font-family: arial, sans-serif; font-size: 13px; line-height: 13px; color: #242729; text-align: left;">
-                                                                Team Name
+                                                                SO for Teams Name
                                                             </td>
                                                         </tr>
                                                     </table>

--- a/docs/email/templates/code/transactional-short.html
+++ b/docs/email/templates/code/transactional-short.html
@@ -289,10 +289,10 @@
                                     <table border="0" cellpadding="0" cellspacing="0" role="presentation" align="left">
                                         <tr>
                                             <td valign="middle" height="19" width="19" style="font-family: arial, sans-serif; font-size: 13px; line-height: 13px; color: #ffffff; background-color: #EB5757; font-weight: bold; text-align: center; border-radius: 3px;">
-                                                T
+                                                S
                                             </td>
                                             <td valign="middle" style="padding-left: 5px; font-family: arial, sans-serif; font-size: 13px; line-height: 13px; color: #242729; text-align: left;">
-                                                Team Name
+                                                SO for Teams Name
                                             </td>
                                         </tr>
                                     </table>


### PR DESCRIPTION
This is meant to fix #158 

I realize some folks will just grab a template and go. I didn't want to be too prescriptive for this one small part of the template, but wanted to do at least _something_ for folks who don't read the [Team Identification](https://stackoverflow.design/email/components/team-identification) page.