### PR TITLE
Rename the installing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,42 +19,24 @@ Stacks documentation can be found at https://stackoverflow.design/
 ## Table of contents
 
 - [Using Stacks](#using-stacks)
-- [Getting setup](#getting-setup)
-- [What's included](#whats-included)
+- [Building Stacks](#building-stacks)
 - [Bugs and feature requests](#bugs-and-feature-requests)
 - [Contributing](#contributing)
-- [Team](#team)
 - [License](#license)
 
 ## Using Stacks
+Using Stacks is outlined in our [usage guidelines](https://stackoverflow.design/product/using-stacks).
 
-You can use Stacks a few different ways.
+## Building Stacks
+To contribute to Stacks documentation or its CSS library, you'll need to build Stacks locally. View our [building guidelines](https://stackoverflow.design/product/guidelines/building).
 
-1. Stacks is currently included within various Stack Overflow projects automatically. If you’re working on a Stack Overflow project, chances are it’s already available for you! If not, reach out to us and we’ll work on getting it setup.
-2. To include it in other projects, you can install it via [NPM](https://www.npmjs.com/package/@stackoverflow/stacks):
-    ```bash
-    npm install --save @stackoverflow/stacks
-    ```
-3. You can also include a minified, compiled Stacks CSS style sheet. This is good for things like Codepen or other quick prototypes:
-    ```html
-    <link rel="stylesheet" href="https://unpkg.com/@stackoverflow/stacks">
-    ```
-
-## Getting setup
-
-To contribute to Stacks documentation or its CSS library, you'll need to install Stacks locally. View our [installation guidelines](https://stackoverflow.design/product/guidelines/installing).
-
-Having trouble getting these steps to work? Open [an issue](https://github.com/StackExchange/issues/new) with a `setup` tag.
+Having trouble getting these steps to work? Open [an issue](https://github.com/StackExchange/issues/new) with a `setup` label.
 
 ## Bugs and feature requests
-
 Have a bug or feature request? First search existing or closed issues to make sure the issue hasn’t been noted yet. If not, review our [issue guidelines](/CONTRIBUTING.md#open-an-issue) for submitting [a bug report](/CONTRIBUTING.md#reporting-bugs) or [feature request](/CONTRIBUTING.md#feature-requests).
 
-
 ## Contributing
-
 If you’d like to contribute to Stacks, please read through our [contribution guidelines](/CONTRIBUTING.md). Included are directions for opening issues, coding standards, and notes on development.
 
 ## License
-
 Code and documentation copyright 2017-2018 Stack Exchange, Inc and released under the [MIT License](/LICENSE.MD).

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -6,8 +6,8 @@
       subsublinks:
         - title: Using Stacks
           url: product/guidelines/using-stacks
-        - title: Installing Stacks
-          url: product/guidelines/installing
+        - title: Building Stacks
+          url: product/guidelines/building
         - title: Customizing Stacks
           url: product/guidelines/customization
         - title: Releasing Stacks

--- a/docs/product/guidelines/building.html
+++ b/docs/product/guidelines/building.html
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: Installing Stacks
-description: The following is a guide to installing and running Stacks locally. You’ll need to install Stacks to contribute to our documentation or add new classes to our CSS library.
+title: Building Stacks
+description: The following is a guide to building and running Stacks locally. You’ll need to be able to build Stacks to contribute to our documentation or add new classes to our CSS library.
 ---
 
 <section class="stacks-section">
@@ -22,7 +22,7 @@ description: The following is a guide to installing and running Stacks locally. 
     <p class="stacks-copy">There are two common ways to <a href="https://help.github.com/articles/cloning-a-repository/">clone a repo</a>:</p>
     <ul class="stacks-list">
         <li>Use the command line: <code class="stacks-code">git clone https://github.com/StackExchange/Stacks.git</code></li>
-        <li>Use GitHub's desktop app.
+        <li>Use GitHub’s desktop app.
             <ol class="stacks-list">
                 <li>Download and install <a href="https://desktop.github.com"></a>GitHub Desktop</a>.</li>
                 <li>Login with your GitHub credentials.</li>

--- a/docs/product/guidelines/customization.html
+++ b/docs/product/guidelines/customization.html
@@ -16,7 +16,6 @@ description: If you compile the Stacks within your project and need to customize
     <p class="stacks-copy">Most configuration options address <em>how</em> varying elements or components look within a theme. However there are a few options that change constants as well. Items such as CSS reset values or responsive breakpoints can be altered.</p>
     <p class="stacks-copy">To customize any configurable area listed below, you must include <code class="stacks-code">stacks.less</code> (or, depending on your need, <code class="stacks-code">stacks-dynamic.less</code> and/or <code class="stacks-code">stacks-static.less</code>) into your Less file and wrap your updated \configuration options within the following mixin:</p>
     <div class="stacks-preview _preview-none mb24">
-{% comment %}the rouge highlighter doesn't support Less :( {% endcomment %}
 {% highlight css linenos %}
 @include "path/to/stacks-dynamic.less";
 

--- a/docs/product/guidelines/using-stacks.html
+++ b/docs/product/guidelines/using-stacks.html
@@ -11,25 +11,39 @@ description: A short guide to Stacks, a robust CSS &amp; Pattern library for rap
 </section>
 
 <section class="stacks-section">
+    {% header h2 | Installing %}
+    <p class="stacks-copy">Stacks is currently included within various Stack Overflow projects automatically. If you’re working on a Stack Overflow project, chances are it’s already available for you! If not, reach out to us and we’ll work on getting it setup.</p>
+    <p class="stacks-copy">To include Stacks in other projects, you can install Stacks via NPM: <code class="stacks-code">npm install --save @stackoverflow/stacks</code></p>
+    <p class="stacks-copy">You can also include a minified, compiled Stacks CSS style sheet that’s delivered via Unkpg, a CDN for NPM packages. This is good for things like Codepen or other quick prototypes. This CDN should not be considered production-ready. <code class="stacks-code">&#x3C;link rel=&#x22;stylesheet&#x22; href=&#x22;https://unpkg.com/@stackoverflow/stacks&#x22;&#x3E;</code></p>
+</section>
+
+<section class="stacks-section">
     {% header h2 | How to Best Use Stacks %}
     <p class="stacks-copy">In order to use Stacks, let’s consider the design you’d like to implement.</p>
 
-    <p class="stacks-copy fw-bold fs-italic mb4">My design uses existing components</p>
-    <p class="stacks-copy">Identify if the design you’re implementing uses any existing components. Great, it does? Grab the markup from that component’s example page and paste that into your view.</p>
-
-    <p class="stacks-copy fw-bold fs-italic mb4">My design uses existing components but has some special cases.</p>
-    <p class="stacks-copy"><em>e.g. background colors, border, font sizes</em>. Awesome, copy the component’s example markup to your view and add a atomic class to override its styling. Practically, this will likely just be adding something like an <a href="{{ "/product/base/spacing" | relative_url }}"><code class="stacks-code">.mb12</code></a> to a button, or hiding something temporarily with <a href="{{ "/product/base/display" | relative_url }}"><code class="stacks-code">.d-none</code></a>.</p>
-
-    <p class="stacks-copy fw-bold fs-italic mb4">My design uses a new pattern that doesn’t have a component yet.</h3>
-    <p class="stacks-copy">No worries, let’s build your view by assembling some atomic classes. If you’re doing this more than once, you should help us identify a new pattern by <a href="https://github.com/StackExchange/Stacks/issues/new">requesting a new component</a>.</p>
-
-    <p class="stacks-copy fw-bold fs-italic mb4">My design is super special and…</p>
-    <p class="stacks-copy">I’m going to write a lot of custom CSS from scratch in its own <code class="stacks-code">.less</code> file that I’ve included in the bundle. You <em>probably</em> shouldn’t be doing this. With atomic classes, you can build <em>most</em> of what you’re attempting to do without writing a single new line of CSS. The Stacks team would prefer you use these pre-existing classes to build new UI. Every line of CSS you write, the more CSS we have to maintain, the more our users have to download, and the more bytes we have to host.</p>
+    <ol class="stacks-list">
+        <li>
+            <p class="stacks-copy fw-bold mb4">My design uses existing components</p>
+            <p class="stacks-copy">Identify if the design you’re implementing uses any existing components. Great, it does? Grab the markup from that component’s example page and paste that into your view.</p>
+        </li>
+        <li>
+            <p class="stacks-copy fw-bold mb4">My design uses existing components but has some special cases.</p>
+            <p class="stacks-copy"><em>e.g. background colors, border, font sizes</em>. Awesome, copy the component’s example markup to your view and add a atomic class to override its styling. Practically, this will likely just be adding something like an <a href="{{ "/product/base/spacing" | relative_url }}"><code class="stacks-code">.mb12</code></a> to a button, or hiding something temporarily with <a href="{{ "/product/base/display" | relative_url }}"><code class="stacks-code">.d-none</code></a>.</p>
+        </li>
+        <li>
+            <p class="stacks-copy fw-bold mb4">My design uses a new pattern that doesn’t have a component yet.</h3>
+            <p class="stacks-copy">No worries, let’s build your view by assembling some atomic classes. If you’re doing this more than once, you should help us identify a new pattern by <a href="https://github.com/StackExchange/Stacks/issues/new">requesting a new component</a>.</p>
+        </li>
+        <li>
+            <p class="stacks-copy fw-bold mb4">My design is super special and…</p>
+            <p class="stacks-copy">I’m going to write a lot of custom CSS from scratch in its own <code class="stacks-code">.less</code> file that I’ve included in the bundle. You <em>probably</em> shouldn’t be doing this. With atomic classes, you can build <em>most</em> of what you’re attempting to do without writing a single new line of CSS. The Stacks team would prefer you use these pre-existing classes to build new UI. Every line of CSS you write, the more CSS we have to maintain, the more our users have to download, and the more bytes we have to host.</p>
+        </li>
+    </ol>
 </section>
 
 <section class="stacks-section">
     {% header h2 | Javascript %}
-    <p class="stacks-copy">At this time Stacks is a pure Less/CSS framework and does not include any Javascript. The Javascript written for our examples is only used to demonstrate the component’s states. It is not meant to be used in production.</p>
+    <p class="stacks-copy">At this time Stacks is a pure Less/CSS framework and does not include any JavaScript. The JavaScript written for our examples is only used to demonstrate the component’s states. It is not meant to be used in production.</p>
 </section>
 
 <section class="stacks-section">


### PR DESCRIPTION
This guide is a little confusing, since including Stacks in your project could be referred to as installing. This renames our "installing" page to "building". Hopefully it's more clear that it refers to building and viewing locally.

Additionally, I've simplified the README and moved some content over from it to the usage guide.