### PR TITLE
Formatted <code> in email

### DIFF
--- a/docs/email/base/typography.html
+++ b/docs/email/base/typography.html
@@ -125,7 +125,7 @@ description: This page provides some common typography patterns for email, but a
     {% header h2 | Code %}
     <div class="stacks-preview mb16">
 {% highlight html linenos %}
-// Preformatted code block
+<!-- Preformatted code block -->
 <pre style="line-height: 17px; background-color: #EFF0F1; padding: 4px 8px; border-radius: 3px; overflow-x: auto;"><code style="margin: 0 0 15px; background-color: #EFF0F1; color: #242729; font-size: 13px; line-height: 17px; font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;">
     …
 </code></pre>

--- a/docs/email/base/typography.html
+++ b/docs/email/base/typography.html
@@ -126,7 +126,7 @@ description: This page provides some common typography patterns for email, but a
     <div class="stacks-preview mb16">
 {% highlight html linenos %}
 <!-- Preformatted code block -->
-<pre style="line-height: 17px; background-color: #EFF0F1; padding: 4px 8px; border-radius: 3px; overflow-x: auto;"><code style="margin: 0 0 15px; background-color: #EFF0F1; color: #242729; font-size: 13px; line-height: 17px; font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;">
+<pre style="margin: 0 0 15px; background-color: #EFF0F1; padding: 4px 8px; border-radius: 3px; overflow-x: auto; font-size: 13px; line-height: 17px; "><code style="color: #242729; font-size: 13px; line-height: 17px; font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;">
     …
 </code></pre>
 
@@ -134,7 +134,7 @@ description: This page provides some common typography patterns for email, but a
 Format <code style="padding: 1px 5px; background-color: #EFF0F1; color: #242729; font-size: 13px; font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;">inline code</code> like this.
 {% endhighlight %}
         <div class="stacks-preview--example" style="font-family: arial, sans-serif; font-size: 15px; line-height: 19px; color: #54595F; text-align: left;">
-<pre style="line-height: 17px; background-color: #EFF0F1; padding: 4px 8px; border-radius: 3px; overflow-x: auto;"><code style="margin: 0 0 15px; background-color: #EFF0F1; color: #242729; font-size: 13px; line-height: 17px; font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;">var obj = {};
+<pre style="margin: 0 0 15px; background-color: #EFF0F1; padding: 4px 8px; border-radius: 3px; overflow-x: auto; font-size: 13px; line-height: 17px; "><code style="color: #242729; font-size: 13px; line-height: 17px; font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;">var obj = {};
 obj.categories = pm.variables.get("category_id");
 obj.packages = pm.variables.get("package_id");
 obj.type = "add";

--- a/docs/email/base/typography.html
+++ b/docs/email/base/typography.html
@@ -130,7 +130,7 @@ description: This page provides some common typography patterns for email, but a
     …
 </code></pre>
 
-// Inline code
+<!-- Inline code -->
 Format <code style="padding: 1px 5px; background-color: #EFF0F1; color: #242729; font-size: 13px; font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;">inline code</code> like this.
 {% endhighlight %}
         <div class="stacks-preview--example" style="font-family: arial, sans-serif; font-size: 15px; line-height: 19px; color: #54595F; text-align: left;">

--- a/docs/email/base/typography.html
+++ b/docs/email/base/typography.html
@@ -122,7 +122,35 @@ description: This page provides some common typography patterns for email, but a
     </div>
 </section>
 <section class="stacks-section">
+    {% header h2 | Code %}
+    <div class="stacks-preview mb16">
+{% highlight html linenos %}
+// Preformatted code block
+<pre style="line-height: 17px; background-color: #EFF0F1; padding: 4px 8px; border-radius: 3px; overflow-x: auto;"><code style="margin: 0 0 15px; background-color: #EFF0F1; color: #242729; font-size: 13px; line-height: 17px; font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;">
+    …
+</code></pre>
 
+// Inline code
+Format <code style="padding: 1px 5px; background-color: #EFF0F1; color: #242729; font-size: 13px; font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;">inline code</code> like this.
+{% endhighlight %}
+        <div class="stacks-preview--example" style="font-family: arial, sans-serif; font-size: 15px; line-height: 19px; color: #54595F; text-align: left;">
+<pre style="line-height: 17px; background-color: #EFF0F1; padding: 4px 8px; border-radius: 3px; overflow-x: auto;"><code style="margin: 0 0 15px; background-color: #EFF0F1; color: #242729; font-size: 13px; line-height: 17px; font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;">var obj = {};
+obj.categories = pm.variables.get("category_id");
+obj.packages = pm.variables.get("package_id");
+obj.type = "add";
+pm.globals.set("switch_json", JSON.stringify(obj));
+console.log("request body: " + pm.globals.get("switch_json"));</code></pre>
+            <p style="margin: 0;">Format <code style="padding: 1px 5px; background-color: #EFF0F1; color: #242729; font-size: 13px; font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;">inline code</code> like this.</p>
+        </div>
+    </div>
+    <div class="grid ai-start s-notice s-notice__warning mb48">
+        <div class="grid--cell mr8">{% icon AlertCircle %}</div>
+        <div class="grid--cell lh-lg">
+            <strong>Known Issue:</strong> in Windows Outlook 2003 - 2019, preformatted code blocks <a href="https://i.stack.imgur.com/OCP1l.png">appear like this</a>.
+        </div>
+    </div>
+</section>
+<section class="stacks-section">
     {% header h2 | Preventing Text Wrapping %}
     <p class="stacks-copy">
         A non-breaking space (<code class="stacks-code">&#38;nbsp;</code>) can be used to prevent a group of words from breaking onto multiple lines. Useful for keeping names together and preventing typographic orphans&nbsp;and&nbsp;widows.

--- a/docs/email/templates/code/promotional.html
+++ b/docs/email/templates/code/promotional.html
@@ -85,6 +85,7 @@
             background-color: #EFF0F1;
             color: #242729;
             font-size: 13px;
+            line-height: inherit;
             font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;
         }
         pre {
@@ -97,6 +98,9 @@
         }
         pre code {
             margin: 0 0 15px;
+            padding: 0;
+            line-height: 17px;
+            background-color: none;
         }
 
         /* What it does: Prevents Gmail from displaying an download button on large, non-linked images. */

--- a/docs/email/templates/code/promotional.html
+++ b/docs/email/templates/code/promotional.html
@@ -79,6 +79,26 @@
             text-decoration: none !important;
         }
 
+        /* What it does: Styles markdown code blocks that we can't write inline CSS for. */
+        code {
+            padding: 1px 5px;
+            background-color: #EFF0F1;
+            color: #242729;
+            font-size: 13px;
+            font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;
+        }
+        pre {
+            margin: 0 0 15px;
+            line-height: 17px;
+            background-color: #EFF0F1;
+            padding: 4px 8px;
+            border-radius: 3px;
+            overflow-x: auto;
+        }
+        pre code {
+            margin: 0 0 15px;
+        }
+
         /* What it does: Prevents Gmail from displaying an download button on large, non-linked images. */
         .a6S {
             display: none !important;

--- a/docs/email/templates/code/transactional-long.html
+++ b/docs/email/templates/code/transactional-long.html
@@ -85,6 +85,7 @@
             background-color: #EFF0F1;
             color: #242729;
             font-size: 13px;
+            line-height: inherit;
             font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;
         }
         pre {
@@ -97,6 +98,9 @@
         }
         pre code {
             margin: 0 0 15px;
+            padding: 0;
+            line-height: 17px;
+            background-color: none;
         }
 
         /* What it does: Prevents Gmail from displaying an download button on large, non-linked images. */

--- a/docs/email/templates/code/transactional-long.html
+++ b/docs/email/templates/code/transactional-long.html
@@ -79,6 +79,26 @@
             text-decoration: none !important;
         }
 
+        /* What it does: Styles markdown code blocks that we can't write inline CSS for. */
+        code {
+            padding: 1px 5px;
+            background-color: #EFF0F1;
+            color: #242729;
+            font-size: 13px;
+            font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;
+        }
+        pre {
+            margin: 0 0 15px;
+            line-height: 17px;
+            background-color: #EFF0F1;
+            padding: 4px 8px;
+            border-radius: 3px;
+            overflow-x: auto;
+        }
+        pre code {
+            margin: 0 0 15px;
+        }
+
         /* What it does: Prevents Gmail from displaying an download button on large, non-linked images. */
         .a6S {
             display: none !important;

--- a/docs/email/templates/code/transactional-short.html
+++ b/docs/email/templates/code/transactional-short.html
@@ -85,6 +85,7 @@
             background-color: #EFF0F1;
             color: #242729;
             font-size: 13px;
+            line-height: inherit;
             font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;
         }
         pre {
@@ -97,6 +98,9 @@
         }
         pre code {
             margin: 0 0 15px;
+            padding: 0;
+            line-height: 17px;
+            background-color: none;
         }
 
         /* What it does: Prevents Gmail from displaying an download button on large, non-linked images. */

--- a/docs/email/templates/code/transactional-short.html
+++ b/docs/email/templates/code/transactional-short.html
@@ -79,6 +79,26 @@
             text-decoration: none !important;
         }
 
+        /* What it does: Styles markdown code blocks that we can't write inline CSS for. */
+        code {
+            padding: 1px 5px;
+            background-color: #EFF0F1;
+            color: #242729;
+            font-size: 13px;
+            font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif;
+        }
+        pre {
+            margin: 0 0 15px;
+            line-height: 17px;
+            background-color: #EFF0F1;
+            padding: 4px 8px;
+            border-radius: 3px;
+            overflow-x: auto;
+        }
+        pre code {
+            margin: 0 0 15px;
+        }
+
         /* What it does: Prevents Gmail from displaying an download button on large, non-linked images. */
         .a6S {
             display: none !important;


### PR DESCRIPTION
Adds support for `code` in email.