### PR TITLE
Adjust jquery.toc spacing

### DIFF
--- a/docs/assets/js/libs/jquery.toc.js
+++ b/docs/assets/js/libs/jquery.toc.js
@@ -91,7 +91,7 @@
 
                 // Add the list item
                 $("<li class='grid--cell fd-column stacks-nav--item' />").appendTo(stack[0]).append(
-                    $("<a class='d-block s-link s-link__muted fs-body1' />").text(elem.text()).attr("href", "#" + elem.attr("id"))
+                    $("<a class='d-block s-link s-link__muted fs-body1 lh-sm py2' />").text(elem.text()).attr("href", "#" + elem.attr("id"))
                 );
 
                 currentLevel = level;


### PR DESCRIPTION
**Problem:**

Both @donnachoi and I noticed the spacing makes multiline TOC links in the right menu hard to read. I realize the preference is to use short titles, but we can't defend against links never spilling onto multiple lines.

This PR tightens up individual links and adds space around them. Single line links are almost identical to current design, but multiline links are easier to pick out.

![toc compared](https://user-images.githubusercontent.com/1172461/49883011-cea1d400-fdff-11e8-8e98-f4c68236aa06.png)
