### PR TITLE
Email: Improve code to negate auto-detected links

### DIFF
--- a/docs/email/templates/code/promotional.html
+++ b/docs/email/templates/code/promotional.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width"> <!-- Forcing initial-scale shouldn't be necessary -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge"> <!-- Use the latest (edge) version of IE rendering engine -->
     <meta name="x-apple-disable-message-reformatting"> <!-- Disable auto-scale in iOS 10 Mail entirely -->
+    <meta name="format-detection" content="telephone=no, address=no, email=no, date=no"> <!-- Tell iOS not to automatically link certain text strings. -->
 
     <!-- CSS Reset : BEGIN -->
     <style>
@@ -54,8 +55,9 @@
             text-decoration: none;
         }
 
-        /* What it does: A work-around for email clients meddling in triggered links. */
-        *[x-apple-data-detectors],  /* iOS */
+        /* What it does: A work-around for email clients automatically linking certain text strings. */
+        /* iOS */
+        *[x-apple-data-detectors],
         .unstyle-auto-detected-links *,
         .aBn {
             border-bottom: 0 !important;
@@ -66,6 +68,16 @@
             font-family: inherit !important;
             font-weight: inherit !important;
             line-height: inherit !important;
+        }
+        u + #body a,        /* Gmail */
+        #MessageViewBody a  /* Samsung Mail */
+        {
+           color: inherit;
+           text-decoration: none;
+           font-size: inherit;
+           font-family: inherit;
+           font-weight: inherit;
+           line-height: inherit;
         }
 
         /* What it does: Prevents Gmail from changing the text color in conversation threads. */

--- a/docs/email/templates/code/transactional-long.html
+++ b/docs/email/templates/code/transactional-long.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width"> <!-- Forcing initial-scale shouldn't be necessary -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge"> <!-- Use the latest (edge) version of IE rendering engine -->
     <meta name="x-apple-disable-message-reformatting"> <!-- Disable auto-scale in iOS 10 Mail entirely -->
+    <meta name="format-detection" content="telephone=no, address=no, email=no, date=no"> <!-- Tell iOS not to automatically link certain text strings. -->
 
     <!-- CSS Reset : BEGIN -->
     <style>
@@ -54,8 +55,9 @@
             text-decoration: none;
         }
 
-        /* What it does: A work-around for email clients meddling in triggered links. */
-        *[x-apple-data-detectors],  /* iOS */
+        /* What it does: A work-around for email clients automatically linking certain text strings. */
+        /* iOS */
+        *[x-apple-data-detectors],
         .unstyle-auto-detected-links *,
         .aBn {
             border-bottom: 0 !important;
@@ -66,6 +68,16 @@
             font-family: inherit !important;
             font-weight: inherit !important;
             line-height: inherit !important;
+        }
+        u + #body a,        /* Gmail */
+        #MessageViewBody a  /* Samsung Mail */
+        {
+           color: inherit;
+           text-decoration: none;
+           font-size: inherit;
+           font-family: inherit;
+           font-weight: inherit;
+           line-height: inherit;
         }
 
         /* What it does: Prevents Gmail from changing the text color in conversation threads. */

--- a/docs/email/templates/code/transactional-short.html
+++ b/docs/email/templates/code/transactional-short.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width"> <!-- Forcing initial-scale shouldn't be necessary -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge"> <!-- Use the latest (edge) version of IE rendering engine -->
     <meta name="x-apple-disable-message-reformatting"> <!-- Disable auto-scale in iOS 10 Mail entirely -->
+    <meta name="format-detection" content="telephone=no, address=no, email=no, date=no"> <!-- Tell iOS not to automatically link certain text strings. -->
 
     <!-- CSS Reset : BEGIN -->
     <style>
@@ -54,8 +55,9 @@
             text-decoration: none;
         }
 
-        /* What it does: A work-around for email clients meddling in triggered links. */
-        *[x-apple-data-detectors],  /* iOS */
+        /* What it does: A work-around for email clients automatically linking certain text strings. */
+        /* iOS */
+        *[x-apple-data-detectors],
         .unstyle-auto-detected-links *,
         .aBn {
             border-bottom: 0 !important;
@@ -66,6 +68,16 @@
             font-family: inherit !important;
             font-weight: inherit !important;
             line-height: inherit !important;
+        }
+        u + #body a,        /* Gmail */
+        #MessageViewBody a  /* Samsung Mail */
+        {
+           color: inherit;
+           text-decoration: none;
+           font-size: inherit;
+           font-family: inherit;
+           font-weight: inherit;
+           line-height: inherit;
         }
 
         /* What it does: Prevents Gmail from changing the text color in conversation threads. */


### PR DESCRIPTION
1. Added a `<meta name="format-detection">` tag as per [Brian's suggestion](https://github.com/StackExchange/Stacks/issues/216#issuecomment-449468156).

2. Left iOS untouched since they're already tightly scoped.

3. Added rules for Gmail and Samsung Mail but didn't include an `!important` because they're more globally defined and would otherwise impact non-auto-detected links.