### PR TITLE
zero out button margins in the meyer reset, not `s-btn`

### DIFF
--- a/lib/css/base/_stacks-reset-meyer.less
+++ b/lib/css/base/_stacks-reset-meyer.less
@@ -57,3 +57,7 @@ sup {
 sup {
     vertical-align: super;
 }
+
+button {
+    margin: 0; /* for Safari */
+}

--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -280,7 +280,6 @@
 //  ----------------------------------------------------------------------------
 .s-btn {
     position: relative;
-    margin: 0; // Something in production is trolling us and adding margins to buttons
     padding: 0.8em;
     border: 1px solid transparent;
     border-radius: @button-border-radius;


### PR DESCRIPTION
8be96c302e3ea634df49c27ecae763a70a47f36c made this change on `s-btn`, which is problematic because

- a component shouldn't do anything about its own margins
- it happens with class specificity

This change applies this to *all* `button`s instead (and thus with element specificity), and it does as part of the CSS reset (only the Meyer reset, this [already existed in the Gallagher reset](https://github.com/StackExchange/Stacks/blob/develop/lib/css/base/_stacks-reset-normalize.less#L246)).