### PR TITLE
Add search icon helper classes

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -29,9 +29,9 @@
         </a>
 
         <div class="grid--cell ps-relative ml16 w100 wmx3 sm:wmx-initial sm:ml0 sm:d-none js-search">
-            <input id="searchbox" class="s-input bar-md w100 pl32 js-stacks-search-bar" type="text" placeholder="Search Stacks…">
-            {% icon Search | pe-none stacks-search-icon %}
-            <span class="ps-absolute t6 r6 px8 ba bc-black-3 bar-sm bg-white fc-black-350 fs-body1 lh-lg pe-none"><span class="ps-relative mln1">/</span></span>
+            <input id="searchbox" class="s-input s-input__search bar-md js-stacks-search-bar" type="text" placeholder="Search Stacks…">
+            {% icon Search | s-input-icon s-input-icon__search %}
+            <span class="ps-absolute t6 b6 r6 px8 ba bc-black-3 bar-sm bg-white fc-black-350 fs-body1 lh-lg pe-none"><span class="ps-relative mln1">/</span></span>
         </div>
         <a class="grid grid__center p8 ml8 s-link s-link__muted d-none sm:d-block js-search-btn" href="#">
             {% icon Search | js-search-icon %}

--- a/docs/_includes/search.html
+++ b/docs/_includes/search.html
@@ -1,5 +1,0 @@
-<div class="ps-relative">
-    <input id="searchbox" class="s-input px32 fs-body2 js-stacks-search-bar" type="text" placeholder="Search Stacks">
-    {% icon Search | stacks-search-icon %}
-    <span class="ps-absolute mrn1 mtn2 t12 r8 px8 ba bc-black-3 bar-sm fc-black-350 fs-body1 lh-lg"><span class="ps-relative mln1">/</span></span>
-</div>

--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -18,9 +18,9 @@
             </a>
 
             <div class="grid--cell ps-relative w100 wmx3 js-search">
-                <input id="searchbox" class="s-input bar-md w100 pl32 ba bc-orange-3 js-stacks-search-bar" type="text" placeholder="Search Stacks…">
-                {% icon Search | pe-none stacks-search-icon %}
-                <span class="ps-absolute t6 r6 px8 ba bc-black-3 bar-sm bg-white fc-black-350 fs-body1 lh-lg pe-none"><span class="ps-relative mln1">/</span></span>
+                <input id="searchbox" class="s-input s-input__search bar-md ba bc-orange-3 js-stacks-search-bar" type="text" placeholder="Search Stacks…">
+                {% icon Search | s-input-icon s-input-icon__search %}
+                <span class="ps-absolute t6 b6 r6 px8 ba bc-black-3 bar-sm bg-white fc-black-350 fs-body1 lh-lg pe-none"><span class="ps-relative mln1">/</span></span>
             </div>
         </div>
         <div class="grid--cell fc-white sm:mt64">

--- a/docs/assets/less/stacks-documentation.less
+++ b/docs/assets/less/stacks-documentation.less
@@ -59,16 +59,6 @@
     }
 }
 
-//  $$  SEARCH BOX ICON
-//  ----------------------------------------------------------------------------
-.stacks-search-icon {
-    position: absolute;
-    top: 50%;
-    left: 10px;
-    margin-top: -10px;
-    color: @black-200;
-}
-
 //  $$  NAV SECONDARY SUBNAV
 //  ----------------------------------------------------------------------------
 .stacks-nav__secondary .stacks-nav__secondary {

--- a/docs/product/components/inputs.html
+++ b/docs/product/components/inputs.html
@@ -157,7 +157,7 @@ description: Input elements are used to gather information from users.
 
 <section id="inputs" class="stacks-section">
     {% header h2 | Search %}
-    <p class="stacks-copy">Stacks provides some helper classes to consistently style an input used for search. First, wrapping your search input in an element with relative positioning. Then, and add <code class="stacks-code">s-input__search</code> to the input itself. Finally, be sure to add <code class="stacks-code">s-input-icon</code> and <code class="stacks-code">s-input-icon__search</code> to the search icon.</p>
+    <p class="stacks-copy">Stacks provides helper classes to consistently style an input used for search. First, wrap your search input in an element with relative positioning. Then, and add <code class="stacks-code">s-input__search</code> to the input itself. Finally, be sure to add <code class="stacks-code">s-input-icon</code> and <code class="stacks-code">s-input-icon__search</code> to the search icon.</p>
 
     <div class="stacks-preview">
 {% highlight html linenos %}

--- a/docs/product/components/inputs.html
+++ b/docs/product/components/inputs.html
@@ -39,9 +39,9 @@ description: Input elements are used to gather information from users.
     {% header h2 | Accessibility %}
     <p class="stacks-copy">The best accessibility is semantic HTML. Most screen readers understand how to parse inputs if they're correctly formatted. When it comes to inputs, there are a few things to keep in mind:</p>
     <ul class="stacks-list">
-        <li>All inputs should have an <code class="stacks-code fs-body2">id</code> attribute.</li>
-        <li>Be sure to associate the input's label by using the <code class="stacks-code fs-body2">for</code> attribute. The value here is the input's <code class="stacks-code fs-body2">id</code>.</li>
-        <li>If you have a group of related inputs, use the <code class="stacks-code fs-body2">fieldset</code> and <code class="stacks-code fs-body2">legend</code> to group them together.</li>
+        <li>All inputs should have an <code class="stacks-code">id</code> attribute.</li>
+        <li>Be sure to associate the input's label by using the <code class="stacks-code">for</code> attribute. The value here is the input's <code class="stacks-code">id</code>.</li>
+        <li>If you have a group of related inputs, use the <code class="stacks-code">fieldset</code> and <code class="stacks-code">legend</code> to group them together.</li>
     </ul>
     <p class="stacks-copy">For more information, please read Gov.UK's article, <a href="https://accessibility.blog.gov.uk/2016/07/22/using-the-fieldset-and-legend-elements/" target="_blank"><em>"Using the fieldset and legend elements"</em></a>.</p>
 </section>
@@ -156,6 +156,26 @@ description: Input elements are used to gather information from users.
 </section>
 
 <section id="inputs" class="stacks-section">
+    {% header h2 | Search %}
+    <p class="stacks-copy">Stacks provides some helper classes to consistently style an input used for search. First, wrapping your search input in an element with relative positioning. Then, and add <code class="stacks-code">s-input__search</code> to the input itself. Finally, be sure to add <code class="stacks-code">s-input-icon</code> and <code class="stacks-code">s-input-icon__search</code> to the search icon.</p>
+
+    <div class="stacks-preview">
+{% highlight html linenos %}
+<div class="ps-relative">
+    <input class="s-input s-input__search" type="text" placeholder="Search…" />
+    @Svg.Search.With("s-input-icon s-input-icon__search")
+</div>
+{% endhighlight %}
+        <div class="stacks-preview--example">
+            <div class="ps-relative">
+                <input class="s-input s-input__search" type="text" placeholder="Search…" />
+                {% icon Search | s-input-icon s-input-icon__search %}
+            </div>
+        </div>
+    </div>
+</section>
+
+<section id="inputs" class="stacks-section">
     {% header h2 | Sizes %}
     <div class="overflow-x-auto mb32">
         <table class="wmn5 s-table s-table__bx-simple va-middle">
@@ -169,7 +189,7 @@ description: Input elements are used to gather information from users.
             </thead>
             <tbody>
                 {% for item in site.data.product.inputs.input %}
-                    {% assign size = item.sizes  %}
+                    {% assign size = item.sizes %}
                     {% for item in size %}
                     <tr>
                         <th scope="row">{{ item.name }}</th>

--- a/docs/product/resources/icons.html
+++ b/docs/product/resources/icons.html
@@ -58,8 +58,8 @@ description: All system icons are inline SVG files, invoked via a Razor helper. 
 <section class="stacks-section mb32" id="js-sortable-list">
     {% header h2 | Icon Set %}
     <div class="ps-relative mb16">
-        <input type="text" class="pl32 fuzzy-search s-input" placeholder="Search icons…" />
-        {% icon Search | pe-none stacks-search-icon %}
+        <input type="text" class="fuzzy-search s-input s-input__search" placeholder="Search icons…" />
+        {% icon Search | s-input-icon s-input-icon__search %}
     </div>
     <div class="grid fw-wrap sm:fd-column gs16 grid__allcells4 list">
         {% assign icon_sort = site.data.product.icons | sort: "helper" %}

--- a/lib/css/components/_stacks-inputs.less
+++ b/lib/css/components/_stacks-inputs.less
@@ -54,7 +54,6 @@
         color: @black-200;
     }
     &::placeholder {
-        padding-top: 1px; // Placeholder text is 1px higher than text that's entered.
         color: @black-200;
     }
 

--- a/lib/css/components/_stacks-inputs.less
+++ b/lib/css/components/_stacks-inputs.less
@@ -62,6 +62,10 @@
     &::-ms-clear { display: none; }
 }
 
+.s-input.s-input__search {
+    padding-left: @su32;
+}
+
 
 //  ============================================================================
 //  $  FIELDSET
@@ -514,15 +518,20 @@ fieldset {
     }
 }
 
-//  $$  ICON
+//  $$  ICONS
 //  ----------------------------------------------------------------------------
 .s-input-icon {
     position: absolute;
     top: 50%;
-    right: 0.8em;
-    margin-top: -0.69em;
-    vertical-align: text-bottom !important;
+    right: 0.7em;
+    margin-top: -9px; // Half the icon's height at 18px for centering;
     pointer-events: none;
+
+    &.s-input-icon__search {
+        right: auto;
+        left: 0.7em;
+        color: @black-200;
+    }
 }
 
 //  $$  MESSAGE


### PR DESCRIPTION
This PR adds a few classes to help properly position a search icon with an `s-input`.

![image](https://user-images.githubusercontent.com/1369864/51698086-f6738280-1fce-11e9-87e5-65879b24ce57.png)

Closes #233