### PR TITLE
Border documentation and style refinements

### DIFF
--- a/docs/_data/product/borders-definitions.yml
+++ b/docs/_data/product/borders-definitions.yml
@@ -1,70 +1,101 @@
 border:
-  - term: ba
-    define: border
-  - term: bt
-    define: border-top
-  - term: bb
-    define: border-bottom
-  - term: bl
-    define: border-left
-  - term: br
-    define: border-right
-  - term: by
-    define: border-top, border-bottom
-  - term: bx
-    define: border-left, border-right
-  - term: 0
-    define: 0px
-  - term: 1
-    define: 1px
-  - term: 2
-    define: 2px
-  - term: 3
-    define: 4px
-  - term: 4
-    define: 8px
+  - class: .ba
+    define: Apply a border to all sides
+    output: "border: solid 1px #000"
+  - class: .bt
+    define: Apply a border to the top side
+    output: "border-top: solid 1px #000"
+  - class: .bb
+    define: Apply a border to the bottom side
+    output: "border-bottom: solid 1px #000"
+  - class: .bl
+    define: Apply a border to the left side
+    output: "border-left: solid 1px #000"
+  - class: .br
+    define: Apply a border to the right side
+    output: "border-right: solid 1px #000"
+  - class: .by
+    define: Apply a border to the top and bottom sides
+    output: "border-top: solid 1px #000; border-bottom: solid 1px #000;"
+  - class: .bx
+    define: Apply a border to the left and right sides
+    output: "border-left: solid 1px #000; border-right: solid 1px #000;"
 
 border-width:
-  - term: baw
-    define: border-width
-  - term: btw
-    define: border-top-width
-  - term: bbw
-    define: border-bottom-width
-  - term: blw
-    define: border-left-width
-  - term: brw
-    define: border-right-width
-  - term: byw
-    define: border-top-width, border-bottom-width
-  - term: bxw
-    define: border-left-width, border-right-width
-  - term: 0
-    define: 0px
-  - term: 1
-    define: 1px
-  - term: 2
-    define: 2px
-  - term: 3
-    define: 4px
-  - term: 4
-    define: 8px
+  - class: .baw0
+    define: Applies a border width of zero to all sides
+    output: "border-width: 0"
+  - class: .btw0
+    define: Applies a border width of zero to the top side
+    output: "border-top-width: 0"
+  - class: .bbw0
+    define: Applies a border width of zero to the bottom side
+    output: "border-bottom-width: 0"
+  - class: .blw0
+    define: Applies a border width of zero to the left side
+    output: "border-left-width: 0"
+  - class: .brw0
+    define: Applies a border width of zero to the right side
+    output: "border-right-width: 0"
+  - class: .byw0
+    define: Applies a border width of zero to the top and bottom sides
+    output: "border-top-width: 0; border-bottom-width: 0;"
+  - class: .bxw0
+    define: Applies a border width of zero to the left and right sides
+    output: "border-left-width: 0; border-right-width: 0;"
+  - class: .baw1
+    define: Applies a border width of 1px to all sides
+    output: "border-width: 1px"
+  - class: .btw1
+    define: Applies a border width of 1px to the top side
+    output: "border-top-width: 1px"
+  - class: .bbw1
+    define: Applies a border width of 1px to the bottom side
+    output: "border-bottom-width: 1px"
+  - class: .blw1
+    define: Applies a border width of 1px to the left side
+    output: "border-left-width: 1px"
+  - class: .brw1
+    define: Applies a border width of 1px to the right side
+    output: "border-right-width: 1px"
+  - class: .byw1
+    define: Applies a border width of 1px to the top and bottom sides
+    output: "border-top-width: 1px; border-bottom-width: 1px;"
+  - class: .bxw1
+    define: Applies a border width of 1px to the left and right sides
+    output: "border-left-width: 1px; border-right-width: 1px;"
 
 border-style:
-  - term: bas-
-    define: border-style
-  - term: bts-
-    define: border-top-style
-  - term: brs-
-    define: border-right-style
-  - term: bbs-
-    define: border-bottom-style
-  - term: bls-
-    define: border-left-style
-  - term: solid
-    define: Solid line style
-  - term: dashed
-    define: Dashed line style
+  - class: bas-solid
+    define: Applies a solid border style to all sides
+    output: "border-style: solid"
+  - class: bts-solid
+    define: Applies a solid border style to the top side
+    output: "border-top-style: solid"
+  - class: brs-solid
+    define: Applies a solid border style to the right side
+    output: "border-right-style: solid"
+  - class: bbs-solid
+    define: Applies a solid border style to the bottom side
+    output: "border-bottom-style: solid"
+  - class: bls-solid
+    define: Applies a solid border style to the left side
+    output: "border-left-style: solid"
+  - class: bas-dashed
+    define: Applies a dashed border style to all sides
+    output: "border-style: dashed"
+  - class: bts-dashed
+    define: Applies a dashed border style to the top side
+    output: "border-top-style: dashed"
+  - class: brs-dashed
+    define: Applies a dashed border style to the right side
+    output: "border-right-style: dashed"
+  - class: bbs-dashed
+    define: Applies a dashed border style to the bottom side
+    output: "border-bottom-style: dashed"
+  - class: bls-dashed
+    define: Applies a dashed border style to the left side
+    output: "border-left-style: dashed"
 
 border-color:
   - term: bc-

--- a/docs/_data/product/borders-definitions.yml
+++ b/docs/_data/product/borders-definitions.yml
@@ -64,6 +64,48 @@ border-width:
   - class: .bxw1
     define: Applies a border width of 1px to the left and right sides
     output: "border-left-width: 1px; border-right-width: 1px;"
+  - class: .baw2
+    define: Applies a border width of 2px to all sides
+    output: "border-width: 2px"
+  - class: .btw2
+    define: Applies a border width of 2px to the top side
+    output: "border-top-width: 2px"
+  - class: .bbw2
+    define: Applies a border width of 2px to the bottom side
+    output: "border-bottom-width: 2px"
+  - class: .blw2
+    define: Applies a border width of 2px to the left side
+    output: "border-left-width: 2px"
+  - class: .brw2
+    define: Applies a border width of 2px to the right side
+    output: "border-right-width: 2px"
+  - class: .byw2
+    define: Applies a border width of 2px to the top and bottom sides
+    output: "border-top-width: 2px; border-bottom-width: 2px;"
+  - class: .bxw2
+    define: Applies a border width of 2px to the left and right sides
+    output: "border-left-width: 2px; border-right-width: 2px;"
+  - class: .baw3
+    define: Applies a border width of 4px to all sides
+    output: "border-width: 4px"
+  - class: .btw3
+    define: Applies a border width of 4px to the top side
+    output: "border-top-width: 4px"
+  - class: .bbw3
+    define: Applies a border width of 4px to the bottom side
+    output: "border-bottom-width: 4px"
+  - class: .blw3
+    define: Applies a border width of 4px to the left side
+    output: "border-left-width: 4px"
+  - class: .brw3
+    define: Applies a border width of 4px to the right side
+    output: "border-right-width: 4px"
+  - class: .byw3
+    define: Applies a border width of 4px to the top and bottom sides
+    output: "border-top-width: 4px; border-bottom-width: 4px;"
+  - class: .bxw3
+    define: Applies a border width of 4px to the left and right sides
+    output: "border-left-width: 4px; border-right-width: 4px;"
 
 border-style:
   - class: bas-solid

--- a/docs/product/base/borders-border.html
+++ b/docs/product/base/borders-border.html
@@ -1,4 +1,4 @@
-<p class="stacks-copy">To apply a border, <code class="stacks-code">.b[direction]</code> classes are provided. The default <code class="stacks-code">border</code> properties are <code class="stacks-code">border-width: 1px;</code> and <code class="stacks-code">border-style: solid;</code>. The browser default border color is black (<code class="stacks-code">#000</code>). To supply a border-color, use the <a href="#border-color">border color classes</a>.</p>
+<p class="stacks-copy">To apply a border, <code class="stacks-code">.b[direction]</code> classes are provided. The default <code class="stacks-code">border</code> properties are <code class="stacks-code">border-width: 1px;</code> and <code class="stacks-code">border-style: solid;</code>. The browser default border color is black (<code class="stacks-code">#000</code>). To supply a border-color, use the <a href="#color">border color classes</a>.</p>
 
 <section class="stacks-section">
     {% header h3 | Border Classes %}
@@ -6,14 +6,16 @@
         <table class="wmn3 s-table s-table__bx-simple">
             <thead>
                 <tr>
-                    <th class="s-table--cell2" scope="col">Abbreviation</th>
+                    <th class="s-table--cell2" scope="col">Class</th>
+                    <th scope="col">Output</th>
                     <th scope="col">Definition</th>
                 </tr>
             </thead>
             <tbody>
                 {% for border in site.data.product.borders-definitions.border %}
                   <tr>
-                      <th scope="row">{{ border.term }}</th>
+                      <th scope="row"><code class="stacks-code">{{ border.class }}</code></th>
+                      <td class="ff-mono">{{ border.output }}</td>
                       <td>{{ border.define }}</td>
                   </tr>
                 {% endfor %}

--- a/docs/product/base/borders-border.html
+++ b/docs/product/base/borders-border.html
@@ -1,5 +1,3 @@
-<p class="stacks-copy">To apply a border, <code class="stacks-code">.b[direction]</code> classes are provided. The default <code class="stacks-code">border</code> properties are <code class="stacks-code">border-width: 1px;</code> and <code class="stacks-code">border-style: solid;</code>. The browser default border color is black (<code class="stacks-code">#000</code>). To supply a border-color, use the <a href="#color">border color classes</a>.</p>
-
 <section class="stacks-section">
     {% header h3 | Border Classes %}
     <div class="overflow-x-auto mb32">

--- a/docs/product/base/borders-style.html
+++ b/docs/product/base/borders-style.html
@@ -5,16 +5,18 @@
         <table class="wmn3 s-table s-table__bx-simple">
             <thead>
                 <tr>
-                    <th class="s-table--cell2" scope="col">Abbreviation</th>
+                    <th class="s-table--cell2" scope="col">Class</th>
+                    <th scope="col">Output</th>
                     <th scope="col">Definition</th>
                 </tr>
             </thead>
             <tbody>
                 {% for border in site.data.product.borders-definitions.border-style %}
-                  <tr>
-                      <th scope="row">{{ border.term }}</th>
-                      <td>{{ border.define }}</td>
-                  </tr>
+                    <tr>
+                        <th scope="row"><code class="stacks-code">{{ border.class }}</code></th>
+                        <td class="ff-mono">{{ border.output }}</td>
+                        <td>{{ border.define }}</td>
+                    </tr>
                 {% endfor %}
             </tbody>
         </table>

--- a/docs/product/base/borders-width.html
+++ b/docs/product/base/borders-width.html
@@ -28,12 +28,16 @@
 <div class="ba bc-orange-3">…</div>
 <div class="ba brw0 bc-orange-3">…</div>
 <div class="ba bbw0 bc-orange-3">…</div>
+<div class="ba baw2 bc-orange-3">…</div>
+<div class="ba baw3 bc-orange-3">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="grid w100 gs8 fw-wrap">
                 <div class="grid--cell p12 bg-orange-100 ba bc-orange-3">1px Border</div>
                 <div class="grid--cell p12 bg-orange-100 ba brw0 bc-orange-3">0px Right Border</div>
                 <div class="grid--cell p12 bg-orange-100 ba bbw0 bc-orange-3">0px Bottom Border</div>
+                <div class="grid--cell p12 bg-orange-100 ba baw2 bc-orange-3">2px Border</div>
+                <div class="grid--cell p12 bg-orange-100 ba baw3 bc-orange-3">4px Border</div>
             </div>
         </div>
     </div>

--- a/docs/product/base/borders-width.html
+++ b/docs/product/base/borders-width.html
@@ -5,16 +5,18 @@
         <table class="wmn3 s-table s-table__bx-simple">
             <thead>
                 <tr>
-                    <th class="s-table--cell2" scope="col">Abbreviation</th>
+                    <th class="s-table--cell2" scope="col">Class</th>
+                    <th scope="col">Output</th>
                     <th scope="col">Definition</th>
                 </tr>
             </thead>
             <tbody>
                 {% for border in site.data.product.borders-definitions.border-width %}
-                  <tr>
-                      <th scope="row">{{ border.term }}</th>
-                      <td>{{ border.define }}</td>
-                  </tr>
+                    <tr>
+                        <th scope="row"><code class="stacks-code">{{ border.class }}</code></th>
+                        <td class="ff-mono">{{ border.output }}</td>
+                        <td>{{ border.define }}</td>
+                    </tr>
                 {% endfor %}
             </tbody>
         </table>

--- a/docs/product/base/borders-width.html
+++ b/docs/product/base/borders-width.html
@@ -25,23 +25,15 @@
     {% header h3 | Width Examples %}
     <div class="stacks-preview">
 {% highlight html linenos %}
-<div class="ba baw0">0px</div>
-<div class="bt btw1 bc-orange-3">1px</div>
-<div class="br brw2 bc-orange-3">2px</div>
-<div class="bb bbw3 bc-orange-3">4px</div>
-<div class="bl blw4 bc-orange-3">8px</div>
-<div class="bx bxw4 bc-orange-3">8px</div>
-<div class="by byw4 bc-orange-3">8px</div>
+<div class="ba bc-orange-3">…</div>
+<div class="ba brw0 bc-orange-3">…</div>
+<div class="ba bbw0 bc-orange-3">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="grid w100 gs8 fw-wrap">
-                <div class="grid--cell p12 bg-orange-100 ba baw0">0px border</div>
-                <div class="grid--cell p12 bg-orange-100 bt bc-orange-3">1px Top Border</div>
-                <div class="grid--cell p12 bg-orange-100 br brw2 bc-orange-3">2px Right Border</div>
-                <div class="grid--cell p12 bg-orange-100 bb bbw3 bc-orange-3">4px Bottom Border</div>
-                <div class="grid--cell p12 bg-orange-100 bl blw4 bc-orange-3">8px Left Border</div>
-                <div class="grid--cell p12 bg-orange-100 bx bxw4 bc-orange-3">8px X Border</div>
-                <div class="grid--cell p12 bg-orange-100 by byw4 bc-orange-3">8px Y Border</div>
+                <div class="grid--cell p12 bg-orange-100 ba bc-orange-3">1px Border</div>
+                <div class="grid--cell p12 bg-orange-100 ba brw0 bc-orange-3">0px Right Border</div>
+                <div class="grid--cell p12 bg-orange-100 ba bbw0 bc-orange-3">0px Bottom Border</div>
             </div>
         </div>
     </div>

--- a/lib/css/atomic/_stacks-borders.less
+++ b/lib/css/atomic/_stacks-borders.less
@@ -28,7 +28,7 @@
 //      bx: border x-axis
 //      by: border y-axis
 //  ----------------------------------------------------------------------------
-.bn             { .bas-none; .baw0; }
+.bn             { border-style: none; .baw0; }
 .ba             { .bas-solid; .baw1; }
 .bt             { .bts-solid; .btw1; }
 .br             { .brs-solid; .brw1; }
@@ -92,31 +92,25 @@
 //  ============================================================================
 //  $   STYLE
 //      s-dashed: dashed border style
-//      s-dotted: dotted border style
 //      s-solid:  solid border style
 //  ============================================================================
 //  $$  All sides
-.bas-none       { border-style: none !important; }
 .bas-solid      { border-style: solid !important; }
 .bas-dashed     { border-style: dashed !important; }
 
 //  $$  Top Border
-.bts-none       { border-top-style: none !important; }
 .bts-solid      { border-top-style: solid !important; }
 .bts-dashed     { border-top-style: dashed !important; }
 
 //  $$  Right Border
-.brs-none       { border-right-style: none !important; }
 .brs-solid      { border-right-style: solid !important; }
 .brs-dashed     { border-right-style: dashed !important; }
 
 //  $$  Bottom Border
-.bbs-none       { border-bottom-style: none !important; }
 .bbs-solid      { border-bottom-style: solid !important; }
 .bbs-dashed     { border-bottom-style: dashed !important; }
 
 //  $$  Left Border
-.bls-none       { border-left-style: none !important; }
 .bls-solid      { border-left-style: solid !important; }
 .bls-dashed     { border-left-style: dashed !important; }
 

--- a/lib/css/atomic/_stacks-borders.less
+++ b/lib/css/atomic/_stacks-borders.less
@@ -49,30 +49,44 @@
 //  $$  All Sides
 .baw0           { border-width: 0 !important; }
 .baw1           { border-width: @su2 / 2 !important; }
+.baw2           { border-width: @su2 !important; }
+.baw3           { border-width: @su4 !important; }
 
 //  $$  Top Border
 .btw0           { border-top-width: 0 !important; }
 .btw1           { border-top-width: @su2 / 2 !important; }
+.btw2           { border-top-width: @su2 !important; }
+.btw3           { border-top-width: @su4 !important; }
 
 //  $$  Right Border
 .brw0           { border-right-width: 0 !important; }
 .brw1           { border-right-width: @su2 / 2 !important; }
+.brw2           { border-right-width: @su2 !important; }
+.brw3           { border-right-width: @su4 !important; }
 
 //  $$  Bottom Border
 .bbw0           { border-bottom-width: 0 !important; }
 .bbw1           { border-bottom-width: @su2 / 2 !important; }
+.bbw2           { border-bottom-width: @su2 !important; }
+.bbw3           { border-bottom-width: @su4 !important; }
 
 //  $$  Left Border
 .blw0           { border-left-width: 0 !important; }
 .blw1           { border-left-width: @su2 / 2 !important; }
+.blw2           { border-left-width: @su2 !important; }
+.blw3           { border-left-width: @su4 !important; }
 
 //  $$  Y-Axis Border
 .byw0           { .btw0; .bbw0; }
 .byw1           { .btw1; .bbw1; }
+.byw2           { .btw2; .bbw2; }
+.byw3           { .btw3; .bbw3; }
 
 //  $$  X-Axis Border
 .bxw0           { .brw0; .blw0; }
 .bxw1           { .brw1; .blw1; }
+.bxw2           { .brw2; .blw2; }
+.bxw3           { .brw3; .blw3; }
 
 
 //  ============================================================================

--- a/lib/css/atomic/_stacks-borders.less
+++ b/lib/css/atomic/_stacks-borders.less
@@ -49,51 +49,30 @@
 //  $$  All Sides
 .baw0           { border-width: 0 !important; }
 .baw1           { border-width: @su2 / 2 !important; }
-.baw2           { border-width: @su2 !important; }
-.baw3           { border-width: @su4 !important; }
-.baw4           { border-width: @su8 !important; }
 
 //  $$  Top Border
 .btw0           { border-top-width: 0 !important; }
 .btw1           { border-top-width: @su2 / 2 !important; }
-.btw2           { border-top-width: @su2 !important; }
-.btw3           { border-top-width: @su4 !important; }
-.btw4           { border-top-width: @su8 !important; }
 
 //  $$  Right Border
 .brw0           { border-right-width: 0 !important; }
 .brw1           { border-right-width: @su2 / 2 !important; }
-.brw2           { border-right-width: @su2 !important; }
-.brw3           { border-right-width: @su4 !important; }
-.brw4           { border-right-width: @su8 !important; }
 
 //  $$  Bottom Border
 .bbw0           { border-bottom-width: 0 !important; }
 .bbw1           { border-bottom-width: @su2 / 2 !important; }
-.bbw2           { border-bottom-width: @su2 !important; }
-.bbw3           { border-bottom-width: @su4 !important; }
-.bbw4           { border-bottom-width: @su8 !important; }
 
 //  $$  Left Border
 .blw0           { border-left-width: 0 !important; }
 .blw1           { border-left-width: @su2 / 2 !important; }
-.blw2           { border-left-width: @su2 !important; }
-.blw3           { border-left-width: @su4 !important; }
-.blw4           { border-left-width: @su8 !important; }
 
 //  $$  Y-Axis Border
 .byw0           { .btw0; .bbw0; }
 .byw1           { .btw1; .bbw1; }
-.byw2           { .btw2; .bbw2; }
-.byw3           { .btw3; .bbw3; }
-.byw4           { .btw4; .bbw4; }
 
 //  $$  X-Axis Border
 .bxw0           { .brw0; .blw0; }
 .bxw1           { .brw1; .blw1; }
-.bxw2           { .brw2; .blw2; }
-.bxw3           { .brw3; .blw3; }
-.bxw4           { .brw4; .blw4; }
 
 
 //  ============================================================================


### PR DESCRIPTION
This PR makes our border documentation a bit more clear. It also removes the thicker border classes, since I have a hard time believing those are actually used anywhere in production.

- [x] Make sure this documentation is an improvement
- [x] Double check the deleted classes aren't used in production