### PR TITLE
Kill .wb-break-word

### DIFF
--- a/docs/_data/product/type-definitions.yaml
+++ b/docs/_data/product/type-definitions.yaml
@@ -166,9 +166,6 @@ type-layout:
   - class: wb-keep-all
     output: "word-break: keep-all;"
     define: Removes word breaks for Chinese, Japanese, and Korean text. All other text behavior is the same as normal.
-  - class: wb-break-word
-    output: "word-break: break-word;"
-    define: To prevent overflow, normally unbreakable words may be broken at arbitrary points if there are no otherwise acceptable break in the line.
   - class: wb-inherit
     output: "word-break: inherit;"
     define: Inherits the parent value.

--- a/docs/_data/product/type-definitions.yaml
+++ b/docs/_data/product/type-definitions.yaml
@@ -156,7 +156,7 @@ type-layout:
     define: Unsets any inherited behavior. Does not work in IE.
   - class: ww-break-word
     output: "word-wrap: break-word;"
-    define: Specifies if a browser should insert line breaks within words to prevent text from overflowing its content box.
+    define: Deprecated, please use the equivalent ow-break-word instead. Specifies if a browser should insert line breaks within words to prevent text from overflowing its content box.
   - class: wb-normal
     output: "word-break: normal;"
     define: Restores word break behavior.

--- a/docs/assets/less/stacks-documentation.less
+++ b/docs/assets/less/stacks-documentation.less
@@ -160,7 +160,7 @@
 
     vertical-align: middle;
     white-space: nowrap;
-    .wb-break-word;
+    .ww-break-word;
 }
 
 .stacks-code {

--- a/docs/assets/less/stacks-documentation.less
+++ b/docs/assets/less/stacks-documentation.less
@@ -160,7 +160,8 @@
 
     vertical-align: middle;
     white-space: nowrap;
-    .ww-break-word;
+    overflow-wrap: break-word;
+    word-wrap: break-word; /* IE11 */
 }
 
 .stacks-code {

--- a/docs/product/base/typography.html
+++ b/docs/product/base/typography.html
@@ -114,7 +114,7 @@ description: Stacks provides atomic classes to override default styling of typog
 <p class="ws-pre-line">White-space: Pre-line</p>
 <p class="ws-unset">White-space: Unset</p>
 
-<p class="ww-break-word">Break word</p>
+<p class="ow-break-word">Break word</p>
 
 <p class="truncate">Truncate: …</p>
 {% endhighlight %}
@@ -130,7 +130,7 @@ description: Stacks provides atomic classes to override default styling of typog
             <p class="grid--cell ws-pre-wrap"><strong>White-space:</strong> Pre-wrap</p>
             <p class="grid--cell ws-pre-line"><strong>White-space:</strong> Pre-line</p>
             <p class="grid--cell ws-unset mb32"><strong>White-space:</strong> Unset</p>
-            <p class="grid--cell ww-break-word mb32"><strong>Word Wrap:</strong> Break word</p>
+            <p class="grid--cell ow-break-word mb32"><strong>Word Wrap:</strong> Break word</p>
             <p class="grid--cell">
                 <div class="truncate wmx3">
                     <strong>Truncate:</strong> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>

--- a/docs/product/guidelines/building.html
+++ b/docs/product/guidelines/building.html
@@ -12,7 +12,7 @@ description: The following is a guide to building and running Stacks locally. Yo
         <li>Install Xcode. You can download it <a href="https://developer.apple.com/xcode/">directly</a>, or install via the Mac App Store.</li>
         <li>Install Xcode’s command line tools <code class="stacks-code">xcode-select --install</code></li>
         <li>Accept the Xcode license. <code class="stacks-code">sudo xcodebuild -license accept</code></li>
-        <li>To Install a fresh version of Ruby, we’ll use <a href="https://brew.sh">Homebrew</a>. Install it by running <code class="stacks-code wb-break-word ws-pre-wrap">/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"</code></li>
+        <li>To Install a fresh version of Ruby, we’ll use <a href="https://brew.sh">Homebrew</a>. Install it by running <code class="stacks-code ww-break-word ws-pre-wrap">/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"</code></li>
         <li>Now you can use Homebrew to install Ruby <code class="stacks-code">brew install ruby</code></li>
         <li>Now’s a good time to quit your Terminal and relaunch it. This will make sure your session is aware of the new dependencies we’ve installed. Don’t just close the window, quit the whole app.</li>
     </ol>

--- a/docs/product/guidelines/building.html
+++ b/docs/product/guidelines/building.html
@@ -12,7 +12,7 @@ description: The following is a guide to building and running Stacks locally. Yo
         <li>Install Xcode. You can download it <a href="https://developer.apple.com/xcode/">directly</a>, or install via the Mac App Store.</li>
         <li>Install Xcode’s command line tools <code class="stacks-code">xcode-select --install</code></li>
         <li>Accept the Xcode license. <code class="stacks-code">sudo xcodebuild -license accept</code></li>
-        <li>To Install a fresh version of Ruby, we’ll use <a href="https://brew.sh">Homebrew</a>. Install it by running <code class="stacks-code ww-break-word ws-pre-wrap">/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"</code></li>
+        <li>To Install a fresh version of Ruby, we’ll use <a href="https://brew.sh">Homebrew</a>. Install it by running <code class="stacks-code ws-pre-wrap">/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"</code></li>
         <li>Now you can use Homebrew to install Ruby <code class="stacks-code">brew install ruby</code></li>
         <li>Now’s a good time to quit your Terminal and relaunch it. This will make sure your session is aware of the new dependencies we’ve installed. Don’t just close the window, quit the whole app.</li>
     </ol>

--- a/docs/product/resources/icons.html
+++ b/docs/product/resources/icons.html
@@ -70,7 +70,7 @@ description: All system icons are inline SVG files, invoked via a Razor helper. 
                         {% icon {{ icon.helper }} | native %}
                     </div>
                     <div class="grid ff-column-nowrap ai-center p8">
-                        <code class="grid--cell fs-caption py8 ff-mono wb-break-word js-name">@Svg.{{ icon.helper }}</code>
+                        <code class="grid--cell fs-caption py8 ff-mono ww-break-word js-name">@Svg.{{ icon.helper }}</code>
                     </div>
                 </div>
             </div>

--- a/docs/product/resources/icons.html
+++ b/docs/product/resources/icons.html
@@ -70,7 +70,7 @@ description: All system icons are inline SVG files, invoked via a Razor helper. 
                         {% icon {{ icon.helper }} | native %}
                     </div>
                     <div class="grid ff-column-nowrap ai-center p8">
-                        <code class="grid--cell fs-caption py8 ff-mono ww-break-word js-name">@Svg.{{ icon.helper }}</code>
+                        <code class="grid--cell fs-caption py8 ff-mono ow-break-word js-name">@Svg.{{ icon.helper }}</code>
                     </div>
                 </div>
             </div>

--- a/lib/css/atomic/_stacks-typography.less
+++ b/lib/css/atomic/_stacks-typography.less
@@ -128,12 +128,13 @@ h1, h2, h3, h4, h5, h6, p {
 //      This property will create a line break only if an entire word cannot be
 //      placed on its own line without overflowing. This was formerly called
 //      word-wrap, which was an unprefixed Microsoft vendor property implemented
-//      by most browsers. Word-wrap is still a supported alias.
-.ow-normal        { overflow-wrap: normal !important; }
-.ow-break-word    { overflow-wrap: break-word !important; }
-.ow-inherit       { overflow-wrap: inherit !important; }
-.ow-initial       { overflow-wrap: initial !important; }
-.ow-unset         { overflow-wrap: inherit !important; }
+//      by most browsers. Word-wrap is still a supported alias, but can be removed
+//      once we no longer support IE11.
+.ow-normal        { overflow-wrap: normal !important; word-wrap: normal !important; }
+.ow-break-word    { overflow-wrap: break-word !important; word-wrap: break-word !important; }
+.ow-inherit       { overflow-wrap: inherit !important; word-wrap: inherit !important; }
+.ow-initial       { overflow-wrap: initial !important; word-wrap: initial !important; }
+.ow-unset         { overflow-wrap: inherit !important; word-wrap: inherit !important; }
 
 .ww-break-word    { word-wrap: break-word !important; }
 

--- a/lib/css/atomic/_stacks-typography.less
+++ b/lib/css/atomic/_stacks-typography.less
@@ -120,7 +120,6 @@ h1, h2, h3, h4, h5, h6, p {
 .wb-normal        { word-break: normal !important; }
 .wb-break-all     { word-break: break-all !important; }
 .wb-keep-all      { word-break: keep-all !important; }
-.wb-break-word    { word-break: break-word !important; }
 .wb-inherit       { word-break: inherit !important; }
 .wb-initial       { word-break: initial !important; }
 .wb-unset         { word-break: inherit !important; }


### PR DESCRIPTION
This PR is a fix for #238. We'll need a corresponding PR in Core and Careers to double replace `wb-break-word` with `.ww-break-word`.

It's used in 16 spots on Core, but in super straightforward ways.