### PR TITLE
Explicitly set the left margin in sidebar widget sub-navigation.

### DIFF
--- a/lib/css/components/_stacks-widget.less
+++ b/lib/css/components/_stacks-widget.less
@@ -195,6 +195,7 @@ table.s-sidebarwidget--content.s-sidebarwidget__items {
 .s-sidebarwidget--subnav {
     list-style-type: none;
     padding-left: 0;
+    margin-left: @su8;
 
     li {
         margin-top: 12px;


### PR DESCRIPTION
The original design spec had this flush left, but the default Q&A CSS for lists caused a 30px margin here, which is why uses of this pattern in Q&A code added explicit `ml8` or `ml12` to fix.

It seems that a little bit of margin is indeed warranted; 8px seems reasonable.

![screenshot with the new 8-pixel margin](https://user-images.githubusercontent.com/1763000/52120872-0d912080-261e-11e9-81bc-64a655e83c02.png)
