### PR TITLE
Add login verb / noun section to grammar and mechanics

### DIFF
--- a/docs/content/grammar-and-mechanics.html
+++ b/docs/content/grammar-and-mechanics.html
@@ -197,7 +197,7 @@ description: A guide to help anyone who writes, edits, or translates public-faci
         </tbody>
     </table>
     <p class="stacks-copy">Use “their” as a singular, gender-neutral pronoun when the gender of the subject is unknown or unimportant. Avoid using gendered terms.</p>
-    <table class="s-table s-table__lg fs-body2 w100 wmx6">
+    <table class="s-table s-table__lg fs-body2 w100 wmx6 mb48">
         <thead>
             <th class="btw0 bxw0 bbw3 bbw3 bc-red-2 fc-red-500 bg-transparent fs-body1 s-table--cell6">{% icon Clear | mtn1 mbn1 %} Don’t</th>
             <th class="btw0 bxw0 bbw3 bc-green-2 fc-green-500 bg-transparent fs-body1 s-table--cell6">{% icon Checkmark | mtn1 mbn1 %} Do</th>
@@ -210,6 +210,25 @@ description: A guide to help anyone who writes, edits, or translates public-faci
             <tr>
                 <td>We appreciate the guys and gals of Stack Overflow.</td>
                 <td>We appreciate the Stack Overflow community.</td>
+            </tr>
+        </tbody>
+    </table>
+
+    {% header h3 | Mind your verbs and nouns %}
+    <p class="stacks-copy">Take extra care when using “login,” and “log in.” The former is a noun while the latter is a verb. Do not use “login” as a verb.</p>
+    <table class="s-table s-table__lg fs-body2 w100 wmx6 mb48">
+        <thead>
+            <th class="btw0 bxw0 bbw3 bbw3 bc-red-2 fc-red-500 bg-transparent fs-body1 s-table--cell6">{% icon Clear | mtn1 mbn1 %} Don’t</th>
+            <th class="btw0 bxw0 bbw3 bc-green-2 fc-green-500 bg-transparent fs-body1 s-table--cell6">{% icon Checkmark | mtn1 mbn1 %} Do</th>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Login to ask a question</td>
+                <td>Log in to ask a question</td>
+            </tr>
+            <tr>
+                <td>Add a log in to your account</td>
+                <td>Add a login to your account</td>
             </tr>
         </tbody>
     </table>

--- a/docs/content/grammar-and-mechanics.html
+++ b/docs/content/grammar-and-mechanics.html
@@ -215,7 +215,7 @@ description: A guide to help anyone who writes, edits, or translates public-faci
     </table>
 
     {% header h3 | Mind your verbs and nouns %}
-    <p class="stacks-copy">Take extra care when using “login,” and “log in.” The former is a noun while the latter is a verb. Do not use “login” as a verb.</p>
+    <p class="stacks-copy">Take extra care when using “login,” and “log in.” The former is a noun while the latter is a verb. Do not use “login” as a verb. The same logic applies to “signup,” “sign up.”</p>
     <table class="s-table s-table__lg fs-body2 w100 wmx6 mb48">
         <thead>
             <th class="btw0 bxw0 bbw3 bbw3 bc-red-2 fc-red-500 bg-transparent fs-body1 s-table--cell6">{% icon Clear | mtn1 mbn1 %} Don’t</th>
@@ -229,6 +229,14 @@ description: A guide to help anyone who writes, edits, or translates public-faci
             <tr>
                 <td>Add a log in to your account</td>
                 <td>Add a login to your account</td>
+            </tr>
+            <tr>
+                <td>Signup to ask a question</td>
+                <td>Sign up to ask a question</td>
+            </tr>
+            <tr>
+                <td>Complete email sign up</td>
+                <td>Complete email signup</td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
This PR closes #259. Since we don't actually use "Signin" or "Sign in", I've codified with "login". We use "sign up", but I don't think there is confusion there.