### PR TITLE
Add color aliases

### DIFF
--- a/docs/product/base/borders-color.html
+++ b/docs/product/base/borders-color.html
@@ -141,6 +141,7 @@
     </div>
 
     {% header h3 | Green %}
+    <p class="stacks-copy">Green borders can also be declared using our <code class="stacks-code">.bc-success</code> <a href="{{ '/product/base/colors#success' | relative_url }}">alias class</a>.</p>
     <div class="stacks-preview">
 {% highlight html linenos %}
 <div class="bb bc-green-3">Dark Green Border</div>
@@ -157,6 +158,7 @@
     </div>
 
     {% header h3 | Red %}
+    <p class="stacks-copy">Red borders can also be declared using our <code class="stacks-code">.bc-error</code> and <code class="stacks-code">.bc-danger</code> <a href="{{ '/product/base/colors#danger-and-error' | relative_url }}">alias classes</a>.</p>
     <div class="stacks-preview">
 {% highlight html linenos %}
 <div class="bb bc-red-3">Dark Red Border</div>
@@ -173,6 +175,7 @@
     </div>
 
     {% header h3 | Yellow %}
+    <p class="stacks-copy">Yellow borders can also be declared using our <code class="stacks-code">.bc-warning</code> <a href="{{ '/product/base/colors#warning' | relative_url }}">alias class</a>.</p>
     <div class="stacks-preview">
 {% highlight html linenos %}
 <div class="bb bc-yellow-3">Dark Yellow Border</div>

--- a/docs/product/base/colors.html
+++ b/docs/product/base/colors.html
@@ -126,7 +126,8 @@ description: To avoid specifying color values by hand, we’ve included a robust
         <thead>
             <tr>
                 <th scope="col" class="s-table--cell3">Text Classes</th>
-                <th scope="col">Background Classes</th>
+                <th scope="col" class="s-table--cell3">Background Classes</th>
+                <th scope="col">Border Classes</th>
             </tr>
         </thead>
         <tbody>
@@ -135,6 +136,10 @@ description: To avoid specifying color values by hand, we’ve included a robust
                 <td class="p8">
                     <div class="bg-danger p8 fc-white bar-sm d-inline-block">.bg-danger</div>
                     <div class="bg-error p8 fc-white bar-sm d-inline-block">.bg-error</div>
+                </td>
+                <td class="p8">
+                    <div class="ba bc-danger p8 bar-sm d-inline-block fc-danger">.bc-danger</div>
+                    <div class="ba bc-error p8 bar-sm d-inline-block fc-error">.bc-error</div>
                 </td>
             </tr>
         </tbody>
@@ -145,7 +150,8 @@ description: To avoid specifying color values by hand, we’ve included a robust
         <thead>
             <tr>
                 <th scope="col" class="s-table--cell3">Text Class</th>
-                <th scope="col">Background Class</th>
+                <th scope="col" class="s-table--cell3">Background Class</th>
+                <th scope="col">Border Class</th>
             </tr>
         </thead>
         <tbody>
@@ -153,6 +159,9 @@ description: To avoid specifying color values by hand, we’ve included a robust
                 <td class="fc-success">.fc-success</td>
                 <td class="p8">
                     <div class="bg-success p8 fc-white bar-sm d-inline-block">.bg-success</div>
+                </td>
+                <td class="p8">
+                    <div class="ba bc-success p8 bar-sm d-inline-block fc-success">.bc-success</div>
                 </td>
             </tr>
         </tbody>
@@ -163,7 +172,8 @@ description: To avoid specifying color values by hand, we’ve included a robust
         <thead>
             <tr>
                 <th scope="col" class="s-table--cell3">Text Class</th>
-                <th scope="col">Background Class</th>
+                <th scope="col" class="s-table--cell3">Background Class</th>
+                <th scope="col">Border Class</th>
             </tr>
         </thead>
         <tbody>
@@ -171,6 +181,9 @@ description: To avoid specifying color values by hand, we’ve included a robust
                 <td class="fc-warning">.fc-warning</td>
                 <td class="p8">
                     <div class="bg-warning p8 fc-white bar-sm d-inline-block">.bg-warning</div>
+                </td>
+                <td class="p8">
+                    <div class="ba bc-warning p8 bar-sm d-inline-block fc-warning">.bc-warning</div>
                 </td>
             </tr>
         </tbody>

--- a/docs/product/base/colors.html
+++ b/docs/product/base/colors.html
@@ -118,3 +118,62 @@ description: To avoid specifying color values by hand, we’ve included a robust
         </div>
     {% endfor %}
 </section>
+
+<section class="stacks-section">
+    {% header h2 | Aliases %}
+    {% header h3 | Danger and Error %}
+    <table class="wmn5 s-table s-table__bx-simple s-table__condensed va-middle fs-caption">
+        <thead>
+            <tr>
+                <th scope="col" class="s-table--cell3">Text Classes</th>
+                <th scope="col">Background Classes</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="ff-mono">
+                <td class="fc-danger"><span class="mr8 d-inline-block">.fc-danger</span> .fc-error</td>
+                <td class="p8">
+                    <div class="bg-danger p8 fc-white bar-sm d-inline-block">.bg-danger</div>
+                    <div class="bg-error p8 fc-white bar-sm d-inline-block">.bg-error</div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+    {% header h3 | Success %}
+    <table class="wmn5 s-table s-table__bx-simple s-table__condensed va-middle fs-caption">
+        <thead>
+            <tr>
+                <th scope="col" class="s-table--cell3">Text Class</th>
+                <th scope="col">Background Class</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="ff-mono">
+                <td class="fc-success">.fc-success</td>
+                <td class="p8">
+                    <div class="bg-success p8 fc-white bar-sm d-inline-block">.bg-success</div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+    {% header h3 | Warning %}
+    <table class="wmn5 s-table s-table__bx-simple s-table__condensed va-middle fs-caption">
+        <thead>
+            <tr>
+                <th scope="col" class="s-table--cell3">Text Class</th>
+                <th scope="col">Background Class</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="ff-mono">
+                <td class="fc-warning">.fc-warning</td>
+                <td class="p8">
+                    <div class="bg-warning p8 fc-white bar-sm d-inline-block">.bg-warning</div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</section>
+

--- a/lib/css/atomic/_stacks-borders.less
+++ b/lib/css/atomic/_stacks-borders.less
@@ -228,7 +228,7 @@
 
 //  $$  YELLOW
 //  ----------------------------------------------------------------------------
-.bc-yellow-1        { border-color: @yellow-050 !important; }
-.bc-yellow-2        { border-color: @yellow-100 !important; }
+.bc-yellow-1        { border-color: @yellow-200 !important; }
+.bc-yellow-2        { border-color: @yellow-400 !important; }
 .bc-yellow-3,
-.bc-warning         { border-color: @yellow-400 !important; }
+.bc-warning         { border-color: @yellow-600 !important; }

--- a/lib/css/atomic/_stacks-borders.less
+++ b/lib/css/atomic/_stacks-borders.less
@@ -163,6 +163,10 @@
 //  ============================================================================
 //  $   COLORS
 //  ============================================================================
+//  $$  TRANSPARENT
+//  ----------------------------------------------------------------------------
+.bc-transparent     { border-color: transparent !important; }
+
 //  $$  WHITE
 //  ----------------------------------------------------------------------------
 .bc-white           { border-color: @white !important; }
@@ -210,21 +214,21 @@
 //  $$  GREEN
 //  ----------------------------------------------------------------------------
 .bc-green-1         { border-color: @green-100 !important; }
-.bc-green-2         { border-color: @green-400 !important; }
+.bc-green-2,
+.bc-success         { border-color: @green-400 !important; }
 .bc-green-3         { border-color: @green-600 !important; }
 
 //  $$  RED
 //  ----------------------------------------------------------------------------
 .bc-red-1           { border-color: @red-100 !important; }
-.bc-red-2           { border-color: @red-400 !important; }
+.bc-red-2,
+.bc-danger,
+.bc-error           { border-color: @red-400 !important; }
 .bc-red-3           { border-color: @red-600 !important; }
 
 //  $$  YELLOW
 //  ----------------------------------------------------------------------------
 .bc-yellow-1        { border-color: @yellow-050 !important; }
 .bc-yellow-2        { border-color: @yellow-100 !important; }
-.bc-yellow-3        { border-color: @yellow-400 !important; }
-
-//  $$  TRANSPARENT
-//  ----------------------------------------------------------------------------
-.bc-transparent     { border-color: transparent !important; }
+.bc-yellow-3,
+.bc-warning         { border-color: @yellow-400 !important; }

--- a/lib/css/atomic/_stacks-colors.less
+++ b/lib/css/atomic/_stacks-colors.less
@@ -114,8 +114,8 @@
 //  ----------------------------------------------------------------------------
 .fc-yellow-900 { color: @yellow-900 !important; }
 .fc-yellow-800 { color: @yellow-800 !important; }
-.fc-yellow-700, .fc-warning { color: @yellow-700 !important; }
-.fc-yellow-600 { color: @yellow-600 !important; }
+.fc-yellow-700 { color: @yellow-700 !important; }
+.fc-yellow-600, .fc-warning { color: @yellow-600 !important; }
 .fc-yellow-500 { color: @yellow-500 !important; }
 .fc-yellow-400 { color: @yellow-400 !important; }
 .fc-yellow-300 { color: @yellow-300 !important; }

--- a/lib/css/atomic/_stacks-colors.less
+++ b/lib/css/atomic/_stacks-colors.less
@@ -100,7 +100,7 @@
 .fc-green-900 { color: @green-900 !important; }
 .fc-green-800 { color: @green-800 !important; }
 .fc-green-700 { color: @green-700 !important; }
-.fc-green-600 { color: @green-600 !important; }
+.fc-green-600, .fc-success { color: @green-600 !important; }
 .h\:fc-green-600:hover { .fc-green-600 }
 .fc-green-500 { color: @green-500 !important; }
 .fc-green-400 { color: @green-400 !important; }
@@ -114,7 +114,7 @@
 //  ----------------------------------------------------------------------------
 .fc-yellow-900 { color: @yellow-900 !important; }
 .fc-yellow-800 { color: @yellow-800 !important; }
-.fc-yellow-700 { color: @yellow-700 !important; }
+.fc-yellow-700, .fc-warning { color: @yellow-700 !important; }
 .fc-yellow-600 { color: @yellow-600 !important; }
 .fc-yellow-500 { color: @yellow-500 !important; }
 .fc-yellow-400 { color: @yellow-400 !important; }
@@ -130,7 +130,7 @@
 .fc-red-700 { color: @red-700 !important; }
 .fc-red-600 { color: @red-600 !important; }
 .h\:fc-red-600:hover { .fc-red-600 }
-.fc-red-500 { color: @red-500 !important; }
+.fc-red-500, .fc-error, .fc-danger { color: @red-500 !important; }
 .fc-red-400 { color: @red-400 !important; }
 .fc-red-300 { color: @red-300 !important; }
 .fc-red-200 { color: @red-200 !important; }
@@ -212,7 +212,7 @@
 .bg-green-700 { background-color: @green-700 !important; }
 .bg-green-600 { background-color: @green-600 !important; }
 .h\:bg-green-600:hover { .bg-green-600 }
-.bg-green-500 { background-color: @green-500 !important; }
+.bg-green-500, .bg-success { background-color: @green-500 !important; }
 .bg-green-400 { background-color: @green-400 !important; }
 .bg-green-300 { background-color: @green-300 !important; }
 .bg-green-200 { background-color: @green-200 !important; }
@@ -225,7 +225,7 @@
 .bg-yellow-900 { background-color: @yellow-900 !important; }
 .bg-yellow-800 { background-color: @yellow-800 !important; }
 .bg-yellow-700 { background-color: @yellow-700 !important; }
-.bg-yellow-600 { background-color: @yellow-600 !important; }
+.bg-yellow-600, .bg-warning { background-color: @yellow-600 !important; }
 .bg-yellow-500 { background-color: @yellow-500 !important; }
 .bg-yellow-400 { background-color: @yellow-400 !important; }
 .bg-yellow-300 { background-color: @yellow-300 !important; }
@@ -240,7 +240,7 @@
 .bg-red-700 { background-color: @red-700 !important; }
 .bg-red-600 { background-color: @red-600 !important; }
 .h\:bg-red-600:hover { .bg-red-600 }
-.bg-red-500 { background-color: @red-500 !important; }
+.bg-red-500, .bg-error, .bg-danger { background-color: @red-500 !important; }
 .bg-red-400 { background-color: @red-400 !important; }
 .bg-red-300 { background-color: @red-300 !important; }
 .bg-red-200 { background-color: @red-200 !important; }


### PR DESCRIPTION
This PR adds color aliases for `.fc-success`, `.fc-danger`, `.fc-error`, and `.fc-warning`. The same aliases apply to background colors as well.

If I'm not mistaken, this should close #187. If it doesn't, I think these are still valuable as a slightly more abstracted case.

@mstum