### PR TITLE
Unship outlined notices

### DIFF
--- a/docs/product/components/notices.html
+++ b/docs/product/components/notices.html
@@ -115,33 +115,6 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
         </div>
     </div>
 
-    {% header h3 | Outlined %}
-    <p class="stacks-copy">Minimal style used to minimally separate notices from the main content</p>
-    <div class="stacks-preview">
-{% highlight html linenos %}
-<aside class="s-notice s-notice__info s-notice__outlined" role="status" aria-hidden="false">…</aside>
-<aside class="s-notice s-notice__success s-notice__outlined" role="status" aria-hidden="false">… <a class="s-link s-link__inherit s-link__underlined" href="…">…</a></aside>
-<aside class="s-notice s-notice__warning s-notice__outlined" role="status" aria-hidden="false">…</aside>
-<aside class="s-notice s-notice__danger s-notice__outlined" role="status" aria-hidden="false">…</aside>
-{% endhighlight %}
-        <div class="stacks-preview--example">
-            <div class="ps-relative grid gs8 gsy fd-column jc-center">
-                <aside class="grid--cell s-notice s-notice__info s-notice__outlined" role="status" aria-hidden="false">
-                    <p class="m0">Info outlined message style</p>
-                </aside>
-                <aside class="grid--cell s-notice s-notice__success s-notice__outlined" role="status" aria-hidden="false">
-                    <p class="m0">Success outlined message style <a class="s-link s-link__inherit s-link__underlined" href="#">Link</a></p>
-                </aside>
-                <aside class="grid--cell s-notice s-notice__warning s-notice__outlined" role="status" aria-hidden="false">
-                    <p class="m0">Warning outlined message style</p>
-                </aside>
-                <aside class="grid--cell s-notice s-notice__danger s-notice__outlined" role="status" aria-hidden="false">
-                    <p class="m0">Danger outlined message style</p>
-                </aside>
-            </div>
-        </div>
-    </div>
-
     {% header h3 | Filled Important %}
     <p class="stacks-copy">Used sparingly for when an important notice needs to be noticed</p>
     <div class="stacks-preview">

--- a/lib/css/components/_stacks-notices.less
+++ b/lib/css/components/_stacks-notices.less
@@ -42,10 +42,6 @@
     border-color: @notice-info-border-color;
     background-color: @notice-info-background-color;
 
-    &.s-notice__outlined {
-        border-color: @blue-500;
-    }
-
     &.s-notice__important {
         background-color: @notice-info-important-background-color;
     }
@@ -56,10 +52,6 @@
 .s-notice__success {
     border-color: @notice-success-border-color;
     background-color: @notice-success-background-color;
-
-    &.s-notice__outlined {
-        border-color: @green-400;
-    }
 
     &.s-notice__important {
         background-color: @notice-success-important-background-color;
@@ -73,10 +65,6 @@
     border-color: @notice-warning-border-color;
     background-color: @notice-warning-background-color;
 
-    &.s-notice__outlined {
-        border-color: @yellow-500;
-    }
-
     &.s-notice__important {
         background-color: @notice-warning-important-background-color;
         color: @fc-dark;
@@ -88,10 +76,6 @@
 .s-notice__danger {
     border-color: @notice-danger-border-color;
     background-color: @notice-danger-background-color;
-
-    &.s-notice__outlined {
-        border-color: @red-400;
-    }
 
     &.s-notice__important {
         background-color: @notice-danger-important-background-color;


### PR DESCRIPTION
The outlined styles for notices were meant to be more subtle than the standard, but I haven't found a good reason for justifying keeping them around, especially since, in my opinion, they're ugly 😬 

This PR removes them entirely. Between standard and `__important`, I think we have enough variations in our notices.