### PR TITLE
Button group responsive refinements

### DIFF
--- a/docs/product/components/button-groups.html
+++ b/docs/product/components/button-groups.html
@@ -44,30 +44,16 @@ description: Button groups are a collection of buttons. This component is used i
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="">
-                <div class="s-btn-group js-btn-group">
-                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Newest</button>
-                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Frequent</button>
-                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">In the</button>
-                    <button class="s-btn s-btn__muted s-btn__outlined s-btn__dropdown js-btn-group-item" role="button">Time of</button>
-                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Chimpanzees</button>
-                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">There</button>
-                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Was</button>
-                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">A Monkey</button>
-                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Two Turntables</button>
-                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">And a</button>
-                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Microphone</button>
-                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Bottles & Cans</button>
-                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Clapped</button>
-                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Hands</button>
-                    <form class="s-btn-group--container">
-                        <button class="s-btn s-btn__muted s-btn__outlined is-selected js-btn-group-item" role="button">Votes</button>
-                    </form>
-                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Active</button>
-                    <form class="s-btn-group--container">
-                        <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Unanswered</button>
-                    </form>
-                </div>
+            <div class="s-btn-group js-btn-group">
+                <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Newest</button>
+                <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Frequent</button>
+                <form class="s-btn-group--container">
+                    <button class="s-btn s-btn__muted s-btn__outlined is-selected js-btn-group-item" role="button">Votes</button>
+                </form>
+                <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Active</button>
+                <form class="s-btn-group--container">
+                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Unanswered</button>
+                </form>
             </div>
         </div>
     </div>

--- a/docs/product/components/button-groups.html
+++ b/docs/product/components/button-groups.html
@@ -44,10 +44,22 @@ description: Button groups are a collection of buttons. This component is used i
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="overflow-x-auto">
+            <div class="">
                 <div class="s-btn-group js-btn-group">
                     <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Newest</button>
                     <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Frequent</button>
+                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">In the</button>
+                    <button class="s-btn s-btn__muted s-btn__outlined s-btn__dropdown js-btn-group-item" role="button">Time of</button>
+                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Chimpanzees</button>
+                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">There</button>
+                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Was</button>
+                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">A Monkey</button>
+                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Two Turntables</button>
+                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">And a</button>
+                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Microphone</button>
+                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Bottles & Cans</button>
+                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Clapped</button>
+                    <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">Hands</button>
                     <form class="s-btn-group--container">
                         <button class="s-btn s-btn__muted s-btn__outlined is-selected js-btn-group-item" role="button">Votes</button>
                     </form>

--- a/lib/css/components/_stacks-button-groups.less
+++ b/lib/css/components/_stacks-button-groups.less
@@ -14,6 +14,7 @@
 //  ----------------------------------------------------------------------------
 .s-btn-group {
     display: flex;
+    flex-wrap: wrap;
 
     .s-btn {
         margin-right: 0; // With Safari in production, we need to collapse white space

--- a/lib/css/components/_stacks-button-groups.less
+++ b/lib/css/components/_stacks-button-groups.less
@@ -17,8 +17,9 @@
 
     .s-btn {
         margin-right: 0; // With Safari in production, we need to collapse white space
+        white-space: nowrap; // When the buttons wrap, they get super tall and mess up the whole layout
 
-        // If it isn't the first button, we should slide button over to account for border thickness
+        // If it isn't the first button, we should slide the button over to account for border thickness
         &:not(:first-child) {
             margin-left: -1px;
         }
@@ -49,7 +50,21 @@
             z-index: @zi-active;
         }
 
+        #stacks-internals #screen-sm({
+            padding-left: 0.4em;
+            padding-right: 0.4em;
+        }, @force-selector: true);
     }
+
+    #stacks-internals #screen-sm({
+        .s-btn.s-btn__dropdown {
+            padding-right: 1.2em;
+
+            &:after {
+                right: 0.4em;
+            }
+        }
+    }, @force-selector: true);
 
     .s-btn-group--container {
         display: flex;

--- a/lib/css/components/_stacks-button-groups.less
+++ b/lib/css/components/_stacks-button-groups.less
@@ -19,12 +19,11 @@
 
     .s-btn {
         margin-bottom: -1px; // When wrapping we need 
-        margin-right: 0; // With Safari in production, we need to collapse white space
         white-space: nowrap; // When the buttons wrap, they get super tall and mess up the whole layout
 
-        // If it isn't the first button, we should slide the button over to account for border thickness
-        &:not(:first-child) {
-            margin-left: -1px;
+        // If it isn't the last button, we should slide the button over to account for border thickness
+        &:not(:last-child) {
+            margin-right: -1px;
         }
 
         // We don't want border-radii on interior buttons
@@ -73,7 +72,7 @@
         display: flex;
 
         .s-btn {
-            margin-left: -1px; // We should slide buttons over to account for border thickness
+            margin-right: -1px; // We should slide buttons over to account for border thickness
         }
 
         &:not(:first-child):not(:last-child) .s-btn {

--- a/lib/css/components/_stacks-button-groups.less
+++ b/lib/css/components/_stacks-button-groups.less
@@ -15,8 +15,10 @@
 .s-btn-group {
     display: flex;
     flex-wrap: wrap;
+    margin-bottom: 1px; // Compensate for buttons having a margin bottom of -1px to account for row wrapping
 
     .s-btn {
+        margin-bottom: -1px; // When wrapping we need 
         margin-right: 0; // With Safari in production, we need to collapse white space
         white-space: nowrap; // When the buttons wrap, they get super tall and mess up the whole layout
 


### PR DESCRIPTION
This PR explores adding some wrapping logic within our button groups. This adds padding overrides to `s-btn` within `s-btn-group` in the smallest breakpoint while accounting for `s-btn__dropdown`. It also forces no wrapping on the button text itself.