### PR TITLE
Block links

### DIFF
--- a/docs/_data/product/links.yaml
+++ b/docs/_data/product/links.yaml
@@ -43,3 +43,23 @@ descendent-anchors:
   - class: .s-anchors__visited
     applies: .s-anchors
     description: Applies the hover / active state styling to all descendent links.
+
+block-links:
+  - class: .s-block-link
+    applies: N/A
+    description: Base block link style
+  - class: .is_active
+    applies: .s-block-link
+    description: Adds the active state to the base block link style.
+  - class: .s-block-link__top
+    applies: .s-block-link
+    description: Applies a border to the top of the selected state.
+  - class: .s-block-link__right
+    applies: .s-block-link
+    description: Applies a border to the right of the selected state.
+  - class: .s-block-link__bottom
+    applies: .s-block-link
+    description: Applies a border to the bottom of the selected state.
+  - class: .s-block-link__left
+    applies: .s-block-link
+    description: Applies a border to the left of the selected state.

--- a/docs/_data/product/links.yaml
+++ b/docs/_data/product/links.yaml
@@ -51,15 +51,9 @@ block-links:
   - class: .is_selected
     applies: .s-block-link
     description: Adds the selected state to the base block link style.
-  - class: .s-block-link__top
-    applies: .s-block-link
-    description: Applies a border to the top of the selected state.
   - class: .s-block-link__right
     applies: .s-block-link
     description: Applies a border to the right of the selected state.
-  - class: .s-block-link__bottom
-    applies: .s-block-link
-    description: Applies a border to the bottom of the selected state.
   - class: .s-block-link__left
     applies: .s-block-link
     description: Applies a border to the left of the selected state.

--- a/docs/_data/product/links.yaml
+++ b/docs/_data/product/links.yaml
@@ -48,9 +48,9 @@ block-links:
   - class: .s-block-link
     applies: N/A
     description: Base block link style
-  - class: .is_active
+  - class: .is_selected
     applies: .s-block-link
-    description: Adds the active state to the base block link style.
+    description: Adds the selected state to the base block link style.
   - class: .s-block-link__top
     applies: .s-block-link
     description: Applies a border to the top of the selected state.

--- a/docs/product/components/links.html
+++ b/docs/product/components/links.html
@@ -157,7 +157,8 @@ description: Links are lightly styled via the <code class="stacks-code">a</code>
     {% header h3 | Block Link Examples %}
     <div class="stacks-preview">
 {% highlight html linenos %}
-<a class="s-block-link s-block-link__left" href="#">…</a>
+<a class="s-block-link" href="#">…</a>
+<a class="s-block-link is-selected" href="#">…</a>
 <a class="s-block-link s-block-link__left is-selected" href="#">…</a>
 {% endhighlight %}
         <div class="stacks-preview--example">

--- a/docs/product/components/links.html
+++ b/docs/product/components/links.html
@@ -162,13 +162,11 @@ description: Links are lightly styled via the <code class="stacks-code">a</code>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="grid gs16 fd-column ws3">
-                <a class="grid--cell s-block-link s-block-link__top" href="#">Block link</a>
+                <a class="grid--cell s-block-link s-block-link__left" href="#">Block link</a>
             </div>
 
             <div class="grid gs16 fd-column ws3">
-                <a class="grid--cell s-block-link s-block-link__top is-selected" href="#">Selected Block Link Top</a>
                 <a class="grid--cell s-block-link s-block-link__right is-selected" href="#">Selected Block Link Right</a>
-                <a class="grid--cell s-block-link s-block-link__bottom is-selected" href="#">Selected Block Link Bottom</a>
                 <a class="grid--cell s-block-link s-block-link__left is-selected" href="#">Selected Block Link Left</a>
             </div>
         </div>

--- a/docs/product/components/links.html
+++ b/docs/product/components/links.html
@@ -157,21 +157,19 @@ description: Links are lightly styled via the <code class="stacks-code">a</code>
     {% header h3 | Block Link Examples %}
     <div class="stacks-preview">
 {% highlight html linenos %}
-Example, please
+<a class="s-block-link s-block-link__left" href="#">…</a>
+<a class="s-block-link s-block-link__left is-selected" href="#">…</a>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="grid gs16 fw-wrap">
-                <a class="grid--cell s-block-link s-block-link__top" href="#">Top</a>
-                <a class="grid--cell s-block-link s-block-link__right" href="#">Right</a>
-                <a class="grid--cell s-block-link s-block-link__bottom" href="#">Bottom</a>
-                <a class="grid--cell s-block-link s-block-link__left" href="#">Left</a>
+            <div class="grid gs16 fd-column ws3">
+                <a class="grid--cell s-block-link s-block-link__top" href="#">Block link</a>
             </div>
 
-            <div class="grid gs16 fw-wrap">
-                <a class="grid--cell s-block-link is-active s-block-link__top" href="#">Top</a>
-                <a class="grid--cell s-block-link s-block-link__right is-active" href="#">Right</a>
-                <a class="grid--cell s-block-link s-block-link__bottom is-active" href="#">Bottom</a>
-                <a class="grid--cell s-block-link s-block-link__left is-active" href="#">Left</a>
+            <div class="grid gs16 fd-column ws3">
+                <a class="grid--cell s-block-link s-block-link__top is-selected" href="#">Selected Block Link Top</a>
+                <a class="grid--cell s-block-link s-block-link__right is-selected" href="#">Selected Block Link Right</a>
+                <a class="grid--cell s-block-link s-block-link__bottom is-selected" href="#">Selected Block Link Bottom</a>
+                <a class="grid--cell s-block-link s-block-link__left is-selected" href="#">Selected Block Link Left</a>
             </div>
         </div>
     </div>

--- a/docs/product/components/links.html
+++ b/docs/product/components/links.html
@@ -159,6 +159,7 @@ description: Links are lightly styled via the <code class="stacks-code">a</code>
 {% highlight html linenos %}
 <a class="s-block-link" href="#">…</a>
 <a class="s-block-link is-selected" href="#">…</a>
+<a class="s-block-link s-block-link__right is-selected" href="#">…</a>
 <a class="s-block-link s-block-link__left is-selected" href="#">…</a>
 {% endhighlight %}
         <div class="stacks-preview--example">

--- a/docs/product/components/links.html
+++ b/docs/product/components/links.html
@@ -166,6 +166,7 @@ description: Links are lightly styled via the <code class="stacks-code">a</code>
             </div>
 
             <div class="grid gs16 fd-column ws3">
+                <a class="grid--cell s-block-link is-selected" href="#">Selected Block Link</a>
                 <a class="grid--cell s-block-link s-block-link__right is-selected" href="#">Selected Block Link Right</a>
                 <a class="grid--cell s-block-link s-block-link__left is-selected" href="#">Selected Block Link Left</a>
             </div>

--- a/docs/product/components/links.html
+++ b/docs/product/components/links.html
@@ -128,3 +128,51 @@ description: Links are lightly styled via the <code class="stacks-code">a</code>
     </div>
     {% endcapture %}{% include example.html html=html %}
 </section>
+
+<section class="stacks-section">
+    {% header h2 | Block Link %}
+    {% header h3 | Block Link Classes %}
+    <div class="overflow-x-auto mb32">
+        <table class="wmn4 s-table s-table__bx-simple">
+            <thead>
+                <tr>
+                    <th scope="col">Class</th>
+                    <th scope="col">Applied to</th>
+                    <th scope="col">Description</th>
+                </tr>
+            </thead>
+            <tbody class="fs-caption">
+                {% for item in site.data.product.links.block-links %}
+                    <tr>
+                        <th scope="row"><code class="stacks-code">{{ item.class }}</code></th>
+                        <td><code class="stacks-code bg-white">{{ item.applies }}</td>
+                        <td class="p8">{{ item.description }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+<section class="stacks-section">
+    {% header h3 | Block Link Examples %}
+    <div class="stacks-preview">
+{% highlight html linenos %}
+Example, please
+{% endhighlight %}
+        <div class="stacks-preview--example">
+            <div class="grid gs16 fw-wrap">
+                <a class="grid--cell s-block-link s-block-link__top" href="#">Top</a>
+                <a class="grid--cell s-block-link s-block-link__right" href="#">Right</a>
+                <a class="grid--cell s-block-link s-block-link__bottom" href="#">Bottom</a>
+                <a class="grid--cell s-block-link s-block-link__left" href="#">Left</a>
+            </div>
+
+            <div class="grid gs16 fw-wrap">
+                <a class="grid--cell s-block-link is-active s-block-link__top" href="#">Top</a>
+                <a class="grid--cell s-block-link s-block-link__right is-active" href="#">Right</a>
+                <a class="grid--cell s-block-link s-block-link__bottom is-active" href="#">Bottom</a>
+                <a class="grid--cell s-block-link s-block-link__left is-active" href="#">Left</a>
+            </div>
+        </div>
+    </div>
+</section>

--- a/docs/product/components/sidebar-widgets.html
+++ b/docs/product/components/sidebar-widgets.html
@@ -381,7 +381,7 @@ description: Sidebar widgets are flexible containers that provide a lot of patte
                 </div>
                 <ul class="s-sidebarwidget--content s-sidebarwidget__items">
                     <li class="s-sidebarwidget--item"><a href="#">Edit Profile</a></li>
-                    <li class="s-sidebarwidget--item" aria-current="page"><a href="#">Developer Story Preferences</a></li>
+                    <li class="s-sidebarwidget--item s-block-link s-block-link__left is-active" aria-current="page"><a href="#">Developer Story Preferences</a></li>
                     <li class="s-sidebarwidget--item"><a href="#">Job Match Preferences</a></li>
                 </ul>
                 <div class="s-sidebarwidget--header">

--- a/docs/product/components/sidebar-widgets.html
+++ b/docs/product/components/sidebar-widgets.html
@@ -381,7 +381,7 @@ description: Sidebar widgets are flexible containers that provide a lot of patte
                 </div>
                 <ul class="s-sidebarwidget--content s-sidebarwidget__items">
                     <li class="s-sidebarwidget--item"><a href="#">Edit Profile</a></li>
-                    <li class="s-sidebarwidget--item s-block-link s-block-link__left is-active" aria-current="page"><a href="#">Developer Story Preferences</a></li>
+                    <li class="s-sidebarwidget--item" aria-current="page"><a href="#">Developer Story Preferences</a></li>
                     <li class="s-sidebarwidget--item"><a href="#">Job Match Preferences</a></li>
                 </ul>
                 <div class="s-sidebarwidget--header">

--- a/lib/css/base/_stacks-configuration-dynamic.less
+++ b/lib/css/base/_stacks-configuration-dynamic.less
@@ -26,6 +26,7 @@
     //  Links
     @link-color-regular:                @blue-600;
     @link-color-hover:                  #4CA3D7;
+    @block-link-highlight:              @orange;
 
     //  Buttons
     @button-font-color:                 @link-color-regular;

--- a/lib/css/components/_stacks-links.less
+++ b/lib/css/components/_stacks-links.less
@@ -142,7 +142,7 @@ button.s-link {
 
 .s-block-link {
     color: @black-600;
-    padding: @su8 @su6;
+    padding: @su6 @su8;
 
     &:hover {
         color: @black-800;
@@ -153,20 +153,21 @@ button.s-link {
         font-weight: bold;
         background-color: fade(@black-800, 5%);
 
+        #stacks-internals #load-config();
         &.s-block-link__top {
-            border-top: 3px solid black;
+            border-top: 3px solid @block-link-highlight;
         }
 
         &.s-block-link__right {
-            border-right: 3px solid black;
+            border-right: 3px solid @block-link-highlight;
         }
 
         &.s-block-link__bottom {
-            border-bottom: 3px solid black;
+            border-bottom: 3px solid @block-link-highlight;
         }
 
         &.s-block-link__left {
-            border-left: 3px solid black;
+            border-left: 3px solid @block-link-highlight;
         }
     }
 }

--- a/lib/css/components/_stacks-links.less
+++ b/lib/css/components/_stacks-links.less
@@ -144,11 +144,12 @@ button.s-link {
     color: @black-600;
     padding: @su6 @su8;
 
-    &:hover {
+    &:hover,
+    &:active {
         color: @black-800;
     }
 
-    &.is-active {
+    &.is-selected {
         color: @black-800;
         font-weight: bold;
         background-color: fade(@black-800, 5%);

--- a/lib/css/components/_stacks-links.less
+++ b/lib/css/components/_stacks-links.less
@@ -156,16 +156,8 @@ button.s-link {
         background-color: fade(@black-800, 5%);
 
         #stacks-internals #load-config();
-        &.s-block-link__top {
-            border-top: 3px solid @block-link-highlight;
-        }
-
         &.s-block-link__right {
             border-right: 3px solid @block-link-highlight;
-        }
-
-        &.s-block-link__bottom {
-            border-bottom: 3px solid @block-link-highlight;
         }
 
         &.s-block-link__left {

--- a/lib/css/components/_stacks-links.less
+++ b/lib/css/components/_stacks-links.less
@@ -141,6 +141,7 @@ button.s-link {
 }
 
 .s-block-link {
+    display: block;
     color: @black-600;
     padding: @su6 @su8;
 

--- a/lib/css/components/_stacks-links.less
+++ b/lib/css/components/_stacks-links.less
@@ -139,3 +139,34 @@ button.s-link {
     .colorize-all(muted, @black-500, darken(@black-500, 10%), lighten(@black-500, 10%));
     .colorize-all(danger, @button-danger-background-color, darken(saturate(@button-danger-background-color, 5%), 15%), lighten(saturate(@button-danger-background-color, 5%), 15%));
 }
+
+.s-block-link {
+    color: @black-600;
+    padding: @su8 @su6;
+
+    &:hover {
+        color: @black-800;
+    }
+
+    &.is-active {
+        color: @black-800;
+        font-weight: bold;
+        background-color: fade(@black-800, 5%);
+
+        &.s-block-link__top {
+            border-top: 3px solid black;
+        }
+
+        &.s-block-link__right {
+            border-right: 3px solid black;
+        }
+
+        &.s-block-link__bottom {
+            border-bottom: 3px solid black;
+        }
+
+        &.s-block-link__left {
+            border-left: 3px solid black;
+        }
+    }
+}


### PR DESCRIPTION
This PR explores adding block links as their own component. These show up on Stack Overflow's left nav, and in the sidebar widgets.

![image](https://user-images.githubusercontent.com/1369864/55653134-2d29fe00-57b3-11e9-97f5-292c6c62cc5c.png)

This allows us to add a selected border to each direction, but perhaps we only allow for choosing left and right? Not sure about the practicality of top and bottom.

This closes #268