### PR TITLE
Resize type scale more aggressively

### DIFF
--- a/lib/css/atomic/_stacks-typography.less
+++ b/lib/css/atomic/_stacks-typography.less
@@ -35,6 +35,19 @@ h1, h2, h3, h4, h5, h6, p {
 .fs-category    { font-size: @fs-caption !important; }
 .fs-fine        { font-size: @fs-fine !important; }
 
+#stacks-internals #screen-sm({
+    .fs-display4    { font-size: 3.8rem !important; }
+    .fs-display3    { font-size: 3.3rem !important; }
+    .fs-display2    { font-size: 3.0rem !important; }
+    .fs-display1    { font-size: 2.6rem !important; }
+    .fs-headline2   { font-size: 2.3rem !important; }
+    .fs-headline1   { font-size: 2rem !important; }
+    .fs-title       { font-size: 1.8rem !important; }
+    .fs-subheading  { font-size: 1.6rem !important; }
+    .fs-body3       { font-size: 1.4rem !important; }
+    .fs-body2       { font-size: 1.3rem !important; }
+}, @force-selector: true);
+
 .fs-category {
     font-weight: 700;
     text-transform: uppercase;


### PR DESCRIPTION
We currently resize the base font size at the smallest breakpoint, but I don't think it goes far enough to resize our largest type sizes. This PR is designed to mitigate that by applying a much more aggressive size reduction.

Let's consider a work in progress layout:

**Before**
![image](https://user-images.githubusercontent.com/1369864/55896622-5916fc00-5b84-11e9-8b32-08032c8d230a.png)

**After**
![image](https://user-images.githubusercontent.com/1369864/55896780-b27f2b00-5b84-11e9-9541-00d67a418bf1.png)