### PR TITLE
Add responsive overrides for border width

### DIFF
--- a/docs/_data/product/borders-definitions.yml
+++ b/docs/_data/product/borders-definitions.yml
@@ -2,18 +2,23 @@ border:
   - class: .ba
     define: Apply a border to all sides
     output: "border: solid 1px #000"
+    responsive: true
   - class: .bt
     define: Apply a border to the top side
     output: "border-top: solid 1px #000"
+    responsive: true
   - class: .bb
     define: Apply a border to the bottom side
     output: "border-bottom: solid 1px #000"
+    responsive: true
   - class: .bl
     define: Apply a border to the left side
     output: "border-left: solid 1px #000"
+    responsive: true
   - class: .br
     define: Apply a border to the right side
     output: "border-right: solid 1px #000"
+    responsive: true
   - class: .by
     define: Apply a border to the top and bottom sides
     output: "border-top: solid 1px #000; border-bottom: solid 1px #000;"
@@ -25,23 +30,18 @@ border-width:
   - class: .baw0
     define: Applies a border width of zero to all sides
     output: "border-width: 0"
-    responsive: true
   - class: .btw0
     define: Applies a border width of zero to the top side
     output: "border-top-width: 0"
-    responsive: true
   - class: .bbw0
     define: Applies a border width of zero to the bottom side
     output: "border-bottom-width: 0"
-    responsive: true
   - class: .blw0
     define: Applies a border width of zero to the left side
     output: "border-left-width: 0"
-    responsive: true
   - class: .brw0
     define: Applies a border width of zero to the right side
     output: "border-right-width: 0"
-    responsive: true
   - class: .byw0
     define: Applies a border width of zero to the top and bottom sides
     output: "border-top-width: 0; border-bottom-width: 0;"

--- a/docs/_data/product/borders-definitions.yml
+++ b/docs/_data/product/borders-definitions.yml
@@ -25,18 +25,23 @@ border-width:
   - class: .baw0
     define: Applies a border width of zero to all sides
     output: "border-width: 0"
+    responsive: true
   - class: .btw0
     define: Applies a border width of zero to the top side
     output: "border-top-width: 0"
+    responsive: true
   - class: .bbw0
     define: Applies a border width of zero to the bottom side
     output: "border-bottom-width: 0"
+    responsive: true
   - class: .blw0
     define: Applies a border width of zero to the left side
     output: "border-left-width: 0"
+    responsive: true
   - class: .brw0
     define: Applies a border width of zero to the right side
     output: "border-right-width: 0"
+    responsive: true
   - class: .byw0
     define: Applies a border width of zero to the top and bottom sides
     output: "border-top-width: 0; border-bottom-width: 0;"

--- a/docs/product/base/borders-border.html
+++ b/docs/product/base/borders-border.html
@@ -7,6 +7,9 @@
                     <th class="s-table--cell2" scope="col">Class</th>
                     <th scope="col">Output</th>
                     <th scope="col">Definition</th>
+                    <th scope="col">
+                        <a class="s-link s-link__inherit" href="{{ "/product/guidelines/conditional-classes#responsive" | relative_url }}">Responsive?</a>
+                    </th>
                 </tr>
             </thead>
             <tbody>
@@ -15,6 +18,11 @@
                       <th scope="row"><code class="stacks-code">{{ border.class }}</code></th>
                       <td class="ff-mono">{{ border.output }}</td>
                       <td>{{ border.define }}</td>
+                      <td class="ta-center">
+                            {% if border.responsive %}
+                                {% icon Checkmark | fc-green-500 %}
+                            {% endif %}
+                        </td>
                   </tr>
                 {% endfor %}
             </tbody>

--- a/docs/product/base/borders-width.html
+++ b/docs/product/base/borders-width.html
@@ -8,9 +8,6 @@
                     <th class="s-table--cell2" scope="col">Class</th>
                     <th scope="col">Output</th>
                     <th scope="col">Definition</th>
-                    <th scope="col">
-                        <a class="s-link s-link__inherit" href="{{ "/product/guidelines/conditional-classes#responsive" | relative_url }}">Responsive?</a>
-                    </th>
                 </tr>
             </thead>
             <tbody>
@@ -19,11 +16,6 @@
                         <th scope="row"><code class="stacks-code">{{ border.class }}</code></th>
                         <td class="ff-mono">{{ border.output }}</td>
                         <td>{{ border.define }}</td>
-                        <td class="ta-center">
-                            {% if border.responsive %}
-                                {% icon Checkmark | fc-green-500 %}
-                            {% endif %}
-                        </td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/docs/product/base/borders-width.html
+++ b/docs/product/base/borders-width.html
@@ -8,6 +8,9 @@
                     <th class="s-table--cell2" scope="col">Class</th>
                     <th scope="col">Output</th>
                     <th scope="col">Definition</th>
+                    <th scope="col">
+                        <a class="s-link s-link__inherit" href="{{ "/product/guidelines/conditional-classes#responsive" | relative_url }}">Responsive?</a>
+                    </th>
                 </tr>
             </thead>
             <tbody>
@@ -16,6 +19,11 @@
                         <th scope="row"><code class="stacks-code">{{ border.class }}</code></th>
                         <td class="ff-mono">{{ border.output }}</td>
                         <td>{{ border.define }}</td>
+                        <td class="ta-center">
+                            {% if border.responsive %}
+                                {% icon Checkmark | fc-green-500 %}
+                            {% endif %}
+                        </td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/lib/css/atomic/_stacks-borders.less
+++ b/lib/css/atomic/_stacks-borders.less
@@ -47,30 +47,31 @@
 //      w4: Fourth step:   8px border width
 //  ----------------------------------------------------------------------------
 //  $$  All Sides
-.baw0           { border-width: 0 !important; }
+#stacks-internals #responsify('.baw0', { border-width: 0 !important; });
 .baw1           { border-width: @su2 / 2 !important; }
 .baw2           { border-width: @su2 !important; }
 .baw3           { border-width: @su4 !important; }
 
 //  $$  Top Border
-.btw0           { border-top-width: 0 !important; }
+#stacks-internals #responsify('.btw0', { border-top-width: 0 !important; });
 .btw1           { border-top-width: @su2 / 2 !important; }
 .btw2           { border-top-width: @su2 !important; }
 .btw3           { border-top-width: @su4 !important; }
 
 //  $$  Right Border
-.brw0           { border-right-width: 0 !important; }
+#stacks-internals #responsify('.brw0', { border-right-width: 0 !important; });
 .brw1           { border-right-width: @su2 / 2 !important; }
 .brw2           { border-right-width: @su2 !important; }
 .brw3           { border-right-width: @su4 !important; }
 
 //  $$  Bottom Border
-.bbw0           { border-bottom-width: 0 !important; }
+#stacks-internals #responsify('.bbw0', { border-bottom-width: 0 !important; });
 .bbw1           { border-bottom-width: @su2 / 2 !important; }
 .bbw2           { border-bottom-width: @su2 !important; }
 .bbw3           { border-bottom-width: @su4 !important; }
 
 //  $$  Left Border
+#stacks-internals #responsify('.blw0', { border-left-width: 0 !important; });
 .blw0           { border-left-width: 0 !important; }
 .blw1           { border-left-width: @su2 / 2 !important; }
 .blw2           { border-left-width: @su2 !important; }

--- a/lib/css/atomic/_stacks-borders.less
+++ b/lib/css/atomic/_stacks-borders.less
@@ -28,12 +28,11 @@
 //      bx: border x-axis
 //      by: border y-axis
 //  ----------------------------------------------------------------------------
-.bn             { border-style: none; .baw0; }
-.ba             { .bas-solid; .baw1; }
-.bt             { .bts-solid; .btw1; }
-.br             { .brs-solid; .brw1; }
-.bb             { .bbs-solid; .bbw1; }
-.bl             { .bls-solid; .blw1; }
+#stacks-internals #responsify('.ba', { .bas-solid; .baw1; });
+#stacks-internals #responsify('.bt', { .bts-solid; .btw1; });
+#stacks-internals #responsify('.br', { .brs-solid; .brw1; });
+#stacks-internals #responsify('.bb', { .bbs-solid; .bbw1; });
+#stacks-internals #responsify('.bl', { .bls-solid; .blw1; });
 .bx             { .bls-solid; .brs-solid; .bxw1; }
 .by             { .bts-solid; .bbs-solid; .byw1; }
 
@@ -47,31 +46,31 @@
 //      w4: Fourth step:   8px border width
 //  ----------------------------------------------------------------------------
 //  $$  All Sides
-#stacks-internals #responsify('.baw0', { border-width: 0 !important; });
+.baw0           { border-width: 0 !important; }
 .baw1           { border-width: @su2 / 2 !important; }
 .baw2           { border-width: @su2 !important; }
 .baw3           { border-width: @su4 !important; }
 
 //  $$  Top Border
-#stacks-internals #responsify('.btw0', { border-top-width: 0 !important; });
+.btw0           { border-top-width: 0 !important; }
 .btw1           { border-top-width: @su2 / 2 !important; }
 .btw2           { border-top-width: @su2 !important; }
 .btw3           { border-top-width: @su4 !important; }
 
 //  $$  Right Border
-#stacks-internals #responsify('.brw0', { border-right-width: 0 !important; });
+.brw0           { border-right-width: 0 !important; }
 .brw1           { border-right-width: @su2 / 2 !important; }
 .brw2           { border-right-width: @su2 !important; }
 .brw3           { border-right-width: @su4 !important; }
 
 //  $$  Bottom Border
-#stacks-internals #responsify('.bbw0', { border-bottom-width: 0 !important; });
+.bbw0           { border-bottom-width: 0 !important; }
 .bbw1           { border-bottom-width: @su2 / 2 !important; }
 .bbw2           { border-bottom-width: @su2 !important; }
 .bbw3           { border-bottom-width: @su4 !important; }
 
 //  $$  Left Border
-#stacks-internals #responsify('.blw0', { border-left-width: 0 !important; });
+.blw0           { border-left-width: 0 !important; }
 .blw0           { border-left-width: 0 !important; }
 .blw1           { border-left-width: @su2 / 2 !important; }
 .blw2           { border-left-width: @su2 !important; }


### PR DESCRIPTION
This PR adds responsive borders. It allows you to set `bt sm:bb bc-black-2` effectively saying "Add a border to the top but at the smallest breakpoint, add one to the bottom."