### PR TITLE
Dead link fix on getting-started.html

### DIFF
--- a/docs/email/guidelines/getting-started.html
+++ b/docs/email/guidelines/getting-started.html
@@ -65,7 +65,7 @@ description: An email design system that helps us work together to create consis
             <div class="mb48">
                 <h3 class="mb8 stacks-h3">Design Best Practices</h3>
                 <p class="fc-medium fs-body2 mb24">Emails don’t need to look the same in every email client, but there are some things to keep in mind when working on emails.</p>
-                <p class="fs-body2"><a href="{{ "/email/guidelines/best-practices" | relative_url }}" class="s-btn s-btn__outlined">View design best practices</a></p>
+                <p class="fs-body2"><a href="{{ "/email/guidelines/design-best-practices" | relative_url }}" class="s-btn s-btn__outlined">View design best practices</a></p>
             </div>
             <div class="mb48">
                 <h3 class="mb8 stacks-h3"><abbr title="Frequently Asked Questions">FAQ</abbr></h3>
@@ -244,7 +244,7 @@ description: An email design system that helps us work together to create consis
                 <div class="ps-absolute t0 b0 l0 z-base bg-black-075" style="width: .5%"></div>
             </div>
             <div class="mb16">
-                <p class="fs-body2"><a href="{{ "/email/guidelines/best-practices#testing" | relative_url }}" class="s-btn s-btn__outlined">Tools for testing</a></p>
+                <p class="fs-body2"><a href="{{ "/email/guidelines/design-best-practices#testing" | relative_url }}" class="s-btn s-btn__outlined">Tools for testing</a></p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
The URL for the "Best practice" page seems to have changed, but the getting started page still links to the old URL.