### PR TITLE
Add s-anchors__underlined

### DIFF
--- a/docs/_data/product/links.yaml
+++ b/docs/_data/product/links.yaml
@@ -27,7 +27,7 @@ descendent-anchors:
     description: A consistent link style is applied to all descendent anchors.
   - class: .s-anchors__default
     applies: .s-anchors
-    description: All deschendent links receive s-link’s default styling.
+    description: All descendent links receive s-link’s default styling.
   - class: .s-anchors__grayscale
     applies: .s-anchors
     description: Applies gray styling to all descendent links.
@@ -37,6 +37,9 @@ descendent-anchors:
   - class: .s-anchors__danger
     applies: .s-anchors
     description: Applies an important, destructive red to all descendent links.
+  - class: .s-anchors__underlined
+    applies: .s-anchors
+    description: Applies an underline to all descendent links.
   - class: .s-anchors__inherit
     applies: .s-anchors
     description: Applies the parent element’s text color to all descendent links.

--- a/docs/product/components/links.html
+++ b/docs/product/components/links.html
@@ -86,20 +86,36 @@ description: Links are lightly styled via the <code class="stacks-code">a</code>
         <code class="stacks-code">s-anchors__danger</code>, or <code class="stacks-code">s-anchors__inherit</code> to the container.
     </p>
 
-    {% capture html %}
-    <div class="s-anchors s-anchors__grayscale s-card mb8 fc-orange-700">
-        <p>There is a <a href="#">gray link here</a>, and <a href="#">another one</a>.</p>
+    <div class="stacks-preview">
+{% highlight html linenos %}
+<a class="s-anchors s-anchors__default" href="#">…</a>
+<a class="s-anchors s-anchors__grayscale" href="#">…</a>
+<a class="s-anchors s-anchors__muted" href="#">…</a>
+<a class="s-anchors s-anchors__danger" href="#">…</a>
+<a class="s-anchors s-anchors__underlined" href="#">…</a>
+<a class="s-anchors s-anchors__inherit" href="#">…</a>
+{% endhighlight %}
+        <div class="stacks-preview--example">
+            <div class="s-anchors s-anchors__default s-card mb8">
+                <p>There is a <a href="#">default link here</a>, and <a href="#">another one</a>.</p>
+            </div>
+            <div class="s-anchors s-anchors__grayscale s-card mb8 fc-orange-700">
+                <p>There is a <a href="#">gray link here</a>, and <a href="#">another one</a>.</p>
+            </div>
+            <div class="s-anchors s-anchors__muted s-card mb8">
+                <p>There is a <a href="#">muted link here</a>, and <a href="#">another one</a>.</p>
+            </div>
+            <div class="s-anchors s-anchors__danger s-card mb8">
+                <p>There is a <a href="#">dangerous link here</a>, and <a href="#">another one</a>.</p>
+            </div>
+            <div class="s-anchors s-anchors__underlined s-card mb8">
+                <p>There is an <a href="#">underlined link here</a>, and <a href="#">another one</a>.</p>
+            </div>
+            <div class="s-anchors s-anchors__inherit s-card mb8 fc-green-500">
+                <p>There is an <a href="#">inheriting link here</a>, and <a href="#">another one</a>.</p>
+            </div>
+        </div>
     </div>
-    <div class="s-anchors s-anchors__muted s-card mb8">
-        <p>There is a <a href="#">muted link here</a>, and <a href="#">another one</a>.</p>
-    </div>
-    <div class="s-anchors s-anchors__danger s-card mb8">
-        <p>There is a <a href="#">dangerous link here</a>, and <a href="#">another one</a>.</p>
-    </div>
-    <div class="s-anchors s-anchors__inherit s-card mb8 fc-green-500">
-        <p>There is an <a href="#">inheriting link here</a>, and <a href="#">another one</a>.</p>
-    </div>
-    {% endcapture %}{% include example.html html=html %}
 
     <p class="stacks-copy">One additional level of nesting is supported, but even that should be exceedingly rare. More than that is not supported.</p>
 

--- a/lib/css/components/_stacks-links.less
+++ b/lib/css/components/_stacks-links.less
@@ -132,6 +132,11 @@ button.s-link {
             }
         }
     }
+    &.s-anchors__underlined {
+        a:not(.s-link) {
+            text-decoration: underline;
+        }
+    }
     #stacks-internals #load-config();
     .colorize-all(default, @link-color-regular, darken(@link-color-regular, 10%), lighten(@link-color-regular, 10%));
     .colorize-all(grayscale, @black-800, @black-900, @black-700);


### PR DESCRIPTION
This PR allows us to add underlined links to `s-anchors`. This will come in handy in low contrast designs.