### PR TITLE
Remove position: relative on form elements

### DIFF
--- a/lib/css/components/_stacks-inputs.less
+++ b/lib/css/components/_stacks-inputs.less
@@ -338,7 +338,6 @@ fieldset {
 //  Focus
 & {
     @focus-style: {
-        position: relative;
         border-color: @blue-300;
         box-shadow: 0 0 0 @su4 fade(@blue-500, 15%);
         outline: 0;


### PR DESCRIPTION
Fixes #333 

I'm not sure why we included `position: relative` on our form elements, but this PR removes it to fix #333. I'll have to look back at the blame for some context there.

I need to do a bit of testing on IE and Edge for this.