### PR TITLE
Add some sanity around visited states in descendent links

### DIFF
--- a/lib/css/components/_stacks-links.less
+++ b/lib/css/components/_stacks-links.less
@@ -118,16 +118,9 @@ button.s-link {
                 &:active {
                     color: @hover;
                 }
-            }
 
-            &.s-anchors__visited {
-                a:not(.s-link) {
+                &:visited {
                     color: @visited;
-    
-                    &:hover,
-                    &:active {
-                        color: @hover;
-                    }
                 }
             }
         }
@@ -138,11 +131,12 @@ button.s-link {
         }
     }
     #stacks-internals #load-config();
-    .colorize-all(default, @link-color-regular, darken(@link-color-regular, 10%), lighten(@link-color-regular, 10%));
-    .colorize-all(grayscale, @black-800, @black-900, @black-700);
+    .colorize-all(default, @link-color-regular, lighten(@link-color-regular, 10%), darken(@link-color-regular, 10%));
+    .colorize-all(visited, @link-color-regular, lighten(@link-color-regular, 10%), darken(@link-color-regular, 10%));
+    .colorize-all(grayscale, @black-800, @black-700, @black-900);
     .colorize-all(inherit, inherit, inherit, inherit);
-    .colorize-all(muted, @black-500, darken(@black-500, 10%), lighten(@black-500, 10%));
-    .colorize-all(danger, @button-danger-background-color, darken(saturate(@button-danger-background-color, 5%), 15%), lighten(saturate(@button-danger-background-color, 5%), 15%));
+    .colorize-all(muted, @black-500, lighten(@black-500, 10%), darken(@black-500, 10%));
+    .colorize-all(danger, @button-danger-background-color, lighten(saturate(@button-danger-background-color, 5%), 15%), darken(saturate(@button-danger-background-color, 5%), 15%));
 }
 
 .s-block-link {

--- a/lib/css/components/_stacks-links.less
+++ b/lib/css/components/_stacks-links.less
@@ -133,7 +133,7 @@ button.s-link {
     #stacks-internals #load-config();
     .colorize-all(default, @link-color-regular, lighten(@link-color-regular, 10%), darken(@link-color-regular, 10%));
     .colorize-all(visited, @link-color-regular, lighten(@link-color-regular, 10%), darken(@link-color-regular, 10%));
-    .colorize-all(grayscale, @black-800, @black-700, @black-900);
+    .colorize-all(grayscale, @black-700, @black-600, @black-900);
     .colorize-all(inherit, inherit, inherit, inherit);
     .colorize-all(muted, @black-500, lighten(@black-500, 10%), darken(@black-500, 10%));
     .colorize-all(danger, @button-danger-background-color, lighten(saturate(@button-danger-background-color, 5%), 15%), darken(saturate(@button-danger-background-color, 5%), 15%));


### PR DESCRIPTION
I'm not sure our descendent links visited state ever made sense. This closes #337 by adding sensible defaults for `hover`, `active`, and `visited` states.

@aalear Will this handle your use-case or do we need to add more here?