### PR TITLE
Update contact info in email footers

### DIFF
--- a/docs/email/components/footers.html
+++ b/docs/email/components/footers.html
@@ -38,8 +38,8 @@ description: Footers are included at the bottom of every email. They typically i
                     <td>Some subscription emails can be edited (eg. the parameters for a tag subscription or job alert).</td>
                 </tr>
                 <tr>
-                    <td>Leave Feedback link</td>
-                    <td>Links to the appropriate meta website. If no network site user exists, links to Meta Stack Exchange.</td>
+                    <td>Contact us link</td>
+                    <td>Links to the contact us page of the appropriate network website. If no network site exists, links to the Stack Overflow contact page.</td>
                 </tr>
                 <tr>
                     <td>Privacy link</td>
@@ -77,7 +77,7 @@ description: Footers are included at the bottom of every email. They typically i
                 <td style="font-size: 12px; line-height: 17px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
                     <a href="" style="color: #9199A1; text-decoration: underline;">Unsubscribe from this email</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    <a href="" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                    <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                 </td>
             </tr>
@@ -136,7 +136,7 @@ description: Footers are included at the bottom of every email. They typically i
                                     <td style="font-size: 12px; line-height: 17px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Unsubscribe from this email</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                                        <a href="" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                                        <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                     </td>
                                 </tr>
@@ -201,7 +201,7 @@ description: Footers are included at the bottom of every email. They typically i
             <tr>
                 <td style="font-size: 12px; line-height: 17px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
                     <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    <a href="" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                    <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                 </td>
             </tr>
@@ -259,7 +259,7 @@ description: Footers are included at the bottom of every email. They typically i
                                 <tr>
                                     <td style="font-size: 12px; line-height: 17px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                                        <a href="" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                                        <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                     </td>
                                 </tr>
@@ -316,7 +316,7 @@ description: Footers are included at the bottom of every email. They typically i
             </tr>
             <tr>
                 <td style="font-size: 12px; line-height: 17px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
-                    <a href="" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                    <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                 </td>
             </tr>
@@ -373,7 +373,7 @@ description: Footers are included at the bottom of every email. They typically i
                                 </tr>
                                 <tr>
                                     <td style="font-size: 12px; line-height: 17px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
-                                        <a href="" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                                        <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                     </td>
                                 </tr>
@@ -445,7 +445,7 @@ description: Footers are included at the bottom of every email. They typically i
                     <a href="" style="color: #9199A1; text-decoration: underline;">Unsubscribe from this email</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9199A1; text-decoration: underline;">Edit $name$</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    <a href="" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                    <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                 </td>
             </tr>
@@ -505,7 +505,7 @@ description: Footers are included at the bottom of every email. They typically i
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Unsubscribe from this email</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Edit $name$</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                                        <a href="" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                                        <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                     </td>
                                 </tr>
@@ -565,7 +565,7 @@ description: Footers are included at the bottom of every email. They typically i
                     <a href="" style="color: #9199A1; text-decoration: underline;">Unsubscribe from this email</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9199A1; text-decoration: underline;">Edit $name$</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    <a href="" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                    <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                 </td>
             </tr>
@@ -625,7 +625,7 @@ description: Footers are included at the bottom of every email. They typically i
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Unsubscribe from this email</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Edit $name$</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                                        <a href="" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                                        <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                     </td>
                                 </tr>
@@ -691,7 +691,7 @@ description: Footers are included at the bottom of every email. They typically i
                 <td style="font-size: 12px; line-height: 17px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
                     <a href="" style="color: #9199A1; text-decoration: underline;">Unsubscribe from emails like this</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    <a href="" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                    <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                 </td>
             </tr>
@@ -750,7 +750,7 @@ description: Footers are included at the bottom of every email. They typically i
                                     <td style="font-size: 12px; line-height: 17px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Unsubscribe from emails like this</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                                        <a href="" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                                        <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                     </td>
                                 </tr>
@@ -807,7 +807,7 @@ description: Footers are included at the bottom of every email. They typically i
             </tr>
             <tr>
                 <td style="font-size: 12px; line-height: 17px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
-                    <a href="" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                    <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                 </td>
             </tr>
@@ -864,7 +864,7 @@ description: Footers are included at the bottom of every email. They typically i
                                 </tr>
                                 <tr>
                                     <td style="font-size: 12px; line-height: 17px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
-                                        <a href="" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                                        <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                     </td>
                                 </tr>

--- a/docs/email/components/footers.html
+++ b/docs/email/components/footers.html
@@ -78,7 +78,7 @@ description: Footers are included at the bottom of every email. They typically i
                     <a href="" style="color: #9199A1; text-decoration: underline;">Unsubscribe from this email</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
+                    <a href="https://stackoverflow.com/legal/privacy-policy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                 </td>
             </tr>
             <!-- Subscription Info : END -->
@@ -137,7 +137,7 @@ description: Footers are included at the bottom of every email. They typically i
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Unsubscribe from this email</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                                        <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
+                                        <a href="https://stackoverflow.com/legal/privacy-policy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                     </td>
                                 </tr>
                                 <tr>
@@ -202,7 +202,7 @@ description: Footers are included at the bottom of every email. They typically i
                 <td style="font-size: 12px; line-height: 17px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
                     <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
+                    <a href="https://stackoverflow.com/legal/privacy-policy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                 </td>
             </tr>
             <!-- Subscription Info : END -->
@@ -260,7 +260,7 @@ description: Footers are included at the bottom of every email. They typically i
                                     <td style="font-size: 12px; line-height: 17px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                                        <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
+                                        <a href="https://stackoverflow.com/legal/privacy-policy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                     </td>
                                 </tr>
                                 <tr>
@@ -317,7 +317,7 @@ description: Footers are included at the bottom of every email. They typically i
             <tr>
                 <td style="font-size: 12px; line-height: 17px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
                     <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
+                    <a href="https://stackoverflow.com/legal/privacy-policy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                 </td>
             </tr>
             <!-- Subscription Info : END -->
@@ -374,7 +374,7 @@ description: Footers are included at the bottom of every email. They typically i
                                 <tr>
                                     <td style="font-size: 12px; line-height: 17px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
                                         <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                                        <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
+                                        <a href="https://stackoverflow.com/legal/privacy-policy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                     </td>
                                 </tr>
                                 <tr>
@@ -446,7 +446,7 @@ description: Footers are included at the bottom of every email. They typically i
                     <a href="" style="color: #9199A1; text-decoration: underline;">Edit $name$</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
+                    <a href="https://stackoverflow.com/legal/privacy-policy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                 </td>
             </tr>
             <!-- Subscription Info : END -->
@@ -506,7 +506,7 @@ description: Footers are included at the bottom of every email. They typically i
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Edit $name$</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                                        <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
+                                        <a href="https://stackoverflow.com/legal/privacy-policy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                     </td>
                                 </tr>
                                 <tr>
@@ -566,7 +566,7 @@ description: Footers are included at the bottom of every email. They typically i
                     <a href="" style="color: #9199A1; text-decoration: underline;">Edit $name$</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
+                    <a href="https://stackoverflow.com/legal/privacy-policy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                 </td>
             </tr>
             <!-- Subscription Info : END -->
@@ -626,7 +626,7 @@ description: Footers are included at the bottom of every email. They typically i
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Edit $name$</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                                        <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
+                                        <a href="https://stackoverflow.com/legal/privacy-policy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                     </td>
                                 </tr>
                                 <tr>
@@ -692,7 +692,7 @@ description: Footers are included at the bottom of every email. They typically i
                     <a href="" style="color: #9199A1; text-decoration: underline;">Unsubscribe from emails like this</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
                     <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
+                    <a href="https://stackoverflow.com/legal/privacy-policy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                 </td>
             </tr>
             <!-- Subscription Info : END -->
@@ -751,7 +751,7 @@ description: Footers are included at the bottom of every email. They typically i
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Unsubscribe from emails like this</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="" style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                         <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                                        <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
+                                        <a href="https://stackoverflow.com/legal/privacy-policy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                     </td>
                                 </tr>
                                 <tr>
@@ -808,7 +808,7 @@ description: Footers are included at the bottom of every email. They typically i
             <tr>
                 <td style="font-size: 12px; line-height: 17px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
                     <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
+                    <a href="https://stackoverflow.com/legal/privacy-policy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                 </td>
             </tr>
             <!-- Subscription Info : END -->
@@ -865,7 +865,7 @@ description: Footers are included at the bottom of every email. They typically i
                                 <tr>
                                     <td style="font-size: 12px; line-height: 17px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
                                         <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                                        <a href="" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
+                                        <a href="https://stackoverflow.com/legal/privacy-policy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                     </td>
                                 </tr>
                                 <tr>

--- a/docs/email/templates/code/promotional.html
+++ b/docs/email/templates/code/promotional.html
@@ -472,7 +472,7 @@
                                     <a href="{{hostedUnsubscribeUrl}}" style="color: #9199A1; text-decoration: underline;">Unsubscribe from emails like this</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                     <a href="https://stackoverflow.email/subscriptions/manage?{{#data}}"
                                     style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                                    <a href="https://meta.stackoverflow.com" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                                    <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                     <a href="Urls.Legal.PrivacyPolicy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                 </td>
                             </tr>

--- a/docs/email/templates/code/transactional-long.html
+++ b/docs/email/templates/code/transactional-long.html
@@ -506,7 +506,7 @@
                                 <td style="font-size: 12px; line-height: 15px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
                                     <a href="https://stackoverflow.email/subscriptions/manage?{{#data}}"
                                     style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                                    <a href="https://meta.stackoverflow.com" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                                    <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                     <a href="Urls.Legal.PrivacyPolicy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                 </td>
                             </tr>

--- a/docs/email/templates/code/transactional-short.html
+++ b/docs/email/templates/code/transactional-short.html
@@ -377,7 +377,7 @@
                                 <td style="font-size: 12px; line-height: 15px; font-family: arial, sans-serif; color: #9199A1; text-align: left;">
                                     <a href="https://stackoverflow.email/subscriptions/manage?{{#data}}"
                                     style="color: #9199A1; text-decoration: underline;">Edit email settings</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                                    <a href="https://meta.stackoverflow.com" style="color: #9199A1; text-decoration: underline;">Leave feedback</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                                    <a href="https://stackoverflow.com/company/contact" style="color: #9199A1; text-decoration: underline;">Contact us</a>&nbsp;&nbsp;&nbsp;&nbsp;
                                     <a href="Urls.Legal.PrivacyPolicy" style="color: #9EA3A9; text-decoration: underline;">Privacy</a>
                                 </td>
                             </tr>


### PR DESCRIPTION
Replacing the direct link to meta with a link to our company contact page.