### PR TITLE
change s-popover z-index from -1 to 0

### DIFF
--- a/lib/css/components/_stacks-popovers.less
+++ b/lib/css/components/_stacks-popovers.less
@@ -22,7 +22,7 @@
     max-width: 24rem;
     width: 100%;
     padding: @su12;
-    z-index: @zi-hide;
+    z-index: @zi-base;
     opacity: 0;
     border-radius: @br-md;
     border: 1px solid @black-100;


### PR DESCRIPTION
this fixes a Safari overscroll bug when a popover has visibility: hidden and it scrolls over the top of the viewport