### PR TITLE
Popover custom background color support

### DIFF
--- a/docs/product/components/popovers.html
+++ b/docs/product/components/popovers.html
@@ -235,4 +235,23 @@ description: Popovers are small content containers that provide a contextual ove
             </div>
         </div>
     </div>
+
+    {% header h3 | background-color %}
+    <p class="stacks-copy">If you want to set the background color to anything other than the default, simply add your desired <code class="stacks-code">bg-*</code> class to the popover itself and a matching <code class="stacks-code">fc-*</code> class to the arrow element.</p>
+
+    <div class="stacks-preview">
+{% highlight html linenos %}
+<div class="s-popover bg-blue-400">
+    <div class="s-popover--arrow__lb fc-blue-400"></div>
+    …
+</div>
+{% endhighlight %}
+        <div class="stacks-preview--example bg-black-025">
+            <div class="s-popover ps-relative z-base bg-blue-400 is-visible">
+                <div class="s-popover--arrow__lb fc-blue-400"></div>
+                <p class="ff-mono mb8">.s-popover--arrow__lb</p>
+                <p class="mb0">Popover arrow appears left bottom</p>
+            </div>
+        </div>
+    </div>
 </section>

--- a/docs/product/components/popovers.html
+++ b/docs/product/components/popovers.html
@@ -139,6 +139,8 @@ description: Popovers are small content containers that provide a contextual ove
 
     <p class="stacks-copy">By default, popovers are hidden and positioned absolutely. Adding the class <code class="stacks-code">.is-visible</code> will show the popover.</p>
 
+    <p class="stacks-copy">If you want to set the background color to something other than the default, simply add your desired <code class="stacks-code">bg-*</code> class to the <code class="stacks-code">s-popover</code> element and a matching <code class="stacks-code">fc-*</code> class to the <code class="stacks-code">s-popover--arrow</code> element.</p>
+
     <div class="stacks-preview">
 {% highlight html linenos %}
 <div class="s-popover">
@@ -226,31 +228,12 @@ description: Popovers are small content containers that provide a contextual ove
                     </div>
                 </div>
                 <div class="grid--cell">
-                    <div class="s-popover ps-relative z-base is-visible">
-                        <div class="s-popover--arrow__lb"></div>
+                    <div class="s-popover ps-relative z-base is-visible bg-blue-300">
+                        <div class="s-popover--arrow__lb fc-blue-300"></div>
                         <p class="ff-mono mb8">.s-popover--arrow__lb</p>
                         <p class="mb0">Popover arrow appears left bottom</p>
                     </div>
                 </div>
-            </div>
-        </div>
-    </div>
-
-    {% header h3 | background-color %}
-    <p class="stacks-copy">If you want to set the background color to anything other than the default, simply add your desired <code class="stacks-code">bg-*</code> class to the popover itself and a matching <code class="stacks-code">fc-*</code> class to the arrow element.</p>
-
-    <div class="stacks-preview">
-{% highlight html linenos %}
-<div class="s-popover bg-blue-400">
-    <div class="s-popover--arrow__lb fc-blue-400"></div>
-    …
-</div>
-{% endhighlight %}
-        <div class="stacks-preview--example bg-black-025">
-            <div class="s-popover ps-relative z-base bg-blue-400 is-visible">
-                <div class="s-popover--arrow__lb fc-blue-400"></div>
-                <p class="ff-mono mb8">.s-popover--arrow__lb</p>
-                <p class="mb0">Popover arrow appears left bottom</p>
             </div>
         </div>
     </div>

--- a/docs/product/components/popovers.html
+++ b/docs/product/components/popovers.html
@@ -228,8 +228,8 @@ description: Popovers are small content containers that provide a contextual ove
                     </div>
                 </div>
                 <div class="grid--cell">
-                    <div class="s-popover ps-relative z-base is-visible bg-blue-300">
-                        <div class="s-popover--arrow__lb fc-blue-300"></div>
+                    <div class="s-popover ps-relative z-base is-visible">
+                        <div class="s-popover--arrow__lb"></div>
                         <p class="ff-mono mb8">.s-popover--arrow__lb</p>
                         <p class="mb0">Popover arrow appears left bottom</p>
                     </div>

--- a/lib/css/components/_stacks-popovers.less
+++ b/lib/css/components/_stacks-popovers.less
@@ -99,6 +99,8 @@
 .s-popover--arrow__rt,
 .s-popover--arrow__rc,
 .s-popover--arrow__rb {
+    border-color: @white;
+
     &:before,
     &:after {
         content: "";
@@ -128,7 +130,7 @@
     }
     &:after {
         top: -(@su8 - 1);
-        border-bottom-color: @white;
+        border-bottom-color: inherit;
     }
 }
 
@@ -148,7 +150,7 @@
     }
     &:after {
         bottom: -(@su8 - 1);
-        border-top-color: @white;
+        border-top-color: inherit;
     }
 }
 
@@ -205,7 +207,7 @@
     }
     &:after {
         left: -(@su8 - 1);
-        border-right-color: @white;
+        border-right-color: inherit;
     }
 }
 
@@ -225,7 +227,7 @@
     }
     &:after {
         right: -(@su8 - 1);
-        border-left-color: @white;
+        border-left-color: inherit;
     }
 }
 

--- a/lib/css/components/_stacks-popovers.less
+++ b/lib/css/components/_stacks-popovers.less
@@ -99,7 +99,7 @@
 .s-popover--arrow__rt,
 .s-popover--arrow__rc,
 .s-popover--arrow__rb {
-    border-color: @white;
+    color: @white;
 
     &:before,
     &:after {
@@ -130,7 +130,7 @@
     }
     &:after {
         top: -(@su8 - 1);
-        border-bottom-color: inherit;
+        border-bottom-color: currentColor;
     }
 }
 
@@ -150,7 +150,7 @@
     }
     &:after {
         bottom: -(@su8 - 1);
-        border-top-color: inherit;
+        border-top-color: currentColor;
     }
 }
 
@@ -207,7 +207,7 @@
     }
     &:after {
         left: -(@su8 - 1);
-        border-right-color: inherit;
+        border-right-color: currentColor;
     }
 }
 
@@ -227,7 +227,7 @@
     }
     &:after {
         right: -(@su8 - 1);
-        border-left-color: inherit;
+        border-left-color: currentColor;
     }
 }
 


### PR DESCRIPTION
Added support for inheriting popover arrow color from `fc-*` classes.

Reasoning for using `fc-*` classes instead of something more obvious:

> The way the popover is coded, the arrow uses a well known trick with borders to create a triangle (excellent browser support). Therefore, the arrow color is controlled by `border-color`.
>
> Stacks only supports so many border colors (like 3 per color. `bg-blue-400` corresponds to `bc-blue-2`). Rather than force Stacks to add a billion more border colors to bring it up to parity (or force devs to restrict themselves to what is available), I wanted to see if I could inherit from `bg-*`.
>
> Unfortunately, you can't inherit from other properties in CSS without having basically declared them first or using some CSS variables scheme (which isn't well supported by IE anyhow). What _is_ supported however is `currentColor`, which lets any color bearing property inherit from the `color` property.
>
> **So in conclusion**, we set `color` with `fc-*` to allow the border color to inherit this value via `currentColor`. Now we can allow the arrow to take advantage of the wide range of `fc-*` classes to match the popover's `bg-*.