### PR TITLE
Focus rings

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -48,6 +48,8 @@
           url: product/base/interactivity
         - title: Opacity
           url: product/base/opacity
+        - title: Outline
+          url: product/base/outline
         - title: Overflow
           url: product/base/overflow
         - title: Positioning

--- a/docs/_data/product/atomic-definitions.yml
+++ b/docs/_data/product/atomic-definitions.yml
@@ -682,6 +682,11 @@ outline:
   - class: outline-none
     output: "outline: 0;"
     define: "<p class='mb0'>Removes the browser’s default focus style. To maintain accessibility, care should be taken to replace the style that’s been removed.</p>"
+    focus: false
+  - class: outline-ring
+    output: "outline: solid @su4 fade(@blue-500, 15%);"
+    define: "<p class='mb0'>Adds an outline that mimics our button focus styling.</p>"
+    focus: true
 
 position:
   - class: ps-absolute

--- a/docs/_data/product/atomic-definitions.yml
+++ b/docs/_data/product/atomic-definitions.yml
@@ -678,6 +678,11 @@ overflow:
     define: "<p class='mb0'>Content is not clipped and may be rendered outside the content box. This is the default value.</p>"
     responsive: false
 
+outline:
+  - class: outline-none
+    output: "outline: 0;"
+    define: "<p class='mb0'>Removes the browser’s default focus style. To maintain accessibility, care should be taken to replace the style that’s been removed.</p>"
+
 position:
   - class: ps-absolute
     output: "position: absolute;"

--- a/docs/_data/product/atomic-definitions.yml
+++ b/docs/_data/product/atomic-definitions.yml
@@ -1,28 +1,25 @@
 box-shadow:
   - class: bs-none
     output: "box-shadow: none;"
-    responsive: false
   - class: bs-sm
     output: "box-shadow: 0 @su2 @su8 fade(@black-700, 10%);"
-    responsive: false
     hover: true
   - class: bs-md
     output: "box-shadow: 0 @su4 @su8 fade(@black-700, 20%);"
-    responsive: false
     hover: true
   - class: bs-lg
     output: "box-shadow: 0 @su4 @su12 fade(@black-800, 20%);"
-    responsive: false
     hover: true
   - class: bs-i-sm
     output: "box-shadow: inset 0 @su2/2 @su8 0 fade(@black-700, 10%);"
-    responsive: false
   - class: bs-i-md
     output: "box-shadow: inset 0 @su2/2 @su8 0 fade(@black-700, 20%);"
-    responsive: false
   - class: bs-i-lg
     output: "box-shadow: inset 0 @su2/2 @su12 0 fade(@black-800, 20%);"
-    responsive: false
+  - class: bs-ring
+    output: "box-shadow: 0 0 0 @su4 fade(@blue-500, 15%);"
+    hover: true
+    focus: true
 
 box-sizing:
   - class: box-content

--- a/docs/product/base/box-shadow.html
+++ b/docs/product/base/box-shadow.html
@@ -12,6 +12,7 @@ description: Box shadow atomic classes allow you to change an element’s box sh
                     <th class="s-table--cell2" scope="col">Class</th>
                     <th scope="col">Output</th>
                     <th scope="col" class="ta-center"><a class="s-link s-link__inherit" href="{{ "/product/guidelines/conditional-classes#hover" | relative_url }}">Hover?</a></th>
+                    <th scope="col" class="ta-center"><a class="s-link s-link__inherit" href="{{ "/product/guidelines/conditional-classes#focus" | relative_url }}">Focus?</a></th>
                 </tr>
             </thead>
             <tbody>
@@ -21,6 +22,11 @@ description: Box shadow atomic classes allow you to change an element’s box sh
                         <td><code class="stacks-code bg-white">{{ atomic.output }}</code></td>
                         <td class="ta-center">
                             {% if atomic.hover %}
+                                {% icon Checkmark | fc-green-500 %}
+                            {% endif %}
+                        </td>
+                        <td class="ta-center">
+                            {% if atomic.focus %}
                                 {% icon Checkmark | fc-green-500 %}
                             {% endif %}
                         </td>
@@ -53,7 +59,7 @@ description: Box shadow atomic classes allow you to change an element’s box sh
                 </div>
             </div>
 
-            <div class="grid jc-space-between grid__allcells3">
+            <div class="grid jc-space-between grid__allcells3 mb16">
                 <div class="grid--cell fd-column p12 bs-i-sm bar-sm h96">
                     .bs-i-sm
                 </div>
@@ -62,6 +68,12 @@ description: Box shadow atomic classes allow you to change an element’s box sh
                 </div>
                 <div class="grid--cell fd-column p12 bs-i-lg bar-sm h96">
                     .bs-i-lg
+                </div>
+            </div>
+
+            <div class="grid jc-space-between grid__allcells3">
+                <div class="grid--cell fd-column p12 bs-ring bar-sm h96">
+                    .bs-ring
                 </div>
             </div>
         </div>

--- a/docs/product/base/outline.html
+++ b/docs/product/base/outline.html
@@ -10,8 +10,9 @@ description:
             <thead>
                 <tr>
                     <th class="s-table--cell2" scope="col">Class</th>
-                    <th class="s-table--cell2" scope="col">Output</th>
+                    <th class="s-table--cell4" scope="col">Output</th>
                     <th scope="col">Definition</th>
+                    <th scope="col" class="ta-center"><a class="s-link s-link__inherit" href="{{ "/product/guidelines/conditional-classes#focus" | relative_url }}">Focus?</a></th>
                 </tr>
             </thead>
             <tbody>
@@ -20,6 +21,11 @@ description:
                         <th scope="row"><code class="stacks-code">.{{ atomic.class }}</code></th>
                         <td><code class="stacks-code bg-white">{{ atomic.output }}</code></td>
                         <td>{{ atomic.define }}</td>
+                        <td class="ta-center">
+                            {% if atomic.focus %}
+                                {% icon Checkmark | fc-green-500 %}
+                            {% endif %}
+                        </td>
                     </tr>
                 {% endfor %}
             </tbody>
@@ -33,6 +39,7 @@ description:
 {% endhighlight %}
         <div class="stacks-preview--example fs-caption ff-mono">
             <div class="outline-none d-inline-block bg-orange-100 p12 ba bc-orange-3">.outline-none</div>
+            <div class="f:outline-ring d-inline-block bg-orange-100 p12 ba bc-orange-3">.outline-ring</div>
         </div>
     </div>
 </section>

--- a/docs/product/base/outline.html
+++ b/docs/product/base/outline.html
@@ -39,7 +39,7 @@ description:
 {% endhighlight %}
         <div class="stacks-preview--example fs-caption ff-mono">
             <div class="outline-none d-inline-block bg-orange-100 p12 ba bc-orange-3">.outline-none</div>
-            <div class="f:outline-ring d-inline-block bg-orange-100 p12 ba bc-orange-3">.outline-ring</div>
+            <div class="outline-ring d-inline-block bg-orange-100 p12 ba bc-orange-3">.outline-ring</div>
         </div>
     </div>
 </section>

--- a/docs/product/base/outline.html
+++ b/docs/product/base/outline.html
@@ -1,0 +1,38 @@
+---
+layout: page
+title: Outline
+description: 
+---
+<section class="stacks-section">
+    {% header h2 | Classes %}
+    <div class="overflow-x-auto mb48">
+        <table class="wmn3 s-table s-table__bx-simple">
+            <thead>
+                <tr>
+                    <th class="s-table--cell2" scope="col">Class</th>
+                    <th class="s-table--cell2" scope="col">Output</th>
+                    <th scope="col">Definition</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for atomic in site.data.product.atomic-definitions.outline %}
+                    <tr class="fs-caption">
+                        <th scope="row"><code class="stacks-code">.{{ atomic.class }}</code></th>
+                        <td><code class="stacks-code bg-white">{{ atomic.output }}</code></td>
+                        <td>{{ atomic.define }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    {% header h2 | Examples %}
+    <div class="stacks-preview">
+{% highlight html linenos %}
+<div class="outline-none">…</div>
+{% endhighlight %}
+        <div class="stacks-preview--example fs-caption ff-mono">
+            <div class="outline-none d-inline-block bg-orange-100 p12 ba bc-orange-3">.outline-none</div>
+        </div>
+    </div>
+</section>

--- a/lib/css/atomic/_stacks-misc.less
+++ b/lib/css/atomic/_stacks-misc.less
@@ -173,9 +173,9 @@
 //  ============================================================================
 //  $  OVERFLOW
 //  ----------------------------------------------------------------------------
-.overflow-auto            { overflow: auto !important; }
-.overflow-x-auto          { overflow-x: auto !important; }
-.overflow-y-auto          { overflow-y: auto !important; }
+.overflow-auto            { overflow: auto !important; -webkit-overflow-scrolling: touch; }
+.overflow-x-auto          { overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+.overflow-y-auto          { overflow-y: auto !important; -webkit-overflow-scrolling: touch; }
 
 .overflow-hidden          { overflow: hidden !important; }
 .overflow-x-hidden        { overflow-x: hidden !important; }

--- a/lib/css/atomic/_stacks-misc.less
+++ b/lib/css/atomic/_stacks-misc.less
@@ -229,6 +229,8 @@
 //  $  OUTLINE
 //  ----------------------------------------------------------------------------
 .outline-none             { outline: 0 !important; }
+.outline-ring             { outline: solid @su4 fade(@blue-500, 15%); }
+.f\:outline-ring          { &:focus, &:focus-within { .outline-ring } }
 
 //  ============================================================================
 //  $  CURRENT COLOR

--- a/lib/css/atomic/_stacks-misc.less
+++ b/lib/css/atomic/_stacks-misc.less
@@ -251,6 +251,9 @@
 .bs-i-sm                  { box-shadow: @bs-i-sm !important; }
 .bs-i-md                  { box-shadow: @bs-i-md !important; }
 .bs-i-lg                  { box-shadow: @bs-i-lg !important; }
+.bs-ring                  { box-shadow: 0 0 0 @su4 fade(@blue-500, 15%); }
+.h\:bs-ring:hover { .bs-ring}
+.f\:bs-ring { &:focus, &:focus-within { .bs-ring } }
 
 //  --  Added hover styles for box-shadow
 .bs-sm.bs-hover:hover     { box-shadow: 0 @su2 @su8 @black-050 !important; }


### PR DESCRIPTION
This PR adds a few different methods for adding focus rings, the same that appear on our form elements.

Documented here

- `outline-none`
- `outline-ring`
- `bs-ring`

Adds optional focus and hover states for each.

Also sneaks in some touch refinements for scrolling.