### PR TITLE
Support for inactive table rows

### DIFF
--- a/docs/product/components/tables.html
+++ b/docs/product/components/tables.html
@@ -975,3 +975,67 @@ description: Tables are used to list all information from a data set. The base s
         </div>
     </div>
 </section>
+<section class="stacks-section">
+    {% header h2 | Disabled rows %}
+    <p class="stacks-copy">Used in tables that display data that’s been disabled or deactivated. Good for tables that include disabled users or teams.</p>
+    <p class="stacks-copy">Optionally inside <code class="stacks-code">&lt;tr class="is-disabled"&gt;</code>, a <code class="stacks-code">.never-disabled</code> class can be applied to any <code class="stacks-code">&lt;th&gt;</code> or <code class="stacks-code">&lt;td&gt;</code> that you’d like to ignore the disabled styling (such as a link to reactivate a disabled account).</p>
+    <div class="stacks-preview">
+{% highlight html %}
+<table class="s-table">
+    <tbody>
+         <tr class="is-disabled">
+            <td>…</td>
+            <td>…</td>
+            <td class="never-disabled">
+                <a>Add</a>
+            </td>
+        </tr>
+    </tbody>
+</table>
+{% endhighlight %}
+        <div class="stacks-preview--example overflow-x-auto">
+            <table class="s-table s-table__bx">
+                <thead>
+                    <tr>
+                        <th scope="col" class="ta-left">Name</th>
+                        <th scope="col">Email</th>
+                        <th scope="col">Last seen</th>
+                        <th scope="col"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <th><a>Aaron Shekey</a></th>
+                        <td>emailaddress@website.com</td>
+                        <td>just now</td>
+                        <td class="ta-right never-disabled"><a class="fc-red-500">Remove</a></td>
+                    </tr>
+                    <tr class="is-disabled">
+                        <th>Joshua Hynes</th>
+                        <td>emailaddress@website.com</td>
+                        <td>Sep 28 ’18</td>
+                        <td class="ta-right never-disabled"><a>Add</a></td>
+                    </tr>
+                    <tr class="is-disabled">
+                        <th>Paweł Ludwiczak</th>
+                        <td>emailaddress@website.com</td>
+                        <td>Apr 17 ’19</td>
+                        <td class="ta-right never-disabled"><a>Add</a></td>
+                    </tr>
+                    <tr>
+                        <th><a>Piper Lawson</a></th>
+                        <td>emailaddress@website.com</td>
+                        <td>Yesterday</td>
+                        <td class="ta-right never-disabled"><a class="fc-red-500">Remove</a></td>
+                    </tr>
+                    <tr>
+                        <th><a>Ted Goas</a></th>
+                        <td>emailaddress@website.com</td>
+                        <td>5min ago</td>
+                        <td class="ta-right never-disabled"><a class="fc-red-500">Remove</a></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</section>

--- a/lib/css/components/_stacks-tables.less
+++ b/lib/css/components/_stacks-tables.less
@@ -304,6 +304,17 @@
         padding-left: 0;
         width: 120px;
     }
+
+    //  $$  Disabled rows
+    //  ------------------------------------------------------------------------
+    tr.is-disabled {
+        background-color: @black-025;
+
+        th:not(.never-disabled),
+        td:not(.never-disabled) {
+            opacity: 0.3;
+        }
+    }
 }
 
 //  ============================================================================


### PR DESCRIPTION
This PR adds proper CSS that visually marks the contents of table row as disabled/inactive while allowing us to omit certain content from appearing inactive (Like say, a link to reactivate the row).

<img width="781" alt="Screen Shot 2019-08-13 at 5 03 17 PM" src="https://user-images.githubusercontent.com/1172461/62977167-45a6c680-bdec-11e9-8026-785371d4ac9a.png">

PR does not include any JS recommendation atm.

---

This PR resolves #361 