### PR TITLE
Add redirects for /product, /content, and /brand

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,22 @@
   command = "grunt build"
 
 [[redirects]]
+  from = "/product"
+  to = "/product/guidelines/using-stacks/"
+
+[[redirects]]
+  from = "/email"
+  to = "/email/guidelines/getting-started"
+
+[[redirects]]
+  from = "/content"
+  to = "/content/guidelines/principles"
+
+[[redirects]]
+  from = "/brand"
+  to = "/brand/principles"
+
+[[redirects]]
   from = "/product/guidelines"
   to = "/product/guidelines/using-stacks"
 
@@ -17,10 +33,6 @@
 [[redirects]]
   from = "/email/guidelines/best-practices"
   to = "/email/guidelines/design-best-practices"
-
-[[redirects]]
-  from = "/email"
-  to = "/email/guidelines/getting-started"
 
 [[redirects]]
   from = "/guidelines/using-stacks"


### PR DESCRIPTION
I noticed only the Email section had a 301 redirect pointing `https://stackoverflow.design/email` to the first page in the email section. Why not add similar redirects for the other sections?

Short URLs are handy to have when directing someone to a section verbally ("visit stackoverflow dot design slash content") or in a presentation (`https://stackoverflow.design/email` is cleaner than `https://stackoverflow.design/email/guidelines/getting-started`).