### PR TITLE
Autocomplete component

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -70,6 +70,8 @@
           url: product/base/z-index
     - title: Components
       subsublinks:
+        - title: Autocomplete
+          url: product/components/autocomplete
         - title: Avatars
           url: product/components/avatars
         - title: Badges

--- a/docs/product/components/autocomplete.html
+++ b/docs/product/components/autocomplete.html
@@ -152,7 +152,7 @@ description: Autocompletes are components that search for text a user entered in
 
     <div class="mb24 p16 bar-sm bg-black-025 ba bc-black-1">
         <div data-controller="s-autocomplete"
-            data-s-autocomplete-url="https://httpbin.org/delay/4">
+            data-s-autocomplete-url="http://deelay.me/2000/https://httpbin.org/status/404">
             <input class="s-input" placeholder="Type to search for users…"
                 data-controller="s-popover"
                 data-target="s-autocomplete.query"
@@ -165,11 +165,14 @@ description: Autocompletes are components that search for text a user entered in
                 <div class="tt-uppercase fs-fine fc-light mb6">
                     Top users
                 </div>
-                <div class="js-spinner p24 grid ai-center jc-center"
+                <div class="p24 grid ai-center jc-center"
                     data-target="s-autocomplete.loading">
                     <div class="s-spinner s-spinner__sm fc-orange-400">
                         <div class="v-visible-sr">Loading…</div>
                     </div>
+                </div>
+                <div class="s-notice s-notice__danger mt8" data-target="s-autocomplete.error">
+                    Something went wrong, please try again.
                 </div>
                 <div class="grid gs4 fw-wrap"
                     data-target="s-autocomplete.results"></div>

--- a/docs/product/components/autocomplete.html
+++ b/docs/product/components/autocomplete.html
@@ -17,10 +17,11 @@ description: Autocompletes are components that search for text a user entered in
                 aria-controls="popover-example-1">
             <div id="popover-example-1" class="s-popover ws2" role="menu" aria-hidden="true">
                 <div class="s-popover--arrow"></div>
-                <div class="tt-uppercase fs-fine fc-light">
-                    What are you looking for?
+                <div class="tt-uppercase fs-fine fc-light mb6">
+                    Search for some tags
                 </div>
-                <div data-target="s-autocomplete.results"></div>
+                <div class="grid gs4 fw-wrap"
+                     data-target="s-autocomplete.results"></div>
             </div>
         </div>
     </div>

--- a/docs/product/components/autocomplete.html
+++ b/docs/product/components/autocomplete.html
@@ -1,0 +1,23 @@
+---
+layout: page
+title: Autocomplete
+description: Autocompletes are components that search for text a user entered into an input field and show search results on the fly. They can be used whenever you want to help the user with suggestions after they've typed a partial search query.
+---
+
+<section class="stacks-section">
+    {% header h2 | Examples %}
+    <div class="mb24 p16 bar-sm bg-black-025 ba bc-black-1 grid ai-center gs8 sm:fd-column">
+        <input class="grid--cell s-input"
+                data-controller="s-popover s-autocomplete"
+                data-s-popover-placement="top-start"
+                data-s-popover-toggle-class="is-selected"
+                data-action="focus->s-popover#show"
+                aria-controls="popover-example-1">
+        <div id="popover-example-1" class="s-popover ws2" role="menu" aria-hidden="true">
+            <div class="s-popover--arrow"></div>
+            <div class="tt-uppercase fs-fine fc-light">
+                What are you looking for?
+            </div>
+        </div>
+    </div>
+</section>

--- a/docs/product/components/autocomplete.html
+++ b/docs/product/components/autocomplete.html
@@ -64,7 +64,8 @@ description: Autocompletes are components that search for text a user entered in
 <section class="stacks-section">
     {% header h2 | Examples %}
     {% header h3 | Simple %}
-    <div data-controller="s-autocomplete">
+    <div data-controller="s-autocomplete"
+        data-s-autocomplete-url="/product/components/examples/autocomplete/tags.html">
         <input class="s-input" placeholder="simple autocompletion"
             data-target="s-autocomplete.query"
             data-s-autocomplete-delay="500"
@@ -88,7 +89,8 @@ description: Autocompletes are components that search for text a user entered in
         to show in case something will go wrong. The autocomplete component will take care of showing
         and hiding the error state on its own.
     </p>
-    <div data-controller="s-autocomplete">
+    <div data-controller="s-autocomplete"
+        data-s-autocomplete-url="https://httpbin.org/status/404">
         <input class="s-input" placeholder="autocompletion with errors"
             data-target="s-autocomplete.query"
             data-s-autocomplete-delay="500"
@@ -97,7 +99,7 @@ description: Autocompletes are components that search for text a user entered in
             <div class="fs-fine fc-light">
                 Autocomplete results go here
             </div>
-            <div class="s-notice s-notice__danger" data-target="s-autocomplete.error">
+            <div class="s-notice s-notice__danger mt8" data-target="s-autocomplete.error">
                 Something went wrong, please try again.
             </div>
             <div class="grid gs4 mt12 fw-wrap" data-target="s-autocomplete.results"></div>
@@ -148,7 +150,8 @@ description: Autocompletes are components that search for text a user entered in
     </p>
 
     <div class="mb24 p16 bar-sm bg-black-025 ba bc-black-1">
-        <div data-controller="s-autocomplete">
+        <div data-controller="s-autocomplete"
+            data-s-autocomplete-url="https://httpbin.org/delay/4">
             <input class="s-input" placeholder="Type to search for users…"
                 data-controller="s-popover"
                 data-target="s-autocomplete.query"

--- a/docs/product/components/autocomplete.html
+++ b/docs/product/components/autocomplete.html
@@ -3,12 +3,78 @@ layout: page
 title: Autocomplete
 description: Autocompletes are components that search for text a user entered into an input field and show search results on the fly. They can be used whenever you want to help the user with suggestions after they've typed a partial search query.
 ---
+<section class="stacks-section">
+    {% header h2 | JavaScript %}
+    {% header h3 | Attributes %}
+    <div class="overflow-x-auto mb32">
+        <table class="wmn4 s-table s-table__bx-simple">
+            <thead>
+                <tr>
+                    <th class="s-table--cell5" scope="col">Attribute</th>
+                    <th class="s-table--cell2" scope="col">Applied to</th>
+                    <th scope="col">Description</th>
+                </tr>
+            </thead>
+            <tbody class="fs-caption">
+                <tr>
+                    <th scope="row"><code class="stacks-code">data-controller="s-autocomplete"</code></th>
+                    <td>Controller element</td>
+                    <td class="p8">Wires up the element to the autocomplete controller. This has to be a wrapper element containing both, the input for the search query as well as the container to display the results.</td>
+                </tr>
+                <tr>
+                    <th scope="row"><code class="stacks-code">data-target="s-autocomplete.query"</code></th>
+                    <td>Input element</td>
+                    <td class="p8">Designates the input element as the source of the autocomplete search query.</td>
+                </tr>
+                <tr>
+                    <th scope="row"><code class="stacks-code">data-target="s-autocomplete.results"</code></th>
+                    <td>Any child of the controller element</td>
+                    <td class="p8">Designates the declaring element as the target where autocomplete results will appear.</td>
+                </tr>
+                <tr>
+                    <th scope="row"><code class="stacks-code">data-action="input->s-autocomplete#query"</code></th>
+                    <td>Input element</td>
+                    <td class="p8">Wires up the input element to trigger a search query after the user has stopped typing.</td>
+                </tr>
+                <tr>
+                    <th scope="row"><code class="stacks-code">data-s-autocomplete-delay="[delay in ms]"</code></th>
+                    <td>Input element</td>
+                    <td class="p8"><span class="s-label--status ml0">Optional</span> Sets a debounce delay in milliseconds. The delay determines the time the autocomplete component will wait <em>after</em> the user stopped typing until it sends the search query. Defaults to 250ms.</td>
+                </tr>
+                <tr>
+                    <th scope="row"><code class="stacks-code">data-s-autocomplete-url="[search url]"</code></th>
+                    <td>Controller element</td>
+                    <td class="p8">Tells the autocomplete component where to send the search query to. The URL endpoint needs to respond with a <code class="stacks-code">text/html</code> response.</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</section>
 
 <section class="stacks-section">
     {% header h2 | Examples %}
+    {% header h3 | Simple %}
+    <div data-controller="s-autocomplete">
+        <input class="s-input" placeholder="simple autocompletion"
+            data-target="s-autocomplete.query"
+            data-s-autocomplete-delay="500"
+            data-action="input->s-autocomplete#query">
+        <div class="my24 p16 bar-sm bg-black-025 ba bc-black-1">
+            <div class="fs-fine fc-light">
+                Autocomplete results go here
+            </div>
+            <div class="grid gs4 mt12 fw-wrap" data-target="s-autocomplete.results"></div>
+        </div>
+    </div>
+
+    {% header h3 | With popover %}
+    <p>A autocomplete component can display its autocomplete results in any element.
+    Often you'll want to display autocomplete results in a <a href="https://stackoverflow.design/product/components/popovers">popover</a> that is attached to the input element itself.</p>
+
+    <p>To do so, you can combine an <code class="stacks-code">s-autocomplete</code> and an <code class="stacks-code">s-popover</code> component.</p>
     <div class="mb24 p16 bar-sm bg-black-025 ba bc-black-1">
         <div data-controller="s-autocomplete">
-            <input class="s-input" placeholder="with loading indicator"
+            <input class="s-input" placeholder="Type to search relevant tags…"
                 data-controller="s-popover"
                 data-target="s-autocomplete.query"
                 data-s-popover-placement="bottom-start"
@@ -18,37 +84,55 @@ description: Autocompletes are components that search for text a user entered in
             <div id="popover-example-1" class="s-popover ws2" role="menu" aria-hidden="true">
                 <div class="s-popover--arrow"></div>
                 <div class="tt-uppercase fs-fine fc-light mb6">
-                    Search for some tags
-                </div>
-                <div class="js-spinner p24 grid ai-center jc-center d-none"
-                     data-target="s-autocomplete.loading">
-                     <div class="s-spinner s-spinner__sm fc-orange-400">
-                        <div class="v-visible-sr">Loading…</div>
-                     </div>
+                    Relevant tags
                 </div>
                 <div class="grid gs4 fw-wrap"
-                     data-target="s-autocomplete.results"></div>
+                    data-target="s-autocomplete.results"></div>
             </div>
         </div>
     </div>
 
+    {% header h3 | Loading indicator %}
+    <p>
+        The autocomplete component supports showing a loading indicator while the search query is running.
+        For longer-running queries and generous debounce delays, this can make the autocompletion feel more snappy to the user.
+    </p>
+
+    <p>
+        To show a loading indicator while waiting for the autocomplete result, add any HTML element as a child to 
+        your <code class="stacks-code">data-controller="s-autocomplete"</code> element and declare it as the element
+        to be displayed while waiting for search results using the <code class="stacks-code">data-target="s-autocomplete.loading"</code> 
+        attribute.
+    </p>
+    <p>
+        The autocomplete component will show the loading indicator automatically while it's waiting for the user to stop typing and
+        for the search results to come in. Once the results are there, or once the user deleted the search query, the loading indicator
+        will be hidden again.
+    </p>
+
     <div class="mb24 p16 bar-sm bg-black-025 ba bc-black-1">
-            <div data-controller="s-autocomplete">
-                <input class="s-input" placeholder="without loading indicator"
-                    data-controller="s-popover"
-                    data-target="s-autocomplete.query"
-                    data-s-popover-placement="bottom-start"
-                    data-s-autocomplete-delay="500"
-                    data-action="focus->s-popover#show input->s-autocomplete#query"
-                    aria-controls="popover-example-2">
-                <div id="popover-example-2" class="s-popover ws2" role="menu" aria-hidden="true">
-                    <div class="s-popover--arrow"></div>
-                    <div class="tt-uppercase fs-fine fc-light mb6">
-                        Search for some tags
-                    </div>
-                    <div class="grid gs4 fw-wrap"
-                         data-target="s-autocomplete.results"></div>
+        <div data-controller="s-autocomplete">
+            <input class="s-input" placeholder="Type to search for users…"
+                data-controller="s-popover"
+                data-target="s-autocomplete.query"
+                data-s-popover-placement="bottom-start"
+                data-s-autocomplete-delay="500"
+                data-action="focus->s-popover#show input->s-autocomplete#query"
+                aria-controls="popover-example-2">
+            <div id="popover-example-2" class="s-popover ws2" role="menu" aria-hidden="true">
+                <div class="s-popover--arrow"></div>
+                <div class="tt-uppercase fs-fine fc-light mb6">
+                    Top users
                 </div>
+                <div class="js-spinner p24 grid ai-center jc-center d-none"
+                    data-target="s-autocomplete.loading">
+                    <div class="s-spinner s-spinner__sm fc-orange-400">
+                        <div class="v-visible-sr">Loading…</div>
+                    </div>
+                </div>
+                <div class="grid gs4 fw-wrap"
+                    data-target="s-autocomplete.results"></div>
             </div>
         </div>
+    </div>
 </section>

--- a/docs/product/components/autocomplete.html
+++ b/docs/product/components/autocomplete.html
@@ -113,8 +113,8 @@ description: Autocompletes are components that search for text a user entered in
     <p>To do so, you can combine an <code class="stacks-code">s-autocomplete</code> and an <code class="stacks-code">s-popover</code> component.</p>
     <div class="mb24 p16 bar-sm bg-black-025 ba bc-black-1">
         <div data-controller="s-autocomplete"
-            data-s-autocomplete-url="/product/components/examples/autocomplete/tags.html">
-            <input class="s-input" placeholder="Type to search relevant tags…"
+            data-s-autocomplete-url="/product/components/examples/autocomplete/teams.html">
+            <input class="s-input" placeholder="Type to search for teams…"
                 data-controller="s-popover"
                 data-target="s-autocomplete.query"
                 data-s-popover-placement="bottom-start"
@@ -123,10 +123,10 @@ description: Autocompletes are components that search for text a user entered in
                 aria-controls="popover-example-1">
             <div id="popover-example-1" class="s-popover ws2" role="menu" aria-hidden="true">
                 <div class="s-popover--arrow"></div>
-                <div class="tt-uppercase fs-fine fc-light mb6">
-                    Relevant tags
+                <div class="tt-uppercase fs-fine fc-light mb12">
+                    My favourite teams
                 </div>
-                <div class="grid gs4 fw-wrap"
+                <div class="grid fd-column"
                     data-target="s-autocomplete.results"></div>
             </div>
         </div>

--- a/docs/product/components/autocomplete.html
+++ b/docs/product/components/autocomplete.html
@@ -6,22 +6,22 @@ description: Autocompletes are components that search for text a user entered in
 
 <section class="stacks-section">
     {% header h2 | Examples %}
-    <div class="mb24 p16 bar-sm bg-black-025 ba bc-black-1 grid ai-center gs8 sm:fd-column">
-        <input class="grid--cell s-input"
-                data-controller="s-popover s-autocomplete"
+    <div class="mb24 p16 bar-sm bg-black-025 ba bc-black-1">
+        <div data-controller="s-autocomplete">
+            <input class="s-input"
+                data-controller="s-popover"
                 data-target="s-autocomplete.query"
                 data-s-popover-placement="bottom-start"
-                data-s-popover-toggle-class="is-selected"
                 data-s-autocomplete-delay="500"
-                data-s-autocomplete-result-element="#popover-example-1 .js-autocomplete-target"
                 data-action="focus->s-popover#show input->s-autocomplete#query"
                 aria-controls="popover-example-1">
-        <div id="popover-example-1" class="s-popover ws2" role="menu" aria-hidden="true">
-            <div class="s-popover--arrow"></div>
-            <div class="tt-uppercase fs-fine fc-light">
-                What are you looking for?
+            <div id="popover-example-1" class="s-popover ws2" role="menu" aria-hidden="true">
+                <div class="s-popover--arrow"></div>
+                <div class="tt-uppercase fs-fine fc-light">
+                    What are you looking for?
+                </div>
+                <div data-target="s-autocomplete.results"></div>
             </div>
-            <div class="js-autocomplete-target"></div>
         </div>
     </div>
 </section>

--- a/docs/product/components/autocomplete.html
+++ b/docs/product/components/autocomplete.html
@@ -8,7 +8,7 @@ description: Autocompletes are components that search for text a user entered in
     {% header h2 | Examples %}
     <div class="mb24 p16 bar-sm bg-black-025 ba bc-black-1">
         <div data-controller="s-autocomplete">
-            <input class="s-input"
+            <input class="s-input" placeholder="with loading indicator"
                 data-controller="s-popover"
                 data-target="s-autocomplete.query"
                 data-s-popover-placement="bottom-start"
@@ -20,9 +20,35 @@ description: Autocompletes are components that search for text a user entered in
                 <div class="tt-uppercase fs-fine fc-light mb6">
                     Search for some tags
                 </div>
+                <div class="js-spinner p24 grid ai-center jc-center d-none"
+                     data-target="s-autocomplete.loading">
+                     <div class="s-spinner s-spinner__sm fc-orange-400">
+                        <div class="v-visible-sr">Loading…</div>
+                     </div>
+                </div>
                 <div class="grid gs4 fw-wrap"
                      data-target="s-autocomplete.results"></div>
             </div>
         </div>
     </div>
+
+    <div class="mb24 p16 bar-sm bg-black-025 ba bc-black-1">
+            <div data-controller="s-autocomplete">
+                <input class="s-input" placeholder="without loading indicator"
+                    data-controller="s-popover"
+                    data-target="s-autocomplete.query"
+                    data-s-popover-placement="bottom-start"
+                    data-s-autocomplete-delay="500"
+                    data-action="focus->s-popover#show input->s-autocomplete#query"
+                    aria-controls="popover-example-2">
+                <div id="popover-example-2" class="s-popover ws2" role="menu" aria-hidden="true">
+                    <div class="s-popover--arrow"></div>
+                    <div class="tt-uppercase fs-fine fc-light mb6">
+                        Search for some tags
+                    </div>
+                    <div class="grid gs4 fw-wrap"
+                         data-target="s-autocomplete.results"></div>
+                </div>
+            </div>
+        </div>
 </section>

--- a/docs/product/components/autocomplete.html
+++ b/docs/product/components/autocomplete.html
@@ -124,7 +124,7 @@ description: Autocompletes are components that search for text a user entered in
                 <div class="tt-uppercase fs-fine fc-light mb6">
                     Top users
                 </div>
-                <div class="js-spinner p24 grid ai-center jc-center d-none"
+                <div class="js-spinner p24 grid ai-center jc-center"
                     data-target="s-autocomplete.loading">
                     <div class="s-spinner s-spinner__sm fc-orange-400">
                         <div class="v-visible-sr">Loading…</div>

--- a/docs/product/components/autocomplete.html
+++ b/docs/product/components/autocomplete.html
@@ -9,15 +9,19 @@ description: Autocompletes are components that search for text a user entered in
     <div class="mb24 p16 bar-sm bg-black-025 ba bc-black-1 grid ai-center gs8 sm:fd-column">
         <input class="grid--cell s-input"
                 data-controller="s-popover s-autocomplete"
-                data-s-popover-placement="top-start"
+                data-target="s-autocomplete.query"
+                data-s-popover-placement="bottom-start"
                 data-s-popover-toggle-class="is-selected"
-                data-action="focus->s-popover#show"
+                data-s-autocomplete-delay="500"
+                data-s-autocomplete-result-element="#popover-example-1 .js-autocomplete-target"
+                data-action="focus->s-popover#show input->s-autocomplete#query"
                 aria-controls="popover-example-1">
         <div id="popover-example-1" class="s-popover ws2" role="menu" aria-hidden="true">
             <div class="s-popover--arrow"></div>
             <div class="tt-uppercase fs-fine fc-light">
                 What are you looking for?
             </div>
+            <div class="js-autocomplete-target"></div>
         </div>
     </div>
 </section>

--- a/docs/product/components/autocomplete.html
+++ b/docs/product/components/autocomplete.html
@@ -64,26 +64,42 @@ description: Autocompletes are components that search for text a user entered in
 <section class="stacks-section">
     {% header h2 | Examples %}
     {% header h3 | Simple %}
-    <div data-controller="s-autocomplete"
-        data-s-autocomplete-url="/product/components/examples/autocomplete/tags.html">
-        <input class="s-input" placeholder="simple autocompletion"
-            data-target="s-autocomplete.query"
-            data-s-autocomplete-delay="500"
-            data-action="input->s-autocomplete#query">
-        <div class="my24 p16 bar-sm bg-black-025 ba bc-black-1">
-            <div class="fs-fine fc-light">
-                Autocomplete results go here
+    <p class="stacks-copy">
+        The most basic example of an autocomplete consists of a wrapping <code class="stacks-code">s-autocomplete</code> controller
+        with a nested <code class="stacks-code">input</code> and an element to contain the autocomplete results.
+    </p>
+
+    <div class="stacks-preview">
+{% highlight html %}
+<div data-controller="s-autocomplete"
+    data-s-autocomplete-url="...">
+    <input class="s-input"
+        data-target="s-autocomplete.query"
+        data-action="input->s-autocomplete#query">
+    <div class="grid gs4 mt12 fw-wrap"
+        data-target="s-autocomplete.results"></div>
+</div>
+{% endhighlight %}
+
+        <div class="stacks-preview--example bg-black-025">
+            <div data-controller="s-autocomplete"
+                data-s-autocomplete-url="/product/components/examples/autocomplete/tags.html">
+                <input class="s-input" placeholder="simple autocompletion"
+                    data-target="s-autocomplete.query"
+                    data-s-autocomplete-delay="500"
+                    data-action="input->s-autocomplete#query">
+                <div class="mt16 fs-fine fc-light">Autocomplete results go here</div>
+                <div class="grid gs4 mt12 fw-wrap" data-target="s-autocomplete.results"></div>
             </div>
-            <div class="grid gs4 mt12 fw-wrap" data-target="s-autocomplete.results"></div>
         </div>
     </div>
 
     {% header h3 | Error State %}
-    <p>
+    <p class="stacks-copy">
         We're fetching data from an external backend and there are many ways this can go wrong.
         Autocompletes support showing custom error states if fetching data fails.
     </p>
-    <p>
+    <p class="stacks-copy">
         Add the <code class="stacks-code">data-target="s-autocomplete.error"</code> attribute to any
         child element of your <code class="stacks-code">s-autocomplete</code> controller that you want
         to show in case something will go wrong. The autocomplete component will take care of showing
@@ -107,10 +123,11 @@ description: Autocompletes are components that search for text a user entered in
     </div>
 
     {% header h3 | With popover %}
-    <p>A autocomplete component can display its autocomplete results in any element.
+    <p class="stacks-copy">A autocomplete component can display its autocomplete results in any element.
     Often you'll want to display autocomplete results in a <a href="https://stackoverflow.design/product/components/popovers">popover</a> that is attached to the input element itself.</p>
 
-    <p>To do so, you can combine an <code class="stacks-code">s-autocomplete</code> and an <code class="stacks-code">s-popover</code> component.</p>
+    <p class="stacks-copy">To do so, you can combine an <code class="stacks-code">s-autocomplete</code> and an <code class="stacks-code">s-popover</code> component.</p>
+
     <div class="mb24 p16 bar-sm bg-black-025 ba bc-black-1">
         <div data-controller="s-autocomplete"
             data-s-autocomplete-url="/product/components/examples/autocomplete/teams.html">
@@ -133,18 +150,18 @@ description: Autocompletes are components that search for text a user entered in
     </div>
 
     {% header h3 | Loading indicator %}
-    <p>
+    <p class="stacks-copy">
         The autocomplete component supports showing a loading indicator while the search query is running.
         For longer-running queries and generous debounce delays, this can make the autocompletion feel more snappy to the user.
     </p>
 
-    <p>
+    <p class="stacks-copy">
         To show a loading indicator while waiting for the autocomplete result, add any HTML element as a child to
         your <code class="stacks-code">data-controller="s-autocomplete"</code> element and declare it as the element
         to be displayed while waiting for search results using the <code class="stacks-code">data-target="s-autocomplete.loading"</code>
         attribute.
     </p>
-    <p>
+    <p class="stacks-copy">
         The autocomplete component will show the loading indicator automatically while it's waiting for the user to stop typing and
         for the search results to come in. Once the results are there, or once the user deleted the search query, the loading indicator
         will be hidden again.

--- a/docs/product/components/autocomplete.html
+++ b/docs/product/components/autocomplete.html
@@ -112,7 +112,8 @@ description: Autocompletes are components that search for text a user entered in
 
     <p>To do so, you can combine an <code class="stacks-code">s-autocomplete</code> and an <code class="stacks-code">s-popover</code> component.</p>
     <div class="mb24 p16 bar-sm bg-black-025 ba bc-black-1">
-        <div data-controller="s-autocomplete">
+        <div data-controller="s-autocomplete"
+            data-s-autocomplete-url="/product/components/examples/autocomplete/tags.html">
             <input class="s-input" placeholder="Type to search relevant tags…"
                 data-controller="s-popover"
                 data-target="s-autocomplete.query"

--- a/docs/product/components/autocomplete.html
+++ b/docs/product/components/autocomplete.html
@@ -105,20 +105,35 @@ description: Autocompletes are components that search for text a user entered in
         to show in case something will go wrong. The autocomplete component will take care of showing
         and hiding the error state on its own.
     </p>
-    <div data-controller="s-autocomplete"
-        data-s-autocomplete-url="https://httpbin.org/status/404">
-        <input class="s-input" placeholder="autocompletion with errors"
-            data-target="s-autocomplete.query"
-            data-s-autocomplete-delay="500"
-            data-action="input->s-autocomplete#query">
-        <div class="my24 p16 bar-sm bg-black-025 ba bc-black-1">
-            <div class="fs-fine fc-light">
-                Autocomplete results go here
+
+    <div class="stacks-preview">
+{% highlight html %}
+<div data-controller="s-autocomplete"
+    data-s-autocomplete-url="...">
+    <input class="s-input"
+        data-target="s-autocomplete.query"
+        data-action="input->s-autocomplete#query">
+    <div data-target="s-autocomplete.results"></div>
+    <div data-target="s-autocomplete.error">
+        Something went wrong, please try again.
+    </div>
+</div>
+{% endhighlight %}
+        <div class="stacks-preview--example bg-black-025">
+            <div data-controller="s-autocomplete"
+                data-s-autocomplete-url="https://httpbin.org/status/404">
+                <input class="s-input" placeholder="autocompletion with errors"
+                    data-target="s-autocomplete.query"
+                    data-s-autocomplete-delay="500"
+                    data-action="input->s-autocomplete#query">
+                <div class="mt16 fs-fine fc-light">
+                    Autocomplete results go here
+                </div>
+                <div class="s-notice s-notice__danger mt16" data-target="s-autocomplete.error">
+                    Something went wrong, please try again.
+                </div>
+                <div class="grid gs4 mt16 fw-wrap" data-target="s-autocomplete.results"></div>
             </div>
-            <div class="s-notice s-notice__danger mt8" data-target="s-autocomplete.error">
-                Something went wrong, please try again.
-            </div>
-            <div class="grid gs4 mt12 fw-wrap" data-target="s-autocomplete.results"></div>
         </div>
     </div>
 
@@ -128,23 +143,40 @@ description: Autocompletes are components that search for text a user entered in
 
     <p class="stacks-copy">To do so, you can combine an <code class="stacks-code">s-autocomplete</code> and an <code class="stacks-code">s-popover</code> component.</p>
 
-    <div class="mb24 p16 bar-sm bg-black-025 ba bc-black-1">
-        <div data-controller="s-autocomplete"
-            data-s-autocomplete-url="/product/components/examples/autocomplete/teams.html">
-            <input class="s-input" placeholder="Type to search for teams…"
-                data-controller="s-popover"
-                data-target="s-autocomplete.query"
-                data-s-popover-placement="bottom-start"
-                data-s-autocomplete-delay="500"
-                data-action="focus->s-popover#show input->s-autocomplete#query"
-                aria-controls="popover-example-1">
-            <div id="popover-example-1" class="s-popover ws2" role="menu" aria-hidden="true">
-                <div class="s-popover--arrow"></div>
-                <div class="tt-uppercase fs-fine fc-light mb12">
-                    My favourite teams
+    <div class="stacks-preview">
+{% highlight html %}
+<div data-controller="s-autocomplete"
+    data-s-autocomplete-url="...">
+    <input class="s-input"
+        data-controller="s-popover"
+        data-s-popover-placement="bottom-start"
+        aria-controls="popover-example-1"
+        data-target="s-autocomplete.query"
+        data-action="focus->s-popover#show input->s-autocomplete#query">
+    <div id="popover-example-1" class="s-popover ws2" role="menu" aria-hidden="true">
+        <div class="s-popover--arrow"></div>
+        <div data-target="s-autocomplete.results"></div>
+    </div>
+</div>
+{% endhighlight %}
+        <div class="stacks-preview--example bg-black-025">
+            <div data-controller="s-autocomplete"
+                data-s-autocomplete-url="/product/components/examples/autocomplete/teams.html">
+                <input class="s-input" placeholder="Type to search for teams…"
+                    data-controller="s-popover"
+                    data-target="s-autocomplete.query"
+                    data-s-popover-placement="bottom-start"
+                    data-s-autocomplete-delay="500"
+                    data-action="focus->s-popover#show input->s-autocomplete#query"
+                    aria-controls="popover-example-1">
+                <div id="popover-example-1" class="s-popover ws2" role="menu" aria-hidden="true">
+                    <div class="s-popover--arrow"></div>
+                    <div class="tt-uppercase fs-fine fc-light mb12">
+                        My favourite teams
+                    </div>
+                    <div class="grid fd-column"
+                        data-target="s-autocomplete.results"></div>
                 </div>
-                <div class="grid fd-column"
-                    data-target="s-autocomplete.results"></div>
             </div>
         </div>
     </div>
@@ -167,32 +199,50 @@ description: Autocompletes are components that search for text a user entered in
         will be hidden again.
     </p>
 
-    <div class="mb24 p16 bar-sm bg-black-025 ba bc-black-1">
-        <div data-controller="s-autocomplete"
-            data-s-autocomplete-url="http://deelay.me/2000/https://httpbin.org/status/404">
-            <input class="s-input" placeholder="Type to search for users…"
-                data-controller="s-popover"
-                data-target="s-autocomplete.query"
-                data-s-popover-placement="bottom-start"
-                data-s-autocomplete-delay="500"
-                data-action="focus->s-popover#show input->s-autocomplete#query"
-                aria-controls="popover-example-2">
-            <div id="popover-example-2" class="s-popover ws2" role="menu" aria-hidden="true">
-                <div class="s-popover--arrow"></div>
-                <div class="tt-uppercase fs-fine fc-light mb6">
-                    Top users
-                </div>
-                <div class="p24 grid ai-center jc-center"
-                    data-target="s-autocomplete.loading">
-                    <div class="s-spinner s-spinner__sm fc-orange-400">
-                        <div class="v-visible-sr">Loading…</div>
+    <div class="stacks-preview">
+{% highlight html %}
+<div data-controller="s-autocomplete"
+    data-s-autocomplete-url="...">
+    <input class="s-input"
+        data-controller="s-popover"
+        data-s-popover-placement="bottom-start"
+        aria-controls="popover-example-2"
+        data-target="s-autocomplete.query"
+        data-action="focus->s-popover#show input->s-autocomplete#query">
+    <div id="popover-example-2" class="s-popover ws2" role="menu" aria-hidden="true">
+        <div class="s-popover--arrow"></div>
+        <div data-target="s-autocomplete.results"></div>
+        <div data-target="s-autocomplete.loading">Loading…</div>
+    </div>
+</div>
+{% endhighlight %}
+        <div class="stacks-preview--example bg-black-025">
+            <div data-controller="s-autocomplete"
+                data-s-autocomplete-url="http://deelay.me/2000/https://httpbin.org/status/404">
+                <input class="s-input" placeholder="Type to search for users…"
+                    data-controller="s-popover"
+                    data-target="s-autocomplete.query"
+                    data-s-popover-placement="bottom-start"
+                    data-s-autocomplete-delay="500"
+                    data-action="focus->s-popover#show input->s-autocomplete#query"
+                    aria-controls="popover-example-2">
+                <div id="popover-example-2" class="s-popover ws2" role="menu" aria-hidden="true">
+                    <div class="s-popover--arrow"></div>
+                    <div class="tt-uppercase fs-fine fc-light mb6">
+                        Top users
                     </div>
+                    <div class="p24 grid ai-center jc-center"
+                        data-target="s-autocomplete.loading">
+                        <div class="s-spinner s-spinner__sm fc-orange-400">
+                            <div class="v-visible-sr">Loading…</div>
+                        </div>
+                    </div>
+                    <div class="s-notice s-notice__danger mt8" data-target="s-autocomplete.error">
+                        Something went wrong, please try again.
+                    </div>
+                    <div class="grid gs4 fw-wrap"
+                        data-target="s-autocomplete.results"></div>
                 </div>
-                <div class="s-notice s-notice__danger mt8" data-target="s-autocomplete.error">
-                    Something went wrong, please try again.
-                </div>
-                <div class="grid gs4 fw-wrap"
-                    data-target="s-autocomplete.results"></div>
             </div>
         </div>
     </div>

--- a/docs/product/components/autocomplete.html
+++ b/docs/product/components/autocomplete.html
@@ -32,6 +32,16 @@ description: Autocompletes are components that search for text a user entered in
                     <td class="p8">Designates the declaring element as the target where autocomplete results will appear.</td>
                 </tr>
                 <tr>
+                    <th scope="row"><code class="stacks-code">data-target="s-autocomplete.loading"</code></th>
+                    <td>Any child of the controller element</td>
+                    <td class="p8">The declaring element will be shown while querying data and hidden once the search results are there.</td>
+                </tr>
+                <tr>
+                    <th scope="row"><code class="stacks-code">data-target="s-autocomplete.error"</code></th>
+                    <td>Any child of the controller element</td>
+                    <td class="p8">The declaring element will be shown if an error occurs while running the search query.</td>
+                </tr>
+                <tr>
                     <th scope="row"><code class="stacks-code">data-action="input->s-autocomplete#query"</code></th>
                     <td>Input element</td>
                     <td class="p8">Wires up the input element to trigger a search query after the user has stopped typing.</td>
@@ -62,6 +72,33 @@ description: Autocompletes are components that search for text a user entered in
         <div class="my24 p16 bar-sm bg-black-025 ba bc-black-1">
             <div class="fs-fine fc-light">
                 Autocomplete results go here
+            </div>
+            <div class="grid gs4 mt12 fw-wrap" data-target="s-autocomplete.results"></div>
+        </div>
+    </div>
+
+    {% header h3 | Error State %}
+    <p>
+        We're fetching data from an external backend and there are many ways this can go wrong.
+        Autocompletes support showing custom error states if fetching data fails.
+    </p>
+    <p>
+        Add the <code class="stacks-code">data-target="s-autocomplete.error"</code> attribute to any
+        child element of your <code class="stacks-code">s-autocomplete</code> controller that you want
+        to show in case something will go wrong. The autocomplete component will take care of showing
+        and hiding the error state on its own.
+    </p>
+    <div data-controller="s-autocomplete">
+        <input class="s-input" placeholder="autocompletion with errors"
+            data-target="s-autocomplete.query"
+            data-s-autocomplete-delay="500"
+            data-action="input->s-autocomplete#query">
+        <div class="my24 p16 bar-sm bg-black-025 ba bc-black-1">
+            <div class="fs-fine fc-light">
+                Autocomplete results go here
+            </div>
+            <div class="s-notice s-notice__danger" data-target="s-autocomplete.error">
+                Something went wrong, please try again.
             </div>
             <div class="grid gs4 mt12 fw-wrap" data-target="s-autocomplete.results"></div>
         </div>
@@ -99,9 +136,9 @@ description: Autocompletes are components that search for text a user entered in
     </p>
 
     <p>
-        To show a loading indicator while waiting for the autocomplete result, add any HTML element as a child to 
+        To show a loading indicator while waiting for the autocomplete result, add any HTML element as a child to
         your <code class="stacks-code">data-controller="s-autocomplete"</code> element and declare it as the element
-        to be displayed while waiting for search results using the <code class="stacks-code">data-target="s-autocomplete.loading"</code> 
+        to be displayed while waiting for search results using the <code class="stacks-code">data-target="s-autocomplete.loading"</code>
         attribute.
     </p>
     <p>

--- a/docs/product/components/examples/autocomplete/tags.html
+++ b/docs/product/components/examples/autocomplete/tags.html
@@ -1,0 +1,7 @@
+<!-- This is dummy data for the s-autocomplete component that will be fetched via AJAX -->
+
+<a href="#" class="s-tag grid--cell">typescript</a>
+<a href="#" class="s-tag grid--cell">clojure</a>
+<a href="#" class="s-tag grid--cell">rust</a>
+<a href="#" class="s-tag grid--cell">html</a>
+<a href="#" class="s-tag grid--cell">php</a>

--- a/docs/product/components/examples/autocomplete/teams.html
+++ b/docs/product/components/examples/autocomplete/teams.html
@@ -1,0 +1,20 @@
+<!-- This is dummy data for the s-autocomplete component that will be fetched via AJAX -->
+
+<a href="#" class="grid--cell p8 s-link s-link__muted f:outline-ring f:bg-black-050">
+    <div class="s-avatar">
+        <div class="s-avatar--letter">P</div>
+    </div>
+    <span class="pl4">Pickles</span>
+</a>
+<a href="#" class="grid--cell p8 s-link s-link__muted f:outline-ring f:bg-black-050">
+    <div class="s-avatar">
+        <div class="s-avatar--letter">G</div>
+    </div>
+    <span class="pl4">Gherkins</span>
+</a>
+<a href="#" class="grid--cell p8 s-link s-link__muted f:outline-ring f:bg-black-050">
+    <div class="s-avatar">
+        <div class="s-avatar--letter">R</div>
+    </div>
+    <span class="pl4">Radishes</span>
+</a>

--- a/lib/ts/controllers/s-autocomplete.ts
+++ b/lib/ts/controllers/s-autocomplete.ts
@@ -87,6 +87,7 @@
          * Show the error state element if present
          */
         private _showErrorState(): void {
+            this._hideLoadingIndicator();
             if (!this.hasErrorTarget) {
                 return;
             }

--- a/lib/ts/controllers/s-autocomplete.ts
+++ b/lib/ts/controllers/s-autocomplete.ts
@@ -1,15 +1,17 @@
 (function () {
     "use strict";
     Stacks.application.register("s-autocomplete", class extends Stacks.StacksController {
-        static targets = ["query"];
+        static targets = ["query", "results"];
 
         declare readonly queryTarget!: HTMLInputElement;
         declare readonly queryTargets!: HTMLInputElement[];
+        declare readonly resultsTarget!: HTMLInputElement;
+        declare readonly resultsTargets!: HTMLInputElement[];
 
         timeouts: number[] = [];
 
         connect() {
-            console.log("Connected autocomplete");
+            this._clearResults();
         };
 
         disconnect() {
@@ -21,14 +23,13 @@
          */
         query() {
             let fun = () => {
-                console.log("firing query", this._query);
                 let response = "<div>1</div><div>2</div>";
                 this._resultElement.innerHTML = response;
             };
 
             // todo: debounce
 
-            let response = fun();
+            fun();
         }
 
         /**
@@ -50,22 +51,16 @@
          * Get the element which should display the autocomplete result
          */
         private get _resultElement(): Element {
-            let selector = this.data.get("result-element");
-            if (selector === null) {
-                throw "no result-element attribute given"
-            }
-
-            let element = document.querySelector(selector);
-            if (element === null) {
-                throw `no element found with selector ${element}`
-            }
-
-            return element;
+            return this.resultsTarget;
         }
 
         private _debounce(fun: () => void, wait: number) {
             this.timeouts.forEach(timeout => window.clearInterval(timeout));
             this.timeouts.push(window.setTimeout(fun, wait));
+        }
+
+        private _clearResults() {
+            this._resultElement.innerHTML = ""
         }
     });
 })();

--- a/lib/ts/controllers/s-autocomplete.ts
+++ b/lib/ts/controllers/s-autocomplete.ts
@@ -15,10 +15,10 @@
 
         connect() {
             this._clearResults();
+            this._hideLoadingIndicator();
         };
 
         disconnect() {
-            console.log("disconnected autocomplete");
         };
 
         /**
@@ -41,7 +41,6 @@
          * @param results 
          */
         private _displayResults(results: string): void {
-            console.log("displaying")
             setTimeout(() => {
                 this._hideLoadingIndicator();
                 this._resultElement.innerHTML = results;

--- a/lib/ts/controllers/s-autocomplete.ts
+++ b/lib/ts/controllers/s-autocomplete.ts
@@ -1,12 +1,15 @@
 (function () {
     "use strict";
     Stacks.application.register("s-autocomplete", class extends Stacks.StacksController {
-        static targets = ["query", "results"];
+        static targets = ["query", "results", "loading"];
 
         declare readonly queryTarget!: HTMLInputElement;
         declare readonly queryTargets!: HTMLInputElement[];
         declare readonly resultsTarget!: HTMLInputElement;
         declare readonly resultsTargets!: HTMLInputElement[];
+        declare readonly loadingTarget!: HTMLInputElement;
+        declare readonly loadingTargets!: HTMLInputElement[];
+        declare readonly hasLoadingTarget!: boolean;
 
         timeouts: number[] = [];
 
@@ -22,15 +25,39 @@
          * Sends a query after a given delay
          */
         query() {
-            let fun = () => {
-                this._query === "" 
-                    ? this._clearResults() 
-                    : this._resultElement.innerHTML = this._stubResponse();
-            };
+            if (this._query === "") {
+                this._clearResults();
+                // todo: stop running queries
+                return;
+            }
 
+            this._showLoadingIndicator();
+            this._displayResults(this._stubResponse());
             // todo: debounce
+        }
 
-            fun();
+        /**
+         * Display autocomplete results in the result element
+         * @param results 
+         */
+        private _displayResults(results: string): void {
+            console.log("displaying")
+            setTimeout(() => {
+                this._hideLoadingIndicator();
+                this._resultElement.innerHTML = results;
+            }, 1500);
+        }
+
+        private _showLoadingIndicator(): void {
+            if (this.hasLoadingTarget) {
+                this.loadingTarget.classList.remove("d-none");
+            }
+        }
+
+        private _hideLoadingIndicator(): void {
+            if (this.hasLoadingTarget) {
+                this.loadingTarget.classList.add("d-none");
+            }
         }
 
         private _stubResponse(): string {
@@ -70,8 +97,16 @@
             this.timeouts.push(window.setTimeout(fun, wait));
         }
 
+        /**
+         * Clear all autocomplete results
+         */
         private _clearResults() {
+            this._hideLoadingIndicator();
             this._resultElement.innerHTML = ""
+        }
+
+        private _initializeKeyboardNavigation() {
+
         }
     });
 })();

--- a/lib/ts/controllers/s-autocomplete.ts
+++ b/lib/ts/controllers/s-autocomplete.ts
@@ -11,14 +11,18 @@
         declare readonly loadingTargets!: HTMLInputElement[];
         declare readonly hasLoadingTarget!: boolean;
 
-        timeouts: number[] = [];
+        private timeouts: number[] = [];
+
+        private _boundKeypressFn!: any;
 
         connect() {
             this._clearResults();
             this._hideLoadingIndicator();
+            this._bindDocumentEvents();
         };
 
         disconnect() {
+            this._unbindDocumentEvents();
         };
 
         /**
@@ -38,7 +42,7 @@
 
         /**
          * Display autocomplete results in the result element
-         * @param results 
+         * @param results
          */
         private _displayResults(results: string): void {
             setTimeout(() => {
@@ -104,8 +108,32 @@
             this._resultElement.innerHTML = ""
         }
 
-        private _initializeKeyboardNavigation() {
+        /**
+         * Binds global events to the document to enable keyboard interaction
+         */
+        private _bindDocumentEvents() {
+            // in order for removeEventListener to remove the right event, this bound function needs a constant reference
+            this._boundKeypressFn = this._boundKeypressFn || this._blurOnEscapePress.bind(this);
 
-        }
+            document.addEventListener("keyup", this._boundKeypressFn);
+        };
+
+        /**
+         * Unbinds global events from the document
+         */
+        private _unbindDocumentEvents() {
+            document.removeEventListener("keyup", this._boundKeypressFn);
+        };
+
+        /**
+         * Blurs the input element if the user presses escape while it is focused
+         * @param {Event} e - The document keyup event
+         */
+        private _blurOnEscapePress(e: KeyboardEvent) {
+            // if the ESC key (27) was pressed, blur
+            if (e.which === 27) {
+                this.queryTarget.blur();
+            }
+        };
     });
 })();

--- a/lib/ts/controllers/s-autocomplete.ts
+++ b/lib/ts/controllers/s-autocomplete.ts
@@ -1,12 +1,12 @@
-
-
 (function () {
     "use strict";
     Stacks.application.register("s-autocomplete", class extends Stacks.StacksController {
-        static targets = [ "query" ];
+        static targets = ["query"];
 
         declare readonly queryTarget!: HTMLInputElement;
         declare readonly queryTargets!: HTMLInputElement[];
+
+        timeouts: number[] = [];
 
         connect() {
             console.log("Connected autocomplete");
@@ -17,14 +17,55 @@
         };
 
         /**
-         * Fires a query after a given delay
+         * Sends a query after a given delay
          */
-        runQuery() {
-            console.log("firing query", this.query)
+        query() {
+            let fun = () => {
+                console.log("firing query", this._query);
+                let response = "<div>1</div><div>2</div>";
+                this._resultElement.innerHTML = response;
+            };
+
+            // todo: debounce
+
+            let response = fun();
         }
 
-        get query() : string {
+        /**
+         * Get the entered search query
+         */
+        private get _query(): string {
             return this.queryTarget.value;
+        }
+
+        /**
+         * Get the specified delay in ms before firing a query
+         * Defaults to 250ms
+         */
+        private get _delay(): number {
+            return parseInt(this.data.get("delay") || "250");
+        }
+
+        /**
+         * Get the element which should display the autocomplete result
+         */
+        private get _resultElement(): Element {
+            let selector = this.data.get("result-element");
+            if (selector === null) {
+                throw "no result-element attribute given"
+            }
+
+            let element = document.querySelector(selector);
+            if (element === null) {
+                throw `no element found with selector ${element}`
+            }
+
+            return element;
+        }
+
+        private _debounce(fun: () => void, wait: number) {
+            this.timeouts.forEach(timeout => window.clearInterval(timeout));
+            this.timeouts.push(window.setTimeout(fun, wait));
         }
     });
 })();

--- a/lib/ts/controllers/s-autocomplete.ts
+++ b/lib/ts/controllers/s-autocomplete.ts
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
     Stacks.application.register("s-autocomplete", class extends Stacks.StacksController {
-        static targets = ["query", "results", "loading"];
+        static targets = ["query", "results", "loading", "error"];
 
         declare readonly queryTarget!: HTMLInputElement;
         declare readonly queryTargets!: HTMLInputElement[];
@@ -10,6 +10,9 @@
         declare readonly loadingTarget!: HTMLInputElement;
         declare readonly loadingTargets!: HTMLInputElement[];
         declare readonly hasLoadingTarget!: boolean;
+        declare readonly errorTarget!: HTMLInputElement;
+        declare readonly errorTargets!: HTMLInputElement[];
+        declare readonly hasErrorTarget!: boolean;
 
         private timeouts: number[] = [];
 
@@ -18,6 +21,7 @@
         connect() {
             this._clearResults();
             this._hideLoadingIndicator();
+            this._hideErrorState();
             this._bindDocumentEvents();
         };
 
@@ -29,6 +33,7 @@
          * Sends a query after a given delay
          */
         query() {
+            this._hideErrorState();
             if (this._query === "") {
                 this._clearResults();
                 // todo: stop running queries
@@ -60,6 +65,18 @@
         private _hideLoadingIndicator(): void {
             if (this.hasLoadingTarget) {
                 this.loadingTarget.classList.add("d-none");
+            }
+        }
+
+        private _showErrorState(): void {
+            if (this.hasErrorTarget) {
+                this.errorTarget.classList.remove("d-none");
+            }
+        }
+
+        private _hideErrorState(): void {
+            if (this.hasErrorTarget) {
+                this.errorTarget.classList.add("d-none");
             }
         }
 

--- a/lib/ts/controllers/s-autocomplete.ts
+++ b/lib/ts/controllers/s-autocomplete.ts
@@ -1,0 +1,30 @@
+
+
+(function () {
+    "use strict";
+    Stacks.application.register("s-autocomplete", class extends Stacks.StacksController {
+        static targets = [ "query" ];
+
+        declare readonly queryTarget!: HTMLInputElement;
+        declare readonly queryTargets!: HTMLInputElement[];
+
+        connect() {
+            console.log("Connected autocomplete");
+        };
+
+        disconnect() {
+            console.log("disconnected autocomplete");
+        };
+
+        /**
+         * Fires a query after a given delay
+         */
+        runQuery() {
+            console.log("firing query", this.query)
+        }
+
+        get query() : string {
+            return this.queryTarget.value;
+        }
+    });
+})();

--- a/lib/ts/controllers/s-autocomplete.ts
+++ b/lib/ts/controllers/s-autocomplete.ts
@@ -23,13 +23,24 @@
          */
         query() {
             let fun = () => {
-                let response = "<div>1</div><div>2</div>";
-                this._resultElement.innerHTML = response;
+                this._query === "" 
+                    ? this._clearResults() 
+                    : this._resultElement.innerHTML = this._stubResponse();
             };
 
             // todo: debounce
 
             fun();
+        }
+
+        private _stubResponse(): string {
+            return `
+                <a href="#" class="s-tag grid--cell">typescript</a>
+                <a href="#" class="s-tag grid--cell">clojure</a>
+                <a href="#" class="s-tag grid--cell">rust</a>
+                <a href="#" class="s-tag grid--cell">html</a>
+                <a href="#" class="s-tag grid--cell">php</a>
+            `;
         }
 
         /**

--- a/lib/ts/controllers/s-autocomplete.ts
+++ b/lib/ts/controllers/s-autocomplete.ts
@@ -65,18 +65,27 @@
             this._resultElement.innerHTML = results;
         }
 
+        /**
+         * Show the loading indicator element, if present
+         */
         private _showLoadingIndicator(): void {
             if (this.hasLoadingTarget) {
                 this.loadingTarget.classList.remove("d-none");
             }
         }
 
+        /**
+         * Hide the loading indicator element, if present
+         */
         private _hideLoadingIndicator(): void {
             if (this.hasLoadingTarget) {
                 this.loadingTarget.classList.add("d-none");
             }
         }
 
+        /**
+         * Show the error state element if present
+         */
         private _showErrorState(): void {
             if (!this.hasErrorTarget) {
                 return;
@@ -84,6 +93,9 @@
             this.errorTarget.classList.remove("d-none");
         }
 
+        /**
+         * Hide the error state element, if present
+         */
         private _hideErrorState(): void {
             if (!this.hasErrorTarget) {
                 return


### PR DESCRIPTION
I've started building an autocomplete component that can be used for type-ahead search, e.g. for searching tags, users or anything else, really.

This is still a work in progress but I wanted to get some things out here to kick off discussions.

* currently the autocomplete component will only respond with the same, static data.
* there's no debouncing yet
* autocomplete supports arbitrary elements to display results, this includes popovers
* rudimentary keyboard navigation is working (`esc` to blur, `tab` to select)
* displaying a loading indicator while a query is running works

Some points I want to put up for discussion:

1. How opinionated do we want the autocomplete component to be? Right now I can declare an arbitrary element to display autocomplete results. I can use popovers and anything else, really, and I think that's spiffy! Check out the examples to get a feeling for this. Alternatively we could always tie the autocomplete component to a popover component but I don't think this will make declaring an `s-autocomplete` much easier.
2. How much keyboard navigation do we want to provide? Right now, I can use the browser's own `tab` and `shift-tab` navigation as long as the autocomplete results are hyperlinks. This is pretty ideal from an accessibility perspective and flexible. The problem is that this is a component that has interaction with arbitrary backends which do the actual search. We need to rely on convention that these server endpoints return autocomplete results that we can navigate through, that's why I'd rely on browser standards (like tab to select the next anchor) to build keyboard navigation. If developers want to provide special behavior when selecting (i.e. hitting enter on) a single autocomplete result, I'd let them implement that event handler themselves
3. Where should the debouncing functionality go? Implement our own and have it part of the autocomplete component for now? Pull in a dependency?