### PR TITLE
Add GitHub button variant

### DIFF
--- a/docs/product/components/buttons.html
+++ b/docs/product/components/buttons.html
@@ -569,6 +569,16 @@ description: Buttons are user interface elements which allows users to take acti
                         <button class="grid--cell s-btn s-btn__icon s-btn__google ws-nowrap mr8" type="button" aria-pressed="false">{% icon Google | native %} Google</button>
                     </td>
                 </tr>
+                <tr>
+                    <th scope="row" class="va-middle">GitHub</th>
+                    <td class="va-middle">
+                        <code class="grid--cell stacks-code">.s-btn__github</code>
+                    </td>
+                    <td class="va-middle">Styles a button consistent with GitHub’s branding</td>
+                    <td class="va-middle grid ai-center">
+                        <button class="grid--cell s-btn s-btn__icon s-btn__github ws-nowrap mr8" type="button" aria-pressed="false">{% icon GitHub %} GitHub</button>
+                    </td>
+                </tr>
             </tbody>
         </table>
     </div>

--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -584,6 +584,12 @@
         background-color: darken(@white, 3%);
         color: darken(#535A60, 5%);
     }
+
+    &:active {
+        border-color: @black-200;
+        background-color: @black-050;
+        color: @black-900;
+    }
 }
 
 .s-btn__facebook {
@@ -595,6 +601,27 @@
     &:focus {
         background-color: darken(#385499, 5%);
         color: fade(@white, 95%);
+    }
+
+    &:active {
+        background-color: darken(#385499, 10%);
+        color: #fff;
+    }
+}
+
+.s-btn__github {
+    background-color: @black-750;
+    color: @white;
+
+    &:hover,
+    &:focus {
+        background-color: @black-800;
+        color: @white;
+    }
+
+     &:active {
+        background-color: @black-900;
+        color: @white;
     }
 }
 


### PR DESCRIPTION
This refines our buttons a bit and adds GitHub-specific styling.

![image](https://user-images.githubusercontent.com/1369864/67031986-4d2e6880-f0d8-11e9-8e2d-acaf001949db.png)