### PR TITLE
Scrollbar refinement

### DIFF
--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -1,5 +1,5 @@
 <div class="grid--cell fl-shrink0 ws2 md:w-auto md:d-none print:d-none js-navigation">
-    <div class="overflow-y-scroll overflow-x-hidden bg-white z-nav py12 fs-body1 ps-fixed wmn2 t64 b0 br bc-black-2 sm:w100 sm:pb0">
+    <div class="overflow-y-scroll overflow-x-hidden bg-white z-nav py12 fs-body1 ps-fixed wmn2 t64 b0 sm:w100 sm:pb0">
         <div class="d-none sm:d-block">
             <div class="grid fd-column ai-center">
                 <div class="s-navigation s-navigation__wrap mx8 mb12 jc-center">

--- a/docs/product/base/overflow.html
+++ b/docs/product/base/overflow.html
@@ -40,47 +40,47 @@ description: Atomic overflow classes allow you to change an element’s overflow
 <div class="overflow-y-scroll">…</div>
 <div class="overflow-visible">…</div>
 {% endhighlight %}
-        <div class="stacks-preview--example fs-caption ff-mono">
-            <div class="grid grid__allcells3 gs16 fw-wrap">
-                <div class="grid--cell bg-orange-100 p12 ba bc-orange-3 overflow-auto hs2">
-                    <span class="mb12">.overflow-auto</span>
-                    <div class="bg-orange-300 ba baw1 bc-orange-3 hs3 ws3"></div>
+        <div class="stacks-preview--example overflow-x-auto fs-caption ff-mono">
+            <div class="grid grid__allcells3 gs16 fw-wrap wmn7">
+                <div class="grid--cell bg-black-050 p12 ba bc-black-3 ws-nowrap overflow-auto hs2">
+                    <div class="mb12">.overflow-auto</div>
+                    <div class="bg-black-075 ba baw1 bc-black-3 hs2 ws2"></div>
                 </div>
-                <div class="grid--cell bg-orange-100 p12 ba bc-orange-3 overflow-x-auto hs2">
-                    <span class="mb12">.overflow-x-auto</span>
-                    <div class="bg-orange-300 ba baw1 bc-orange-3 hs3 ws3"></div>
+                <div class="grid--cell bg-black-050 p12 ba bc-black-3 ws-nowrap overflow-x-auto hs2">
+                    <div class="mb12">.overflow-x-auto</div>
+                    <div class="bg-black-075 ba baw1 bc-black-3 hs2 ws2"></div>
                 </div>
-                <div class="grid--cell bg-orange-100 p12 ba bc-orange-3 overflow-y-auto hs2">
-                    <span class="mb12">.overflow-y-auto</span>
-                    <div class="bg-orange-300 ba baw1 bc-orange-3 hs3 ws3"></div>
+                <div class="grid--cell bg-black-050 p12 ba bc-black-3 ws-nowrap overflow-y-auto hs2">
+                    <div class="mb12">.overflow-y-auto</div>
+                    <div class="bg-black-075 ba baw1 bc-black-3 hs2 ws2"></div>
                 </div>
-                <div class="grid--cell bg-orange-100 p12 ba bc-orange-3 overflow-hidden hs2">
-                    <span class="mb12">.overflow-hidden</span>
-                    <div class="bg-orange-300 ba baw1 bc-orange-3 hs3 ws3"></div>
+                <div class="grid--cell bg-black-050 p12 ba bc-black-3 ws-nowrap overflow-hidden hs2">
+                    <div class="mb12">.overflow-hidden</div>
+                    <div class="bg-black-075 ba baw1 bc-black-3 hs2 ws2"></div>
                 </div>
-                <div class="grid--cell bg-orange-100 p12 ba bc-orange-3 overflow-x-hidden hs2">
-                    <span class="mb12">.overflow-x-hidden</span>
-                    <div class="bg-orange-300 ba baw1 bc-orange-3 hs3 ws3"></div>
+                <div class="grid--cell bg-black-050 p12 ba bc-black-3 ws-nowrap overflow-x-hidden hs2">
+                    <div class="mb12">.overflow-x-hidden</div>
+                    <div class="bg-black-075 ba baw1 bc-black-3 hs2 ws2"></div>
                 </div>
-                <div class="grid--cell bg-orange-100 p12 ba bc-orange-3 overflow-y-hidden hs2">
-                    <span class="mb12">.overflow-y-hidden</span>
-                    <div class="bg-orange-300 ba baw1 bc-orange-3 hs3 ws3"></div>
+                <div class="grid--cell bg-black-050 p12 ba bc-black-3 ws-nowrap overflow-y-hidden hs2">
+                    <div class="mb12">.overflow-y-hidden</div>
+                    <div class="bg-black-075 ba baw1 bc-black-3 hs2 ws2"></div>
                 </div>
-                <div class="grid--cell bg-orange-100 p12 ba bc-orange-3 overflow-scroll hs2">
-                    <span class="mb12">.overflow-scroll</span>
-                    <div class="bg-orange-300 ba baw1 bc-orange-3 hs3 ws3"></div>
+                <div class="grid--cell bg-black-050 p12 ba bc-black-3 ws-nowrap overflow-scroll hs2">
+                    <div class="mb12">.overflow-scroll</div>
+                    <div class="bg-black-075 ba baw1 bc-black-3 hs2 ws2"></div>
                 </div>
-                <div class="grid--cell bg-orange-100 p12 ba bc-orange-3 overflow-x-scroll hs2">
-                    <span class="mb12">.overflow-x-scroll</span>
-                    <div class="bg-orange-300 ba baw1 bc-orange-3 hs3 ws3"></div>
+                <div class="grid--cell bg-black-050 p12 ba bc-black-3 ws-nowrap overflow-x-scroll hs2">
+                    <div class="mb12">.overflow-x-scroll</div>
+                    <div class="bg-black-075 ba baw1 bc-black-3 hs2 ws2"></div>
                 </div>
-                <div class="grid--cell bg-orange-100 p12 ba bc-orange-3 overflow-y-scroll hs2">
-                    <span class="mb12">.overflow-y-scroll</span>
-                    <div class="bg-orange-300 ba baw1 bc-orange-3 hs3 ws3"></div>
+                <div class="grid--cell bg-black-050 p12 ba bc-black-3 ws-nowrap overflow-y-scroll hs2">
+                    <div class="mb12">.overflow-y-scroll</div>
+                    <div class="bg-black-075 ba baw1 bc-black-3 hs2 ws2"></div>
                 </div>
-                <div class="grid--cell bg-orange-100 p12 ba bc-orange-3 overflow-visible hs2">
-                    <span class="mb12">.overflow-visible</span>
-                    <div class="bg-orange-300 ba baw1 bc-orange-3 hs3 ws3"></div>
+                <div class="grid--cell bg-black-050 p12 ba bc-black-3 ws-nowrap overflow-visible hs1 ws1">
+                    <div class="mb12">.overflow-visible</div>
+                    <div class="bg-black-075 ba baw1 bc-black-3 hs1 ws1"></div>
                 </div>
             </div>
         </div>

--- a/lib/css/atomic/_stacks-misc.less
+++ b/lib/css/atomic/_stacks-misc.less
@@ -173,17 +173,17 @@
 //  ============================================================================
 //  $  OVERFLOW
 //  ----------------------------------------------------------------------------
-.overflow-auto            { overflow: auto !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
-.overflow-x-auto          { overflow-x: auto !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
-.overflow-y-auto          { overflow-y: auto !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
+.overflow-auto            { overflow: auto !important; @scrollbar-styles(); }
+.overflow-x-auto          { overflow-x: auto !important; @scrollbar-styles(); }
+.overflow-y-auto          { overflow-y: auto !important; @scrollbar-styles(); }
 
-.overflow-hidden          { overflow: hidden !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
-.overflow-x-hidden        { overflow-x: hidden !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
-.overflow-y-hidden        { overflow-y: hidden !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
+.overflow-hidden          { overflow: hidden !important; @scrollbar-styles(); }
+.overflow-x-hidden        { overflow-x: hidden !important; @scrollbar-styles(); }
+.overflow-y-hidden        { overflow-y: hidden !important; @scrollbar-styles(); }
 
-.overflow-scroll          { overflow: scroll !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
-.overflow-x-scroll        { overflow-x: scroll !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
-.overflow-y-scroll        { overflow-y: scroll !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
+.overflow-scroll          { overflow: scroll !important; @scrollbar-styles(); }
+.overflow-x-scroll        { overflow-x: scroll !important; @scrollbar-styles(); }
+.overflow-y-scroll        { overflow-y: scroll !important; @scrollbar-styles(); }
 
 .overflow-visible         { overflow: visible !important; }
 

--- a/lib/css/atomic/_stacks-misc.less
+++ b/lib/css/atomic/_stacks-misc.less
@@ -173,17 +173,17 @@
 //  ============================================================================
 //  $  OVERFLOW
 //  ----------------------------------------------------------------------------
-.overflow-auto            { overflow: auto !important; -webkit-overflow-scrolling: touch; }
-.overflow-x-auto          { overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
-.overflow-y-auto          { overflow-y: auto !important; -webkit-overflow-scrolling: touch; }
+.overflow-auto            { overflow: auto !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
+.overflow-x-auto          { overflow-x: auto !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
+.overflow-y-auto          { overflow-y: auto !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
 
-.overflow-hidden          { overflow: hidden !important; }
-.overflow-x-hidden        { overflow-x: hidden !important; }
-.overflow-y-hidden        { overflow-y: hidden !important; }
+.overflow-hidden          { overflow: hidden !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
+.overflow-x-hidden        { overflow-x: hidden !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
+.overflow-y-hidden        { overflow-y: hidden !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
 
-.overflow-scroll          { overflow: scroll !important; -webkit-overflow-scrolling: touch; }
-.overflow-x-scroll        { overflow-x: scroll !important; -webkit-overflow-scrolling: touch; }
-.overflow-y-scroll        { overflow-y: scroll !important; -webkit-overflow-scrolling: touch; }
+.overflow-scroll          { overflow: scroll !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
+.overflow-x-scroll        { overflow-x: scroll !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
+.overflow-y-scroll        { overflow-y: scroll !important; -webkit-overflow-scrolling: touch; @scrollbar-styles(); }
 
 .overflow-visible         { overflow: visible !important; }
 

--- a/lib/css/components/_stacks-navigation.less
+++ b/lib/css/components/_stacks-navigation.less
@@ -23,30 +23,7 @@
         overflow-x: auto;
         flex-wrap: nowrap;
 
-        // Webkit scrollbars
-        &::-webkit-scrollbar {
-            width: @su8;
-            height: @su8;
-            background-color: transparent;
-        }
-
-        &::-webkit-scrollbar-track {
-            border-radius: @su8;
-            background-color: transparent;
-        }
-
-        &::-webkit-scrollbar-thumb {
-            border-radius: @su8;
-            background-color: fade(@black-900, 10%);
-        }
-
-        &::-webkit-scrollbar-corner {
-            background-color: transparent;
-        }
-
-        // Firefox
-        scrollbar-color: fade(@black-900, 10%) transparent;
-        scrollbar-width: thin;
+        @scrollbar-styles();
     }
 }
 

--- a/lib/css/exports/_stacks-constants-helpers.less
+++ b/lib/css/exports/_stacks-constants-helpers.less
@@ -95,3 +95,34 @@
 
 @default-transition-duration:       0.1s;
 @transition-time:                   @default-transition-duration;
+
+
+//  ============================================================================
+//  $   SCROLLBAR STYLING
+//  ----------------------------------------------------------------------------
+@scrollbar-styles: {
+    &::-webkit-scrollbar {
+        width: @su8;
+        height: @su8;
+        background-color: transparent;
+    }
+
+    &::-webkit-scrollbar-track {
+        border-radius: @su8;
+        background-color: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb
+    {
+        border-radius: @su8;
+        background-color: rgba(0, 0, 0, .15);
+    }
+
+    &::-webkit-scrollbar-corner {
+        background-color: transparent;
+        border-color: transparent;
+    }
+
+    scrollbar-color: rgba(0, 0, 0, .15) transparent;
+    scrollbar-width: thin;
+}

--- a/lib/css/exports/_stacks-constants-helpers.less
+++ b/lib/css/exports/_stacks-constants-helpers.less
@@ -101,6 +101,8 @@
 //  $   SCROLLBAR STYLING
 //  ----------------------------------------------------------------------------
 @scrollbar-styles: {
+    -webkit-overflow-scrolling: touch;
+
     &::-webkit-scrollbar {
         width: @su8;
         height: @su8;

--- a/lib/css/exports/_stacks-constants-helpers.less
+++ b/lib/css/exports/_stacks-constants-helpers.less
@@ -115,7 +115,7 @@
     &::-webkit-scrollbar-thumb
     {
         border-radius: @su8;
-        background-color: rgba(0, 0, 0, .15);
+        background-color: rgba(0, 0, 0, .20);
     }
 
     &::-webkit-scrollbar-corner {
@@ -123,6 +123,6 @@
         border-color: transparent;
     }
 
-    scrollbar-color: rgba(0, 0, 0, .15) transparent;
+    scrollbar-color: rgba(0, 0, 0, .20) transparent;
     scrollbar-width: thin;
 }


### PR DESCRIPTION
Any time `overflow-[x]` is added to an element, we can add some sensible styling to the scrollbar. This moves that styling into a mixin that can be called by our components.

It also modifies the documentation site to use the mixin and removes an unnecessary border.

| macOS Safari / Chrome | macOS Firefox |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1369864/67528873-32339980-f680-11e9-9c31-de408e600d89.png) | ![image](https://user-images.githubusercontent.com/1369864/67528902-46779680-f680-11e9-9630-c437524702b5.png) |

| Windows Chrome | Windows Firefox | Windows Edge |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/1369864/67529012-8dfe2280-f680-11e9-85e9-b5d5f0b954ef.png) | ![image](https://user-images.githubusercontent.com/1369864/67529063-abcb8780-f680-11e9-97c4-6e448e1f0d02.png) | ![image](https://user-images.githubusercontent.com/1369864/67529347-7ecba480-f681-11e9-82c5-5d10c2386597.png) |


