### PR TITLE
Email/team badge mobile

### DIFF
--- a/docs/email/components/team-identification.html
+++ b/docs/email/components/team-identification.html
@@ -15,24 +15,34 @@ description: Emails sent from a Team on <a href="https://stackoverflow.com/teams
     {% header h2 | Example %}
     <div class="stacks-preview mb24">
 {% highlight html %}
-<table border="0" cellpadding="0" cellspacing="0" role="presentation" align="left">
+<table border="0" cellpadding="0" cellspacing="0" role="presentation">
     <tr>
-        <td valign="middle" height="19" width="19" style="font-family: arial, sans-serif; font-size: 13px; line-height: 13px; color: #ffffff; background-color: #EB5757; font-weight: bold; text-align: center; border-radius: 3px;">
-            T
+        <td valign="top" width="19">
+            <table border="0" cellpadding="0" cellspacing="0" role="presentation" align="left">
+                <tr>
+                    <td valign="middle" height="19" width="19" style="font-family: arial, sans-serif; font-size: 13px; line-height: 13px; color: #ffffff; background-color: #EB5757; font-weight: bold; text-align: center; border-radius: 3px;">
+                        T
+                    </td>
+                </tr>
+            </table>
         </td>
-        <!-- Optional table cell for Team name : BEGIN -->
         <td valign="middle" style="padding-left: 5px; font-family: arial, sans-serif; font-size: 13px; line-height: 13px; color: #242729; text-align: left;">
             Team Name
         </td>
-        <!-- Optional table cell for Team name : END -->
     </tr>
 </table>
 {% endhighlight %}
         <div class="stacks-preview--example" style="text-align: left;">
             <table border="0" cellpadding="0" cellspacing="0" role="presentation">
                 <tr>
-                    <td valign="middle" height="19" width="19" style="font-family: arial, sans-serif; font-size: 13px; line-height: 13px; color: #ffffff; background-color: #EB5757; font-weight: bold; text-align: center; border-radius: 3px;">
-                        S
+                    <td valign="top" width="19">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" align="left">
+                            <tr>
+                                <td valign="middle" height="19" width="19" style="font-family: arial, sans-serif; font-size: 13px; line-height: 13px; color: #ffffff; background-color: #EB5757; font-weight: bold; text-align: center; border-radius: 3px;">
+                                    S
+                                </td>
+                            </tr>
+                        </table>
                     </td>
                     <td valign="middle" style="padding-left: 5px; font-family: arial, sans-serif; font-size: 13px; line-height: 13px; color: #242729; text-align: left;">
                         SO for Teams Name

--- a/docs/email/templates/code/transactional-long.html
+++ b/docs/email/templates/code/transactional-long.html
@@ -331,10 +331,16 @@
                                     <!-- Team Name : BEGIN -->
                                     <tr>
                                         <td dir="ltr" style="padding-bottom: 10px;">
-                                            <table border="0" cellpadding="0" cellspacing="0" role="presentation" align="left">
+                                            <table border="0" cellpadding="0" cellspacing="0" role="presentation">
                                                 <tr>
-                                                    <td valign="middle" height="19" width="19" style="font-family: arial, sans-serif; font-size: 13px; line-height: 13px; color: #ffffff; background-color: #EB5757; font-weight: bold; text-align: center; border-radius: 3px;">
-                                                        S
+                                                    <td valign="top" width="19">
+                                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" align="left">
+                                                            <tr>
+                                                                <td valign="middle" height="19" width="19" style="font-family: arial, sans-serif; font-size: 13px; line-height: 13px; color: #ffffff; background-color: #EB5757; font-weight: bold; text-align: center; border-radius: 3px;">
+                                                                    S
+                                                                </td>
+                                                            </tr>
+                                                        </table>
                                                     </td>
                                                     <td valign="middle" style="padding-left: 5px; font-family: arial, sans-serif; font-size: 13px; line-height: 13px; color: #242729; text-align: left;">
                                                         SO for Teams Name


### PR DESCRIPTION
This PR fixes #387 

---

**Current**
When a long team name wraps onto multiple lines, the whole `<table>` stretches to adjust for multiple lines. Unfortunately the first table cell has a background color directly applied, so when it stretches the "square" appearance gets stretched vertically:

<img width="257" alt="Screen Shot 2019-10-28 at 4 28 26 PM" src="https://user-images.githubusercontent.com/1172461/67715432-39201c00-f9a0-11e9-9b63-1bca32882f05.png">

---

**Proposed fix**

If we wrap the "color" square in an additional `<table>`, the container `<table>` will stretch vertically without impacting the color square:

<img width="251" alt="Screen Shot 2019-10-28 at 4 29 07 PM" src="https://user-images.githubusercontent.com/1172461/67715624-92884b00-f9a0-11e9-94b4-534bada099c6.png">
