### PR TITLE
Add "s-navigation__muted" secondary style for the Navigation component

### DIFF
--- a/docs/_data/product/navigation.yml
+++ b/docs/_data/product/navigation.yml
@@ -2,6 +2,9 @@ classes:
   - class: .s-navigation
     applies: N/A
     description: Base parent container for navigation
+  - class: .s-navigation__muted
+    applies: <code class="stacks-code">.s-navigation</code>
+    description: Secondary navigation style. To be used on pages that already have a primary navigation
   - class: .s-navigation__scroll
     applies: <code class="stacks-code">.s-navigation</code>
     description: When the navigation items overflow the width of the component, enable horizontal scrolling. By default, navigation items will wrap

--- a/docs/product/components/navigation.html
+++ b/docs/product/components/navigation.html
@@ -28,7 +28,7 @@ description: Our navigation component is a collection of pill-shaped buttons tha
 </section>
 <section class="stacks-section">
     {% header h2 | Examples %}
-    <p class="stacks-copy">Care should be taken to only include a single navigation per page. When navigations end up being nested, it can cause user confusion, and lead to a muddled page composition.</p>
+    <p class="stacks-copy">Care should be taken to only include at most one primary and one secondary navigation per page. Using multiple navigations with the same style can cause user confusion.</p>
     <p class="stacks-copy">Forcing a navigation to scroll is an established pattern on mobile devices, so it may be appropriate to use it in that context. Wrapping tends to make more sense on larger screens, where the user isn’t forced to scroll passed a ton of navigation chrome.</p>
 
     {% header h3 | Default %}
@@ -85,3 +85,35 @@ description: Our navigation component is a collection of pill-shaped buttons tha
         </div>
     </div>
 </section>
+
+{% header h3 | Muted %}
+    <div class="stacks-preview">
+{% highlight html %}
+<div class="s-navigation s-navigation__muted">
+    <a href="…" class="s-navigation--item is-selected">Product</a>
+    <a href="…" class="s-navigation--item">Email</a>
+    <a href="…" class="s-navigation--item">Content</a>
+    <a href="…" class="s-navigation--item">Brand</a>
+    <a href="…" class="s-navigation--item">Marketing</a>
+</div>
+{% endhighlight %}
+        <div class="stacks-preview--example">
+            <p class="ff-mono mb8">Full width</p>
+            <div class="s-navigation s-navigation__muted mb32">
+                <a class="s-navigation--item is-selected">Product</a>
+                <a class="s-navigation--item">Email</a>
+                <a class="s-navigation--item">Content</a>
+                <a class="s-navigation--item">Brand</a>
+                <a class="s-navigation--item">Marketing</a>
+            </div>
+
+            <p class="ff-mono mb8">Wrapped</p>
+            <div class="s-navigation s-navigation__muted wmx2">
+                <a class="s-navigation--item is-selected">Product</a>
+                <a class="s-navigation--item">Email</a>
+                <a class="s-navigation--item">Content</a>
+                <a class="s-navigation--item">Brand</a>
+                <a class="s-navigation--item">Marketing</a>
+            </div>
+        </div>
+    </div>

--- a/lib/css/components/_stacks-navigation.less
+++ b/lib/css/components/_stacks-navigation.less
@@ -8,9 +8,46 @@
 //
 //  TABLE OF CONTENTS
 //  • BASE STYLE
+//  • MUTED STYLE
+
+
+& { // create a single scope to load the config into, at least for now
+    #stacks-internals #load-config();
+
+//      MIXIN:
+//      Navigation item
 //
+//      HOW IT WORKS:
+//      Defines the s-navigation--item with the colors to be used. 
+//      The default values are the ones used by the base style.
+//      Style modifications can pass different colors as needed.
+//  ----------------------------------------------------------------------------
+.s-navigation--item(@fc: @black-600, @hover-bg: @black-100, @hover-fc: @black-600, @selected-bg: @navigation-link-highlight, @selected-fc: @white){
+    .s-navigation--item {
+        padding: @su6 @su16;
+        border-radius: 1000px;
+        margin: @su2;
+        color: @fc;
+    
+        &:hover,
+        &:active {
+            background: @hover-bg;
+            color: @hover-fc;
+        }
+    
+        &.is-selected {
+            background: @selected-bg;
+            color: @selected-fc;
+    
+            &:hover {
+                background: darken(@selected-bg,10%);
+            }
+        }
+    }
+}
+
 //  ============================================================================
-//  $   BASE STYLES
+//  $   BASE STYLE
 //  ----------------------------------------------------------------------------
 .s-navigation {
     display: flex;
@@ -25,27 +62,15 @@
 
         @scrollbar-styles();
     }
+
+    .s-navigation--item();
 }
 
-.s-navigation--item {
-    #stacks-internals #load-config();
-    padding: @su6 @su16;
-    border-radius: 1000px;
-    margin: @su2;
-    color: @black-600;
+//  ============================================================================
+//  $   MUTED STYLE
+//  ----------------------------------------------------------------------------
+.s-navigation__muted {
+    .s-navigation--item(@selected-bg: @black-050, @selected-fc:@black-800);
+}
 
-    &:hover,
-    &:active {
-        background: @black-100;
-        color: @black-600;
-    }
-
-    &.is-selected {
-        background: @navigation-link-highlight;
-        color: @white;
-
-        &:hover {
-            background: darken(@navigation-link-highlight,10%);
-        }
-    }
 }

--- a/lib/css/components/_stacks-navigation.less
+++ b/lib/css/components/_stacks-navigation.less
@@ -11,45 +11,12 @@
 //  • MUTED STYLE
 
 
-& { // create a single scope to load the config into, at least for now
-    #stacks-internals #load-config();
-
-//      MIXIN:
-//      Navigation item
-//
-//      HOW IT WORKS:
-//      Defines the s-navigation--item with the colors to be used. 
-//      The default values are the ones used by the base style.
-//      Style modifications can pass different colors as needed.
-//  ----------------------------------------------------------------------------
-.s-navigation--item(@fc: @black-600, @hover-bg: @black-100, @hover-fc: @black-600, @selected-bg: @navigation-link-highlight, @selected-fc: @white){
-    .s-navigation--item {
-        padding: @su6 @su16;
-        border-radius: 1000px;
-        margin: @su2;
-        color: @fc;
-    
-        &:hover,
-        &:active {
-            background: @hover-bg;
-            color: @hover-fc;
-        }
-    
-        &.is-selected {
-            background: @selected-bg;
-            color: @selected-fc;
-    
-            &:hover {
-                background: darken(@selected-bg,10%);
-            }
-        }
-    }
-}
-
 //  ============================================================================
 //  $   BASE STYLE
 //  ----------------------------------------------------------------------------
 .s-navigation {
+    #stacks-internals #load-config();
+
     display: flex;
     margin: -@su2;
     padding: @su2 0;
@@ -63,14 +30,40 @@
         @scrollbar-styles();
     }
 
-    .s-navigation--item();
-}
+    .s-navigation--item {
+        padding: @su6 @su16;
+        border-radius: 1000px;
+        margin: @su2;
+        color: @black-600;
+    
+        &:hover,
+        &:active {
+            background: @black-100;
+            color: @black-600;
+        }
+    
+        &.is-selected {
+            background: @navigation-link-highlight;
+            color: @white;
+    
+            &:hover {
+                background: darken(@navigation-link-highlight,10%);
+            }
+        }
+    }
 
-//  ============================================================================
-//  $   MUTED STYLE
-//  ----------------------------------------------------------------------------
-.s-navigation__muted {
-    .s-navigation--item(@selected-bg: @black-050, @selected-fc:@black-800);
-}
+    //  ============================================================================
+    //  $   MUTED STYLE
+    //  ----------------------------------------------------------------------------
 
+    &.s-navigation__muted .s-navigation--item {
+        &.is-selected {
+            background: @black-050;
+            color: @black-800;
+
+            &:hover {
+                background: @black-100;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Stacks only support 1 style for the Navigation component, and trying to add 2 of these components on the same page can look confusing for the user. 

This PR introduces a "Muted" variation of the component that can be used as a secondary navigation on a page that already has a primary one. 

This is how it looks:

![image](https://user-images.githubusercontent.com/6766854/67898516-3d367000-fb3f-11e9-8667-282eba6d2238.png)

In order to use it, the class `s-navigation__muted` should be added to the parent element, using the same pattern that the muted variation for buttons use (`s-btn s-btn__muted`)