### PR TITLE
Remove webkit-overflow-scroll

### DIFF
--- a/lib/css/exports/_stacks-constants-helpers.less
+++ b/lib/css/exports/_stacks-constants-helpers.less
@@ -101,8 +101,6 @@
 //  $   SCROLLBAR STYLING
 //  ----------------------------------------------------------------------------
 @scrollbar-styles: {
-    -webkit-overflow-scrolling: touch;
-
     &::-webkit-scrollbar {
         width: @su8;
         height: @su8;


### PR DESCRIPTION
Inertial scrolling is now default on iOS 13. Killing this, since it was also causing a bug in our proposed topbar.