### PR TITLE
Content: Success messages

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -190,6 +190,8 @@
           url: content/examples/alt-text
         - title: Error messages
           url: content/examples/error-messages
+        - title: Success messages
+          url: content/examples/success-messages
 - title: Brand
   url: brand/principles
   sublinks:

--- a/docs/content/examples/success-messages.html
+++ b/docs/content/examples/success-messages.html
@@ -70,18 +70,22 @@ description: It’s important that we keep users informed when actions are succe
         </thead>
         <tbody>
             <tr>
-                <td>“We’ve saved your profile changes.”
+                <td>
+                    <p>“We’ve saved your profile changes.”</p>
                     <button class="s-btn s-btn__primary" type="button">OK</button>
                 </td>
-                <td>“We’ve saved your profile changes.”
+                <td>
+                    <p>“We’ve saved your profile changes.”</p>
                     <button class="s-btn s-btn__primary" type="button">View profile</button>
                 </td>
             </tr>
             <tr>
-                <td>“Your payment is complete.”
+                <td>
+                    <p>“Your payment is complete.”</p>
                     <button class="s-btn s-btn__primary" type="button">OK</button>
                 </td>
-                <td>“Your payment is complete.”
+                <td>
+                    <p>“Your payment is complete.”</p>
                     <button class="s-btn s-btn__primary" type="button">View receipt</button>
                 </td>
             </tr>

--- a/docs/content/examples/success-messages.html
+++ b/docs/content/examples/success-messages.html
@@ -71,25 +71,19 @@ description: It’s important that we keep users informed when actions are succe
         <tbody>
             <tr>
                 <td>“We’ve saved your profile changes.”
-                  <div class="grid gs8 gsx ai-center">
                       <button class="grid--cell s-btn s-btn__primary js-modal-primary-btn" type="button">OK</button>
-                  </div>
                 </td>
                 <td>“We’ve saved your profile changes.”
-                  <div class="grid gs8 gsx ai-center">
                       <button class="grid--cell s-btn s-btn__primary js-modal-primary-btn" type="button">View profile</button>
-                  </div>
                 </td>
             </tr>
             <tr>
                 <td>“Your payment is complete.”
-                  <div class="grid gs8 gsx ai-center">
                       <button class="grid--cell s-btn s-btn__primary js-modal-primary-btn" type="button">OK</button>
-                  </div></td>
+                    </td>
                 <td>“Your payment is complete.”
-                  <div class="grid gs8 gsx ai-center">
                       <button class="grid--cell s-btn s-btn__primary js-modal-primary-btn" type="button">View receipt</button>
-                  </div></td>
+                    </td>
             </tr>
         </tbody>
     </table>

--- a/docs/content/examples/success-messages.html
+++ b/docs/content/examples/success-messages.html
@@ -1,0 +1,103 @@
+---
+layout: page
+title: Success messages
+description: It’s important that we keep users informed when actions are successfully completed. Success states throughout the user flow let users know that they’re either getting closer to achieving the goal, or have completed it.
+---
+<section class="stacks-section">
+    {% header h2 | Understand the situation %}
+    <p class="stacks-copy">
+        Before writing anything, make sure you know the answers to these questions:
+    </p>
+    <ul class="stacks-list">
+        <li>How close is the user to achieving the intended goal?</li>
+        <li>What does the user need to do next?</li>
+        <li>Is this message likely to appear frequently or is it unique?</li>
+    </ul>
+</section>
+<section class="stacks-section">
+    {% header h2 | Be specific %}
+    <p class="stacks-copy">
+        A good success message provides clear information that the performed action was completed. It’s fine to let users know that what they did was successful, but even better to be specific about the action they took.
+    </p>
+    <table class="s-table s-table__lg fs-body2 va-top w100 wmx6 mb48">
+        <thead>
+            <th class="btw0 bxw0 bbw3 bbw3 bc-red-2 fc-red-500 bg-transparent fs-body1 s-table--cell4">{% icon Clear | mtn1 mbn1 %} Don’t</th>
+            <th class="btw0 bxw0 bbw3 bc-green-2 fc-green-500 bg-transparent fs-body1 s-table--cell4">{% icon Checkmark | mtn1 mbn1 %} Do</th>
+        </thead>
+        <tbody>
+            <tr>
+                <td>“Successfully saved.”</td>
+                <td>“Your account details have been saved.”</td>
+            </tr>
+            <tr>
+                <td>“Upgrade complete.”</td>
+                <td>“You’ve upgraded to the Business tier of Teams.”</td>
+            </tr>
+        </tbody>
+    </table>
+</section>
+<section class="stacks-section">
+    {% header h2 | Use the right tone %}
+    <p class="stacks-copy">
+        <a href="{{ "/content/guidelines/voice-and-tone#tone" | relative_url }}">Tone is how you say something</a>. Excitement makes sense for successfully finishing a large task, but avoid overdoing it for a regular system success. Limit <a href="{{ "/content/guidelines/grammar-and-mechanics#exclamation-points" | relative_url }}">exclamation marks</a> to one per page.
+    </p>
+    <table class="s-table s-table__lg fs-body2 va-top w100 wmx6 mb48">
+        <thead>
+            <th class="btw0 bxw0 bbw3 bbw3 bc-red-2 fc-red-500 bg-transparent fs-body1 s-table--cell4">{% icon Clear | mtn1 mbn1 %} Don’t</th>
+            <th class="btw0 bxw0 bbw3 bc-green-2 fc-green-500 bg-transparent fs-body1 s-table--cell4">{% icon Checkmark | mtn1 mbn1 %} Do</th>
+        </thead>
+        <tbody>
+            <tr>
+                <td>“Thanks for updating your email.”</td>
+                <td>“Your email has been updated.”</td>
+            </tr>
+            <tr>
+                <td>“Account created.”</td>
+                <td>“Thanks for signing up. Your account has been created.”</td>
+            </tr>
+        </tbody>
+    </table>
+</section>
+<section class="stacks-section">
+    {% header h2 | What happens next %}
+    <p class="stacks-copy">
+        Is the success part of a larger goal? Are there other recommended actions that need to be performed? Success messages can be a good way to guide the user to the next action for a more seamless interaction.
+    </p>
+    <table class="s-table s-table__lg fs-body2 va-top w100 wmx6 mb48">
+        <thead>
+            <th class="btw0 bxw0 bbw3 bbw3 bc-red-2 fc-red-500 bg-transparent fs-body1 s-table--cell4">{% icon Clear | mtn1 mbn1 %} Don’t</th>
+            <th class="btw0 bxw0 bbw3 bc-green-2 fc-green-500 bg-transparent fs-body1 s-table--cell4">{% icon Checkmark | mtn1 mbn1 %} Do</th>
+        </thead>
+        <tbody>
+            <tr>
+                <td>“We’ve saved your profile changes.”
+                  <div class="grid gs8 gsx ai-center">
+                      <button class="grid--cell s-btn s-btn__primary js-modal-primary-btn" type="button">OK</button>
+                  </div>
+                </td>
+                <td>“We’ve saved your profile changes.”
+                  <div class="grid gs8 gsx ai-center">
+                      <button class="grid--cell s-btn s-btn__primary js-modal-primary-btn" type="button">View profile</button>
+                  </div>
+                </td>
+            </tr>
+            <tr>
+                <td>“Your payment is complete.”
+                  <div class="grid gs8 gsx ai-center">
+                      <button class="grid--cell s-btn s-btn__primary js-modal-primary-btn" type="button">OK</button>
+                  </div></td>
+                <td>“Your payment is complete.”
+                  <div class="grid gs8 gsx ai-center">
+                      <button class="grid--cell s-btn s-btn__primary js-modal-primary-btn" type="button">View receipt</button>
+                  </div></td>
+            </tr>
+        </tbody>
+    </table>
+<section class="stacks-section">
+    {% header h2 | Design, placement, and timing %}
+    <ul class="stacks-list">
+        <li><a href="{{ "/product/components/inputs#validation-states" | relative_url }}">Inline validation</a> styles are best for displaying success in <strong>UI with form fields</strong>.</li>
+        <li><a href="{{ "/product/components/notices#inline" | relative_url }}">Toasts</a> are best for <strong>common success messages</strong>. Since they appear away from the layout and disappear after a few seconds, these are great for simple actions that were successfully completed.</li>
+    <li><a href="{{ "/product/components/modals" | relative_url }}">Modals</a> are best when you want to ensure you <strong>capture someone’s focus</strong> for a decision.</li>
+    </ul>
+</section>

--- a/docs/content/examples/success-messages.html
+++ b/docs/content/examples/success-messages.html
@@ -71,19 +71,19 @@ description: It’s important that we keep users informed when actions are succe
         <tbody>
             <tr>
                 <td>“We’ve saved your profile changes.”
-                      <button class="grid--cell s-btn s-btn__primary js-modal-primary-btn" type="button">OK</button>
+                    <button class="s-btn s-btn__primary" type="button">OK</button>
                 </td>
                 <td>“We’ve saved your profile changes.”
-                      <button class="grid--cell s-btn s-btn__primary js-modal-primary-btn" type="button">View profile</button>
+                    <button class="s-btn s-btn__primary" type="button">View profile</button>
                 </td>
             </tr>
             <tr>
                 <td>“Your payment is complete.”
-                      <button class="grid--cell s-btn s-btn__primary js-modal-primary-btn" type="button">OK</button>
-                    </td>
+                    <button class="s-btn s-btn__primary" type="button">OK</button>
+                </td>
                 <td>“Your payment is complete.”
-                      <button class="grid--cell s-btn s-btn__primary js-modal-primary-btn" type="button">View receipt</button>
-                    </td>
+                    <button class="s-btn s-btn__primary" type="button">View receipt</button>
+                </td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
This PR is for issue #394 . Similar to error messages, we often find ourselves writing lots of "success" or "confirmation" messages in the product. It would be helpful to have a framework for us to quickly write consistent, helpful confirmation messages.

I've revised the draft based on feedback and have created a new Stacks page within the content section. 

### To-do
- [x] Create new page
- [x] Add content into page
- [x] Fix buttons in the do/dont table
- [ ] Feedback on everything