### PR TITLE
Add CSS selectors that force Samsung email clients to display emails at full width

### DIFF
--- a/docs/email/templates/code/promotional.html
+++ b/docs/email/templates/code/promotional.html
@@ -14,7 +14,7 @@
         /* Beware: It can remove the padding / margin and add a background color to the compose a reply window. */
         html,
         body {
-            margin: 0 !important;
+            margin: 0 auto !important;
             padding: 0 !important;
             height: 100% !important;
             width: 100% !important;
@@ -43,6 +43,12 @@
             border: 0;
             border-spacing: 0;
             border-collapse: collapse
+        }
+
+        /* What it does: Forces Samsung Android mail clients to use the entire viewport. */
+        #MessageViewBody,
+        #MessageWebViewDiv{
+            width: 100% !important;
         }
 
         /* What it does: Uses a better rendering method when resizing images in IE. */

--- a/docs/email/templates/code/transactional-long.html
+++ b/docs/email/templates/code/transactional-long.html
@@ -14,7 +14,7 @@
         /* Beware: It can remove the padding / margin and add a background color to the compose a reply window. */
         html,
         body {
-            margin: 0 !important;
+            margin: 0 auto !important;
             padding: 0 !important;
             height: 100% !important;
             width: 100% !important;
@@ -43,6 +43,12 @@
             border: 0;
             border-spacing: 0;
             border-collapse: collapse
+        }
+
+        /* What it does: Forces Samsung Android mail clients to use the entire viewport. */
+        #MessageViewBody,
+        #MessageWebViewDiv{
+            width: 100% !important;
         }
 
         /* What it does: Uses a better rendering method when resizing images in IE. */

--- a/docs/email/templates/code/transactional-short.html
+++ b/docs/email/templates/code/transactional-short.html
@@ -14,7 +14,7 @@
         /* Beware: It can remove the padding / margin and add a background color to the compose a reply window. */
         html,
         body {
-            margin: 0 !important;
+            margin: 0 auto !important;
             padding: 0 !important;
             height: 100% !important;
             width: 100% !important;
@@ -43,6 +43,12 @@
             border: 0;
             border-spacing: 0;
             border-collapse: collapse
+        }
+
+        /* What it does: Forces Samsung Android mail clients to use the entire viewport. */
+        #MessageViewBody,
+        #MessageWebViewDiv{
+            width: 100% !important;
         }
 
         /* What it does: Uses a better rendering method when resizing images in IE. */


### PR DESCRIPTION
This PR fixes a bug where our emails weren't displaying at 100% width in Samsung email clients.

Before vs after:

<img width="947" alt="Screen Shot 2019-12-03 at 9 11 38 AM" src="https://user-images.githubusercontent.com/1172461/70058475-f956e080-15ac-11ea-8696-d0d6d7629dd8.png">

---

This fixes #421 