### PR TITLE
Fix bad popover attribute documentation

### DIFF
--- a/docs/product/components/popovers.html
+++ b/docs/product/components/popovers.html
@@ -50,7 +50,7 @@ description: Popovers are small content containers that provide a contextual ove
                     <td class="p8">Wires up the element to the popover controller. This may be a toggling element or a wrapper element.</td>
                 </tr>
                 <tr>
-                    <th scope="row"><code class="stacks-code">data-s-popover-reference-element="[css selector]"</code></th>
+                    <th scope="row"><code class="stacks-code">data-s-popover-reference-selector="[css selector]"</code></th>
                     <td>Controller element</td>
                     <td class="p8"><span class="s-label--status ml0">Optional</span> Designates the element to use as the popover reference. If left unset, the value defaults to the controller element.</td>
                 </tr>


### PR DESCRIPTION
Fixes bad attribute from `reference-element` to `reference-selector` (which is what is used in the code and the existing example).