### PR TITLE
 Allow s-tag-sponsor to contain an svg icon

### DIFF
--- a/lib/css/components/_stacks-tags.less
+++ b/lib/css/components/_stacks-tags.less
@@ -116,6 +116,11 @@ a.s-tag {
     margin: -(@su2 + 1) @su4 -(@su2) -(@su2);
     max-width: 18px;
     border-radius: @br-sm - 1;
+
+    .svg-icon, img {
+        width: 100%;
+        height: 100%;
+    }
 }
 
 


### PR DESCRIPTION
On occasion we might need a sponsor's image to be an svg icon. This change allows us to wrap the icon with the `.s-tag--sponsor` class like so:

```html
    <div class="ba bc-black-8 bg-black-025 s-tag--sponsor">
        @Svg.Person.With("fc-black-700")
    </div>
```

We then get  something like:

![image](https://user-images.githubusercontent.com/14169651/73109208-86912400-3ed0-11ea-9826-e29c00ae8c6b.png)
