### PR TITLE
Various improvements to modals

### DIFF
--- a/docs/product/components/examples/banners.html
+++ b/docs/product/components/examples/banners.html
@@ -1,5 +1,5 @@
 <!-- Additional javascript -->
-<script src="{{ "/assets/js/feature.banners.js" | relative_url }}"></script>
+<script src="{{ site.baseurl }}/{{ site.js }}/feature.banners.js" defer></script>
 
 <!-- Override stacks classes for demos -->
 <style>

--- a/docs/product/components/modals.html
+++ b/docs/product/components/modals.html
@@ -57,7 +57,7 @@ description: Modals are dialog overlays that prevent the user from interacting w
 </aside>
 {% endhighlight %}
         <div class="stacks-preview--example ps-relative grid jc-center hs3">
-            <aside class="s-modal ps-absolute bbr-sm z-base mn1" id="modal-base" aria-hidden="false" style="-webkit-backdrop-filter: blur(0) grayscale(0);">
+            <aside class="s-modal ps-absolute bbr-sm z-base mtn1 mrn1 mbn1 mln1" id="modal-base" aria-hidden="false">
                 <div class="s-modal--dialog ps-relative" role="document" style="transform: none;">
                     <h1 class="s-modal--header" id="modal-title">Example title</h1>
                     <p class="s-modal--body" id="modal-description">Nullam ornare lectus vitae lacus sagittis, at sodales leo viverra. Suspendisse nec nulla dignissim elit varius tempus. Cras viverra neque at imperdiet vehicula. Curabitur condimentum id dolor vitae ultrices. Pellentesque scelerisque nunc sit amet leo fringilla bibendum. Etiam feugiat imperdiet mi, eu blandit arcu cursus a.</p>
@@ -137,7 +137,7 @@ description: Modals are dialog overlays that prevent the user from interacting w
 </aside>
 {% endhighlight %}
         <div class="stacks-preview--example ps-relative grid jc-center hs3">
-            <aside class="s-modal s-modal__danger ps-absolute bbr-sm z-base mn1" id="modal-base" aria-hidden="false" style="-webkit-backdrop-filter: blur(0) grayscale(0);">
+            <aside class="s-modal s-modal__danger ps-absolute bbr-sm z-base mtn1 mrn1 mbn1 mln1" id="modal-base" aria-hidden="false">
                 <div class="s-modal--dialog ps-relative" role="document" style="transform: none;">
                     <h1 class="s-modal--header" id="modal-title">Example title</h1>
                     <p class="s-modal--body" id="modal-description">Nullam ornare lectus vitae lacus sagittis, at sodales leo viverra. Suspendisse nec nulla dignissim elit varius tempus. Cras viverra neque at imperdiet vehicula. Curabitur condimentum id dolor vitae ultrices. Pellentesque scelerisque nunc sit amet leo fringilla bibendum. Etiam feugiat imperdiet mi, eu blandit arcu cursus a.</p>

--- a/docs/product/components/modals.html
+++ b/docs/product/components/modals.html
@@ -179,4 +179,4 @@ description: Modals are dialog overlays that prevent the user from interacting w
     </div>
 </section>
 
-<script src="{{ "/assets/js/feature.modals.js" | relative_url }}"></script>
+<script src="{{ site.baseurl }}/{{ site.js }}/feature.modals.js" defer></script>

--- a/docs/product/components/modals.html
+++ b/docs/product/components/modals.html
@@ -56,8 +56,8 @@ description: Modals are dialog overlays that prevent the user from interacting w
     </div>
 </aside>
 {% endhighlight %}
-        <div class="stacks-preview--example ps-relative grid jc-center" style="height: 320px;">
-            <aside class="s-modal ps-absolute bbr-sm z-base mn1" id="modal-base" aria-hidden="false">
+        <div class="stacks-preview--example ps-relative grid jc-center hs3">
+            <aside class="s-modal ps-absolute bbr-sm z-base mn1" id="modal-base" aria-hidden="false" style="-webkit-backdrop-filter: blur(0) grayscale(0);">
                 <div class="s-modal--dialog ps-relative" role="document" style="transform: none;">
                     <h1 class="s-modal--header" id="modal-title">Example title</h1>
                     <p class="s-modal--body" id="modal-description">Nullam ornare lectus vitae lacus sagittis, at sodales leo viverra. Suspendisse nec nulla dignissim elit varius tempus. Cras viverra neque at imperdiet vehicula. Curabitur condimentum id dolor vitae ultrices. Pellentesque scelerisque nunc sit amet leo fringilla bibendum. Etiam feugiat imperdiet mi, eu blandit arcu cursus a.</p>
@@ -136,9 +136,9 @@ description: Modals are dialog overlays that prevent the user from interacting w
     </div>
 </aside>
 {% endhighlight %}
-        <div class="stacks-preview--example ps-relative grid jc-center" style="height: 320px;">
-            <aside class="s-modal has-danger ps-absolute bbr-sm z-base" id="modal-base" aria-hidden="false" style="margin: -1px;">
-                <div class="s-modal--dialog ps-relative" role="document"  style="transform: none;">
+        <div class="stacks-preview--example ps-relative grid jc-center hs3">
+            <aside class="s-modal has-danger ps-absolute bbr-sm z-base mn1" id="modal-base" aria-hidden="false" style="-webkit-backdrop-filter: blur(0) grayscale(0);">
+                <div class="s-modal--dialog ps-relative" role="document" style="transform: none;">
                     <h1 class="s-modal--header" id="modal-title">Example title</h1>
                     <p class="s-modal--body" id="modal-description">Nullam ornare lectus vitae lacus sagittis, at sodales leo viverra. Suspendisse nec nulla dignissim elit varius tempus. Cras viverra neque at imperdiet vehicula. Curabitur condimentum id dolor vitae ultrices. Pellentesque scelerisque nunc sit amet leo fringilla bibendum. Etiam feugiat imperdiet mi, eu blandit arcu cursus a.</p>
                     <div class="grid gs8 gsx s-modal--footer">

--- a/docs/product/components/modals.html
+++ b/docs/product/components/modals.html
@@ -19,7 +19,7 @@ description: Modals are dialog overlays that prevent the user from interacting w
 </aside>
 
 <!-- Example danger modal content -->
-<aside class="s-modal has-danger js-modal-overlay js-modal-close" id="modal-danger" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true">
+<aside class="s-modal s-modal__danger js-modal-overlay js-modal-close" id="modal-danger" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true">
     <div class="s-modal--dialog js-modal-dialog" role="document">
         <h1 class="s-modal--header" id="modal-title">Example danger title</h1>
         <p class="s-modal--body" id="modal-description">Nullam ornare lectus vitae lacus sagittis, at sodales leo viverra. Suspendisse nec nulla dignissim elit varius tempus. Cras viverra neque at imperdiet vehicula. Curabitur condimentum id dolor vitae ultrices. Pellentesque scelerisque nunc sit amet leo fringilla bibendum. Etiam feugiat imperdiet mi, eu blandit arcu cursus a. Pellentesque cursus massa id dolor ullamcorper, at condimentum nunc ultrices.</p>
@@ -119,10 +119,10 @@ description: Modals are dialog overlays that prevent the user from interacting w
 
 <section class="stacks-section">
     {% header h2 | Danger state %}
-    <p class="stacks-copy">Not every modal is sunshine and rainbows. Sometimes there are potentially drastic things that could happen by hitting a confirm button in a modal—such as deleting an account. In moments like this, add the <code class="stacks-code">.has-danger</code> class to <code class="stacks-code">.s-modal</code>. Additionally, you should switch the buttons to <code class="stacks-code">.s-btn__danger.s-btn__filled</code>, since the main call to action will be destructive.</p>
+    <p class="stacks-copy">Not every modal is sunshine and rainbows. Sometimes there are potentially drastic things that could happen by hitting a confirm button in a modal—such as deleting an account. In moments like this, add the <code class="stacks-code">.s-modal__danger</code> class to <code class="stacks-code">.s-modal</code>. Additionally, you should switch the buttons to <code class="stacks-code">.s-btn__danger.s-btn__filled</code>, since the main call to action will be destructive.</p>
     <div class="stacks-preview">
 {% highlight html %}
-<aside class="s-modal has-danger js-modal-overlay js-modal-close" id="modal-base" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true">
+<aside class="s-modal s-modal__danger js-modal-overlay js-modal-close" id="modal-base" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true">
     <div class="s-modal--dialog js-modal-dialog" role="document">
         <h1 class="s-modal--header" id="modal-title">…</h1>
         <p class="s-modal--body" id="modal-description">…</p>
@@ -137,7 +137,7 @@ description: Modals are dialog overlays that prevent the user from interacting w
 </aside>
 {% endhighlight %}
         <div class="stacks-preview--example ps-relative grid jc-center hs3">
-            <aside class="s-modal has-danger ps-absolute bbr-sm z-base mn1" id="modal-base" aria-hidden="false" style="-webkit-backdrop-filter: blur(0) grayscale(0);">
+            <aside class="s-modal s-modal__danger ps-absolute bbr-sm z-base mn1" id="modal-base" aria-hidden="false" style="-webkit-backdrop-filter: blur(0) grayscale(0);">
                 <div class="s-modal--dialog ps-relative" role="document" style="transform: none;">
                     <h1 class="s-modal--header" id="modal-title">Example title</h1>
                     <p class="s-modal--body" id="modal-description">Nullam ornare lectus vitae lacus sagittis, at sodales leo viverra. Suspendisse nec nulla dignissim elit varius tempus. Cras viverra neque at imperdiet vehicula. Curabitur condimentum id dolor vitae ultrices. Pellentesque scelerisque nunc sit amet leo fringilla bibendum. Etiam feugiat imperdiet mi, eu blandit arcu cursus a.</p>

--- a/docs/product/components/notices.html
+++ b/docs/product/components/notices.html
@@ -4,7 +4,7 @@ title: Notices
 description: Notices deliver <strong>System</strong> and <strong>Engagement</strong> messaging, informing the user about product or account statuses and related actions.
 ---
 <!-- Example notice content -->
-<script src="{{ "/assets/js/feature.notices.js" | relative_url }}"></script>
+<script src="{{ site.baseurl }}/{{ site.js }}/feature.notices.js" defer></script>
 <div class="s-toast js-notice-toast" aria-hidden="true">
     <aside class="s-notice s-notice__success">
         <div class="grid gs16 gsx ai-center jc-space-between" aria-describedby="notice-message">

--- a/lib/css/components/_stacks-modals.less
+++ b/lib/css/components/_stacks-modals.less
@@ -34,6 +34,7 @@
     backface-visibility: hidden;
     transition: opacity 100ms @te-smooth 0s, z-index 0s 100ms, visibility 0s 100ms; // Transition out
     will-change: visibility, z-index, opacity; // Not supported in Edge
+    -webkit-backdrop-filter: blur(3px) grayscale(0.5); // For webkit, let's blur the backdrop and fade the colors a bit
 
     &[aria-hidden="false"],
     &[aria-hidden="false"] .s-modal--dialog {

--- a/lib/css/components/_stacks-modals.less
+++ b/lib/css/components/_stacks-modals.less
@@ -34,8 +34,8 @@
     backface-visibility: hidden;
     transition: opacity 100ms @te-smooth 0s, z-index 0s 100ms, visibility 0s 100ms; // Transition out
     will-change: visibility, z-index, opacity; // Not supported in Edge
-    -webkit-backdrop-filter: blur(3px) grayscale(0.5); // Let's blur the backdrop and fade the colors a bit if your browser supports it.
-    backdrop-filter: blur(3px) grayscale(0.5); // Safari 12-13 needs the prefixing, but Chrome 79 does not.
+    -webkit-backdrop-filter: blur(3px) grayscale(0.25); // Let's blur the backdrop and fade the colors a bit if your browser supports it.
+    backdrop-filter: blur(3px) grayscale(0.25); // Safari 12-13 needs the prefixing, but Chrome 79 does not.
 
     &[aria-hidden="false"],
     &[aria-hidden="false"] .s-modal--dialog {

--- a/lib/css/components/_stacks-modals.less
+++ b/lib/css/components/_stacks-modals.less
@@ -34,8 +34,6 @@
     backface-visibility: hidden;
     transition: opacity 100ms @te-smooth 0s, z-index 0s 100ms, visibility 0s 100ms; // Transition out
     will-change: visibility, z-index, opacity; // Not supported in Edge
-    -webkit-backdrop-filter: blur(3px) grayscale(0.25); // Let's blur the backdrop and fade the colors a bit if your browser supports it.
-    backdrop-filter: blur(3px) grayscale(0.25); // Safari 12-13 needs the prefixing, but Chrome 79 does not.
 
     &[aria-hidden="false"],
     &[aria-hidden="false"] .s-modal--dialog {

--- a/lib/css/components/_stacks-modals.less
+++ b/lib/css/components/_stacks-modals.less
@@ -34,7 +34,7 @@
     backface-visibility: hidden;
     transition: opacity 100ms @te-smooth 0s, z-index 0s 100ms, visibility 0s 100ms; // Transition out
     will-change: visibility, z-index, opacity; // Not supported in Edge
-    -webkit-backdrop-filter: blur(3px) grayscale(0.5); // For webkit, let's blur the backdrop and fade the colors a bit
+    -webkit-backdrop-filter: blur(3px) grayscale(0.5); // In Safari, let's blur the backdrop and fade the colors a bit
 
     &[aria-hidden="false"],
     &[aria-hidden="false"] .s-modal--dialog {
@@ -58,26 +58,13 @@
     box-shadow: @bs-lg;
     opacity: 0;
     backface-visibility: hidden;
-    transform: translate(0, 30%) scale(0.6, 0.6); // This translate default is added for IE11 but is overwritten to translate3d see [1]
+    transform: translate3d(0, 30%, 0) scale3d(0.6, 0.6, 0.6);
 
     transition: opacity 200ms @te-smooth 0s, z-index 0s 100ms, visibility 0s 100ms, transform 100ms @te-smooth 0s, transform 100ms @te-smooth 0s; // Transition out
-    will-change: visibility, z-index, opacity, transform; // Not supported in IE11 / Edge
-    -webkit-overflow-scrolling: touch; // Make scrolling have inertia on mobile devices.
+    will-change: visibility, z-index, opacity, transform; // Not supported by Edge
 
     .s-modal[aria-hidden="false"] & {
-        transform: translate(0, 0) scale(1, 1); // This translate default is added for IE11 but is overwritten to translate3d see [1]
-    }
-
-    // [1] Things are blurry when using translate3d in IE11. translate3d is required for
-    // hardware acceleration everywhere else, so let's default to standard translate, but check for
-    // modern browsers and use translate3d there..
-    // It doesn't matter what feature query we check -- IE doesn't support @supports.
-    @supports (display: block) {
-        transform: translate3d(0, 30%, 0) scale3d(0.6, 0.6, 0.6);
-
-        .s-modal[aria-hidden="false"] & {
-            transform: translate3d(0, 0, 0) scale3d(1, 1, 1);
-        }
+        transform: translate3d(0, 0, 0) scale3d(1, 1, 1); // Transition in
     }
 }
 

--- a/lib/css/components/_stacks-modals.less
+++ b/lib/css/components/_stacks-modals.less
@@ -34,7 +34,8 @@
     backface-visibility: hidden;
     transition: opacity 100ms @te-smooth 0s, z-index 0s 100ms, visibility 0s 100ms; // Transition out
     will-change: visibility, z-index, opacity; // Not supported in Edge
-    -webkit-backdrop-filter: blur(3px) grayscale(0.5); // In Safari, let's blur the backdrop and fade the colors a bit
+    -webkit-backdrop-filter: blur(3px) grayscale(0.5); // Let's blur the backdrop and fade the colors a bit if your browser supports it.
+    backdrop-filter: blur(3px) grayscale(0.5); // Safari 12-13 needs the prefixing, but Chrome 79 does not.
 
     &[aria-hidden="false"],
     &[aria-hidden="false"] .s-modal--dialog {

--- a/lib/css/components/_stacks-modals.less
+++ b/lib/css/components/_stacks-modals.less
@@ -116,7 +116,8 @@
 //  ============================================================================
 //  $   STATES
 //  ----------------------------------------------------------------------------
-.s-modal.has-danger {
+.s-modal.has-danger,
+.s-modal.s-modal__danger {
     background-color: darken(fade(@red-900, 50%), 23%);
 
     .s-modal--header {
@@ -125,7 +126,7 @@
 }
 
 #stacks-internals #darkmode('.s-modal.has-danger .s-modal--dialog', { background-color: var(--black-050) });
-
+#stacks-internals #darkmode('.s-modal.s-modal__danger .s-modal--dialog', { background-color: var(--black-050) });
 
 //  ============================================================================
 //  $   SIZES


### PR DESCRIPTION
This PR fixes some in-page JS, renames `.has-danger` to `.s-modal__danger` to be more consistent with our naming. It also removes some additional IE11 workarounds.

With Webkit, I've also experimented with blurring our backdrop.

![Screen Shot 2020-01-27 at 1 59 49 PM](https://user-images.githubusercontent.com/1369864/73209159-4b2f6900-410d-11ea-970c-7671179a41d8.png)