### PR TITLE
Refine scrollbar normalization

### DIFF
--- a/lib/css/exports/_stacks-constants-helpers.less
+++ b/lib/css/exports/_stacks-constants-helpers.less
@@ -101,18 +101,18 @@
 //  ----------------------------------------------------------------------------
 @scrollbar-styles: {
     &::-webkit-scrollbar {
-        width: @su8;
-        height: @su8;
+        width: @su812;
+        height: @su12;
         background-color: transparent;
     }
 
     &::-webkit-scrollbar-track {
-        border-radius: @su8;
+        border-radius: @su12;
         background-color: transparent;
     }
 
     &::-webkit-scrollbar-thumb {
-        border-radius: @su8;
+        border-radius: @su12;
         background-color: var(--scrollbar);
     }
 
@@ -122,5 +122,4 @@
     }
 
     scrollbar-color: var(--scrollbar) transparent;
-    scrollbar-width: thin;
 }

--- a/lib/css/exports/_stacks-constants-helpers.less
+++ b/lib/css/exports/_stacks-constants-helpers.less
@@ -101,18 +101,18 @@
 //  ----------------------------------------------------------------------------
 @scrollbar-styles: {
     &::-webkit-scrollbar {
-        width: @su12;
-        height: @su12;
+        width: @su12 - @su2;
+        height: @su12 - @su2;
         background-color: transparent;
     }
 
     &::-webkit-scrollbar-track {
-        border-radius: @su12;
+        border-radius: @su12 - @su2;
         background-color: transparent;
     }
 
     &::-webkit-scrollbar-thumb {
-        border-radius: @su12;
+        border-radius: @su12 - @su2;
         background-color: var(--scrollbar);
     }
 

--- a/lib/css/exports/_stacks-constants-helpers.less
+++ b/lib/css/exports/_stacks-constants-helpers.less
@@ -101,7 +101,7 @@
 //  ----------------------------------------------------------------------------
 @scrollbar-styles: {
     &::-webkit-scrollbar {
-        width: @su812;
+        width: @su12;
         height: @su12;
         background-color: transparent;
     }


### PR DESCRIPTION
This PR bumps the scrollbar size from `8px` to `10px` and removes `scrollbar-width: thin` from Firefox.

# Mac

### Firefox
![Screen Shot 2020-02-10 at 6 15 07 PM](https://user-images.githubusercontent.com/1369864/74202962-a300c080-4c33-11ea-9287-9387a98d8a3d.png)

### Chrome
![Screen Shot 2020-02-10 at 6 17 14 PM](https://user-images.githubusercontent.com/1369864/74202983-b449cd00-4c33-11ea-8061-132ed9f0a449.png)

### Safari
![Screen Shot 2020-02-10 at 6 18 02 PM](https://user-images.githubusercontent.com/1369864/74202990-ba3fae00-4c33-11ea-8a4f-80f78c21809e.png)

# Windows

### Firefox
![Screen Shot 2020-02-10 at 6 30 03 PM](https://user-images.githubusercontent.com/1369864/74203012-c88dca00-4c33-11ea-9a4c-f86b78d5e14f.png)

### Chrome
![Screen Shot 2020-02-10 at 6 26 37 PM](https://user-images.githubusercontent.com/1369864/74203016-ccb9e780-4c33-11ea-89c6-5e9fba0c77ac.png)

### Edge
![Screen Shot 2020-02-10 at 6 30 49 PM](https://user-images.githubusercontent.com/1369864/74203024-d3485f00-4c33-11ea-910d-66bf4d0d05ca.png)