### PR TITLE
Email spacers

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -165,6 +165,8 @@
           url: email/components/footers
         - title: Images
           url: email/components/images
+        - title: Spacers
+          url: email/components/spacers
         - title: Tags
           url: email/components/tags
         - title: Team identification

--- a/docs/email/components/spacers.html
+++ b/docs/email/components/spacers.html
@@ -1,0 +1,130 @@
+---
+layout: page
+title: Spacers
+description: Vertical spacers to create separation between table rows.
+---
+<section class="stacks-section">
+    {% header h2 | Base %}
+    <p class="stacks-copy">The best way to control spacing between components in HTML email is to use <code class="stacks-code">padding</code> (applied to <code class="stacks-code">&lt;td&gt;</code>’s) and <code class="stacks-code">margin</code> (applied to <code class="stacks-code">&lt;h&gt;</code> tags, <code class="stacks-code">&lt;p&gt;</code>’s, <code class="stacks-code">&lt;ol&gt;</code>’s, <code class="stacks-code">&lt;li&gt;</code>’s, etc.).</p>
+    <p class="stacks-copy">However <code class="stacks-code">padding</code> and <code class="stacks-code">margin</code> cannot be reliably used to space out <code class="stacks-code">&lt;table&gt;</code>’s or <code class="stacks-code">&lt;tr&gt;</code>’s. In these cases, it's best to use a spacer to create separation.</p>
+    <div class="stacks-preview mb24 bbr-sm">
+{% highlight html %}
+<tr>
+    <td aria-hidden="true" height="30" style="font-size: 0px; line-height: 0px;">
+        &nbsp;
+    </td>
+</tr>
+{% endhighlight %}
+        <div class="stacks-preview--example">
+            <div class="ba bc-black-5 bas-dashed fc-light fs-caption ta-center grid ai-center jc-center" style="height: 30px">
+                (size of the spacer)
+            </div>
+        </div>
+    </div>
+    {% header h3 | Syntax %}
+    <div class="overflow-x-auto mb32">
+        <table class="s-table s-table__bx-simple va-middle">
+            <thead>
+                <tr>
+                    <th class="s-table--cell5" scope="col">Name</th>
+                    <th scope="col">Description / Purpose</th>
+               </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><code class="stacks-code">height</code></td>
+                    <td>Size of the spacer.</td>
+                </tr>
+                <tr>
+                    <td><code class="stacks-code">aria-hidden="true"</code></td>
+                    <td>Hide the <code class="stacks-code">&amp;nbsp;</code> from screen readers.</td>
+                </tr>
+                <tr>
+                    <td><code class="stacks-code">&amp;nbsp;</code></td>
+                    <td>Some email clients will collapse the spacer's height if there’s no content.</td>
+                </tr>
+                <tr>
+                    <td><code class="stacks-code">style="font-size: 0px; line-height: 0px;"</code></td>
+                    <td>Some clients will add additional space inherited from the <code class="stacks-code">&amp;nbsp;</code>’s <code class="stacks-code">font-size</code> and <code class="stacks-code">line-height</code>.</td>
+                </tr>
+                <tr>
+                    <td><code class="stacks-code">background-color</code> <span class="s-badge s-badge__mini ml8">Optional</span></td>
+                    <td>Spacers are transparent by default but can be any color.</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    {% header h2 | Examples %}
+    {% header h3 | Spacer between two table rows %}
+    <p class="stacks-copy">Create separation between two table rows in the same section.</p>
+    <div class="stacks-preview mb24">
+{% highlight html %}
+<tr>
+    <td> … </td>
+</tr>
+<tr>
+    <td aria-hidden="true" height="30" style="font-size: 0px; line-height: 0px;">
+        &nbsp;
+    </td>
+</tr>
+<tr>
+    <td> … </td>
+</tr>
+{% endhighlight %}
+        <div class="stacks-preview--example">
+            <div class="grid ai-center">
+                <img src="https://placehold.it/192" width="96" height="96" alt="alt_text" border="0" class="mr16">
+                <div>
+                    <h2 class="fs-body3 fw-bold fc-dark mt0 mb8">Are your preferences up to date?</h2>
+                    <p class="fs-body2 fc-medium m0">Make sure we are recommending the best content for you.</p>
+                </div>
+            </div>
+            <div class="ba bc-black-5 bas-dashed fc-light fs-caption ta-center grid ai-center jc-center" style="height: 30px">
+                (spacer)
+            </div>
+            <div class="grid ai-center">
+                <img src="https://placehold.it/192" width="96" height="96" alt="alt_text" border="0" class="mr16">
+                <div>
+                    <h2 class="fs-body3 fw-bold fc-dark mt0 mb8">Are your preferences up to date?</h2>
+                    <p class="fs-body2 fc-medium m0">Make sure we are recommending the best content for you.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% header h3 | Spacer between two sections %}
+    <p class="stacks-copy">Create separation between two email sections.</p>
+    <div class="stacks-preview mb24">
+{% highlight html %}
+<tr>
+    <td style="background-color: #ffffff;" class="bar"> … </td>
+</tr>
+<tr>
+    <td aria-hidden="true" height="30" style="font-size: 0px; line-height: 0px;">
+        &nbsp;
+    </td>
+</tr>
+<tr>
+    <td style="background-color: #ffffff;" class="bar"> … </td>
+</tr>
+{% endhighlight %}
+        <div class="stacks-preview--example bg-black-050">
+            <div class="grid ai-center bg-white wmx5 mx-auto bar-md p16">
+                <img src="https://placehold.it/192" width="96" height="96" alt="alt_text" border="0" class="mr16">
+                <div>
+                    <h2 class="fs-body3 fw-bold fc-dark mt0 mb8">Are your preferences up to date?</h2>
+                    <p class="fs-body2 fc-medium m0">Make sure we are recommending the best content for you.</p>
+                </div>
+            </div>
+            <div class="fc-light fs-caption ta-center grid ai-center jc-center" style="height: 30px">
+                (spacer)
+            </div>
+            <div class="grid ai-center bg-white wmx5 mx-auto bar-md p16">
+                <img src="https://placehold.it/192" width="96" height="96" alt="alt_text" border="0" class="mr16">
+                <div>
+                    <h2 class="fs-body3 fw-bold fc-dark mt0 mb8">Are your preferences up to date?</h2>
+                    <p class="fs-body2 fc-medium m0">Make sure we are recommending the best content for you.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/docs/email/components/spacers.html
+++ b/docs/email/components/spacers.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Spacers
-description: Vertical spacers to create separation between table rows.
+description: Spacers are used to add separation between table rows.
 ---
 <section class="stacks-section">
     {% header h2 | Base %}

--- a/docs/email/components/spacers.html
+++ b/docs/email/components/spacers.html
@@ -6,7 +6,7 @@ description: Vertical spacers to create separation between table rows.
 <section class="stacks-section">
     {% header h2 | Base %}
     <p class="stacks-copy">The best way to control spacing between components in HTML email is to use <code class="stacks-code">padding</code> (applied to <code class="stacks-code">&lt;td&gt;</code>’s) and <code class="stacks-code">margin</code> (applied to <code class="stacks-code">&lt;h&gt;</code> tags, <code class="stacks-code">&lt;p&gt;</code>’s, <code class="stacks-code">&lt;ol&gt;</code>’s, <code class="stacks-code">&lt;li&gt;</code>’s, etc.).</p>
-    <p class="stacks-copy">However <code class="stacks-code">padding</code> and <code class="stacks-code">margin</code> cannot be reliably used to space out <code class="stacks-code">&lt;table&gt;</code>’s or <code class="stacks-code">&lt;tr&gt;</code>’s. In these cases, it's best to use a spacer to create separation.</p>
+    <p class="stacks-copy">However <code class="stacks-code">padding</code> and <code class="stacks-code">margin</code> cannot be used reliably to space out <code class="stacks-code">&lt;table&gt;</code>’s or <code class="stacks-code">&lt;tr&gt;</code>’s. In these cases, it's best to use a spacer to create separation.</p>
     <div class="stacks-preview mb24 bbr-sm">
 {% highlight html %}
 <tr>

--- a/docs/email/components/spacers.html
+++ b/docs/email/components/spacers.html
@@ -41,7 +41,7 @@ description: Spacers are used to add separation between table rows.
                 </tr>
                 <tr>
                     <td><code class="stacks-code">&amp;nbsp;</code></td>
-                    <td>Some email clients will collapse the spacer's height if there’s no content.</td>
+                    <td>Some email clients will collapse the spacer’s height if there’s no content.</td>
                 </tr>
                 <tr>
                     <td><code class="stacks-code">style="font-size: 0px; line-height: 0px;"</code></td>


### PR DESCRIPTION
This page documents how we use spacers to create vertical separation when `padding` and `margin` can't be used.

We've informally had this pattern [in one of our starter templates](https://github.com/StackExchange/Stacks/blob/develop/docs/email/templates/code/transactional-long.html#L410) from the start and I've pointed people to it enough times where I felt the need to document it here.

---

**Question:** Should we rename this to "Vertical Spacers?" I've never had the need to create a horizontal one.