### PR TITLE
Missing table cell

### DIFF
--- a/docs/product/base/colors.html
+++ b/docs/product/base/colors.html
@@ -126,6 +126,7 @@ description: To avoid specifying color values by hand, we’ve included a robust
                         <td>.bg-transparent</td>
                         <td></td>
                         <td></td>
+                        <td></td>
                     </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
There's a missing table cell causing little border glitch, especially visible in dark mode.

![image](https://user-images.githubusercontent.com/108287/74339632-c26b2b00-4da4-11ea-9c65-26a5a5132e4d.png)

¯\_(ツ)_/¯