### PR TITLE
Remove code color variables

### DIFF
--- a/lib/css/exports/_stacks-constants-colors.less
+++ b/lib/css/exports/_stacks-constants-colors.less
@@ -432,16 +432,3 @@ body.has-darkmode {
 body.has-darkmode__forced {
     .dark-colors();
 }
-
-//  ============================================================================
-//  $   PRODUCT-SPECIFIC COLOR VALUES
-//      These are used only within the code and badge displays
-//  ----------------------------------------------------------------------------
-//  --  Product / UI Colors
-@code-black:    #303336;
-@code-gray:     #858c93;
-@code-blue:     #0f74bd;
-@code-maroon:   #7d2727;
-@code-purple:   #101094;
-@code-teal:     #2b91af;
-@code-red:      #e64320;

--- a/lib/css/exports/_stacks-constants-colors.less
+++ b/lib/css/exports/_stacks-constants-colors.less
@@ -15,12 +15,12 @@
 @orange: #f48024;
 
 //  --  Accent Colors
-@yellow:    #fbf2d4;
-@green:     #5eba7d;
-@blue:      #0077cc;
-@powder:    #e1ecf4;
-@red:       #d1383d;
-@fog:       #f7f8f8;
+@yellow: #fbf2d4;
+@green: #5eba7d;
+@blue: #0077cc;
+@powder: #e1ecf4;
+@red: #d1383d;
+@fog: #f7f8f8;
 
 // Black
 @black-025: #fafafb;
@@ -114,15 +114,15 @@
 
 //  $  BADGES
 //  ----------------------------------------------------------------------------
-@gold:           #ffcc01;
-@gold-lighter:   #fff4d1;
-@gold-darker:    #f1b600;
+@gold: #ffcc01;
+@gold-lighter: #fff4d1;
+@gold-darker: #f1b600;
 
-@silver:         #b4b8bc;
+@silver: #b4b8bc;
 @silver-lighter: #e8e8e8;
-@silver-darker:  #9a9c9f;
+@silver-darker: #9a9c9f;
 
-@bronze:         #caa789;
+@bronze: #caa789;
 @bronze-lighter: #f2e9e1;
 @bronze-darker:  #ab825f;
 


### PR DESCRIPTION
We can apply these colors directly using pre-existing values from our color scales :v:

No need to keep these original colors around.

![image](https://user-images.githubusercontent.com/1369864/75196433-92674480-5721-11ea-89b5-de32ae8d4438.png)