### PR TITLE
Consolidate some badges

### DIFF
--- a/docs/_data/badges.json
+++ b/docs/_data/badges.json
@@ -24,30 +24,6 @@
     "description": "Bronze badge achievement that a user earns within a community."
   },
   {
-    "name": "Tag Badge, Gold",
-    "image": "BadgeGold",
-    "class": "s-badge__tag",
-    "html": "s-badge s-badge__tag",
-    "label": "css",
-    "description": "Tag badge achievement that a user earns through answering a set number of questions and earning a particular reputation score."
-  },
-  {
-    "name": "Tag Badge, Silver",
-    "image": "BadgeSilver",
-    "class": "s-badge__tag",
-    "html": "s-badge s-badge__tag",
-    "label": "javascript",
-    "description": "Tag badge achievement that a user earns through answering a set number of questions and earning a particular reputation score."
-  },
-  {
-    "name": "Tag Badge, Bronze",
-    "image": "BadgeBronze",
-    "class": "s-badge__tag",
-    "html": "s-badge s-badge__tag",
-    "label": "react-js",
-    "description": "Tag badge achievement that a user earns through answering a set number of questions and earning a particular reputation score."
-  },
-  {
     "name": "Number Count, Gold",
     "image": "BadgeGold",
     "class": "s-badge__gold",

--- a/docs/product/components/badges.html
+++ b/docs/product/components/badges.html
@@ -66,34 +66,6 @@ description: Badges are labels used for flags, earned achievements, and number t
         </div>
     </div>
 
-    {% header "h3", "Tag badge" %}
-    <div class="stacks-preview">
-{% highlight html %}
-<span class="s-badge s-badge__tag">
-    <img class="s-badge--image" src="BadgeGold.svg" aria-hidden="true"> css
-</span>
-<span class="s-badge s-badge__tag">
-    <img class="s-badge--image" src="BadgeSilver.svg" aria-hidden="true"> javascript
-</span>
-<span class="s-badge s-badge__tag">
-    <img class="s-badge--image" src="BadgeBronze.svg" aria-hidden="true"> swift
-</span>
-{% endhighlight %}
-        <div class="stacks-preview--example">
-            <div class="grid gs4 fw-wrap">
-                <span class="grid--cell s-badge s-badge__tag">
-                    <img class="s-badge--image" src="/assets/img/BadgeGold.svg" aria-hidden="true"> css
-                </span>
-                <span class="grid--cell s-badge s-badge__tag">
-                    <img class="s-badge--image" src="/assets/img/BadgeSilver.svg" aria-hidden="true"> javascript
-                </span>
-                <span class="grid--cell s-badge s-badge__tag">
-                    <img class="s-badge--image" src="/assets/img/BadgeBronze.svg" aria-hidden="true"> swift
-                </span>
-            </div>
-        </div>
-    </div>
-
     {% header "h3", "Badge counts" %}
     <div class="stacks-preview">
 {% highlight html %}

--- a/lib/css/components/_stacks-badges.less
+++ b/lib/css/components/_stacks-badges.less
@@ -26,7 +26,6 @@
     }
 }
 
-
 //  ===========================================================================
 //  $   BASE STYLE
 //      The same style is applied to all badges. Do not modify the core style.
@@ -37,7 +36,8 @@
     justify-content: center;
     min-width: 0;
     padding: 0 @su6;
-    border: 1px solid transparent;
+    border-width: 1px;
+    border-style: solid;
     border-radius: @br-sm;
     font-size: @fs-caption;
     font-weight: normal;
@@ -46,7 +46,7 @@
     vertical-align: middle;
     white-space: nowrap;
 
-    .badge-styles(transparent, var(--black-800), var(--black-025));
+    .badge-styles(var(--black-100), var(--black-050), var(--black-700));
 
     a&:hover {
         text-decoration: none;
@@ -63,27 +63,16 @@
     margin-left: -(@su4 + 1);
 }
 
-
-//  ===========================================================================
-//  $   STYLE VARIATIONS
-//      This is what can be modified on each community (for the most part).
-//  ===========================================================================
-//  $$  Tag Badges
-//  ---------------------------------------------------------------------------
-.s-badge__tag {
-    .badge-styles(var(--black-100), var(--black-050), var(--black-700));
-}
-
 //  $$  Badge Counts
 //  ---------------------------------------------------------------------------
 .s-badge__gold {
-    .badge-styles(var(--gold-darker), var(--gold-lighter), var(--black-900));
+    .badge-styles(var(--gold-darker), var(--gold-lighter), var(--black-700));
 }
 .s-badge__silver {
-    .badge-styles(var(--silver-darker), var(--silver-lighter), var(--black-900));
+    .badge-styles(var(--silver-darker), var(--silver-lighter), var(--black-700));
 }
 .s-badge__bronze {
-    .badge-styles(var(--bronze-darker), var(--bronze-lighter), var(--black-900));
+    .badge-styles(var(--bronze-darker), var(--bronze-lighter), var(--black-700));
 }
 
 //  $$  Number Counts

--- a/lib/css/components/_stacks-badges.less
+++ b/lib/css/components/_stacks-badges.less
@@ -77,13 +77,13 @@
 //  $$  Badge Counts
 //  ---------------------------------------------------------------------------
 .s-badge__gold {
-    .badge-styles(var(--gold), var(--gold-lighter), var(--black-900));
+    .badge-styles(var(--gold-darker), var(--gold-lighter), var(--black-900));
 }
 .s-badge__silver {
-    .badge-styles(var(--silver), var(--silver-lighter), var(--black-900));
+    .badge-styles(var(--silver-darker), var(--silver-lighter), var(--black-900));
 }
 .s-badge__bronze {
-    .badge-styles(var(--bronze), var(--bronze-lighter), var(--black-900));
+    .badge-styles(var(--bronze-darker), var(--bronze-lighter), var(--black-900));
 }
 
 //  $$  Number Counts


### PR DESCRIPTION
In my opinion, we don't need to discern between tag badges and regular badges, since the regular badges are _so_ dark for no reason. This PR merges the approach. This should be safe since `s-badge__tag` isn't used in production yet.