### PR TITLE
Rename body classes to theme-*

### DIFF
--- a/docs/_includes/darkmode.html
+++ b/docs/_includes/darkmode.html
@@ -8,12 +8,12 @@ Include this right at the start of body to be loaded as fast as possible to avoi
         var darkModeEnabled = forceSetting === "true" || (!forceSetting && browserPrefersDark);
 
         if (browserPrefersDark) {
-            document.body.classList.toggle("has-darkmode", darkModeEnabled);
-            document.body.classList.toggle("has-darkmode__forced", false);
+            document.body.classList.toggle("theme-system", darkModeEnabled);
+            document.body.classList.toggle("theme-dark", false);
         }
         else {
-            document.body.classList.toggle("has-darkmode", true);
-            document.body.classList.toggle("has-darkmode__forced", darkModeEnabled);
+            document.body.classList.toggle("theme-system", true);
+            document.body.classList.toggle("theme-dark", darkModeEnabled);
         }
     }());
 </script>

--- a/docs/_includes/layouts/home.html
+++ b/docs/_includes/layouts/home.html
@@ -2,7 +2,7 @@
 <html lang="en-us" class="h100">
 {% include head.html %}
 
-<body class="grid fd-column bg-black-025 has-darkmode">
+<body class="grid fd-column bg-black-025 theme-system">
     {% include darkmode.html %}
     <div class="grid fl1 bg-orange-400 fd-column ai-center px64 sm:pl24 sm:pr24">
         <div class="grid fd-column jc-space-between fl1 w100 wmx12 stacks-intro py64 sm:pt16 sm:pb24">

--- a/docs/_includes/layouts/page-nomenu.html
+++ b/docs/_includes/layouts/page-nomenu.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 {% include head.html %}
 
-<body class="has-darkmode">
+<body class="theme-system">
     {% include darkmode.html %}
     {% include header.html %}
 

--- a/docs/_includes/layouts/page.html
+++ b/docs/_includes/layouts/page.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 {% include head.html %}
 
-<body class="has-darkmode">
+<body class="theme-system">
     {% include darkmode.html %}
     {% include header.html %}
 

--- a/docs/assets/js/feature.darkmode.js
+++ b/docs/assets/js/feature.darkmode.js
@@ -8,15 +8,15 @@ $(document).ready(function () {
 
         var browserPrefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
 
-        var isForcedDarkMode = body.hasClass("has-darkmode__forced");
-        var isUnforcedDarkMode = browserPrefersDark && body.hasClass("has-darkmode");
+        var isForcedDarkMode = body.hasClass("theme-dark");
+        var isUnforcedDarkMode = browserPrefersDark && body.hasClass("theme-system");
 
         if (browserPrefersDark) {
-            body.toggleClass("has-darkmode", !isUnforcedDarkMode);
-            body.toggleClass("has-darkmode__forced", false);
+            body.toggleClass("theme-system", !isUnforcedDarkMode);
+            body.toggleClass("theme-dark", false);
         } else {
-            body.toggleClass("has-darkmode", true);
-            body.toggleClass("has-darkmode__forced", !isForcedDarkMode);
+            body.toggleClass("theme-system", true);
+            body.toggleClass("theme-dark", !isForcedDarkMode);
         }
 
         localStorage.setItem("forceDarkModeOn", !(isUnforcedDarkMode || isForcedDarkMode));

--- a/lib/css/base/_stacks-internals.less
+++ b/lib/css/base/_stacks-internals.less
@@ -29,13 +29,13 @@
     #darkmode(@class, @rules) {
         @classname: ~"@{class}"; // Interpolate the @class passed to us so we can generate proper CSS rules from it
 
-        body.has-darkmode @{classname} {
+        body.theme-system @{classname} {
             @media (prefers-color-scheme: dark) {
                 @rules();
             }
         }
 
-        body.has-darkmode__forced @{classname} {
+        body.theme-dark @{classname} {
             @rules();
         }
     }

--- a/lib/css/exports/_stacks-constants-colors.less
+++ b/lib/css/exports/_stacks-constants-colors.less
@@ -423,12 +423,12 @@ body {
     --scrollbar: rgba(255, 255, 255, .2);
 }
 
-body.has-darkmode {
+body.theme-system {
     @media (prefers-color-scheme: dark) {
         .dark-colors();
     }
 }
 
-body.has-darkmode__forced {
+body.theme-dark 
     .dark-colors();
 }

--- a/lib/css/exports/_stacks-constants-colors.less
+++ b/lib/css/exports/_stacks-constants-colors.less
@@ -429,6 +429,6 @@ body.theme-system {
     }
 }
 
-body.theme-dark 
+body.theme-dark {
     .dark-colors();
 }


### PR DESCRIPTION
This PR renames our theming classes to something a bit more sensible from the outside:

`theme-light` nothing is wired up to this, but we'll be applying it by default to our body in production for clarity.
`theme-dark` currently called `has-darkmode__forced`
`theme-system` automatically shifts based on the media query, currently called `has-darkmode`

`theme-light has-highcontrast` a future flag on top of our themes
`theme-dark has-highcontrast`
`theme-system has-highcontrast`