### PR TITLE
Link Previews: Convert s-link-preview--truncated to s-link-preview--misc

### DIFF
--- a/docs/_data/link-previews.json
+++ b/docs/_data/link-previews.json
@@ -46,9 +46,9 @@
       "description": "URL of the linked file"
     },
     {
-      "class": ".s-link-preview--truncated",
+      "class": ".s-link-preview--misc",
       "parent": ".s-link-preview--footer",
-      "description": "(optional) Include if the link preview truncates the link’s content"
+      "description": "(optional) A small catch-all for anything you might need. This page contains a few use cases."
     },
     {
       "class": ".linenums",

--- a/docs/product/components/link-previews.html
+++ b/docs/product/components/link-previews.html
@@ -44,6 +44,7 @@ description: Link previews add rich previews to links included in questions and 
     <div class="s-link-preview--body">…</div>
     <div class="s-link-preview--footer">
         <a href="#" class="s-link-preview--url">…</a>
+        <a href="#" class="s-link-preview--misc">Privacy notice</a>
     </div>
 </div>
 {% endhighlight %}
@@ -70,6 +71,7 @@ description: Link previews add rich previews to links included in questions and 
                 </div>
                 <div class="s-link-preview--footer">
                     <a href="#" class="s-link-preview--url">https://stackoverflow.atlassian.net/projects/SREREQ/queues/custom/1</a>
+                    <a href="#" class="s-link-preview--misc">Privacy notice</a>
                 </div>
             </div>
         </div>
@@ -95,6 +97,7 @@ description: Link previews add rich previews to links included in questions and 
     </div>
     <div class="s-link-preview--footer">
         <a href="#" class="s-link-preview--url">…</a>
+        <div class="s-link-preview--misc">(truncated)</div>
     </div>
 </div>
 {% endhighlight %}
@@ -134,7 +137,7 @@ description: Link previews add rich previews to links included in questions and 
                 </div>
                 <div class="s-link-preview--footer">
                     <a href="https://github.com/StackExchange/Stacks/blob/develop/Gruntfile.js" class="s-link-preview--url">https://github.com/StackExchange/Stacks/blob/develop/Gruntfile.js</a>
-                    <div class="s-link-preview--truncated">(truncated)</div>
+                    <div class="s-link-preview--misc">(truncated)</div>
                 </div>
             </div>
         </div>
@@ -179,6 +182,7 @@ description: Link previews add rich previews to links included in questions and 
     </div>
     <div class="s-link-preview--footer">
         <a href="#" class="s-link-preview--url">…</a>
+        <div class="s-link-preview--misc">(truncated)</div>
     </div>
 </div>
 {% endhighlight %}
@@ -235,7 +239,7 @@ description: Link previews add rich previews to links included in questions and 
                 </div>
                 <div class="s-link-preview--footer">
                     <a href="https://github.com/StackExchange/Stacks/blob/develop/Gruntfile.js" class="s-link-preview--url">https://github.com/StackExchange/Stacks/blob/develop/Gruntfile.js</a>
-                    <div class="s-link-preview--truncated">(truncated)</div>
+                    <div class="s-link-preview--misc">(truncated)</div>
                 </div>
             </div>
         </div>

--- a/lib/css/components/_stacks-link-previews.less
+++ b/lib/css/components/_stacks-link-previews.less
@@ -121,7 +121,7 @@ a.s-link-preview--title {
     white-space: nowrap;
 }
 
-.s-link-preview--truncated {
+.s-link-preview--misc {
     color: var(--black-500);
     padding-left: @su4;
 
@@ -132,7 +132,7 @@ a.s-link-preview--title {
 }
 
 .s-link-preview--details a,
-a.s-link-preview--url {
+.s-link-preview--footer a {
     text-decoration: none;
     cursor: pointer;
     color: var(--black-500);


### PR DESCRIPTION
A few uses cases came up where it would help to have `s-link-preview--truncated` handle more than just truncation. This PR updates this class name to be a catch-all.