### PR TITLE
Button refinements

### DIFF
--- a/docs/product/components/buttons.html
+++ b/docs/product/components/buttons.html
@@ -331,7 +331,7 @@ description: Buttons are user interface elements which allows users to take acti
 <button class="s-btn" type="button">
     Badge
     <span class="s-btn--badge">
-        <span class="s-btn--number">200</span>
+        <span class="s-btn--number">198</span>
     </span>
 </button>
 {% endhighlight %}
@@ -377,7 +377,7 @@ description: Buttons are user interface elements which allows users to take acti
                                         Active <span class="s-btn--badge"><span class="s-btn--number">198</span></span>
                                     </button>
                                 </td>
-                                <td class="va-middle px4">
+                                <td class="va-middle ta-center px4">
                                     <button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button" aria-pressed="false" disabled>
                                         Active <span class="s-btn--badge"><span class="s-btn--number">198</span></span>
                                     </button>

--- a/lib/css/base/_stacks-configuration-dynamic.less
+++ b/lib/css/base/_stacks-configuration-dynamic.less
@@ -99,9 +99,9 @@
     @button-danger-outlined-disabled-border-color:   var(--black-200);
 
     //  Button Danger Filled
-    @button-danger-filled-color:                     var(--white);
+    @button-danger-filled-color:                     @white;
     @button-danger-filled-background-color:          var(--red-500);
-    @button-danger-filled-hover-color:               var(--white);
+    @button-danger-filled-hover-color:               @white;
     @button-danger-filled-hover-background-color:    var(--red-600);
     @button-danger-filled-active-background-color:   var(--red-700);
     @button-danger-filled-disabled-color:            var(--white);
@@ -112,9 +112,9 @@
     @button-danger-filled-number-color:              var(--black-900);
 
     //  Button Primary
-    @button-primary-color:                           var(--white);
+    @button-primary-color:                           @white;
     @button-primary-background-color:                var(--blue-500);
-    @button-primary-hover-color:                     var(--white);
+    @button-primary-hover-color:                     @white;
     @button-primary-hover-background-color:          var(--blue-600);
     @button-primary-active-background-color:         var(--blue-700);
     @button-primary-disabled-color:                  var(--white);
@@ -155,7 +155,7 @@
 
     //  Pagination
     @pagination-select-background:                   var(--orange-500);
-    @pagination-select-color:                        var(--white);
+    @pagination-select-color:                        @white;
 
     // Sidebar widgets
     @widget-navigation-current-color:                var(--orange);

--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -190,6 +190,8 @@
     }
 }
 
+#stacks-internals #darkmode('.s-btn__primary:not(.is-selected):not([disabled]) .s-btn--number, .s-btn__danger.s-btn__filled:not(.is-selected):not([disabled]) .s-btn--number', { color: @black; });
+
 //  ============================================================================
 //  $   DEFAULT (SECONDARY) STYLES
 //  ============================================================================


### PR DESCRIPTION
Contrast was lacking a bit on our primary buttons in dark mode. This PR forces white text and improves the badges a bit.

**Before**
![image](https://user-images.githubusercontent.com/1369864/77028128-07ffb280-6966-11ea-950a-3bd786dba54c.png)

**After**
![image](https://user-images.githubusercontent.com/1369864/77028106-fae2c380-6965-11ea-8e63-5daaf561bec7.png)
