### PR TITLE
Fix documentation bug when script executes prior to library loading

### DIFF
--- a/docs/product/components/popovers.html
+++ b/docs/product/components/popovers.html
@@ -401,8 +401,10 @@ Stacks.setTooltipHtml(el,
         </div>
     </div>
     <script>
-        Stacks.setTooltipText(document.querySelector(".js-text-tooltip-example"), "Only members of this Team can see the information posted here. It will never be shared publicly or accessible outside of your Team.", { placement: "top-start" });
-        Stacks.setTooltipHtml(document.querySelector(".js-html-tooltip-example"), "View all questions with <span class='s-tag'>stacks</span>", { placement: "top-end" });
+        window.addEventListener("load", () => {
+            Stacks.setTooltipText(document.querySelector(".js-text-tooltip-example"), "Only members of this Team can see the information posted here. It will never be shared publicly or accessible outside of your Team.", { placement: "top-start" });
+            Stacks.setTooltipHtml(document.querySelector(".js-html-tooltip-example"), "View all questions with <span class='s-tag'>stacks</span>", { placement: "top-end" });
+        });
     </script>
 
     {% header "h4", "Rich tooltips" %}


### PR DESCRIPTION
This fixes an issue where the script-generated tooltips fail to appear because the script is evaluated before the Stacks JavaScript is loaded.