### PR TITLE
Let badge__mini be used with any coloration

### DIFF
--- a/docs/_data/badges.json
+++ b/docs/_data/badges.json
@@ -83,17 +83,17 @@
     "description": "Badge which notes reputation points taken away."
   },
   {
-    "name": "Mini Number Count",
-    "class": "s-badge__mini",
-    "html": "s-badge s-badge__mini",
-    "label": "99+",
-    "description": "Badge which notes activity."
-  },
-  {
-    "name": "Mini Number Count, Important",
+    "name": "Number Count, Important",
     "class": "s-badge__important",
     "html": "s-badge s-badge__mini s-badge__important",
     "label": "99+",
     "description": "Badge which notes important activity."
+  },
+  {
+    "name": "Badge, Small",
+    "class": "s-badge__sm",
+    "html": "s-badge s-badge__sm",
+    "label": "99+",
+    "description": "Decreases the badge size."
   }
 ]

--- a/docs/product/components/badges.html
+++ b/docs/product/components/badges.html
@@ -102,8 +102,7 @@ description: Badges are labels used for flags, earned achievements, and number t
 <span class="s-badge s-badge__answered">154</span>
 <span class="s-badge s-badge__rep">+15</span>
 <span class="s-badge s-badge__rep-down">-2</span>
-<span class="s-badge s-badge__mini">99+</span>
-<span class="s-badge s-badge__mini s-badge__important">99+</span>
+<span class="s-badge s-badge__important">99+</span>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="grid gs4 fw-wrap">
@@ -112,8 +111,24 @@ description: Badges are labels used for flags, earned achievements, and number t
                 <span class="grid--cell s-badge s-badge__answered">154</span>
                 <span class="grid--cell s-badge s-badge__rep">+15</span>
                 <span class="grid--cell s-badge s-badge__rep-down">-2</span>
-                <span class="grid--cell s-badge s-badge__mini">99+</span>
-                <span class="grid--cell s-badge s-badge__mini s-badge__important">99+</span>
+                <span class="grid--cell s-badge s-badge__important">99+</span>
+            </div>
+        </div>
+    </div>
+</section>
+
+    {% header "h3", "Badge sizes" %}
+    <div class="stacks-preview">
+{% highlight html %}
+<span class="s-badge">Regular</span>
+<span class="s-badge s-badge__sm">Small</span>
+<span class="s-badge s-badge__sm s-badge__gold">Small gold</span>
+{% endhighlight %}
+        <div class="stacks-preview--example">
+            <div class="grid gs4 fw-wrap">
+                <span class="grid--cell s-badge">Regular</span>
+                <span class="grid--cell s-badge s-badge__sm">Small</span>
+                <span class="grid--cell s-badge s-badge__sm s-badge__gold">Small gold</span>
             </div>
         </div>
     </div>

--- a/lib/css/components/_stacks-badges.less
+++ b/lib/css/components/_stacks-badges.less
@@ -63,6 +63,17 @@
     margin-left: -(@su4 + 1);
 }
 
+//  $   BADGE SIZE
+//  ---------------------------------------------------------------------------
+.s-badge__mini {
+    align-self: flex-start;
+    padding-right: @su4;
+    padding-left: @su4 - 1;
+    font-size: @fs-fine;
+    line-height: 1.8;
+    .badge-styles(transparent, var(--blue-600), var(--white));
+}
+
 //  $$  Badge Counts
 //  ---------------------------------------------------------------------------
 .s-badge__gold {
@@ -91,14 +102,6 @@
 }
 .s-badge__rep-down {
     .badge-styles(var(--red-400), var(--white), var(--red-500));
-}
-.s-badge__mini {
-    align-self: flex-start;
-    padding-right: @su4;
-    padding-left: @su4 - 1;
-    font-size: @fs-fine;
-    line-height: 1.8;
-    .badge-styles(transparent, var(--blue-600), var(--white));
 }
 .s-badge__important {
     .badge-styles(transparent, var(--red-600), var(--white));

--- a/lib/css/components/_stacks-badges.less
+++ b/lib/css/components/_stacks-badges.less
@@ -65,13 +65,12 @@
 
 //  $   BADGE SIZE
 //  ---------------------------------------------------------------------------
-.s-badge__mini {
+.s-badge__sm {
     align-self: flex-start;
     padding-right: @su4;
     padding-left: @su4 - 1;
     font-size: @fs-fine;
     line-height: 1.8;
-    .badge-styles(transparent, var(--blue-600), var(--white));
 }
 
 //  $$  Badge Counts


### PR DESCRIPTION
## What?

Renames `s-badge__mini` to `s-badge__sm` and moves it further up in the file so it's specificity is lower than the other classes. This allows it to be used with any other class, not just `important`.

## Example

```html
<span class="s-badge s-badge__important s-badge__mini">Mini important!</span>
<span class="s-badge s-badge__gold s-badge__mini">Mini gold!</span>
```
Actually looks like:

![image](https://user-images.githubusercontent.com/14169651/77863326-7a3a8780-71ef-11ea-8e6d-62421db0a009.png)

With these changes in place it becomes:

```html
<span class="s-badge s-badge__important s-badge__sm">Mini important!</span>
<span class="s-badge s-badge__gold s-badge__sm">Mini gold!</span>
```

![image](https://user-images.githubusercontent.com/14169651/77863347-ad7d1680-71ef-11ea-8347-90d4b8bde01e.png)

## Breaking changes

`s-badge__mini` has been renamed to `s-badge__sm`. In addition, it no longer gives a `blue-600` background. Migrations will need to both rename `mini` to `sm` and add `s-badge__bounty` to regain the blue background.