### PR TITLE
Remove outdated mozilla SVG hack

### DIFF
--- a/lib/css/base/_stacks-icons.less
+++ b/lib/css/base/_stacks-icons.less
@@ -9,7 +9,6 @@
 
 .svg-icon {
     vertical-align: bottom; // Make icons play nicely while inline with text by default
-    -moz-transform: rotate(360deg); // Hack to make icons look crisp in Firefox
 
     &:not(.native) {
         * {


### PR DESCRIPTION
We needed this hack in older versions of Firefox, but doesn't look like it's necessary anymore. 👋 