### PR TITLE
Migrate rep badges to use award-bling

### DIFF
--- a/docs/_data/badges.json
+++ b/docs/_data/badges.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Badge, Gold",
-    "image": "BadgeGold",
+    "repType": "gold",
     "class": "s-badge",
     "html": "s-badge",
     "label": "Great Question",
@@ -9,7 +9,7 @@
   },
   {
     "name": "Badge, Silver",
-    "image": "BadgeSilver",
+    "repType": "silver",
     "class": "s-badge",
     "html": "s-badge",
     "label": "Favorite Question",
@@ -17,7 +17,7 @@
   },
   {
     "name": "Badge, Bronze",
-    "image": "BadgeBronze",
+    "repType": "bronze",
     "class": "s-badge",
     "html": "s-badge",
     "label": "Altruist",
@@ -25,7 +25,7 @@
   },
   {
     "name": "Number Count, Gold",
-    "image": "BadgeGold",
+    "repType": "gold",
     "class": "s-badge__gold",
     "html": "s-badge s-badge__gold",
     "label": 635,
@@ -33,7 +33,7 @@
   },
   {
     "name": "Number Count, Silver",
-    "image": "BadgeSilver",
+    "repType": "silver",
     "class": "s-badge__silver",
     "html": "s-badge s-badge__silver",
     "label": 7624,
@@ -41,7 +41,7 @@
   },
   {
     "name": "Number Count, Bronze",
-    "image": "BadgeBronze",
+    "repType": "bronze",
     "class": "s-badge__bronze",
     "html": "s-badge s-badge__bronze",
     "label": 8234,

--- a/docs/product/components/badges.html
+++ b/docs/product/components/badges.html
@@ -106,7 +106,7 @@ description: Badges are labels used for flags, earned achievements, and number t
                     </span> 
                 </span>
                 <span class="grid--cell s-badge s-badge__silver">
-                    <span class="award-bling award-bling__gold">
+                    <span class="award-bling award-bling__silver">
                         7624
                     </span> 
                 </span>

--- a/docs/product/components/badges.html
+++ b/docs/product/components/badges.html
@@ -21,7 +21,7 @@ description: Badges are labels used for flags, earned achievements, and number t
                         <td>
                             {% if item.repType %}
                                 <span class="{{ item.html }}">
-                                    <span class="s-reputation s-reputation__{{ item.repType }}">
+                                    <span class="award-bling award-bling__{{ item.repType }}">
                                         {{ item.label }}
                                     </span>
                                 </span>
@@ -43,17 +43,17 @@ description: Badges are labels used for flags, earned achievements, and number t
     <div class="stacks-preview">
 {% highlight html %}
 <span class="s-badge">
-    <span class="s-reputation s-reputation__gold">
+    <span class="award-bling award-bling__gold">
         Great Question
     </span> 
 </span>
 <span class="s-badge">
-    <span class="s-reputation s-reputation__silver">
+    <span class="award-bling award-bling__silver">
         Favorite Question
     </span> 
 </span>
 <span class="s-badge">
-    <span class="s-reputation s-reputation__bronze">
+    <span class="award-bling award-bling__bronze">
         Altruist
     </span> 
 </span>
@@ -61,17 +61,17 @@ description: Badges are labels used for flags, earned achievements, and number t
         <div class="stacks-preview--example">
             <div class="grid gs4 fw-wrap">
                 <span class="grid--cell s-badge">
-                    <span class="s-reputation s-reputation__gold">
+                    <span class="award-bling award-bling__gold">
                         Great Question
                     </span> 
                 </span>
                 <span class="grid--cell s-badge">
-                    <span class="s-reputation s-reputation__silver">
+                    <span class="award-bling award-bling__silver">
                         Favorite Question
                     </span> 
                 </span>
                 <span class="grid--cell s-badge">
-                    <span class="s-reputation s-reputation__bronze">
+                    <span class="award-bling award-bling__bronze">
                         Altruist
                     </span> 
                 </span>
@@ -83,17 +83,17 @@ description: Badges are labels used for flags, earned achievements, and number t
     <div class="stacks-preview">
 {% highlight html %}
 <span class="s-badge s-badge__gold">
-    <span class="s-reputation s-reputation__gold">
+    <span class="award-bling award-bling__gold">
         635
     </span> 
 </span>
 <span class="s-badge s-badge__silver">
-    <span class="s-reputation s-reputation__silver">
+    <span class="award-bling award-bling__silver">
         7624
     </span> 
 </span>
 <span class="s-badge s-badge__bronze">
-    <span class="s-reputation s-reputation__bronze">
+    <span class="award-bling award-bling__bronze">
         8234
     </span> 
 </span>
@@ -101,17 +101,17 @@ description: Badges are labels used for flags, earned achievements, and number t
         <div class="stacks-preview--example">
             <div class="grid gs4 fw-wrap">
                 <span class="grid--cell s-badge s-badge__gold">
-                    <span class="s-reputation s-reputation__gold">
+                    <span class="award-bling award-bling__gold">
                         635
                     </span> 
                 </span>
                 <span class="grid--cell s-badge s-badge__silver">
-                    <span class="s-reputation s-reputation__gold">
+                    <span class="award-bling award-bling__gold">
                         7624
                     </span> 
                 </span>
                 <span class="grid--cell s-badge s-badge__bronze">
-                    <span class="s-reputation s-reputation__gold">
+                    <span class="award-bling award-bling__gold">
                         8234
                     </span> 
                 </span>

--- a/docs/product/components/badges.html
+++ b/docs/product/components/badges.html
@@ -21,7 +21,7 @@ description: Badges are labels used for flags, earned achievements, and number t
                         <td>
                             {% if item.repType %}
                                 <span class="{{ item.html }}">
-                                    <span class="award-bling award-bling__{{ item.repType }}">
+                                    <span class="s-award-bling s-award-bling__{{ item.repType }}">
                                         {{ item.label }}
                                     </span>
                                 </span>
@@ -43,17 +43,17 @@ description: Badges are labels used for flags, earned achievements, and number t
     <div class="stacks-preview">
 {% highlight html %}
 <span class="s-badge">
-    <span class="award-bling award-bling__gold">
+    <span class="s-award-bling s-award-bling__gold">
         Great Question
     </span> 
 </span>
 <span class="s-badge">
-    <span class="award-bling award-bling__silver">
+    <span class="s-award-bling s-award-bling__silver">
         Favorite Question
     </span> 
 </span>
 <span class="s-badge">
-    <span class="award-bling award-bling__bronze">
+    <span class="s-award-bling s-award-bling__bronze">
         Altruist
     </span> 
 </span>
@@ -61,17 +61,17 @@ description: Badges are labels used for flags, earned achievements, and number t
         <div class="stacks-preview--example">
             <div class="grid gs4 fw-wrap">
                 <span class="grid--cell s-badge">
-                    <span class="award-bling award-bling__gold">
+                    <span class="s-award-bling s-award-bling__gold">
                         Great Question
                     </span> 
                 </span>
                 <span class="grid--cell s-badge">
-                    <span class="award-bling award-bling__silver">
+                    <span class="s-award-bling s-award-bling__silver">
                         Favorite Question
                     </span> 
                 </span>
                 <span class="grid--cell s-badge">
-                    <span class="award-bling award-bling__bronze">
+                    <span class="s-award-bling s-award-bling__bronze">
                         Altruist
                     </span> 
                 </span>
@@ -83,17 +83,17 @@ description: Badges are labels used for flags, earned achievements, and number t
     <div class="stacks-preview">
 {% highlight html %}
 <span class="s-badge s-badge__gold">
-    <span class="award-bling award-bling__gold">
+    <span class="s-award-bling s-award-bling__gold">
         635
     </span> 
 </span>
 <span class="s-badge s-badge__silver">
-    <span class="award-bling award-bling__silver">
+    <span class="s-award-bling s-award-bling__silver">
         7624
     </span> 
 </span>
 <span class="s-badge s-badge__bronze">
-    <span class="award-bling award-bling__bronze">
+    <span class="s-award-bling s-award-bling__bronze">
         8234
     </span> 
 </span>
@@ -101,17 +101,17 @@ description: Badges are labels used for flags, earned achievements, and number t
         <div class="stacks-preview--example">
             <div class="grid gs4 fw-wrap">
                 <span class="grid--cell s-badge s-badge__gold">
-                    <span class="award-bling award-bling__gold">
+                    <span class="s-award-bling s-award-bling__gold">
                         635
                     </span> 
                 </span>
                 <span class="grid--cell s-badge s-badge__silver">
-                    <span class="award-bling award-bling__silver">
+                    <span class="s-award-bling s-award-bling__silver">
                         7624
                     </span> 
                 </span>
                 <span class="grid--cell s-badge s-badge__bronze">
-                    <span class="award-bling award-bling__bronze">
+                    <span class="s-award-bling s-award-bling__bronze">
                         8234
                     </span> 
                 </span>

--- a/docs/product/components/badges.html
+++ b/docs/product/components/badges.html
@@ -19,10 +19,11 @@ description: Badges are labels used for flags, earned achievements, and number t
                     <tr>
                         <th scope="row"><code class="stacks-code">.{{ item.class }}</code></th>
                         <td>
-                            {% if item.image %}
+                            {% if item.repType %}
                                 <span class="{{ item.html }}">
-
-                                    <img class="s-badge--image" src="/assets/img/{{ item.image}}.svg" aria-hidden="true"> {{ item.label }}
+                                    <span class="s-reputation s-reputation__{{ item.repType }}">
+                                        {{ item.label }}
+                                    </span>
                                 </span>
                             {% else %}
                                 <span class="{{ item.html }}">{{ item.label }}</span>
@@ -42,25 +43,37 @@ description: Badges are labels used for flags, earned achievements, and number t
     <div class="stacks-preview">
 {% highlight html %}
 <span class="s-badge">
-    <img class="s-badge--image" src="BadgeGold.svg" aria-hidden="true"> Great Question
+    <span class="s-reputation s-reputation__gold">
+        Great Question
+    </span> 
 </span>
 <span class="s-badge">
-    <img class="s-badge--image" src="BadgeSilver.svg" aria-hidden="true"> Favorite Question
+    <span class="s-reputation s-reputation__silver">
+        Favorite Question
+    </span> 
 </span>
 <span class="s-badge">
-    <img class="s-badge--image" src="BadgeBronze.svg" aria-hidden="true"> Altruist
+    <span class="s-reputation s-reputation__bronze">
+        Altruist
+    </span> 
 </span>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="grid gs4 fw-wrap">
                 <span class="grid--cell s-badge">
-                    <img class="s-badge--image" src="/assets/img/BadgeGold.svg" aria-hidden="true"> Great Question
+                    <span class="s-reputation s-reputation__gold">
+                        Great Question
+                    </span> 
                 </span>
                 <span class="grid--cell s-badge">
-                    <img class="s-badge--image" src="/assets/img/BadgeSilver.svg" aria-hidden="true"> Favorite Question
+                    <span class="s-reputation s-reputation__silver">
+                        Favorite Question
+                    </span> 
                 </span>
                 <span class="grid--cell s-badge">
-                    <img class="s-badge--image" src="/assets/img/BadgeBronze.svg" aria-hidden="true"> Altruist
+                    <span class="s-reputation s-reputation__bronze">
+                        Altruist
+                    </span> 
                 </span>
             </div>
         </div>
@@ -70,25 +83,37 @@ description: Badges are labels used for flags, earned achievements, and number t
     <div class="stacks-preview">
 {% highlight html %}
 <span class="s-badge s-badge__gold">
-    <img class="s-badge--image" src="BadgeGold.svg" aria-hidden="true"> 635
+    <span class="s-reputation s-reputation__gold">
+        635
+    </span> 
 </span>
 <span class="s-badge s-badge__silver">
-    <img class="s-badge--image" src="BadgeSilver.svg" aria-hidden="true"> 7624
+    <span class="s-reputation s-reputation__silver">
+        7624
+    </span> 
 </span>
 <span class="s-badge s-badge__bronze">
-    <img class="s-badge--image" src="BadgeBronze.svg" aria-hidden="true"> 8234
+    <span class="s-reputation s-reputation__bronze">
+        8234
+    </span> 
 </span>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="grid gs4 fw-wrap">
                 <span class="grid--cell s-badge s-badge__gold">
-                    <img class="s-badge--image" src="/assets/img/BadgeGold.svg" aria-hidden="true"> 635
+                    <span class="s-reputation s-reputation__gold">
+                        635
+                    </span> 
                 </span>
                 <span class="grid--cell s-badge s-badge__silver">
-                    <img class="s-badge--image" src="/assets/img/BadgeSilver.svg" aria-hidden="true"> 7624
+                    <span class="s-reputation s-reputation__gold">
+                        7624
+                    </span> 
                 </span>
                 <span class="grid--cell s-badge s-badge__bronze">
-                    <img class="s-badge--image" src="/assets/img/BadgeBronze.svg" aria-hidden="true"> 8234
+                    <span class="s-reputation s-reputation__gold">
+                        8234
+                    </span> 
                 </span>
             </div>
         </div>

--- a/docs/product/components/badges.html
+++ b/docs/product/components/badges.html
@@ -111,7 +111,7 @@ description: Badges are labels used for flags, earned achievements, and number t
                     </span> 
                 </span>
                 <span class="grid--cell s-badge s-badge__bronze">
-                    <span class="award-bling award-bling__gold">
+                    <span class="award-bling award-bling__bronze">
                         8234
                     </span> 
                 </span>

--- a/lib/css/components/_stacks-badges.less
+++ b/lib/css/components/_stacks-badges.less
@@ -116,7 +116,7 @@
     &:before {
         content: "";
         margin-top: -1px;
-        margin-right: 3px;
+        margin-right: 4px;
         width: 8px;
         height: 8px;
         border-radius: 100%;

--- a/lib/css/components/_stacks-badges.less
+++ b/lib/css/components/_stacks-badges.less
@@ -108,7 +108,7 @@
 
 //  $$  Award Count
 //  ---------------------------------------------------------------------------
-.award-bling {
+.s-award-bling {
     display: flex;
     align-items: center;
     color: inherit;

--- a/lib/css/components/_stacks-badges.less
+++ b/lib/css/components/_stacks-badges.less
@@ -105,3 +105,44 @@
 .s-badge__important {
     .badge-styles(transparent, var(--red-600), var(--white));
 }
+
+//  $$  Reputation
+//  ---------------------------------------------------------------------------
+.s-reputation {
+    display: flex;
+    align-items: center;
+    color: inherit;
+
+    &:before {
+        content: "";
+        margin-top: -1px;
+        margin-right: 3px;
+        width: 8px;
+        height: 8px;
+        border-radius: 100%;
+    }
+
+    &.s-reputation__gold {
+        &:before {
+            background-color: var(--gold);
+        }
+
+        //color: var(--gold-darker);
+    }
+
+    &.s-reputation__silver {
+        &:before {
+            background-color: var(--silver);
+        }
+
+        //color: var(--silver-darker);
+    }
+
+    &.s-reputation__bronze {
+        &:before {
+            background-color: var(--bronze);
+        }
+
+        //color: var(--bronze-darker);
+    }
+}

--- a/lib/css/components/_stacks-badges.less
+++ b/lib/css/components/_stacks-badges.less
@@ -122,19 +122,19 @@
         border-radius: 100%;
     }
 
-    &.award-bling__gold {
+    &.s-award-bling__gold {
         &:before {
             background-color: var(--gold);
         }
     }
 
-    &.award-bling__silver {
+    &.s-award-bling__silver {
         &:before {
             background-color: var(--silver);
         }
     }
 
-    &.award-bling__bronze {
+    &.s-award-bling__bronze {
         &:before {
             background-color: var(--bronze);
         }

--- a/lib/css/components/_stacks-badges.less
+++ b/lib/css/components/_stacks-badges.less
@@ -106,9 +106,9 @@
     .badge-styles(transparent, var(--red-600), var(--white));
 }
 
-//  $$  Reputation
+//  $$  Award Count
 //  ---------------------------------------------------------------------------
-.s-reputation {
+.award-bling {
     display: flex;
     align-items: center;
     color: inherit;
@@ -122,27 +122,21 @@
         border-radius: 100%;
     }
 
-    &.s-reputation__gold {
+    &.award-bling__gold {
         &:before {
             background-color: var(--gold);
         }
-
-        //color: var(--gold-darker);
     }
 
-    &.s-reputation__silver {
+    &.award-bling__silver {
         &:before {
             background-color: var(--silver);
         }
-
-        //color: var(--silver-darker);
     }
 
-    &.s-reputation__bronze {
+    &.award-bling__bronze {
         &:before {
             background-color: var(--bronze);
         }
-
-        //color: var(--bronze-darker);
     }
 }

--- a/lib/css/components/_stacks-badges.less
+++ b/lib/css/components/_stacks-badges.less
@@ -115,7 +115,6 @@
 
     &:before {
         content: "";
-        margin-top: -1px;
         margin-right: 4px;
         width: 8px;
         height: 8px;


### PR DESCRIPTION
This PR is a WIP.

It moves some badges to use `s-reputation` and adds the badge via pseudo element instead of a SVG.

1) One thing that is interesting is the text colour on the reputation. If I set it on the rep itself, it overrides the colour in a badge (this could mean in our examples, inside a badge, the text colour would be the same gold, silver, etc, where we'd want it to be fc-medium. We do however, want text to be that colour in certain places (i.e. in the user card). This is unfinished and may just have to be an atomic class in the user card.

2) I'm also not at all sold on the use of spans and divs here. Maybe we leave this to the devs in product? But we should be using the specific HMTL element where appropriate and avoiding the use of spans if we can.

Open to thoughts.