### PR TITLE
Add atomic grid display classes

### DIFF
--- a/docs/_data/atomics.json
+++ b/docs/_data/atomics.json
@@ -153,19 +153,19 @@
     {
       "class": "d-inline",
       "output": "display: inline;",
-      "define": "<p class='mb0'>This turns any element into an inline element that flows like text.</p>",
+      "define": "<p class='mb0'>Turns any element into an inline element that flows like text.</p>",
       "responsive": true
     },
     {
       "class": "d-inline-block",
       "output": "display: inline-block;",
-      "define": "<p class='mb0'>This turns any element into a block-level box that will be flowed with surrounding content as if it were a single inline box (behaving much like a replaced element would)</p>",
+      "define": "<p class='mb0'>Turns any element into a block-level box that will be flowed with surrounding content as if it were a single inline box (behaving much like a replaced element would)</p>",
       "responsive": true
     },
     {
       "class": "d-flex",
       "output": "display: flex;",
-      "define": "<p class='mb0'>The lays out an element and its contents using flow layout.</p>",
+      "define": "<p class='mb0'>Lays out its content according to the flexbox model.</p>",
       "responsive": false
     },
     {
@@ -173,6 +173,18 @@
       "output": "display: inline-flex;",
       "define": "<p class='mb0'>This makes the element behave like an inline element and lays out its content according to the flexbox model.</p>",
       "responsive": false
+    },
+    {
+      "class": "d-grid",
+      "output": "display: grid;",
+      "define": "<p class='mb0'>This lays out an element and its contents using grid layout.</p>",
+      "responsive": true
+    },
+    {
+      "class": "d-inline-flex",
+      "output": "display: inline-flex;",
+      "define": "<p class='mb0'>This makes the element behave like an inline element and lays out its content according to the grid model.</p>",
+      "responsive": true
     },
     {
       "class": "d-table",

--- a/docs/_data/atomics.json
+++ b/docs/_data/atomics.json
@@ -181,8 +181,8 @@
       "responsive": true
     },
     {
-      "class": "d-inline-flex",
-      "output": "display: inline-flex;",
+      "class": "d-inline-grid",
+      "output": "display: inline-grid;",
       "define": "<p class='mb0'>This makes the element behave like an inline element and lays out its content according to the grid model.</p>",
       "responsive": true
     },

--- a/lib/css/atomic/_stacks-misc.less
+++ b/lib/css/atomic/_stacks-misc.less
@@ -14,6 +14,8 @@
 @media print { .print\:d-block { display: block !important; } }
 .d-flex                   { display: flex !important; }
 .d-inline-flex            { display: inline-flex !important; }
+#stacks-internals #responsify('.d-grid', { display: grid !important; });
+#stacks-internals #responsify('.d-inline-grid', { display: inline-grid !important; });
 #stacks-internals #responsify('.d-inline', { display: inline !important; });
 #stacks-internals #responsify('.d-inline-block', { display: inline-block !important; });
 .d-table                  { display: table !important; }


### PR DESCRIPTION
This PR adds `d-grid` and `d-inline-grid` before #423 drops.