### PR TITLE
Improve notice buttons presentation

### DIFF
--- a/docs/_data/notices.json
+++ b/docs/_data/notices.json
@@ -6,6 +6,11 @@
       "description": "Default style used to separate notices from the main content."
     },
     {
+      "class": ".s-notice--btn",
+      "applies": "N/A",
+      "description": "Child element applied to .s-btn within a toast to give it a subtle tint that’s appropriate in that context."
+    },
+    {
       "class": ".s-notice__info",
       "applies": ".s-notice",
       "description": "Visual style for information notices."

--- a/docs/product/components/notices.html
+++ b/docs/product/components/notices.html
@@ -7,13 +7,13 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
 <script src="{{ "/assets/js/feature.notices.js" | relative_url }}" defer></script>
 
 <div class="s-toast js-notice-toast" aria-hidden="true">
-    <aside class="s-notice s-notice__success">
+    <aside class="s-notice s-notice__success p8 pl16">
         <div class="grid gs16 gsx ai-center jc-space-between" aria-describedby="notice-message">
             <div class="grid--cell" aria-label="notice-message">
-                <p class="m0">Email settings have been successfully updated.</p>
+                Email settings have been successfully updated.
             </div>
-            <div class="grid--cell mr0" aria-label="notice-dismiss">
-                <a class="p8 s-btn grid grid__center fc-dark js-notice-close">
+            <div class="grid--cell" aria-label="notice-dismiss">
+                <a class="s-btn js-notice-close">
                     {% icon "ClearSm", "m0" %}
                 </a>
             </div>
@@ -242,14 +242,14 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
     <div class="stacks-preview">
 {% highlight html %}
 <aside class="s-toast">
-    <div class="s-notice s-notice__success" role="status" aria-hidden="false">
+    <div class="s-notice s-notice__success p8 pl16" role="status" aria-hidden="false">
         <div class="grid gs16 gsx ai-center jc-space-between" aria-describedby="notice-message">
             <div class="grid--cell" aria-label="notice-message">
                 Toast notice message
             </div>
-            <div class="grid--cell mr0" aria-label="notice-dismiss">
-                <a class="p8 s-btn grid grid__center fc-dark">
-                    @Svg.ClearSm.With("m0")
+            <div class="grid--cell" aria-label="notice-dismiss">
+                <a class="s-btn">
+                    @Svg.ClearSm
                 </a>
             </div>
         </div>
@@ -258,32 +258,30 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="ps-relative grid grid__center gs8 gsy fd-column jc-center">
-                <div class="grid--cell s-notice s-notice__success py8 bs-sm" role="status">
+                <div class="grid--cell s-notice s-notice__success p8 pl16 bs-sm" role="status">
                     <div class="grid gs16 gsx ai-center jc-space-between" aria-describedby="notice-message">
                         <div class="grid--cell" aria-label="notice-message">
                             <p class="m0">Toast notice message styling</p>
                         </div>
-                        <div class="grid--cell mr0" aria-label="notice-dismiss">
-                            <a class="p8 s-btn grid grid__center fc-dark">
-                                {% icon "ClearSm", "m0" %}
+                        <div class="grid--cell" aria-label="notice-dismiss">
+                            <a class="s-btn">
+                                {% icon "ClearSm" %}
                             </a>
                         </div>
                     </div>
                 </div>
 
-                <div class="grid--cell s-notice s-notice__success py8 bs-sm" role="status">
-                    <div class="grid gs16 gsx ai-center jc-space-between" aria-describedby="notice-message">
+                <div class="grid--cell s-notice s-notice__success p8 pl16 bs-sm" role="status">
+                    <div class="grid gsx gs16 ai-center jc-space-between" aria-describedby="notice-message">
                         <div class="grid--cell" aria-label="notice-message">
-                            <p class="m0">Toast notice message with an undo button</p>
+                            Toast notice message with an undo button
                         </div>
-                        <div class="grid--cell" aria-label="notice-message">
-                            <a href="#" class="d-block p8 s-btn fc-dark">
+                        <div class="grid">
+                            <a href="#" class="s-btn">
                                 Undo
                             </a>
-                        </div>
-                        <div class="grid--cell mr0 ml0" aria-label="notice-dismiss">
-                            <a href="#" class="d-block p8 s-btn grid grid__center fc-dark">
-                                {% icon "ClearSm", "m0" %}
+                            <a href="#" class="s-btn">
+                                {% icon "ClearSm" %}
                             </a>
                         </div>
                     </div>

--- a/docs/product/components/notices.html
+++ b/docs/product/components/notices.html
@@ -13,7 +13,7 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
                 Email settings have been successfully updated.
             </div>
             <div class="grid--cell" aria-label="notice-dismiss">
-                <a class="s-btn js-notice-close">
+                <a class="s-btn s-notice--btn js-notice-close">
                     {% icon "ClearSm", "m0" %}
                 </a>
             </div>
@@ -235,7 +235,7 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
     </div>
 
     {% header "h3", "Toast" %}
-    <p class="stacks-copy">Floating notices, but aligned to the top and center of the page and they disappear after a set time</p>
+    <p class="stacks-copy">Floating notices, but aligned to the top and center of the page and they disappear after a set time. When including buttons, you can apply <code class="stacks-code">.s-notice--btn</code> to buttons to apply a toast-specific color.</p>
     <div class="mb24 p16 bar-sm bg-black-025 ba bc-black-1">
         <button class="grid--cell s-btn s-btn__filled js-notice-toast-open">Launch example toast notice</button>
     </div>
@@ -247,10 +247,10 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
             Toast notice message
         </div>
         <div class="grid">
-            <a href="#" class="s-btn">
+            <a href="#" class="s-btn s-notice--btn">
                 Undo
             </a>
-            <a href="#" class="s-btn">
+            <a href="#" class="s-btn s-notice--btn">
                 @Svg.ClearSm
             </a>
         </div>
@@ -265,10 +265,10 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
                             Toast notice message with an undo button
                         </div>
                         <div class="grid">
-                            <a href="#" class="s-btn">
+                            <a href="#" class="s-btn s-notice--btn">
                                 Undo
                             </a>
-                            <a href="#" class="s-btn">
+                            <a href="#" class="s-btn s-notice--btn">
                                 {% icon "ClearSm" %}
                             </a>
                         </div>
@@ -281,10 +281,10 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
                             Toast notice message with an undo button
                         </div>
                         <div class="grid">
-                            <a href="#" class="s-btn">
+                            <a href="#" class="s-btn s-notice--btn">
                                 Undo
                             </a>
-                            <a href="#" class="s-btn">
+                            <a href="#" class="s-btn s-notice--btn">
                                 {% icon "ClearSm" %}
                             </a>
                         </div>
@@ -297,10 +297,10 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
                             Toast notice message with an undo button
                         </div>
                         <div class="grid">
-                            <a href="#" class="s-btn">
+                            <a href="#" class="s-btn s-notice--btn">
                                 Undo
                             </a>
-                            <a href="#" class="s-btn">
+                            <a href="#" class="s-btn s-notice--btn">
                                 {% icon "ClearSm" %}
                             </a>
                         </div>
@@ -313,10 +313,10 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
                             Toast notice message with an undo button
                         </div>
                         <div class="grid">
-                            <a href="#" class="s-btn">
+                            <a href="#" class="s-btn s-notice--btn">
                                 Undo
                             </a>
-                            <a href="#" class="s-btn">
+                            <a href="#" class="s-btn s-notice--btn">
                                 {% icon "ClearSm" %}
                             </a>
                         </div>

--- a/docs/product/components/notices.html
+++ b/docs/product/components/notices.html
@@ -241,17 +241,18 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
     </div>
     <div class="stacks-preview">
 {% highlight html %}
-<aside class="s-toast">
-    <div class="s-notice s-notice__success p8 pl16" role="status" aria-hidden="false">
-        <div class="grid gs16 gsx ai-center jc-space-between" aria-describedby="notice-message">
-            <div class="grid--cell" aria-label="notice-message">
-                Toast notice message
-            </div>
-            <div class="grid--cell" aria-label="notice-dismiss">
-                <a class="s-btn">
-                    @Svg.ClearSm
-                </a>
-            </div>
+<aside class="grid--cell s-notice s-notice__info p8 pl16 bs-sm" role="status">
+    <div class="grid gsx gs16 ai-center jc-space-between" aria-describedby="notice-message">
+        <div class="grid--cell" aria-label="notice-message">
+            Toast notice message
+        </div>
+        <div class="grid">
+            <a href="#" class="s-btn">
+                Undo
+            </a>
+            <a href="#" class="s-btn">
+                @Svg.ClearSm
+            </a>
         </div>
     </div>
 </aside>
@@ -259,19 +260,54 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
         <div class="stacks-preview--example">
             <div class="ps-relative grid grid__center gs8 gsy fd-column jc-center">
                 <div class="grid--cell s-notice s-notice__success p8 pl16 bs-sm" role="status">
-                    <div class="grid gs16 gsx ai-center jc-space-between" aria-describedby="notice-message">
+                    <div class="grid gsx gs16 ai-center jc-space-between" aria-describedby="notice-message">
                         <div class="grid--cell" aria-label="notice-message">
-                            <p class="m0">Toast notice message styling</p>
+                            Toast notice message with an undo button
                         </div>
-                        <div class="grid--cell" aria-label="notice-dismiss">
-                            <a class="s-btn">
+                        <div class="grid">
+                            <a href="#" class="s-btn">
+                                Undo
+                            </a>
+                            <a href="#" class="s-btn">
                                 {% icon "ClearSm" %}
                             </a>
                         </div>
                     </div>
                 </div>
 
-                <div class="grid--cell s-notice s-notice__success p8 pl16 bs-sm" role="status">
+                <div class="grid--cell s-notice s-notice__info p8 pl16 bs-sm" role="status">
+                    <div class="grid gsx gs16 ai-center jc-space-between" aria-describedby="notice-message">
+                        <div class="grid--cell" aria-label="notice-message">
+                            Toast notice message with an undo button
+                        </div>
+                        <div class="grid">
+                            <a href="#" class="s-btn">
+                                Undo
+                            </a>
+                            <a href="#" class="s-btn">
+                                {% icon "ClearSm" %}
+                            </a>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="grid--cell s-notice s-notice__warning p8 pl16 bs-sm" role="status">
+                    <div class="grid gsx gs16 ai-center jc-space-between" aria-describedby="notice-message">
+                        <div class="grid--cell" aria-label="notice-message">
+                            Toast notice message with an undo button
+                        </div>
+                        <div class="grid">
+                            <a href="#" class="s-btn">
+                                Undo
+                            </a>
+                            <a href="#" class="s-btn">
+                                {% icon "ClearSm" %}
+                            </a>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="grid--cell s-notice s-notice__danger p8 pl16 bs-sm" role="status">
                     <div class="grid gsx gs16 ai-center jc-space-between" aria-describedby="notice-message">
                         <div class="grid--cell" aria-label="notice-message">
                             Toast notice message with an undo button

--- a/lib/css/components/_stacks-notices.less
+++ b/lib/css/components/_stacks-notices.less
@@ -30,7 +30,7 @@
         pointer-events: all;
     }
 
-    .s-btn {
+    .s-notice--btn {
         color: var(--fc-dark);
         padding: @su8;
     }
@@ -52,7 +52,7 @@
     }
 
     // Improve the presentation of buttons
-    .s-btn {
+    .s-notice--btn {
         &:hover {
             background-color: var(--powder-300);
         }
@@ -77,7 +77,7 @@
     }
 
     // Improve the presentation of buttons
-    .s-btn {
+    .s-notice--btn {
         &:hover {
             background-color: var(--green-100);
         }
@@ -102,7 +102,7 @@
     }
 
     // Improve the presentation of buttons
-    .s-btn {
+    .s-notice--btn {
         &:hover {
             background-color: var(--yellow-200);
         }
@@ -126,7 +126,7 @@
     }
 
     // Improve the presentation of buttons
-    .s-btn {
+    .s-notice--btn {
         &:hover {
             background-color: var(--red-100);
         }

--- a/lib/css/components/_stacks-notices.less
+++ b/lib/css/components/_stacks-notices.less
@@ -29,6 +29,11 @@
         box-shadow: var(--bs-sm);
         pointer-events: all;
     }
+
+    .s-btn {
+        color: var(--fc-dark);
+        padding: @su8;
+    }
 }
 
 //  ============================================================================
@@ -45,6 +50,17 @@
     &.s-banner__important {
         background-color: var(--blue-500);
     }
+
+    // Improve the presentation of buttons
+    .s-btn {
+        &:hover {
+            background-color: var(--powder-300);
+        }
+
+        &:active {
+            background-color: var(--powder-400);
+        }
+    }
 }
 
 //  $$  SUCCESS
@@ -58,6 +74,17 @@
     &.s-banner__important {
         background-color: var(--green-400);
         color: var(--black-900);
+    }
+
+    // Improve the presentation of buttons
+    .s-btn {
+        &:hover {
+            background-color: var(--green-100);
+        }
+
+        &:active {
+            background-color: var(--green-200);
+        }
     }
 }
 
@@ -73,6 +100,17 @@
         background-color: var(--yellow-400);
         color: var(--black-900);
     }
+
+    // Improve the presentation of buttons
+    .s-btn {
+        &:hover {
+            background-color: var(--yellow-200);
+        }
+
+        &:active {
+            background-color: var(--yellow-300);
+        }
+    }
 }
 
 //  $$  DANGER
@@ -85,6 +123,17 @@
     &.s-notice__important,
     &.s-banner__important {
         background-color: var(--red-400);
+    }
+
+    // Improve the presentation of buttons
+    .s-btn {
+        &:hover {
+            background-color: var(--red-100);
+        }
+
+        &:active {
+            background-color: var(--red-200);
+        }
     }
 }
 


### PR DESCRIPTION
This PR tints the stock `s-btn` appropriately within an `s-notice`.