### PR TITLE
Add autofill styling to inputs, textareas, and select menus

### DIFF
--- a/lib/css/components/_stacks-inputs.less
+++ b/lib/css/components/_stacks-inputs.less
@@ -73,6 +73,9 @@
 
     // --  STYLE SCROLLBARS
     @scrollbar-styles();
+
+    // --  STYLE AUTOFILL STATES
+    @autofill();
 }
 
 .s-input.s-input__search,
@@ -265,6 +268,9 @@ fieldset {
             font-size: 16px;
             padding: .4em .55em; // Compensate for the larger font size so we generally keep the input the same size
         }
+
+        // --  STYLE AUTOFILL STATES
+        @autofill();
     }
 }
 
@@ -623,3 +629,18 @@ fieldset {
     padding: 0.4em 0.5em;
     border-radius: @br-md;
 }
+
+@autofill: {
+    &:-webkit-autofill {
+        border-color: var(--blue-300);
+        -webkit-text-fill-color: var(--black);
+        -webkit-box-shadow: 0 0 0px 1000px var(--blue-050) inset; // This acts as a background color by stretching an inset box shadow across the input
+        transition: background-color 0s 50000s; // A hack to infinitely delay background styles that come from the browser.
+
+        &:focus {
+            border-color: var(--blue-300);
+            // Since the box shadow is overwritten to show a background, we have to re-add the focus outline
+            -webkit-box-shadow: 0 0 0 1000px var(--blue-050) inset, 0 0 0 @su4 var(--focus-ring);
+        }
+    }
+};

--- a/lib/css/components/_stacks-inputs.less
+++ b/lib/css/components/_stacks-inputs.less
@@ -631,6 +631,10 @@ fieldset {
 }
 
 @autofill: {
+    &:not(.s-input:-webkit-autofill)::-webkit-contacts-auto-fill-button {
+        background-color: var(--black); // In Safari, make the autocomplete button darkmode-aware
+    }
+
     &:-webkit-autofill {
         border-color: var(--blue-300);
         -webkit-text-fill-color: var(--black);

--- a/lib/css/components/_stacks-inputs.less
+++ b/lib/css/components/_stacks-inputs.less
@@ -631,7 +631,7 @@ fieldset {
 }
 
 @autofill: {
-    &:not(.s-input:-webkit-autofill)::-webkit-contacts-auto-fill-button {
+    &::-webkit-contacts-auto-fill-button {
         background-color: var(--black); // In Safari, make the autocomplete button darkmode-aware
     }
 


### PR DESCRIPTION
This closes #502 by applying a blue background to autofilled form elements. 
![image](https://user-images.githubusercontent.com/1369864/86051231-b661cc00-ba1a-11ea-959d-3681913ee47a.png)

![image](https://user-images.githubusercontent.com/1369864/86051255-bfeb3400-ba1a-11ea-9104-7177bbd3df99.png)

The border radius rendering isn't perfect, but this is a huge improvement over what is currently shipping.
