### PR TITLE
Forced theme override class

### DIFF
--- a/docs/product/guidelines/conditional-classes.html
+++ b/docs/product/guidelines/conditional-classes.html
@@ -204,10 +204,20 @@ description: Stacks provides conditional atomic classes to easily build complex 
     <p class="stacks-copy">Stacks provides darkmode-only atomic classes. By applying <code class="stacks-code">.d:bg-green-100</code>, you’re saying “In dark mode, apply a background of green 100.”</p>
     <div class="stacks-preview">
 {% highlight html %}
-<div class="bg-yellow-100 d:bg-green-100 d:bc-transparent"></div>
+<div class="bc-yellow-1 bg-yellow-100 d:bg-green-100 d:bc-transparent"></div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="bar-sm p12 bg-yellow-100 ba bc-black-2 d:bg-green-100 d:bc-transparent">This element will be yellow with a border by default but green without a border in dark mode.</div>
+            <div class="bar-sm p12 bg-yellow-100 ba bc-yellow-1 d:bg-green-100 d:bc-transparent">This element will be yellow with a border by default but green without a border in dark mode.</div>
+        </div>
+    </div>
+
+    <p class="stacks-copy">In addition to specific overrides, you can force an element’s colors to be light or dark by applying <code class="stacks-code">.theme-dark__forced</code> or <code class="stacks-code">.theme-light__forced</code>. This comes in handy when showing users a preview of light or dark interface elements.</p>
+    <div class="stacks-preview">
+{% highlight html %}
+<div class="bg-yellow-100"></div>
+{% endhighlight %}
+        <div class="stacks-preview--example theme-dark__forced">
+            <div class="bar-sm p12 fc-dark bg-yellow-100 ba bc-yellow-1">This element will be rendered with dark mode colors regardless of theme preference.</div>
         </div>
     </div>
 </section>

--- a/lib/css/base/_stacks-internals.less
+++ b/lib/css/base/_stacks-internals.less
@@ -35,7 +35,8 @@
             }
         }
 
-        body.theme-dark @{classname} {
+        body.theme-dark @{classname},
+        .theme-dark__forced @{classname} {
             @rules();
         }
     }

--- a/lib/css/exports/_stacks-constants-colors.less
+++ b/lib/css/exports/_stacks-constants-colors.less
@@ -155,7 +155,8 @@
 //  ----------------------------------------------------------------------------
 
 //  --  Primary Colors
-body, .theme-light__forced {
+body,
+.theme-light__forced {
     --white: @white;
     --black: @black;
     --orange: @orange;
@@ -426,6 +427,7 @@ body.theme-system {
     }
 }
 
-body.theme-dark, .theme-dark__forced {
+body.theme-dark,
+.theme-dark__forced {
     .dark-colors();
 }

--- a/lib/css/exports/_stacks-constants-colors.less
+++ b/lib/css/exports/_stacks-constants-colors.less
@@ -155,7 +155,7 @@
 //  ----------------------------------------------------------------------------
 
 //  --  Primary Colors
-body {
+body, .theme-light__forced {
     --white: @white;
     --black: @black;
     --orange: @orange;
@@ -426,6 +426,6 @@ body.theme-system {
     }
 }
 
-body.theme-dark {
+body.theme-dark, .theme-dark__forced {
     .dark-colors();
 }


### PR DESCRIPTION
Add ability to set a `theme-x__forced` class on an element to force it to use the variables of that theme. This is useful in cases where you want to show previews of how something will look in dark vs light mode on a single page.