### PR TITLE
Add official browserslist to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,21 @@
     "grunt-ts": "^6.0.0-beta.22",
     "@stackoverflow/stacks-icons": "^2.8.0",
     "typescript": "^3.9.5"
-  }
+  },
+  "browserslist": [
+    "last 2 versions",
+    "not dead",
+    "not ie > 0",
+    "no op_mini all",
+    "not baidu > 0",
+    "not and_ff > 0",
+    "not and_qq > 0",
+    "not kaios > 0",
+    "not op_mob > 0",
+    "not ie_mob > 0",
+    "not and_uc > 0",
+    "not Samsung > 0",
+    "not Android > 0",
+    "edge 18"
+  ]
 }


### PR DESCRIPTION
Currently, this has absolutely no effect on building/bundling/anything, but it would be nice to get an official "source of truth" / place to point to when asked what browsers we support.