### PR TITLE
Focus and placeholder refinements for Firefox

### DIFF
--- a/lib/css/components/_stacks-inputs.less
+++ b/lib/css/components/_stacks-inputs.less
@@ -374,6 +374,7 @@ fieldset {
     @focus-style: {
         border-color: var(--blue-300);
         box-shadow: 0 0 0 @su4 var(--focus-ring);
+        color: var(--black);
         outline: 0;
     };
 

--- a/lib/css/components/_stacks-inputs.less
+++ b/lib/css/components/_stacks-inputs.less
@@ -65,6 +65,7 @@
     }
     &::placeholder {
         color: var(--black-200);
+        opacity: 1;
     }
 
     //  --  REMOVE EDGE ADDITIONS


### PR DESCRIPTION
As reported in https://meta.stackoverflow.com/questions/399907/selects-that-are-focused-have-black-font-text-color-in-dark-mode, this should improve a Firefox edgecase with our select inputs.