### PR TITLE
Tweak s-prose styles

### DIFF
--- a/lib/css/components/_stacks-prose.less
+++ b/lib/css/components/_stacks-prose.less
@@ -66,34 +66,34 @@
 
     h1,
     h1 code {
-        font-size: @fs-headline2;
+        font-size: @fs-headline1;
         margin-bottom: .2em;
     }
 
     h2,
     h2 code {
-        font-size: @fs-headline1;
+        font-size: @fs-title;
         margin-bottom: .3em;
     }
 
     h3,
     h3 code {
-        font-size: @fs-title;
+        font-size: @fs-subheading;
     }
 
     h4,
     h4 code {
-        font-size: @fs-subheading;
+        font-size: @fs-body3;
     }
     
     h5,
     h5 code {
-        font-size: @fs-body3;
+        font-size: @fs-body2;
     }
     
     h6,
     h6 code {
-        font-size: @fs-body2;
+        font-size: @fs-body1;
     }
 
     // ============================================================================
@@ -167,6 +167,7 @@
         > ul,
         > ol {
             padding-top: 0.5em;
+            margin-bottom: 0;
         }
     }
 
@@ -280,6 +281,7 @@
         border-radius: @br-md;
         color: var(--black-800);
         cursor: pointer;
+        min-height: 48px;
 
         > * {
             opacity: 0;
@@ -325,7 +327,7 @@
     kbd {
         display: inline-block;
         margin: 0 .1em;
-        padding: .1em .4em;
+        padding: .1em .6em;
         font-family: @ff-sans;
         font-size: @fs-fine;
         line-height: @lh-lg;

--- a/lib/css/components/_stacks-prose.less
+++ b/lib/css/components/_stacks-prose.less
@@ -281,7 +281,7 @@
         border-radius: @br-md;
         color: var(--black-800);
         cursor: pointer;
-        min-height: 48px;
+        min-height: @su48; // TODO: Let's find a solution that doesn't have a magic number
 
         > * {
             opacity: 0;


### PR DESCRIPTION
A PR in haiku:

```
To align with prod
tweak the styles to match what's there
(for compat reasons)
```

```
Headlines shift one size
instead of the two we had
for lower impact
```

```
Change keyboard margins
back to their prior value.
Not sure on this one
```

```
Reduce the padding
of lists within other lists
since they look too tall
```

```
When they are empty
a spoiler's height will collapse,
so add a min-height
```