### PR TITLE
Increasing contrast in sidebar widget header

### DIFF
--- a/lib/css/components/_stacks-widget-static.less
+++ b/lib/css/components/_stacks-widget-static.less
@@ -89,7 +89,7 @@
 .s-sidebarwidget--header {
     padding: @s-sidebarwidget-content-inner-spacing @s-sidebarwidget-content-padding;
     background: @s-sidebarwidget-header-background-color;
-    color: var(--black-500);
+    color: var(--black-600);
     font-size: @fs-body2;
     font-weight: normal;
 


### PR DESCRIPTION
Super simple. Just trying to increase sidebar header copy color from 500 to 600. I think it makes quite a difference in readability.