### PR TITLE
Tighten up the line height of code blocks

### DIFF
--- a/lib/css/components/_stacks-code-blocks.less
+++ b/lib/css/components/_stacks-code-blocks.less
@@ -1,7 +1,7 @@
 pre.s-code-block {
     font-size: @fs-body1;
     font-family: @ff-mono;
-    line-height: @lh-lg;
+    line-height: @lh-md;
     color: var(--highlight-color);
     background-color: var(--highlight-bg);
     border-radius: @br-md;

--- a/lib/css/components/_stacks-prose.less
+++ b/lib/css/components/_stacks-prose.less
@@ -367,6 +367,7 @@
         max-height: 600px;
         overflow: auto;
         font-size: 13px;
+        line-height: @lh-md;
         background-color: var(--highlight-bg);
         border-radius: @br-md;
 

--- a/lib/css/components/_stacks-prose.less
+++ b/lib/css/components/_stacks-prose.less
@@ -366,7 +366,7 @@
         width: auto;
         max-height: 600px;
         overflow: auto;
-        font-size: 13px;
+        font-size: @fs-body1;
         line-height: @lh-md;
         background-color: var(--highlight-bg);
         border-radius: @br-md;


### PR DESCRIPTION
Folks have complained that the code blocks are too much space, so let's drop these down a line height step. This does not apply to paragraphs, just the code blocks.