### PR TITLE
Tweak link-preview code styling

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -115,7 +115,7 @@ module.exports = function(eleventyConfig) {
         }
 
         var newContent =
-            '<code class="s-code-block--line-numbers nocode">' +
+            '<code class="s-code-block--line-numbers">' +
             output +
             "</code>" +
             content;

--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -78,8 +78,61 @@ module.exports = function(eleventyConfig) {
     return {version}.version;
   });
 
+
+  // highlightjs line-numbering support
+  // add `linenums` or `linenums:startNumber` to the start of your code for detection
+  class HljsInsertLineNums {
+    constructor() {
+        this.shouldInsert = false;
+        this.startNumber = 1;
+    }
+
+    "before:highlight"(data) {
+        var match = /^linenums(:\d+)?/.exec(data.code);
+        if (!match) {
+            return;
+        }
+        var startNumber = +(match[1] || "").slice(1) || 1;
+
+        this.shouldInsert = true;
+        this.startNumber = startNumber;
+        data.code = data.code.replace(/^linenums(:\d+)?/, "");
+    }
+
+    "after:highlight"(result) {
+        if (!this.shouldInsert) {
+            return;
+        }
+
+        var startNumber = this.startNumber;
+
+        var content = result.value;
+        var lines = content.split(/\r?\n/);
+
+        var output = "";
+        for (var i = 0; i < lines.length; i++) {
+            output += "<div>" + (i + startNumber) + "</div>";
+        }
+
+        var newContent =
+            '<code class="s-code-block--line-numbers nocode">' +
+            output +
+            "</code>" +
+            content;
+        result.value = newContent;
+
+        this.shouldInsert = false;
+      }
+  }
+
   // Add syntax highlighting
-  eleventyConfig.addPlugin(syntaxHighlight, { className: "s-code-block" });
+  eleventyConfig.addPlugin(syntaxHighlight, {
+      className: "s-code-block",
+      init: function ({ hljs }) {
+          // TODO custom plugin taken from Prod - should probably be an npm package?
+          hljs.addPlugin(new HljsInsertLineNums());
+      },
+  });
 
   // Add markdown shortcode
   eleventyConfig.addPlugin(markdownShortcode, {

--- a/docs/product/components/link-previews.html
+++ b/docs/product/components/link-previews.html
@@ -79,7 +79,7 @@ description: Link previews add rich previews to links included in questions and 
 
     {% header "h3", "Code blocks" %}
     <p class="stacks-copy">Use for links whose expected body is code like code files or GitHub Gists. In these scenarios, replace <code class="stacks-code ws-nowrap">s-link-preview--body</code> class with <code class="stacks-code ws-nowrap">s-link-preview--code</code>.</p>
-    <p class="stacks-copy">Add a <code class="stacks-code">prettyprint</code> class to the <code class="stacks-code">&lt;pre&gt;</code> tag if you’d like to apply <a href="https://github.com/google/code-prettify">Prettify’s</a> syntax highlighting on Stack Exchange sites with this option enabled.</p>
+    <p class="stacks-copy">Add a <code class="stacks-code">s-code-block</code> class to the <code class="stacks-code">&lt;pre&gt;</code> tag if you’d like to apply <a href="https://github.com/google/code-prettify">Prettify’s</a> syntax highlighting on Stack Exchange sites with this option enabled.</p>
     <div class="stacks-preview">
 {% highlight html %}
 <div class="s-link-preview">
@@ -91,7 +91,7 @@ description: Link previews add rich previews to links included in questions and 
         </div>
     </div>
     <div class="s-link-preview--code">
-        <pre class="prettyprint">
+        <pre class="s-code-block">
             <code>…</code>
         </pre>
     </div>
@@ -117,23 +117,25 @@ description: Link previews add rich previews to links included in questions and 
                     </div>
                 </div>
                 <div class="s-link-preview--code">
-                    <pre class="prettyprint"><code><span class="fc-red-800">'use strict'</span>;
+{% highlight js %}
+'use strict';
 
-<span class="fc-blue-800">module</span>.exports = <span class="fc-blue-800">function</span>(grunt) {
+module.exports = function(grunt) {
     grunt.initConfig({
-        pkg: grunt.file.readJSON(<span class="fc-red-800">'package.json'</span>),
-        version: <span class="fc-red-800">'<%= pkg.version %>'</span>,
+        pkg: grunt.file.readJSON('package.json'),
+        version: '<%= pkg.version %>',
 
-        <span class="fc-black-400">// Shell commands for use in Grunt tasks</span>
+        // Shell commands for use in Grunt tasks
         shell: {
             eleventyBuild: {
-                command: <span class="fc-red-800">'npx @11ty/eleventy'</span>,
+                command: 'npx @11ty/eleventy',
                 options: {
-                    stderr: <span class="fc-blue-800">false</span>,
+                    stderr: false,
                     execOptions: {
-                        cwd: <span class="fc-red-800">'docs'</span>
+                        cwd: 'docs'
                     }
-                }</code></pre>
+                }
+{% endhighlight %}
                 </div>
                 <div class="s-link-preview--footer">
                     <a href="https://github.com/StackExchange/Stacks/blob/develop/Gruntfile.js" class="s-link-preview--url">https://github.com/StackExchange/Stacks/blob/develop/Gruntfile.js</a>
@@ -176,7 +178,7 @@ description: Link previews add rich previews to links included in questions and 
         </div>
     </div>
     <div class="s-link-preview--code">
-        <pre class="prettyprint linenums">
+        <pre class="s-code-block linenums">
             <code>…</code>
         </pre>
     </div>
@@ -202,40 +204,25 @@ description: Link previews add rich previews to links included in questions and 
                     </div>
                 </div>
                 <div class="s-link-preview--code">
-                    <pre class="prettyprint m0 bar0 px8 py12 ff-mono overflow-auto fs-body1 lh-sm bg-black-050">
-                        <div class="linenums">1
-2
-3
-4
-5
-6
-7
-8
-9
-10
-11
-12
-13
-14
-15
-16
-17</div><code><span class="fc-red-800">'use strict'</span>;
+{% highlight js %}
+linenums'use strict';
 
-<span class="fc-blue-800">module</span>.exports = <span class="fc-blue-800">function</span>(grunt) {
+module.exports = function(grunt) {
     grunt.initConfig({
-        pkg: grunt.file.readJSON(<span class="fc-red-800">'package.json'</span>),
-        version: <span class="fc-red-800">'<%= pkg.version %>'</span>,
+        pkg: grunt.file.readJSON('package.json'),
+        version: '<%= pkg.version %>',
 
-        <span class="fc-black-400">// Shell commands for use in Grunt tasks</span>
+        // Shell commands for use in Grunt tasks
         shell: {
             eleventyBuild: {
-                command: <span class="fc-red-800">'npx @11ty/eleventy'</span>,
+                command: 'npx @11ty/eleventy',
                 options: {
-                    stderr: <span class="fc-blue-800">false</span>,
+                    stderr: false,
                     execOptions: {
-                        cwd: <span class="fc-red-800">'docs'</span>
+                        cwd: 'docs'
                     }
-                }</code></pre>
+                }
+{% endhighlight %}
                 </div>
                 <div class="s-link-preview--footer">
                     <a href="https://github.com/StackExchange/Stacks/blob/develop/Gruntfile.js" class="s-link-preview--url">https://github.com/StackExchange/Stacks/blob/develop/Gruntfile.js</a>

--- a/docs/product/components/link-previews.html
+++ b/docs/product/components/link-previews.html
@@ -79,7 +79,7 @@ description: Link previews add rich previews to links included in questions and 
 
     {% header "h3", "Code blocks" %}
     <p class="stacks-copy">Use for links whose expected body is code like code files or GitHub Gists. In these scenarios, replace <code class="stacks-code ws-nowrap">s-link-preview--body</code> class with <code class="stacks-code ws-nowrap">s-link-preview--code</code>.</p>
-    <p class="stacks-copy">Add a <code class="stacks-code">s-code-block</code> class to the <code class="stacks-code">&lt;pre&gt;</code> tag if you’d like to apply <a href="https://github.com/google/code-prettify">Prettify’s</a> syntax highlighting on Stack Exchange sites with this option enabled.</p>
+    <p class="stacks-copy">Add a <code class="stacks-code">s-code-block</code> class to the <code class="stacks-code">&lt;pre&gt;</code> tag if you’d like to apply <a href="https://highlightjs.org/">highlight.js’s</a> syntax highlighting on Stack Exchange sites with this option enabled.</p>
     <div class="stacks-preview">
 {% highlight html %}
 <div class="s-link-preview">
@@ -146,7 +146,7 @@ module.exports = function(grunt) {
     </div>
 
     {% header "h3", "Code blocks with line numbers" %}
-    <p class="stacks-copy">You can further configure Prettify’s syntax highlighting to include line numbers by adding the class <code class="stacks-code">linenums</code> to the prettified <code class="stacks-code">&lt;pre&gt;</code> tag containing the code.</p>
+    <p class="stacks-copy">You can further configure highlight.js’s syntax highlighting to include line numbers by adding the class <code class="stacks-code">linenums</code> to the prettified <code class="stacks-code">&lt;pre&gt;</code> tag containing the code.</p>
     <div class="overflow-x-auto mb16">
         <table class="wmn4 s-table s-table__bx-simple">
             <thead>

--- a/docs/product/components/prose.html
+++ b/docs/product/components/prose.html
@@ -76,7 +76,7 @@ description: The prose component provides proper styling for rendered Markdown.
 </section>
 
 <section class="stacks-section">
-    {% header "h3", "Example post with a link preview " %}
+    {% header "h3", "Example post with a link preview" %}
     <p class="stacks-copy">The following is a <a href="https://meta.stackexchange.com/questions/350544/the-new-moderator-agreement-is-now-live-for-moderators-to-accept-across-the-netw">real-world post</a> taken from Meta Stack Exchange.</p>
     <div class="stacks-preview">
         <div class="stacks-preview--example d:bg-white bar-sm btw1">

--- a/docs/product/components/prose.html
+++ b/docs/product/components/prose.html
@@ -76,6 +76,57 @@ description: The prose component provides proper styling for rendered Markdown.
 </section>
 
 <section class="stacks-section">
+    {% header "h3", "Example post with a link preview " %}
+    <p class="stacks-copy">The following is a <a href="https://meta.stackexchange.com/questions/350544/the-new-moderator-agreement-is-now-live-for-moderators-to-accept-across-the-netw">real-world post</a> taken from Meta Stack Exchange.</p>
+    <div class="stacks-preview">
+        <div class="stacks-preview--example d:bg-white bar-sm btw1">
+            <div class="s-prose">
+                <div class="s-link-preview">
+                    <div class="s-link-preview--header">
+                        <div class="s-link-preview--icon">
+                            {% icon "GitHub" %}
+                        </div>
+                        <div>
+                            <a href="https://github.com/StackExchange/Stacks/blob/develop/Gruntfile.js" class="s-link-preview--title">
+                                Gruntfile.js
+                            </a>
+                            <div class="s-link-preview--details">
+                                Located in <a href="https://github.com/StackExchange/Stacks/">StackExchange / Stacks</a>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="s-link-preview--code">
+{% highlight js %}
+linenums'use strict';
+
+module.exports = function(grunt) {
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+        version: '<%= pkg.version %>',
+
+        // Shell commands for use in Grunt tasks
+        shell: {
+            eleventyBuild: {
+                command: 'npx @11ty/eleventy',
+                options: {
+                    stderr: false,
+                    execOptions: {
+                        cwd: 'docs'
+                    }
+                }
+{% endhighlight %}
+                    </div>
+                    <div class="s-link-preview--footer">
+                        <a href="https://github.com/StackExchange/Stacks/blob/develop/Gruntfile.js" class="s-link-preview--url">https://github.com/StackExchange/Stacks/blob/develop/Gruntfile.js</a>
+                        <div class="s-link-preview--misc">(truncated)</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="stacks-section">
     {% header "h2", "Sizing" %}
 
     {% header "h3", "Extra Small" %}

--- a/lib/css/components/_stacks-code-blocks.less
+++ b/lib/css/components/_stacks-code-blocks.less
@@ -99,3 +99,18 @@ code[class*="language-"] {
         font-weight: bold;
     }
 }
+
+pre.s-code-block .s-code-block--line-numbers {
+    float: left;
+    color: var(--black-300);
+    text-align: right;
+    border-width: 0;
+    border-style: solid;
+    border-color: var(--black-100);
+    border-right-width: 1px;
+    margin: -12px;
+    margin-right: 12px;
+    padding: 12px;
+    padding-right: 6px;
+    background-color: var(--black-075);
+}

--- a/lib/css/components/_stacks-code-blocks.less
+++ b/lib/css/components/_stacks-code-blocks.less
@@ -108,9 +108,9 @@ pre.s-code-block .s-code-block--line-numbers {
     border-style: solid;
     border-color: var(--black-100);
     border-right-width: 1px;
-    margin: -12px;
-    margin-right: 12px;
-    padding: 12px;
-    padding-right: 6px;
+    margin: -@su12;
+    margin-right: @su12;
+    padding: @su12;
+    padding-right: @su6;
     background-color: var(--black-075);
 }

--- a/lib/css/components/_stacks-code-blocks.less
+++ b/lib/css/components/_stacks-code-blocks.less
@@ -6,7 +6,7 @@ pre.s-code-block {
     background-color: var(--highlight-bg);
     border-radius: @br-md;
     margin: 0;
-    padding: @su8 @su12;
+    padding: @su12;
     overflow: auto;
 
     @scrollbar-styles();

--- a/lib/css/components/_stacks-code-blocks.less
+++ b/lib/css/components/_stacks-code-blocks.less
@@ -112,5 +112,9 @@ pre.s-code-block .s-code-block--line-numbers {
     margin-right: @su12;
     padding: @su12;
     padding-right: @su6;
-    background-color: var(--black-075);
+    background-color: var(--black-050);
 }
+
+#stacks-internals #darkmode('pre.s-code-block .s-code-block--line-numbers', {
+    background-color: var(--black-025);
+});

--- a/lib/css/components/_stacks-link-previews.less
+++ b/lib/css/components/_stacks-link-previews.less
@@ -73,7 +73,7 @@ a.s-link-preview--title {
 }
 .s-link-preview--code {
     pre {
-        border-radius: 0;
+        border-radius: 0 !important;
         margin: 0;
         max-height: 400px;
     }

--- a/lib/css/components/_stacks-link-previews.less
+++ b/lib/css/components/_stacks-link-previews.less
@@ -77,29 +77,6 @@ a.s-link-preview--title {
         margin: 0;
         max-height: 400px;
     }
-
-    // TODO remove entirely after prettify is removed from prod
-    pre:not(.s-code-block) {
-        @scrollbar-styles();
-        display: flex;
-        width: 100%;
-        padding: @su12;
-        overflow: auto;
-        font-size: @fs-body1;
-        line-height: @lh-sm;
-        font-family: @ff-mono;
-
-        .linenums {
-            flex-shrink: 0;
-            height: 100%;
-            color: var(--black-300);
-            border-right: 1px solid var(--black-100);
-            text-align: right;
-            padding: @su12 @su6 @su12 @su12;
-            background-color: var(--black-075);
-            margin: -@su12 @su12 -@su12 -@su12
-        }
-    }
 }
 
 .s-link-preview--footer {

--- a/lib/css/components/_stacks-link-previews.less
+++ b/lib/css/components/_stacks-link-previews.less
@@ -35,6 +35,7 @@
     font-weight: bold;
     color: var(--black-900);
 }
+
 a.s-link-preview--title {
     #stacks-internals #load-config();
     text-decoration: none;
@@ -54,6 +55,7 @@ a.s-link-preview--title {
         text-decoration: none;
     }
 }
+
 .s-link-preview--details {
     font-size: @fs-caption;
     color: var(--black-500);
@@ -63,6 +65,7 @@ a.s-link-preview--title {
         margin-top: @su4;
     });
 }
+
 .s-link-preview--body {
     padding: @su12;
     font-size: @fs-body2;
@@ -71,6 +74,7 @@ a.s-link-preview--title {
         margin-bottom: 0;
     }
 }
+
 .s-link-preview--code {
     pre {
         border-radius: 0 !important;
@@ -116,10 +120,11 @@ a.s-link-preview--title {
     text-decoration: none;
     cursor: pointer;
     color: var(--black-500);
-    
+
     &:visited {
         color: var(--black-700);
     }
+
     &:hover,
     &:active,
     &:focus {

--- a/lib/css/components/_stacks-link-previews.less
+++ b/lib/css/components/_stacks-link-previews.less
@@ -77,6 +77,30 @@ a.s-link-preview--title {
         margin: 0;
         max-height: 400px;
     }
+
+    // TODO remove entirely after prettify is removed from prod
+    pre:not(.s-code-block) {
+        @scrollbar-styles();
+        display: flex;
+        width: 100%;
+        padding: @su12;
+        overflow: auto;
+        font-size: @fs-body1;
+        line-height: @lh-sm;
+        background-color: var(--black-050);
+        font-family: @ff-mono;
+
+        .linenums {
+            flex-shrink: 0;
+            height: 100%;
+            color: var(--black-300);
+            border-right: 1px solid var(--black-100);
+            text-align: right;
+            padding: @su12 @su6 @su12 @su12;
+            background-color: var(--black-075);
+            margin: -@su12 @su12 -@su12 -@su12
+        }
+    }
 }
 
 .s-link-preview--footer {

--- a/lib/css/components/_stacks-link-previews.less
+++ b/lib/css/components/_stacks-link-previews.less
@@ -87,7 +87,6 @@ a.s-link-preview--title {
         overflow: auto;
         font-size: @fs-body1;
         line-height: @lh-sm;
-        background-color: var(--black-050);
         font-family: @ff-mono;
 
         .linenums {

--- a/lib/css/components/_stacks-link-previews.less
+++ b/lib/css/components/_stacks-link-previews.less
@@ -73,29 +73,9 @@ a.s-link-preview--title {
 }
 .s-link-preview--code {
     pre {
-        @scrollbar-styles();
-        display: flex;
-        width: 100%;
-        margin: 0;
         border-radius: 0;
-        padding: @su12;
-        overflow: auto;
-        font-size: @fs-body1;
-        line-height: @lh-sm;
-        background-color: var(--black-050);
-        font-family: @ff-mono;
+        margin: 0;
         max-height: 400px;
-
-        .linenums {
-            flex-shrink: 0;
-            height: 100%;
-            color: var(--black-300);
-            border-right: 1px solid var(--black-100);
-            text-align: right;
-            padding: @su12 @su6 @su12 @su12;
-            background-color: var(--black-075);
-            margin: -@su12 @su12 -@su12 -@su12
-        }
     }
 }
 


### PR DESCRIPTION
Tweaks link-previews to use `s-code-block` in all the docs / prod. Also, added a linenumbers plugin that is very similar to what we'll be using in prod. Requires some slightly funky syntax to enable, but it's the best I can do.

Also, tweaked s-code-block padding to match that used in `s-prose pre` so we don't get style flickers on highlight.

Creating as a draft since it will likely require a few tweaks (and some testing in Core).