### PR TITLE
Add pointer events to spoilers

### DIFF
--- a/docs/_includes/markdown-sandbox.md
+++ b/docs/_includes/markdown-sandbox.md
@@ -269,7 +269,7 @@ Not indented
 - Create a spoiler with `>!`:
 
 <blockquote class="spoiler js-spoiler" data-spoiler="Reveal spoiler">
-    <p>Tyler Durden is Luke Skywalker’s father.</p>
+    <p>Tyler Durden is <a href="#">Luke Skywalker’s</a> father.</p>
     <p>Keyser Söze was dead the whole time.</p>
 </blockquote>
 

--- a/lib/css/components/_stacks-prose.less
+++ b/lib/css/components/_stacks-prose.less
@@ -297,7 +297,6 @@
             visibility: hidden; // hidden elements don't respond to mouse events, but still retain their space
             opacity: 0;
             transition: opacity 0.1s ease-in-out;
-            pointer-events: none;
         }
 
         &.is-visible {
@@ -306,7 +305,6 @@
             > * {
                 visibility: visible;
                 opacity: 1;
-                pointer-events: auto;
             }
         }
 
@@ -328,6 +326,7 @@
             top: 1em;
             right: 1em;
             transition: opacity 0.1s ease-in-out;
+            pointer-events: none;
 
             #stacks-internals #screen-sm({
                 top: 9px; // Adjust the position in the smallest breakpoint

--- a/lib/css/components/_stacks-prose.less
+++ b/lib/css/components/_stacks-prose.less
@@ -297,6 +297,7 @@
             visibility: hidden; // hidden elements don't respond to mouse events, but still retain their space
             opacity: 0;
             transition: opacity 0.1s ease-in-out;
+            pointer-events: none;
         }
 
         &.is-visible {
@@ -305,6 +306,7 @@
             > * {
                 visibility: visible;
                 opacity: 1;
+                pointer-events: auto;
             }
         }
 


### PR DESCRIPTION
Addresses https://meta.stackexchange.com/questions/353670/reveal-spoiler-label-blocks-mouse-interaction-after-revealing-the-spoiler