### PR TITLE
Fix user-select inconsistency with buttons and links

### DIFF
--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -540,7 +540,7 @@
     background: none;
     box-shadow: none;
     cursor: default;
-    user-select: all;
+    user-select: auto;
 }
 
 .s-btn__unset:focus {

--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -33,6 +33,7 @@
     text-align: center;
     text-decoration: none;
     cursor: pointer;
+    user-select: none;
 
     // Override for buttons having inline-block by default
     &.grid {
@@ -539,6 +540,7 @@
     background: none;
     box-shadow: none;
     cursor: default;
+    user-select: all;
 }
 
 .s-btn__unset:focus {

--- a/lib/css/components/_stacks-links.less
+++ b/lib/css/components/_stacks-links.less
@@ -20,6 +20,7 @@ a,
     text-decoration: none;
     color: @link-color;
     cursor: pointer;
+    user-select: auto;
 
     &.s-link__visited:visited {
         color: @link-color-visited;
@@ -101,6 +102,7 @@ button.s-link {
     border: 0;
     padding: 0;
     line-height: inherit;
+    user-select: auto;
 
     &:focus {
         outline: none;


### PR DESCRIPTION
Closes #540 by adding appropriate user-select parameters to buttons and links to cause consistent behavior:

* buttons **cannot** be selected,
* links **can** be selected.

This is my first PR here, so if I have forgotten something, please tell me; especially when I need to build the LESS foöes (couldn't find a build product, hence I didn't try). :)