### PR TITLE
Add full borders classes

### DIFF
--- a/docs/product/base/borders.html
+++ b/docs/product/base/borders.html
@@ -197,29 +197,39 @@ description: Stacks provides atomic classes for borders.
     {% header "h3", "Black" %}
     <div class="stacks-preview">
 {% highlight html %}
-<div class="bb bc-black-10">Black Border: Tenth Step</div>
-<div class="bb bc-black-9">Black Border: Ninth Step</div>
-<div class="bb bc-black-8">Black Border: Eighth Step</div>
-<div class="bb bc-black-7">Black Border: Seventh Step</div>
-<div class="bb bc-black-6">Black Border: Sixth Step</div>
-<div class="bb bc-black-5">Black Border: Fifth Step</div>
-<div class="bb bc-black-4">Black Border: Fourth Step</div>
-<div class="bb bc-black-3">Black Border: Third Step</div>
-<div class="bb bc-black-2">Black Border: Second Step</div>
-<div class="bb bc-black-1">Black Border: First Step</div>
+<div class="ba bc-black-900"></div>
+<div class="ba bc-black-800"></div>
+<div class="ba bc-black-750"></div>
+<div class="ba bc-black-700"></div>
+<div class="ba bc-black-600"></div>
+<div class="ba bc-black-500"></div>
+<div class="ba bc-black-400"></div>
+<div class="ba bc-black-350"></div>
+<div class="ba bc-black-300"></div>
+<div class="ba bc-black-200"></div>
+<div class="ba bc-black-150"></div>
+<div class="ba bc-black-100"></div>
+<div class="ba bc-black-075"></div>
+<div class="ba bc-black-050"></div>
+<div class="ba bc-black-025"></div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="grid ff-column-nowrap w100 gs8 gsy">
-                <div class="grid--cell ai-center p8 bb bc-black-10">Black Border: Tenth Step</div>
-                <div class="grid--cell ai-center p8 bb bc-black-9">Black Border: Ninth Step</div>
-                <div class="grid--cell ai-center p8 bb bc-black-8">Black Border: Eighth Step</div>
-                <div class="grid--cell ai-center p8 bb bc-black-7">Black Border: Seventh Step</div>
-                <div class="grid--cell ai-center p8 bb bc-black-6">Black Border: Sixth Step</div>
-                <div class="grid--cell ai-center p8 bb bc-black-5">Black Border: Fifth Step</div>
-                <div class="grid--cell ai-center p8 bb bc-black-4">Black Border: Fourth Step</div>
-                <div class="grid--cell ai-center p8 bb bc-black-3">Black Border: Third Step</div>
-                <div class="grid--cell ai-center p8 bb bc-black-2">Black Border: Second Step</div>
-                <div class="grid--cell ai-center p8 bb bc-black-1">Black Border: First Step</div>
+            <div class="grid ff-column-nowrap w100 gs12 gsy">
+                <div class="grid--cell ai-center p8 ba bc-black-900">Black 900</div>
+                <div class="grid--cell ai-center p8 ba bc-black-800">Black 800</div>
+                <div class="grid--cell ai-center p8 ba bc-black-750">Black 750</div>
+                <div class="grid--cell ai-center p8 ba bc-black-700">Black 700</div>
+                <div class="grid--cell ai-center p8 ba bc-black-600">Black 600</div>
+                <div class="grid--cell ai-center p8 ba bc-black-500">Black 500</div>
+                <div class="grid--cell ai-center p8 ba bc-black-400">Black 400</div>
+                <div class="grid--cell ai-center p8 ba bc-black-350">Black 350</div>
+                <div class="grid--cell ai-center p8 ba bc-black-300">Black 300</div>
+                <div class="grid--cell ai-center p8 ba bc-black-200">Black 200</div>
+                <div class="grid--cell ai-center p8 ba bc-black-150">Black 150</div>
+                <div class="grid--cell ai-center p8 ba bc-black-100">Black 100</div>
+                <div class="grid--cell ai-center p8 ba bc-black-075">Black 75</div>
+                <div class="grid--cell ai-center p8 ba bc-black-050">Black 50</div>
+                <div class="grid--cell ai-center p8 ba bc-black-025">Black 25</div>
             </div>
         </div>
     </div>
@@ -227,15 +237,15 @@ description: Stacks provides atomic classes for borders.
     {% header "h3", "White" %}
     <div class="stacks-preview">
 {% highlight html %}
-<div class="bb bc-white-3">White Border: Third Step</div>
-<div class="bb bc-white-2">White Border: Second Step</div>
-<div class="bb bc-white-1">White Border: First Step</div>
+<div class="ba bc-white-3">White Border: Third Step</div>
+<div class="ba bc-white-2">White Border: Second Step</div>
+<div class="ba bc-white-1">White Border: First Step</div>
 {% endhighlight %}
         <div class="stacks-preview--example bg-black-750">
-            <div class="grid ff-column-nowrap w100 gs8 gsy">
-                <div class="grid--cell ai-center p8 bb bc-white-3 fc-white">White Border: Third Step</div>
-                <div class="grid--cell ai-center p8 bb bc-white-2 fc-white">White Border: Second Step</div>
-                <div class="grid--cell ai-center p8 bb bc-white-1 fc-white">White Border: First Step</div>
+            <div class="grid ff-column-nowrap w100 gs12 gsy">
+                <div class="grid--cell ai-center p8 ba bc-white-3 fc-white">White Border: Third Step</div>
+                <div class="grid--cell ai-center p8 ba bc-white-2 fc-white">White Border: Second Step</div>
+                <div class="grid--cell ai-center p8 ba bc-white-1 fc-white">White Border: First Step</div>
             </div>
         </div>
     </div>
@@ -243,15 +253,29 @@ description: Stacks provides atomic classes for borders.
     {% header "h3", "Orange" %}
     <div class="stacks-preview">
 {% highlight html %}
-<div class="bb bc-orange-3">Dark orange border</div>
-<div class="bb bc-orange-2">Orange border</div>
-<div class="bb bc-orange-1">Light orange border</div>
+<div class="ba bc-orange-900"></div>
+<div class="ba bc-orange-800"></div>
+<div class="ba bc-orange-700"></div>
+<div class="ba bc-orange-600"></div>
+<div class="ba bc-orange-500"></div>
+<div class="ba bc-orange-400"></div>
+<div class="ba bc-orange-300"></div>
+<div class="ba bc-orange-200"></div>
+<div class="ba bc-orange-100"></div>
+<div class="ba bc-orange-050"></div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="grid ff-column-nowrap w100 gs8 gsy">
-                <div class="grid--cell ai-center p8 bb bc-orange-3">Dark Orange Border</div>
-                <div class="grid--cell ai-center p8 bb bc-orange-2">Orange Border</div>
-                <div class="grid--cell ai-center p8 bb bc-orange-1">Light Orange Border</div>
+            <div class="grid ff-column-nowrap w100 gs12 gsy">
+                <div class="grid--cell ai-center p8 ba bc-orange-900">Orange 900</div>
+                <div class="grid--cell ai-center p8 ba bc-orange-800">Orange 800</div>
+                <div class="grid--cell ai-center p8 ba bc-orange-700">Orange 700</div>
+                <div class="grid--cell ai-center p8 ba bc-orange-600">Orange 600</div>
+                <div class="grid--cell ai-center p8 ba bc-orange-500">Orange 500</div>
+                <div class="grid--cell ai-center p8 ba bc-orange-400">Orange 400</div>
+                <div class="grid--cell ai-center p8 ba bc-orange-300">Orange 300</div>
+                <div class="grid--cell ai-center p8 ba bc-orange-200">Orange 200</div>
+                <div class="grid--cell ai-center p8 ba bc-orange-100">Orange 100</div>
+                <div class="grid--cell ai-center p8 ba bc-orange-050">Orange 50</div>
             </div>
         </div>
     </div>
@@ -259,15 +283,29 @@ description: Stacks provides atomic classes for borders.
     {% header "h3", "Blue" %}
     <div class="stacks-preview">
 {% highlight html %}
-<div class="bb bc-blue-3">Dark blue border</div>
-<div class="bb bc-blue-2">Blue border</div>
-<div class="bb bc-blue-1">Light blue border</div>
+<div class="ba bc-blue-900"></div>
+<div class="ba bc-blue-800"></div>
+<div class="ba bc-blue-700"></div>
+<div class="ba bc-blue-600"></div>
+<div class="ba bc-blue-500"></div>
+<div class="ba bc-blue-400"></div>
+<div class="ba bc-blue-300"></div>
+<div class="ba bc-blue-200"></div>
+<div class="ba bc-blue-100"></div>
+<div class="ba bc-blue-050"></div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="grid ff-column-nowrap w100 gs8 gsy">
-                <div class="grid--cell ai-center p8 bb bc-blue-3">Dark blue Border</div>
-                <div class="grid--cell ai-center p8 bb bc-blue-2">Blue border</div>
-                <div class="grid--cell ai-center p8 bb bc-blue-1">Light blue border</div>
+            <div class="grid ff-column-nowrap w100 gs12 gsy">
+                <div class="grid--cell ai-center p8 ba bc-blue-900">Blue 900</div>
+                <div class="grid--cell ai-center p8 ba bc-blue-800">Blue 800</div>
+                <div class="grid--cell ai-center p8 ba bc-blue-700">Blue 700</div>
+                <div class="grid--cell ai-center p8 ba bc-blue-600">Blue 600</div>
+                <div class="grid--cell ai-center p8 ba bc-blue-500">Blue 500</div>
+                <div class="grid--cell ai-center p8 ba bc-blue-400">Blue 400</div>
+                <div class="grid--cell ai-center p8 ba bc-blue-300">Blue 300</div>
+                <div class="grid--cell ai-center p8 ba bc-blue-200">Blue 200</div>
+                <div class="grid--cell ai-center p8 ba bc-blue-100">Blue 100</div>
+                <div class="grid--cell ai-center p8 ba bc-blue-050">Blue 50</div>
             </div>
         </div>
     </div>
@@ -275,15 +313,29 @@ description: Stacks provides atomic classes for borders.
     {% header "h3", "Powder" %}
     <div class="stacks-preview">
 {% highlight html %}
-<div class="bb bc-powder-3">Dark powder border</div>
-<div class="bb bc-powder-2">Powder border</div>
-<div class="bb bc-powder-1">Light powder border</div>
+<div class="ba bc-powder-900"></div>
+<div class="ba bc-powder-800"></div>
+<div class="ba bc-powder-700"></div>
+<div class="ba bc-powder-600"></div>
+<div class="ba bc-powder-500"></div>
+<div class="ba bc-powder-400"></div>
+<div class="ba bc-powder-300"></div>
+<div class="ba bc-powder-200"></div>
+<div class="ba bc-powder-100"></div>
+<div class="ba bc-powder-050"></div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="grid ff-column-nowrap w100 gs8 gsy">
-                <div class="grid--cell ai-center p8 bb bc-powder-3">Dark powder border</div>
-                <div class="grid--cell ai-center p8 bb bc-powder-2">Powder border</div>
-                <div class="grid--cell ai-center p8 bb bc-powder-1">Light powder border</div>
+            <div class="grid ff-column-nowrap w100 gs12 gsy">
+                <div class="grid--cell ai-center p8 ba bc-powder-900">Powder 900</div>
+                <div class="grid--cell ai-center p8 ba bc-powder-800">Powder 800</div>
+                <div class="grid--cell ai-center p8 ba bc-powder-700">Powder 700</div>
+                <div class="grid--cell ai-center p8 ba bc-powder-600">Powder 600</div>
+                <div class="grid--cell ai-center p8 ba bc-powder-500">Powder 500</div>
+                <div class="grid--cell ai-center p8 ba bc-powder-400">Powder 400</div>
+                <div class="grid--cell ai-center p8 ba bc-powder-300">Powder 300</div>
+                <div class="grid--cell ai-center p8 ba bc-powder-200">Powder 200</div>
+                <div class="grid--cell ai-center p8 ba bc-powder-100">Powder 100</div>
+                <div class="grid--cell ai-center p8 ba bc-powder-050">Powder 50</div>
             </div>
         </div>
     </div>
@@ -292,15 +344,31 @@ description: Stacks provides atomic classes for borders.
     <p class="stacks-copy">Green borders can also be declared using our <code class="stacks-code">.bc-success</code> <a href="{{ '/product/base/colors#success' | relative_url }}">alias class</a>.</p>
     <div class="stacks-preview">
 {% highlight html %}
-<div class="bb bc-green-3">Dark green border</div>
-<div class="bb bc-green-2">Green border</div>
-<div class="bb bc-green-1">Light green border</div>
+<div class="ba bc-green-900"></div>
+<div class="ba bc-green-800"></div>
+<div class="ba bc-green-700"></div>
+<div class="ba bc-green-600"></div>
+<div class="ba bc-green-500"></div>
+<div class="ba bc-green-400"></div>
+<div class="ba bc-green-300"></div>
+<div class="ba bc-green-200"></div>
+<div class="ba bc-green-100"></div>
+<div class="ba bc-green-050"></div>
+<div class="ba bc-green-025"></div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="grid ff-column-nowrap w100 gs8 gsy">
-                <div class="grid--cell ai-center p8 bb bc-green-3">Dark green border</div>
-                <div class="grid--cell ai-center p8 bb bc-green-2">Green border</div>
-                <div class="grid--cell ai-center p8 bb bc-green-1">Light green border</div>
+            <div class="grid ff-column-nowrap w100 gs12 gsy">
+                <div class="grid--cell ai-center p8 ba bc-green-900">Green 900</div>
+                <div class="grid--cell ai-center p8 ba bc-green-800">Green 800</div>
+                <div class="grid--cell ai-center p8 ba bc-green-700">Green 700</div>
+                <div class="grid--cell ai-center p8 ba bc-green-600">Green 600</div>
+                <div class="grid--cell ai-center p8 ba bc-green-500">Green 500</div>
+                <div class="grid--cell ai-center p8 ba bc-green-400">Green 400</div>
+                <div class="grid--cell ai-center p8 ba bc-green-300">Green 300</div>
+                <div class="grid--cell ai-center p8 ba bc-green-200">Green 200</div>
+                <div class="grid--cell ai-center p8 ba bc-green-100">Green 100</div>
+                <div class="grid--cell ai-center p8 ba bc-green-050">Green 50</div>
+                <div class="grid--cell ai-center p8 ba bc-green-025">Green 25</div>
             </div>
         </div>
     </div>
@@ -309,15 +377,29 @@ description: Stacks provides atomic classes for borders.
     <p class="stacks-copy">Red borders can also be declared using our <code class="stacks-code">.bc-error</code> and <code class="stacks-code">.bc-danger</code> <a href="{{ '/product/base/colors#danger-and-error' | relative_url }}">alias classes</a>.</p>
     <div class="stacks-preview">
 {% highlight html %}
-<div class="bb bc-red-3">Dark red Border</div>
-<div class="bb bc-red-2">Red border</div>
-<div class="bb bc-red-1">Light red border</div>
+<div class="ba bc-red-900"></div>
+<div class="ba bc-red-800"></div>
+<div class="ba bc-red-700"></div>
+<div class="ba bc-red-600"></div>
+<div class="ba bc-red-500"></div>
+<div class="ba bc-red-400"></div>
+<div class="ba bc-red-300"></div>
+<div class="ba bc-red-200"></div>
+<div class="ba bc-red-100"></div>
+<div class="ba bc-red-050"></div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="grid ff-column-nowrap w100 gs8 gsy">
-                <div class="grid--cell ai-center p8 bb bc-red-3">Dark red border</div>
-                <div class="grid--cell ai-center p8 bb bc-red-2">Red border</div>
-                <div class="grid--cell ai-center p8 bb bc-red-1">Light red border</div>
+            <div class="grid ff-column-nowrap w100 gs12 gsy">
+                <div class="grid--cell ai-center p8 ba bc-red-900">Red 900</div>
+                <div class="grid--cell ai-center p8 ba bc-red-800">Red 800</div>
+                <div class="grid--cell ai-center p8 ba bc-red-700">Red 700</div>
+                <div class="grid--cell ai-center p8 ba bc-red-600">Red 600</div>
+                <div class="grid--cell ai-center p8 ba bc-red-500">Red 500</div>
+                <div class="grid--cell ai-center p8 ba bc-red-400">Red 400</div>
+                <div class="grid--cell ai-center p8 ba bc-red-300">Red 300</div>
+                <div class="grid--cell ai-center p8 ba bc-red-200">Red 200</div>
+                <div class="grid--cell ai-center p8 ba bc-red-100">Red 100</div>
+                <div class="grid--cell ai-center p8 ba bc-red-050">Red 50</div>
             </div>
         </div>
     </div>
@@ -326,15 +408,29 @@ description: Stacks provides atomic classes for borders.
     <p class="stacks-copy">Yellow borders can also be declared using our <code class="stacks-code">.bc-warning</code> <a href="{{ '/product/base/colors#warning' | relative_url }}">alias class</a>.</p>
     <div class="stacks-preview">
 {% highlight html %}
-<div class="bb bc-yellow-3">Dark yellow Border</div>
-<div class="bb bc-yellow-2">Yellow border</div>
-<div class="bb bc-yellow-1">Light yellow border</div>
+<div class="ba bc-yellow-900"></div>
+<div class="ba bc-yellow-800"></div>
+<div class="ba bc-yellow-700"></div>
+<div class="ba bc-yellow-600"></div>
+<div class="ba bc-yellow-500"></div>
+<div class="ba bc-yellow-400"></div>
+<div class="ba bc-yellow-300"></div>
+<div class="ba bc-yellow-200"></div>
+<div class="ba bc-yellow-100"></div>
+<div class="ba bc-yellow-050"></div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="grid ff-column-nowrap w100 gs8 gsy">
-                <div class="grid--cell ai-center p8 bb bc-yellow-3">Dark yellow border</div>
-                <div class="grid--cell ai-center p8 bb bc-yellow-2">Yellow border</div>
-                <div class="grid--cell ai-center p8 bb bc-yellow-1">Light yellow border</div>
+            <div class="grid ff-column-nowrap w100 gs12 gsy">
+                <div class="grid--cell ai-center p8 ba bc-yellow-900">Yellow 900</div>
+                <div class="grid--cell ai-center p8 ba bc-yellow-800">Yellow 800</div>
+                <div class="grid--cell ai-center p8 ba bc-yellow-700">Yellow 700</div>
+                <div class="grid--cell ai-center p8 ba bc-yellow-600">Yellow 600</div>
+                <div class="grid--cell ai-center p8 ba bc-yellow-500">Yellow 500</div>
+                <div class="grid--cell ai-center p8 ba bc-yellow-400">Yellow 400</div>
+                <div class="grid--cell ai-center p8 ba bc-yellow-300">Yellow 300</div>
+                <div class="grid--cell ai-center p8 ba bc-yellow-200">Yellow 200</div>
+                <div class="grid--cell ai-center p8 ba bc-yellow-100">Yellow 100</div>
+                <div class="grid--cell ai-center p8 ba bc-yellow-050">Yellow 50</div>
             </div>
         </div>
     </div>

--- a/docs/product/base/colors.html
+++ b/docs/product/base/colors.html
@@ -61,10 +61,11 @@ description: To avoid specifying color values by hand, we’ve included a robust
                 <thead>
                     <tr>
                         <th scope="col" width="36px"></th>
+                        <th scope="col">CSS</th>
                         <th scope="col">Less</th>
-                        <th scope="col">Variable</th>
                         <th scope="col">Text class</th>
                         <th scope="col">Background class</th>
+                        <th scope="col">Border class</th>
                         <th scope="col" class="ta-center"><a class="s-link s-link__inherit" href="{{ "/product/guidelines/conditional-classes#hover" | relative_url }}">Hover?</a></th>
                         <th scope="col" class="ta-center"><a class="s-link s-link__inherit" href="{{ "/product/guidelines/conditional-classes#focus" | relative_url }}">Focus?</a></th>
                         <th scope="col" class="ta-center"><a class="s-link s-link__inherit" href="{{ "/product/guidelines/conditional-classes#dark-mode" | relative_url }}">Dark?</a></th>
@@ -77,9 +78,10 @@ description: To avoid specifying color values by hand, we’ve included a robust
                           <div class="stacks-swatch bar-sm bg-{{ color.name }}-{{ stop.stop }}"></div>
                         </th>
                         <td class="ff-mono">var(--{{ color.name }}-{{ stop.stop }})</td>
-                        <td class="ff-mono">#{{ stop.hex }}</td>
+                        <td class="ff-mono">@{{ color.name }}-{{ stop.stop }}</td>
                         <td class="ff-mono">.fc-{{ color.name }}-{{ stop.stop }}</td>
                         <td class="ff-mono">.bg-{{ color.name }}-{{ stop.stop }}</td>
+                        <td class="ff-mono">.bc-{{ color.name }}-{{ stop.stop }}</td>
                         <td class="ta-center">{% icon "Checkmark", "fc-green-500" %}</td>
                         <td class="ta-center">{% icon "Checkmark", "fc-green-500" %}</td>
                         <td class="ta-center">{% icon "Checkmark", "fc-green-500" %}</td>
@@ -89,10 +91,11 @@ description: To avoid specifying color values by hand, we’ve included a robust
                         <th scope="row">
                           <div class="stacks-swatch bar-sm bg-white"></div>
                         </th>
+                        <td class="ff-mono">var(--white)</td>
                         <td class="ff-mono">@white</td>
-                        <td class="ff-mono">#ffffff</td>
                         <td class="ff-mono">.fc-white</td>
                         <td class="ff-mono">.bg-white</td>
+                        <td class="ff-mono">.bc-white</td>
                         <td class="ta-center">{% icon "Checkmark", "fc-green-500" %}</td>
                         <td class="ta-center">{% icon "Checkmark", "fc-green-500" %}</td>
                         <td class="ta-center">{% icon "Checkmark", "fc-green-500" %}</td>
@@ -105,6 +108,7 @@ description: To avoid specifying color values by hand, we’ve included a robust
                         <td class="fc-light">N/A</td>
                         <td class="fc-light">N/A</td>
                         <td>.bg-transparent</td>
+                        <td>.bc-transparent</td>
                         <td class="ta-center">{% icon "Checkmark", "fc-green-500" %}</td>
                         <td></td>
                         <td></td>

--- a/lib/css/atomic/_stacks-borders.less
+++ b/lib/css/atomic/_stacks-borders.less
@@ -191,16 +191,31 @@
 
 //  $$  BLACK
 //  ----------------------------------------------------------------------------
-.bc-black-1         { border-color: var(--black-050) !important; }
-.bc-black-2         { border-color: var(--black-075) !important; }
-.bc-black-3         { border-color: var(--black-100) !important; }
-.bc-black-4         { border-color: var(--black-200) !important; }
-.bc-black-5         { border-color: var(--black-300) !important; }
-.bc-black-6         { border-color: var(--black-400) !important; }
-.bc-black-7         { border-color: var(--black-500) !important; }
-.bc-black-8         { border-color: var(--black-700) !important; }
-.bc-black-9         { border-color: var(--black-800) !important; }
-.bc-black-10        { border-color: var(--black-900) !important; }
+.bc-black-025 { border-color: var(--black-025) !important; }
+.bc-black-1,
+.bc-black-050 { border-color: var(--black-050) !important; }
+.bc-black-2,
+.bc-black-075 { border-color: var(--black-075) !important; }
+.bc-black-3,
+.bc-black-100 { border-color: var(--black-100) !important; }
+.bc-black-150 { border-color: var(--black-150) !important; }
+.bc-black-4,
+.bc-black-200 { border-color: var(--black-200) !important; }
+.bc-black-5,
+.bc-black-300 { border-color: var(--black-300) !important; }
+.bc-black-350 { border-color: var(--black-350) !important; }
+.bc-black-6,
+.bc-black-400 { border-color: var(--black-400) !important; }
+.bc-black-7,
+.bc-black-500 { border-color: var(--black-500) !important; }
+.bc-black-600 { border-color: var(--black-600) !important; }
+.bc-black-8,
+.bc-black-700 { border-color: var(--black-700) !important; }
+.bc-black-750 { border-color: var(--black-750) !important; }
+.bc-black-9,
+.bc-black-800 { border-color: var(--black-800) !important; }
+.bc-black-10,
+.bc-black-900 { border-color: var(--black-900) !important; }
 
 //  $$  ORANGE
 //  ----------------------------------------------------------------------------

--- a/lib/css/atomic/_stacks-borders.less
+++ b/lib/css/atomic/_stacks-borders.less
@@ -219,9 +219,19 @@
 
 //  $$  ORANGE
 //  ----------------------------------------------------------------------------
-.bc-orange-1        { border-color: var(--orange-100) !important; }
-.bc-orange-2        { border-color: var(--orange-400) !important; }
-.bc-orange-3        { border-color: var(--orange-600) !important; }
+.bc-orange-050 { border-color: var(--orange-050) !important; }
+.bc-orange-1,
+.bc-orange-100 { border-color: var(--orange-100) !important; }
+.bc-orange-200 { border-color: var(--orange-200) !important; }
+.bc-orange-300 { border-color: var(--orange-300) !important; }
+.bc-orange-2,
+.bc-orange-400 { border-color: var(--orange-400) !important; }
+.bc-orange-500 { border-color: var(--orange-500) !important; }
+.bc-orange-3,
+.bc-orange-600 { border-color: var(--orange-600) !important; }
+.bc-orange-700 { border-color: var(--orange-700) !important; }
+.bc-orange-800 { border-color: var(--orange-800) !important; }
+.bc-orange-900 { border-color: var(--orange-900) !important; }
 
 //  $$  BLUE
 //  ----------------------------------------------------------------------------

--- a/lib/css/atomic/_stacks-borders.less
+++ b/lib/css/atomic/_stacks-borders.less
@@ -267,6 +267,7 @@
 
 //  $$  GREEN
 //  ----------------------------------------------------------------------------
+.bc-green-025 { border-color: var(--green-025) !important; }
 .bc-green-050 { border-color: var(--green-050) !important; }
 .bc-green-1,
 .bc-green-100 { border-color: var(--green-100) !important; }

--- a/lib/css/atomic/_stacks-borders.less
+++ b/lib/css/atomic/_stacks-borders.less
@@ -235,37 +235,85 @@
 
 //  $$  BLUE
 //  ----------------------------------------------------------------------------
-.bc-blue-1          { border-color: var(--blue-100) !important; }
-.bc-blue-2          { border-color: var(--blue-400) !important; }
-.bc-blue-3          { border-color: var(--blue-600) !important; }
+.bc-blue-050 { border-color: var(--blue-050) !important; }
+.bc-blue-1,
+.bc-blue-100 { border-color: var(--blue-100) !important; }
+.bc-blue-200 { border-color: var(--blue-200) !important; }
+.bc-blue-300 { border-color: var(--blue-300) !important; }
+.bc-blue-2,
+.bc-blue-400 { border-color: var(--blue-400) !important; }
+.bc-blue-500 { border-color: var(--blue-500) !important; }
+.bc-blue-3,
+.bc-blue-600 { border-color: var(--blue-600) !important; }
+.bc-blue-700 { border-color: var(--blue-700) !important; }
+.bc-blue-800 { border-color: var(--blue-800) !important; }
+.bc-blue-900 { border-color: var(--blue-900) !important; }
 
 //  $$  POWDER
 //  ----------------------------------------------------------------------------
-.bc-powder-1        { border-color: var(--powder-100) !important; }
-.bc-powder-2        { border-color: var(--powder-400) !important; }
-.bc-powder-3        { border-color: var(--powder-600) !important; }
+.bc-powder-050 { border-color: var(--powder-050) !important; }
+.bc-powder-1,
+.bc-powder-100 { border-color: var(--powder-100) !important; }
+.bc-powder-200 { border-color: var(--powder-200) !important; }
+.bc-powder-300 { border-color: var(--powder-300) !important; }
+.bc-powder-2,
+.bc-powder-400 { border-color: var(--powder-400) !important; }
+.bc-powder-500 { border-color: var(--powder-500) !important; }
+.bc-powder-3,
+.bc-powder-600 { border-color: var(--powder-600) !important; }
+.bc-powder-700 { border-color: var(--powder-700) !important; }
+.bc-powder-800 { border-color: var(--powder-800) !important; }
+.bc-powder-900 { border-color: var(--powder-900) !important; }
 
 //  $$  GREEN
 //  ----------------------------------------------------------------------------
-.bc-green-1         { border-color: var(--green-100) !important; }
+.bc-green-050 { border-color: var(--green-050) !important; }
+.bc-green-1,
+.bc-green-100 { border-color: var(--green-100) !important; }
+.bc-green-200 { border-color: var(--green-200) !important; }
+.bc-green-300 { border-color: var(--green-300) !important; }
 .bc-green-2,
-.bc-success         { border-color: var(--green-400) !important; }
-.bc-green-3         { border-color: var(--green-600) !important; }
+.bc-green-400 { border-color: var(--green-400) !important; }
+.bc-green-500 { border-color: var(--green-500) !important; }
+.bc-green-3,
+.bc-green-600 { border-color: var(--green-600) !important; }
+.bc-green-700 { border-color: var(--green-700) !important; }
+.bc-green-800 { border-color: var(--green-800) !important; }
+.bc-green-900 { border-color: var(--green-900) !important; }
 
 //  $$  RED
 //  ----------------------------------------------------------------------------
-.bc-red-1           { border-color: var(--red-100) !important; }
+.bc-red-050 { border-color: var(--red-050) !important; }
+.bc-red-1,
+.bc-red-100 { border-color: var(--red-100) !important; }
+.bc-red-200 { border-color: var(--red-200) !important; }
+.bc-red-300 { border-color: var(--red-300) !important; }
 .bc-red-2,
-.bc-danger,
-.bc-error           { border-color: var(--red-400) !important; }
-.bc-red-3           { border-color: var(--red-600) !important; }
+.bc-error,
+.bc-red-400 { border-color: var(--red-400) !important; }
+.bc-red-500 { border-color: var(--red-500) !important; }
+.bc-red-3,
+.bc-red-600 { border-color: var(--red-600) !important; }
+.bc-red-700 { border-color: var(--red-700) !important; }
+.bc-red-800 { border-color: var(--red-800) !important; }
+.bc-red-900 { border-color: var(--red-900) !important; }
 
 //  $$  YELLOW
 //  ----------------------------------------------------------------------------
-.bc-yellow-1        { border-color: var(--yellow-200) !important; }
-.bc-yellow-2        { border-color: var(--yellow-400) !important; }
+.bc-yellow-050 { border-color: var(--yellow-050) !important; }
+.bc-yellow-1,
+.bc-yellow-100 { border-color: var(--yellow-100) !important; }
+.bc-yellow-200 { border-color: var(--yellow-200) !important; }
+.bc-yellow-300 { border-color: var(--yellow-300) !important; }
+.bc-yellow-2,
+.bc-yellow-400 { border-color: var(--yellow-400) !important; }
+.bc-yellow-500 { border-color: var(--yellow-500) !important; }
 .bc-yellow-3,
-.bc-warning         { border-color: var(--yellow-600) !important; }
+.bc-warning,
+.bc-yellow-600 { border-color: var(--yellow-600) !important; }
+.bc-yellow-700 { border-color: var(--yellow-700) !important; }
+.bc-yellow-800 { border-color: var(--yellow-800) !important; }
+.bc-yellow-900 { border-color: var(--yellow-900) !important; }
 
 //  $$  TRANSPARENT
 //  ----------------------------------------------------------------------------

--- a/lib/css/atomic/_stacks-borders.less
+++ b/lib/css/atomic/_stacks-borders.less
@@ -192,42 +192,42 @@
 //  $$  BLACK
 //  ----------------------------------------------------------------------------
 .bc-black-025 { border-color: var(--black-025) !important; }
-.bc-black-1,
+.bc-black-1, // Deprecated
 .bc-black-050 { border-color: var(--black-050) !important; }
-.bc-black-2,
+.bc-black-2, // Deprecated
 .bc-black-075 { border-color: var(--black-075) !important; }
-.bc-black-3,
+.bc-black-3, // Deprecated
 .bc-black-100 { border-color: var(--black-100) !important; }
 .bc-black-150 { border-color: var(--black-150) !important; }
-.bc-black-4,
+.bc-black-4, // Deprecated
 .bc-black-200 { border-color: var(--black-200) !important; }
-.bc-black-5,
+.bc-black-5, // Deprecated
 .bc-black-300 { border-color: var(--black-300) !important; }
 .bc-black-350 { border-color: var(--black-350) !important; }
-.bc-black-6,
+.bc-black-6, // Deprecated
 .bc-black-400 { border-color: var(--black-400) !important; }
-.bc-black-7,
+.bc-black-7, // Deprecated
 .bc-black-500 { border-color: var(--black-500) !important; }
 .bc-black-600 { border-color: var(--black-600) !important; }
-.bc-black-8,
+.bc-black-8, // Deprecated
 .bc-black-700 { border-color: var(--black-700) !important; }
 .bc-black-750 { border-color: var(--black-750) !important; }
-.bc-black-9,
+.bc-black-9, // Deprecated
 .bc-black-800 { border-color: var(--black-800) !important; }
-.bc-black-10,
+.bc-black-10, // Deprecated
 .bc-black-900 { border-color: var(--black-900) !important; }
 
 //  $$  ORANGE
 //  ----------------------------------------------------------------------------
 .bc-orange-050 { border-color: var(--orange-050) !important; }
-.bc-orange-1,
+.bc-orange-1, // Deprecated
 .bc-orange-100 { border-color: var(--orange-100) !important; }
 .bc-orange-200 { border-color: var(--orange-200) !important; }
 .bc-orange-300 { border-color: var(--orange-300) !important; }
-.bc-orange-2,
+.bc-orange-2, // Deprecated
 .bc-orange-400 { border-color: var(--orange-400) !important; }
 .bc-orange-500 { border-color: var(--orange-500) !important; }
-.bc-orange-3,
+.bc-orange-3, // Deprecated
 .bc-orange-600 { border-color: var(--orange-600) !important; }
 .bc-orange-700 { border-color: var(--orange-700) !important; }
 .bc-orange-800 { border-color: var(--orange-800) !important; }
@@ -236,14 +236,14 @@
 //  $$  BLUE
 //  ----------------------------------------------------------------------------
 .bc-blue-050 { border-color: var(--blue-050) !important; }
-.bc-blue-1,
+.bc-blue-1, // Deprecated
 .bc-blue-100 { border-color: var(--blue-100) !important; }
 .bc-blue-200 { border-color: var(--blue-200) !important; }
 .bc-blue-300 { border-color: var(--blue-300) !important; }
-.bc-blue-2,
+.bc-blue-2, // Deprecated
 .bc-blue-400 { border-color: var(--blue-400) !important; }
 .bc-blue-500 { border-color: var(--blue-500) !important; }
-.bc-blue-3,
+.bc-blue-3, // Deprecated
 .bc-blue-600 { border-color: var(--blue-600) !important; }
 .bc-blue-700 { border-color: var(--blue-700) !important; }
 .bc-blue-800 { border-color: var(--blue-800) !important; }
@@ -252,14 +252,14 @@
 //  $$  POWDER
 //  ----------------------------------------------------------------------------
 .bc-powder-050 { border-color: var(--powder-050) !important; }
-.bc-powder-1,
+.bc-powder-1, // Deprecated
 .bc-powder-100 { border-color: var(--powder-100) !important; }
 .bc-powder-200 { border-color: var(--powder-200) !important; }
 .bc-powder-300 { border-color: var(--powder-300) !important; }
-.bc-powder-2,
+.bc-powder-2, // Deprecated
 .bc-powder-400 { border-color: var(--powder-400) !important; }
 .bc-powder-500 { border-color: var(--powder-500) !important; }
-.bc-powder-3,
+.bc-powder-3, // Deprecated
 .bc-powder-600 { border-color: var(--powder-600) !important; }
 .bc-powder-700 { border-color: var(--powder-700) !important; }
 .bc-powder-800 { border-color: var(--powder-800) !important; }
@@ -269,14 +269,15 @@
 //  ----------------------------------------------------------------------------
 .bc-green-025 { border-color: var(--green-025) !important; }
 .bc-green-050 { border-color: var(--green-050) !important; }
-.bc-green-1,
+.bc-green-1, // Deprecated
 .bc-green-100 { border-color: var(--green-100) !important; }
 .bc-green-200 { border-color: var(--green-200) !important; }
 .bc-green-300 { border-color: var(--green-300) !important; }
-.bc-green-2,
+.bc-green-2, // Deprecated
 .bc-green-400 { border-color: var(--green-400) !important; }
 .bc-green-500 { border-color: var(--green-500) !important; }
-.bc-green-3,
+.bc-green-3, // Deprecated
+.bc-success,
 .bc-green-600 { border-color: var(--green-600) !important; }
 .bc-green-700 { border-color: var(--green-700) !important; }
 .bc-green-800 { border-color: var(--green-800) !important; }
@@ -285,15 +286,15 @@
 //  $$  RED
 //  ----------------------------------------------------------------------------
 .bc-red-050 { border-color: var(--red-050) !important; }
-.bc-red-1,
+.bc-red-1, // Deprecated
 .bc-red-100 { border-color: var(--red-100) !important; }
 .bc-red-200 { border-color: var(--red-200) !important; }
 .bc-red-300 { border-color: var(--red-300) !important; }
-.bc-red-2,
+.bc-red-2, // Deprecated
 .bc-error,
 .bc-red-400 { border-color: var(--red-400) !important; }
 .bc-red-500 { border-color: var(--red-500) !important; }
-.bc-red-3,
+.bc-red-3, // Deprecated
 .bc-red-600 { border-color: var(--red-600) !important; }
 .bc-red-700 { border-color: var(--red-700) !important; }
 .bc-red-800 { border-color: var(--red-800) !important; }
@@ -302,14 +303,14 @@
 //  $$  YELLOW
 //  ----------------------------------------------------------------------------
 .bc-yellow-050 { border-color: var(--yellow-050) !important; }
-.bc-yellow-1,
+.bc-yellow-1, // Deprecated
 .bc-yellow-100 { border-color: var(--yellow-100) !important; }
 .bc-yellow-200 { border-color: var(--yellow-200) !important; }
 .bc-yellow-300 { border-color: var(--yellow-300) !important; }
-.bc-yellow-2,
+.bc-yellow-2, // Deprecated
 .bc-yellow-400 { border-color: var(--yellow-400) !important; }
 .bc-yellow-500 { border-color: var(--yellow-500) !important; }
-.bc-yellow-3,
+.bc-yellow-3, // Deprecated
 .bc-warning,
 .bc-yellow-600 { border-color: var(--yellow-600) !important; }
 .bc-yellow-700 { border-color: var(--yellow-700) !important; }


### PR DESCRIPTION
Let's add the rest of the border color classes and see what it'll cost us in bytes. cc: @benjamin-hodgson 

This deprecates the `bc-black-3` naming scheme and keeps it consistent with other classes `bc-black-100`.