### PR TITLE
Highlight.js update + new theme classes

### DIFF
--- a/docs/product/components/code-blocks.html
+++ b/docs/product/components/code-blocks.html
@@ -350,6 +350,54 @@ namespace MyApplication
         </div>
     </div>
 
+    {% header "h3", "LaTeX" %}
+    <div class="stacks-preview">
+{% highlight html %}
+<pre class="s-code-block language-csharp">
+    …
+</pre>
+{% endhighlight %}
+        <div class="stacks-preview--example">
+{% highlight latex %}
+% !TeX encoding = utf8
+\documentclass{article}
+
+\usepackage[T1]{fontenc}
+\usepackage{lmodern}
+\usepackage{amsfonts}
+\usepackage{xparse}
+\usepackage{mathtools}
+
+\newcommand\hi[1]{Hello #1!}
+
+\ExplSyntaxOn
+  % Convert a roman number into an arabic one
+  \NewDocumentCommand \romantonum { m }
+    { \int_from_roman:n { #1 } }
+\ExplSyntaxOff
+
+\begin{document}
+
+\section{Highlight.js}
+\hi{you}
+This is \LaTeX\ syntax highlighted by \verb|highlight.js|.
+You should look at section~\ref{sec:fermat} next.
+
+Did you know that MDCLXI is \romantonum{MDCLXI}? % It's 1661.
+
+\subsection{Fermat}\label{sec:fermat}
+I have a wonderful proof that
+\[
+  a^n + b^n \neq c^n
+\]
+for \(a, b, c, d, n \in \mathbb{Z}_+\) with \(n > 2\).
+Sadly, it is too large to fit in this code snippet.
+
+\end{document}
+{% endhighlight %}
+        </div>
+    </div>
+
     {% header "h3", "SQL" %}
     <div class="stacks-preview">
 {% highlight html %}

--- a/lib/css/components/_stacks-code-blocks.less
+++ b/lib/css/components/_stacks-code-blocks.less
@@ -98,6 +98,11 @@ code[class*="language-"] {
     .hljs-strong {
         font-weight: bold;
     }
+
+    // TODO
+    .hljs-class, .hljs-operator, .hljs-tag, .hljs-function, .hljs-params, .hljs-formula, .hljs-punctuation {
+        color: inherit;
+    }
 }
 
 pre.s-code-block .s-code-block--line-numbers {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3575,9 +3575,9 @@
       }
     },
     "highlight.js": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.2.tgz",
-      "integrity": "sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA==",
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.3.2.tgz",
+      "integrity": "sha512-3jRT7OUYsVsKvukNKZCtnvRcFyCJqSEIuIMsEybAXRiFSwpt65qjPd/Pr+UOdYt7WJlt+lj3+ypUsHiySBp/Jw==",
       "dev": true
     },
     "homedir-polyfill": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "grunt-contrib-watch": "^1.1.0",
     "grunt-shell": "^3.0.1",
     "grunt-ts": "^6.0.0-beta.22",
+    "highlight.js": "^10.3.2",
     "typescript": "^4.0.3"
   },
   "browserslist": [


### PR DESCRIPTION
This is a draft PR exploring how we might take advantage of the new classes / syntax fixes that the most recent version of highlight.js has added.

Something I'd like to explore in this PR are some possible changes to the LaTeX theme. The tex community was not terribly happy with the new syntax highlighting/theme, so they took it upon themselves to contribute better highlighting detection upstream. I'd love to support these new classes so their hard work doesn't go to waste. They have a post [here](https://tex.meta.stackexchange.com/questions/8688/adapting-the-highlighting-colors-for-the-new-highlight-js-version) with suggestions on how to incorporate some of the changes into a new theme.

### Changes

I've explicitly added highlight.js as a devDependency so we can tell what version our styles are being built against. I've also added a few of the unused classes to the `_stacks-code-block` with a TODO comment on them, as well as a LaTeX code example to the docs.