### PR TITLE
Add aria-label to icon-only breadcrumb

### DIFF
--- a/docs/product/components/breadcrumbs.html
+++ b/docs/product/components/breadcrumbs.html
@@ -77,7 +77,7 @@ description: Breadcrumbs are used to provide context for the currently-viewed pa
 {% highlight html %}
 <nav class="s-breadcrumbs mb6 sm:mb2" aria-label="breadcrumb">
     <div class="s-breadcrumbs--item">
-        <a class="s-breadcrumbs--link" href="…">@Svg.LogoGlyphXxs.With("mtn2")</a>
+        <a class="s-breadcrumbs--link" href="…" aria-label="Stack Overflow">@Svg.LogoGlyphXxs.With("mtn2")</a>
         @Svg.ArrowRightAltSm.With("s-breadcrumbs--divider")
     </div>
     <div class="s-breadcrumbs--item">
@@ -92,7 +92,7 @@ description: Breadcrumbs are used to provide context for the currently-viewed pa
         <div class="stacks-preview--example">
             <nav class="s-breadcrumbs mb6 sm:mb2" aria-label="breadcrumb">
                 <div class="s-breadcrumbs--item">
-                    <a class="s-breadcrumbs--link" href="#">{% icon "LogoGlyphXxs", "mtn2" %}</a>
+                    <a class="s-breadcrumbs--link" href="#" aria-label="Stack Overflow">{% icon "LogoGlyphXxs", "mtn2" %}</a>
                     {% icon "ArrowRightAltSm", "s-breadcrumbs--divider" %}
                 </div>
                 <div class="s-breadcrumbs--item">


### PR DESCRIPTION
The icon-only variant needs an aria-label on it's link.

> *Aside*: I am floored at how closely the design here conforms to the [wai recommendations](https://www.w3.org/TR/wai-aria-practices-1.1/examples/breadcrumb/index.html). :100: