### PR TITLE
Add 6px gutter classes

### DIFF
--- a/docs/_data/grids.json
+++ b/docs/_data/grids.json
@@ -71,6 +71,10 @@
       "output": "4px"
     },
     {
+      "class": ".gs6",
+      "output": "6px"
+    },
+    {
       "class": ".gs8",
       "output": "8px"
     },

--- a/lib/css/atomic/_stacks-grid.less
+++ b/lib/css/atomic/_stacks-grid.less
@@ -200,6 +200,7 @@
 //  ----------------------------------------------------------------------------
 .gs2    { #stacks-internals #grid-builder-helpers .gutter-spacing(@su2); }        //  2px
 .gs4    { #stacks-internals #grid-builder-helpers .gutter-spacing(@su4); }        //  4px
+.gs6    { #stacks-internals #grid-builder-helpers .gutter-spacing(@su6); }        //  6px
 .gs8    { #stacks-internals #grid-builder-helpers .gutter-spacing(@su8); }        //  8px
 .gs12   { #stacks-internals #grid-builder-helpers .gutter-spacing(@su12); }       //  12px
 .gs16   { #stacks-internals #grid-builder-helpers .gutter-spacing(@su16); }       //  16px


### PR DESCRIPTION
Since adding `@su6`, this has been missing.

`develop` original size: 250820 / gzipped size: 36234

`feature/gs6` original size: 252621 / gzipped size: 36409

Currently firefox is the only browser that accepts `gap` as a property on flex layouts. When enough browsers support that, we can drop all these generators and save a _ton_ of bytes.