### PR TITLE
Support link-like buttons in .s-anchors

### DIFF
--- a/docs/product/components/links.html
+++ b/docs/product/components/links.html
@@ -97,22 +97,22 @@ description: Links are lightly styled via the <code class="stacks-code">a</code>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="s-anchors s-anchors__default s-card mb8">
-                <p>There is a <a href="#">default link here</a>, and <a href="#">another one</a>.</p>
+                <p>There is a <a href="#">default link here</a>, <button class="s-btn s-btn__link">a button</button>, and <a href="#">another one</a>.</p>
             </div>
             <div class="s-anchors s-anchors__grayscale s-card mb8 fc-orange-700">
-                <p>There is a <a href="#">gray link here</a>, and <a href="#">another one</a>.</p>
+                <p>There is a <a href="#">gray link here</a>, <button class="s-btn s-btn__link">a button</button>, and <a href="#">another one</a>.</p>
             </div>
             <div class="s-anchors s-anchors__muted s-card mb8">
-                <p>There is a <a href="#">muted link here</a>, and <a href="#">another one</a>.</p>
+                <p>There is a <a href="#">muted link here</a>, <button class="s-btn s-btn__link">a button</button>, and <a href="#">another one</a>.</p>
             </div>
             <div class="s-anchors s-anchors__danger s-card mb8">
-                <p>There is a <a href="#">dangerous link here</a>, and <a href="#">another one</a>.</p>
+                <p>There is a <a href="#">dangerous link here</a>, <button class="s-btn s-btn__link">a button</button>, and <a href="#">another one</a>.</p>
             </div>
             <div class="s-anchors s-anchors__underlined s-card mb8">
-                <p>There is an <a href="#">underlined link here</a>, and <a href="#">another one</a>.</p>
+                <p>There is an <a href="#">underlined link here</a>, <button class="s-btn s-btn__link">a button</button>, and <a href="#">another one</a>.</p>
             </div>
             <div class="s-anchors s-anchors__inherit s-card mb8 fc-green-500">
-                <p>There is an <a href="#">inheriting link here</a>, and <a href="#">another one</a>.</p>
+                <p>There is an <a href="#">inheriting link here</a>, <button class="s-btn s-btn__link">a button</button>, and <a href="#">another one</a>.</p>
             </div>
         </div>
     </div>

--- a/lib/css/components/_stacks-links.less
+++ b/lib/css/components/_stacks-links.less
@@ -113,7 +113,8 @@ button.s-link {
     .colorize-all(@name, @normal, @hover, @visited) {
         &.s-anchors__@{name},
         & .s-anchors.s-anchors__@{name} {
-            a:not(.s-link) {
+            a:not(.s-link),
+            .s-btn.s-btn__link {
                 color: @normal;
 
                 &:hover,
@@ -128,7 +129,8 @@ button.s-link {
         }
     }
     &.s-anchors__underlined {
-        a:not(.s-link) {
+        a:not(.s-link),
+        .s-btn.s-btn__link {
             text-decoration: underline;
         }
     }

--- a/lib/css/components/_stacks-links.less
+++ b/lib/css/components/_stacks-links.less
@@ -110,7 +110,7 @@ button.s-link {
 }
 
 .s-anchors {
-    .colorize-all(@name, @normal, @hover, @visited) {
+    .colorize-all(@name, @normal, @hover) {
         &.s-anchors__@{name},
         & .s-anchors.s-anchors__@{name} {
             a:not(.s-link),
@@ -123,7 +123,12 @@ button.s-link {
                 }
 
                 &:visited {
-                    color: @visited;
+                    color: @normal;
+
+                    &:hover,
+                    &:active {
+                        color: @hover;
+                    }
                 }
             }
         }
@@ -135,11 +140,11 @@ button.s-link {
         }
     }
     #stacks-internals #load-config();
-    .colorize-all(default, @link-color, @link-color-hover, @link-color-visited);
-    .colorize-all(grayscale, var(--black-700), var(--black-600), var(--black-900));
-    .colorize-all(inherit, inherit, inherit, inherit);
-    .colorize-all(muted, var(--black-500), var(--black-400), var(--black-600));
-    .colorize-all(danger, var(--red-500), var(--red-400), var(--red-600));
+    .colorize-all(default, @link-color, @link-color-hover);
+    .colorize-all(grayscale, var(--black-700), var(--black-600));
+    .colorize-all(inherit, inherit, inherit);
+    .colorize-all(muted, var(--black-500), var(--black-400));
+    .colorize-all(danger, var(--red-500), var(--red-400));
 }
 
 .s-block-link {


### PR DESCRIPTION
When working on a tiny menu component that has elements that are both links and link-like buttons, it can be tough to have a consistent set of hover / visited / active states. This normalizes any `s-btn.s-btn__link` to look like a true anchor when mixed.