### PR TITLE
Prevent override of user-card--link style

### DIFF
--- a/lib/css/components/_stacks-widget-static.less
+++ b/lib/css/components/_stacks-widget-static.less
@@ -28,7 +28,7 @@
     font-size: @fs-body1;
     background-color: var(--white);
 
-    &:not(.s-anchors) a:not(.button):not(.s-btn):not(.post-tag):not(.s-sidebarwidget--action) {
+    &:not(.s-anchors) a:not(.button):not(.s-btn):not(.post-tag):not(.s-sidebarwidget--action):not(.s-user-card--link ) {
         &, &:visited {
             color: var(--black-500);
         }


### PR DESCRIPTION
When using a usercard in a sidebar widget, we want to preserve the link styling.

**BEFORE**
<img width="428" alt="Screen Shot 2020-12-09 at 7 06 07 PM" src="https://user-images.githubusercontent.com/371114/101703938-a7635900-3a51-11eb-9f9e-449b39f79c23.png">


**AFTER**
<img width="481" alt="Screen Shot 2020-12-09 at 7 06 19 PM" src="https://user-images.githubusercontent.com/371114/101703943-aaf6e000-3a51-11eb-85d9-62fe67bfcb33.png">

