### PR TITLE
Tweak badge__sm size and margin

### DIFF
--- a/lib/css/components/_stacks-badges.less
+++ b/lib/css/components/_stacks-badges.less
@@ -66,6 +66,7 @@
 //  $   BADGE SIZES
 //  ---------------------------------------------------------------------------
 .s-badge__sm {
+    min-width: 18px;
     align-self: flex-start;
     padding-right: @su4;
     padding-left: @su4;

--- a/lib/css/components/_stacks-badges.less
+++ b/lib/css/components/_stacks-badges.less
@@ -68,7 +68,7 @@
 .s-badge__sm {
     align-self: flex-start;
     padding-right: @su4;
-    padding-left: @su4 - 1;
+    padding-left: @su4;
     font-size: @fs-fine;
     line-height: 1.8;
 }


### PR DESCRIPTION
This evens out the margin on the left and right of the small variant of the s-badge.
It also enforces a slightly larger min-width at 18px, which is very similar to the computed min-width of the full version