### PR TITLE
Call out when exactly to use `aria-pressed`

### DIFF
--- a/docs/product/components/buttons.html
+++ b/docs/product/components/buttons.html
@@ -58,7 +58,7 @@ description: Buttons are user interface elements which allows users to take acti
                                     </div>
                                 </td>
                                 <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }}" type="button">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} is-selected" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} is-selected" type="button" aria-pressed="true">Ask question</button></td>
                                 <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }}" type="button" disabled>Ask question</button></td>
                             </tr>
                             {% endfor %}
@@ -105,7 +105,7 @@ description: Buttons are user interface elements which allows users to take acti
                                     </div>
                                 </td>
                                 <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }}" type="button">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} is-selected" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} is-selected" type="button" aria-pressed="true">Ask question</button></td>
                                 <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }}" type="button" disabled>Ask question</button></td>
                             </tr>
                             {% endfor %}
@@ -154,7 +154,7 @@ description: Buttons are user interface elements which allows users to take acti
                                     </div>
                                 </td>
                                 <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }}" type="button">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }} is-selected" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }} is-selected" type="button" aria-pressed="true">Ask question</button></td>
                                 <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }}" type="button" disabled>Ask question</button></td>
                             </tr>
                             {% endfor %}
@@ -203,7 +203,7 @@ description: Buttons are user interface elements which allows users to take acti
                                     </div>
                                 </td>
                                 <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }}" type="button">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }} is-selected" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }} is-selected" type="button" aria-pressed="true">Ask question</button></td>
                                 <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }}" type="button" disabled>Ask question</button></td>
                             </tr>
                             {% endfor %}
@@ -258,7 +258,7 @@ description: Buttons are user interface elements which allows users to take acti
                                     </div>
                                 </td>
                                 <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }} is-selected" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }} is-selected" type="button" aria-pressed="true">Ask question</button></td>
                                 <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button" disabled>Ask question</button></td>
                             </tr>
                             {% endfor %}
@@ -310,7 +310,7 @@ description: Buttons are user interface elements which allows users to take acti
                                     </div>
                                 </td>
                                 <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }} is-selected" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }} is-selected" type="button" aria-pressed="true">Ask question</button></td>
                                 <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button" disabled>Ask question</button></td>
                             </tr>
                             {% endfor %}
@@ -373,7 +373,7 @@ description: Buttons are user interface elements which allows users to take acti
                                     </button>
                                 </td>
                                 <td class="va-middle ta-center px4">
-                                    <button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }} is-selected" type="button">
+                                    <button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }} is-selected" type="button" aria-pressed="true">
                                         Active <span class="s-btn--badge"><span class="s-btn--number">198</span></span>
                                     </button>
                                 </td>

--- a/docs/product/components/buttons.html
+++ b/docs/product/components/buttons.html
@@ -24,9 +24,9 @@ description: Buttons are user interface elements which allows users to take acti
     <p class="stacks-copy">A button’s visual weight should correspond to the importance of the button’s action. The more important the action, the heavier the button’s visual weight.</p>
     <div class="stacks-preview">
 {% highlight html %}
-<button class="s-btn" type="button" aria-pressed="false">…</button>
-<button class="s-btn s-btn__outlined" type="button" aria-pressed="false">…</button>
-<button class="s-btn s-btn__filled" type="button" aria-pressed="false">…</button>
+<button class="s-btn" type="button">…</button>
+<button class="s-btn s-btn__outlined" type="button">…</button>
+<button class="s-btn s-btn__filled" type="button">…</button>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="overflow-x-auto">
@@ -57,9 +57,9 @@ description: Buttons are user interface elements which allows users to take acti
                                         {% endif %}
                                     </div>
                                 </td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }}" type="button" aria-pressed="false">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} is-selected" type="button" aria-pressed="false">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }}" type="button" aria-pressed="false" disabled>Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }}" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} is-selected" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }}" type="button" disabled>Ask question</button></td>
                             </tr>
                             {% endfor %}
                         {% endfor %}
@@ -73,7 +73,7 @@ description: Buttons are user interface elements which allows users to take acti
     <p class="stacks-copy">A visual style used to highlight the most important actions. To avoid confusing users, don’t use more than one primary button within a section or view.</p>
     <div class="stacks-preview">
 {% highlight html %}
-<button class="s-btn s-btn__primary" type="button" aria-pressed="false">…</button>
+<button class="s-btn s-btn__primary" type="button">…</button>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="overflow-x-auto">
@@ -104,9 +104,9 @@ description: Buttons are user interface elements which allows users to take acti
                                         {% endif %}
                                     </div>
                                 </td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }}" type="button" aria-pressed="false">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} is-selected" type="button" aria-pressed="false">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }}" type="button" aria-pressed="false" disabled>Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }}" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} is-selected" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }}" type="button" disabled>Ask question</button></td>
                             </tr>
                             {% endfor %}
                         {% endfor %}
@@ -120,9 +120,9 @@ description: Buttons are user interface elements which allows users to take acti
     <p class="stacks-copy">Danger buttons are a secondary button style, used to visually communicate destructive actions such as deleting content, accounts, or canceling services.</p>
     <div class="stacks-preview">
 {% highlight html %}
-<button class="s-btn s-btn__danger" type="button" aria-pressed="false">…</button>
-<button class="s-btn s-btn__outlined s-btn__danger" type="button" aria-pressed="false">…</button>
-<button class="s-btn s-btn__filled s-btn__danger" type="button" aria-pressed="false">…</button>
+<button class="s-btn s-btn__danger" type="button">…</button>
+<button class="s-btn s-btn__outlined s-btn__danger" type="button">…</button>
+<button class="s-btn s-btn__filled s-btn__danger" type="button">…</button>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="overflow-x-auto">
@@ -153,9 +153,9 @@ description: Buttons are user interface elements which allows users to take acti
                                         {% endif %}
                                     </div>
                                 </td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }}" type="button" aria-pressed="false">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }} is-selected" type="button" aria-pressed="false">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }}" type="button" aria-pressed="false" disabled>Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }}" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }} is-selected" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }}" type="button" disabled>Ask question</button></td>
                             </tr>
                             {% endfor %}
                         {% endfor %}
@@ -169,9 +169,9 @@ description: Buttons are user interface elements which allows users to take acti
     <p class="stacks-copy">Muted buttons are a secondary button style, a grayscale visual treatment. Used in layouts for the least important items or currently inactive actions.</p>
     <div class="stacks-preview">
 {% highlight html %}
-<button class="s-btn s-btn__muted" type="button" aria-pressed="false">…</button>
-<button class="s-btn s-btn__outlined s-btn__muted" type="button" aria-pressed="false">…</button>
-<button class="s-btn s-btn__filled s-btn__muted" type="button" aria-pressed="false">…</button>
+<button class="s-btn s-btn__muted" type="button">…</button>
+<button class="s-btn s-btn__outlined s-btn__muted" type="button">…</button>
+<button class="s-btn s-btn__filled s-btn__muted" type="button">…</button>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="overflow-x-auto">
@@ -202,9 +202,9 @@ description: Buttons are user interface elements which allows users to take acti
                                         {% endif %}
                                     </div>
                                 </td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }}" type="button" aria-pressed="false">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }} is-selected" type="button" aria-pressed="false">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }}" type="button" aria-pressed="false" disabled>Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }}" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }} is-selected" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ btn.class }} {{ class.class }}" type="button" disabled>Ask question</button></td>
                             </tr>
                             {% endfor %}
                         {% endfor %}
@@ -220,10 +220,10 @@ description: Buttons are user interface elements which allows users to take acti
     <p class="stacks-copy">Any button can have a loading state applied by adding the <code class="stacks-code">.is-loading</code> state class.</p>
     <div class="stacks-preview">
 {% highlight html %}
-<button class="s-btn is-loading" type="button" aria-pressed="false">…</button>
-<button class="s-btn s-btn__outlined is-loading" type="button" aria-pressed="false">…</button>
-<button class="s-btn s-btn__filled is-loading" type="button" aria-pressed="false">…</button>
-<button class="s-btn s-btn__primary is-loading" type="button" aria-pressed="false">…</button>
+<button class="s-btn is-loading" type="button">…</button>
+<button class="s-btn s-btn__outlined is-loading" type="button">…</button>
+<button class="s-btn s-btn__filled is-loading" type="button">…</button>
+<button class="s-btn s-btn__primary is-loading" type="button">…</button>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="overflow-x-auto">
@@ -257,9 +257,9 @@ description: Buttons are user interface elements which allows users to take acti
                                         {% endif %}
                                     </div>
                                 </td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button" aria-pressed="false">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }} is-selected" type="button" aria-pressed="false">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button" aria-pressed="false" disabled>Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }} is-selected" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button" disabled>Ask question</button></td>
                             </tr>
                             {% endfor %}
                         {% endfor %}
@@ -309,9 +309,9 @@ description: Buttons are user interface elements which allows users to take acti
                                         {% endif %}
                                     </div>
                                 </td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button" aria-pressed="false">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }} is-selected" type="button" aria-pressed="false">Ask question</button></td>
-                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button" aria-pressed="false" disabled>Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }} is-selected" type="button">Ask question</button></td>
+                                <td class="va-middle ta-center px4"><button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button" disabled>Ask question</button></td>
                             </tr>
                             {% endfor %}
                         {% endfor %}
@@ -368,17 +368,17 @@ description: Buttons are user interface elements which allows users to take acti
                                     </div>
                                 </td>
                                 <td class="va-middle ta-center px4">
-                                    <button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button" aria-pressed="false">
+                                    <button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button">
                                         Active <span class="s-btn--badge"><span class="s-btn--number">198</span></span>
                                     </button>
                                 </td>
                                 <td class="va-middle ta-center px4">
-                                    <button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }} is-selected" type="button" aria-pressed="false">
+                                    <button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }} is-selected" type="button">
                                         Active <span class="s-btn--badge"><span class="s-btn--number">198</span></span>
                                     </button>
                                 </td>
                                 <td class="va-middle ta-center px4">
-                                    <button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button" aria-pressed="false" disabled>
+                                    <button class="ws-nowrap s-btn {{ class.class }} {% if class.class2 %}{{ class.class2 }}{% endif %} {{ btn.class }}" type="button" disabled>
                                         Active <span class="s-btn--badge"><span class="s-btn--number">198</span></span>
                                     </button>
                                 </td>
@@ -418,11 +418,38 @@ description: Buttons are user interface elements which allows users to take acti
                         {% endif %}
                     </td>
                     <td class="va-middle">{{ size.fs }}</td>
-                    <td class="va-middle"><button class="s-btn s-btn__primary ws-nowrap {{ size.class }}" type="button" aria-pressed="false">Ask question</button></td>
+                    <td class="va-middle"><button class="s-btn s-btn__primary ws-nowrap {{ size.class }}" type="button">Ask question</button></td>
                 </tr>
                 {% endfor %}
             </tbody>
         </table>
+    </div>
+</section>
+
+<section class="stacks-section">
+    {% header "h2", "Toggle buttons" %}
+    <p class="stacks-copy">Each button class has a selected state which can be visially activated by applying the <code class="stacks-code">.is-selected</code> class. When a button can switch between selected and unselected states, it is important to also annotate the button with the <code class="stacks-code">aria-pressed</code> attribute for accessibility. A <code class="stacks-code">title</code> attribute may also be appropriate to describe what will happen when pressing the button.</p>
+
+    <div class="stacks-preview">
+{% highlight html %}
+<button class="s-btn" type="button" aria-pressed="false" title="…">…</button>
+<button class="s-btn is-selected" type="button" aria-pressed="true" title="…">…</button>
+{% endhighlight %}
+{% highlight javascript %}
+toggleButton.addEventListener('click', () => {
+    let wasSelected = toggleButton.getAttribute('aria-pressed') === 'true';
+    let isSelected = !wasSelected;
+    toggleButton.classList.toggle('is-selected', isSelected);
+    toggleButton.setAttribute('aria-pressed', isSelected.toString());
+    …
+});
+{% endhighlight %}
+        <div class="stacks-preview--example">
+            <div class="grid gs4 fw-wrap">
+                <button class="grid--cell s-btn js-toggle-button" type="button" aria-pressed="false" title="Click to toggle this button's state">Initially unselected toggle button</button>
+                <button class="grid--cell s-btn js-toggle-button is-selected" type="button" aria-pressed="true" title="Click to toggle this button's state">Initially selected toggle button</button>
+            </div>
+        </div>
     </div>
 </section>
 
@@ -448,7 +475,7 @@ description: Buttons are user interface elements which allows users to take acti
                         <code class="grid--cell stacks-code">.s-btn__unset</code>
                     </td>
                     <td class="va-middle">Removes all styling from a button including its focus state.</td>
-                    <td class="va-middle"><button class="s-btn s-btn__unset ws-nowrap" type="button" aria-pressed="false">Unset button</button></td>
+                    <td class="va-middle"><button class="s-btn s-btn__unset ws-nowrap" type="button">Unset button</button></td>
                 </tr>
                 <tr>
                     <th scope="row" class="va-middle">Link</th>
@@ -456,7 +483,7 @@ description: Buttons are user interface elements which allows users to take acti
                         <code class="grid--cell stacks-code">.s-btn__link</code>
                     </td>
                     <td class="va-middle">Styles a button element as though it were a link.</td>
-                    <td class="va-middle"><button class="s-btn s-btn__link ws-nowrap" type="button" aria-pressed="false">Link button</button></td>
+                    <td class="va-middle"><button class="s-btn s-btn__link ws-nowrap" type="button">Link button</button></td>
                 </tr>
             </tbody>
         </table>
@@ -481,8 +508,8 @@ description: Buttons are user interface elements which allows users to take acti
                     </td>
                     <td class="va-middle">Adds some margin overrides that apply to an icon within a button</td>
                     <td class="va-middle grid ai-center">
-                        <button class="grid--cell s-btn s-btn__danger s-btn__icon ws-nowrap mr8" type="button" aria-pressed="false">{% icon "Trash" %} Delete</button>
-                        <button class="grid--cell s-btn s-btn__icon s-btn__link" type="button" aria-pressed="false">{% icon "ArrowUpLg" %}</button>
+                        <button class="grid--cell s-btn s-btn__danger s-btn__icon ws-nowrap mr8" type="button">{% icon "Trash" %} Delete</button>
+                        <button class="grid--cell s-btn s-btn__icon s-btn__link" type="button">{% icon "ArrowUpLg" %}</button>
                     </td>
                 </tr>
             </tbody>
@@ -508,7 +535,7 @@ description: Buttons are user interface elements which allows users to take acti
                     </td>
                     <td class="va-middle">Styles a button consistent with Facebook’s branding</td>
                     <td class="va-middle grid ai-center">
-                        <button class="grid--cell s-btn s-btn__icon s-btn__facebook ws-nowrap mr8" type="button" aria-pressed="false">{% icon "Facebook" %} Facebook</button>
+                        <button class="grid--cell s-btn s-btn__icon s-btn__facebook ws-nowrap mr8" type="button">{% icon "Facebook" %} Facebook</button>
                     </td>
                 </tr>
                 <tr>
@@ -518,7 +545,7 @@ description: Buttons are user interface elements which allows users to take acti
                     </td>
                     <td class="va-middle">Styles a button consistent with Google’s branding</td>
                     <td class="va-middle grid ai-center">
-                        <button class="grid--cell s-btn s-btn__icon s-btn__google ws-nowrap mr8" type="button" aria-pressed="false">{% icon "Google", "native" %} Google</button>
+                        <button class="grid--cell s-btn s-btn__icon s-btn__google ws-nowrap mr8" type="button">{% icon "Google", "native" %} Google</button>
                     </td>
                 </tr>
                 <tr>
@@ -528,7 +555,7 @@ description: Buttons are user interface elements which allows users to take acti
                     </td>
                     <td class="va-middle">Styles a button consistent with GitHub’s branding</td>
                     <td class="va-middle grid ai-center">
-                        <button class="grid--cell s-btn s-btn__icon s-btn__github ws-nowrap mr8" type="button" aria-pressed="false">{% icon "GitHub" %} GitHub</button>
+                        <button class="grid--cell s-btn s-btn__icon s-btn__github ws-nowrap mr8" type="button">{% icon "GitHub" %} GitHub</button>
                     </td>
                 </tr>
             </tbody>
@@ -609,3 +636,14 @@ description: Buttons are user interface elements which allows users to take acti
         </div>
     </div>
 </section>
+<script>
+    for (const toggleButton of document.querySelectorAll('.js-toggle-button'))
+    {
+        toggleButton.addEventListener('click', () => {
+            let wasSelected = toggleButton.getAttribute('aria-pressed') === 'true';
+            let isSelected = !wasSelected;
+            toggleButton.classList.toggle('is-selected', isSelected);
+            toggleButton.setAttribute('aria-pressed', isSelected.toString());
+        });
+    }
+</script>

--- a/docs/product/components/buttons.html
+++ b/docs/product/components/buttons.html
@@ -428,26 +428,27 @@ description: Buttons are user interface elements which allows users to take acti
 
 <section class="stacks-section">
     {% header "h2", "Toggle buttons" %}
-    <p class="stacks-copy">Each button class has a selected state which can be visially activated by applying the <code class="stacks-code">.is-selected</code> class. When a button can switch between selected and unselected states, it is important to also annotate the button with the <code class="stacks-code">aria-pressed</code> attribute for accessibility. A <code class="stacks-code">title</code> attribute may also be appropriate to describe what will happen when pressing the button.</p>
+    <p class="stacks-copy">Each button class has a selected state which can be visually activated by applying the <code class="stacks-code">.is-selected</code> class. When a button can switch between selected and unselected states, it is important to also annotate the button with the <code class="stacks-code">aria-pressed</code> attribute for accessibility. A <code class="stacks-code">title</code> attribute may also be appropriate to describe what will happen when pressing the button.</p>
 
     <div class="stacks-preview">
 {% highlight html %}
 <button class="s-btn" type="button" aria-pressed="false" title="…">…</button>
 <button class="s-btn is-selected" type="button" aria-pressed="true" title="…">…</button>
-{% endhighlight %}
-{% highlight javascript %}
-toggleButton.addEventListener('click', () => {
-    let wasSelected = toggleButton.getAttribute('aria-pressed') === 'true';
-    let isSelected = !wasSelected;
-    toggleButton.classList.toggle('is-selected', isSelected);
-    toggleButton.setAttribute('aria-pressed', isSelected.toString());
-    …
-});
+
+<script>
+    toggleButton.addEventListener('click', () => {
+        let wasSelected = toggleButton.getAttribute('aria-pressed') === 'true';
+        let isSelected = !wasSelected;
+        toggleButton.classList.toggle('is-selected', isSelected);
+        toggleButton.setAttribute('aria-pressed', isSelected.toString());
+        …
+    });
+</script>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="grid gs4 fw-wrap">
-                <button class="grid--cell s-btn js-toggle-button" type="button" aria-pressed="false" title="Click to toggle this button's state">Initially unselected toggle button</button>
-                <button class="grid--cell s-btn js-toggle-button is-selected" type="button" aria-pressed="true" title="Click to toggle this button's state">Initially selected toggle button</button>
+                <button class="grid--cell s-btn s-btn__primary js-toggle-button" type="button" aria-pressed="false" title="Click to toggle this button’s state">Initially unselected toggle button</button>
+                <button class="grid--cell s-btn s-btn__primary js-toggle-button is-selected" type="button" aria-pressed="true" title="Click to toggle this button’s state">Initially selected toggle button</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
I've seen a few PRs where people are applying `aria-pressed="false"` to buttons that really shouldn't have it.

For context, `<button>Ask question</button>` is read as something like "Ask question, button ... To click this button press Control-Option-Space". `<button aria-pressed="false">Ask question</button>` is read as something like "Ask question, toggle button ... To select or deselect this checkbox, press Control-Option-Space".

This removes the attributes from the examples and adds a section demonstrating how to use `.is-selected` (We didn't already.) and how to use it accessibly.