### PR TITLE
s-user-card improvements

### DIFF
--- a/docs/product/components/user-cards.html
+++ b/docs/product/components/user-cards.html
@@ -239,12 +239,14 @@ description: User cards are a combination of a user and metadata about the user 
     <a href="…" class="s-avatar s-avatar__24 s-user-card--avatar">
         <img class="s-avatar--image" src="…" />
     </a>
-    <ul class="s-user-card--awards">
-        <li class="s-user-card--rep">…</li>
-        <li class="s-award-bling s-award-bling__gold">…</li>
-        <li class="s-award-bling s-award-bling__silver">…</li>
-        <li class="s-award-bling s-award-bling__bronze">…</li>
-    </ul>
+    <div class="s-user-card--info">
+        <ul class="s-user-card--awards">
+            <li class="s-user-card--rep">…</li>
+            <li class="s-award-bling s-award-bling__gold">…</li>
+            <li class="s-award-bling s-award-bling__silver">…</li>
+            <li class="s-award-bling s-award-bling__bronze">…</li>
+        </ul>
+    </div>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
@@ -252,13 +254,14 @@ description: User cards are a combination of a user and metadata about the user 
                 <a href="#" class="s-avatar s-avatar__24 s-user-card--avatar">
                     <img class="s-avatar--image" src="https://picsum.photos/48" />
                 </a>
-
-                <ul class="s-user-card--awards">
-                    <li class="s-user-card--rep">2,500</li>
-                    <li class="s-award-bling s-award-bling__gold">5</li>
-                    <li class="s-award-bling s-award-bling__silver">9</li>
-                    <li class="s-award-bling s-award-bling__bronze">1</li>
-                </ul>
+                <div class="s-user-card--info">
+                    <ul class="s-user-card--awards">
+                        <li class="s-user-card--rep">2,500</li>
+                        <li class="s-award-bling s-award-bling__gold">5</li>
+                        <li class="s-award-bling s-award-bling__silver">9</li>
+                        <li class="s-award-bling s-award-bling__bronze">1</li>
+                    </ul>
+                </div>
             </div>
         </div>
     </div>
@@ -270,10 +273,12 @@ description: User cards are a combination of a user and metadata about the user 
 {% highlight html %}
 <div class="s-user-card s-user-card__minimal">
     <time class="s-user-card--time">…</time>
-    <a href="…" class="s-user-card--link">…</a>
-    <ul class="s-user-card--awards">
-        <li class="s-user-card--rep">…</li>
-    </ul>
+    <div class="s-user-card--info">
+        <a href="…" class="s-user-card--link">…</a>
+        <ul class="s-user-card--awards">
+            <li class="s-user-card--rep">…</li>
+        </ul>
+    </div>
 </div>
 
 <div class="s-user-card s-user-card__minimal">
@@ -281,21 +286,25 @@ description: User cards are a combination of a user and metadata about the user 
     <a href="…" class="s-avatar s-user-card--avatar">
         <img class="s-avatar--image" src="…" />
     </a>
-    <a href="#" class="s-user-card--link">…</a>
-    <ul class="s-user-card--awards">
-        <li class="s-user-card--rep">…</li>
-    </ul>
+    <div class="s-user-card--info">
+        <a href="#" class="s-user-card--link">…</a>
+        <ul class="s-user-card--awards">
+            <li class="s-user-card--rep">…</li>
+        </ul>
+    </div>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="s-user-card s-user-card__minimal">
                 <time class="s-user-card--time">3 minutes ago</time>
-                <a href="#" class="s-user-card--link">
-                    Paul Wright
-                </a>
-                <ul class="s-user-card--awards">
-                    <li class="s-user-card--rep">2,500</li>
-                </ul>
+                <div class="s-user-card--info">
+                    <a href="#" class="s-user-card--link">
+                        Paul Wright
+                    </a>
+                    <ul class="s-user-card--awards">
+                        <li class="s-user-card--rep">2,500</li>
+                    </ul>
+                </div>
             </div>
 
             <div class="s-user-card s-user-card__minimal mt16">
@@ -303,12 +312,14 @@ description: User cards are a combination of a user and metadata about the user 
                 <a href="#" class="s-avatar s-user-card--avatar">
                     <img class="s-avatar--image" src="https://picsum.photos/32" />
                 </a>
-                <a href="#" class="s-user-card--link">
-                    Paul Wright
-                </a>
-                <ul class="s-user-card--awards">
-                    <li class="s-user-card--rep">2,500</li>
-                </ul>
+                <div class="s-user-card--info">
+                    <a href="#" class="s-user-card--link">
+                        Paul Wright
+                    </a>
+                    <ul class="s-user-card--awards">
+                        <li class="s-user-card--rep">2,500</li>
+                    </ul>
+                </div>
             </div>
         </div>
     </div>
@@ -332,20 +343,32 @@ description: User cards are a combination of a user and metadata about the user 
     <div class="s-avatar s-avatar__32 s-user-card--avatar">
         <img class="s-avatar--image" src="…" />
     </div>
-    <div class="s-user-card--info">Paul Wright</div>
+    <div class="s-user-card--info">
+        <div class="s-user-card--link">
+            Paul Wright
+        </div>
+    </div>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="s-user-card s-user-card__deleted">
                 <time class="s-user-card--time">3 minutes ago</time>
                 <div class="s-avatar s-avatar__32 s-user-card--avatar demo-background"></div>
-                <div class="s-user-card--info">Paul Wright</div>
+                <div class="s-user-card--info">
+                    <div class="s-user-card--link">
+                        Paul Wright
+                    </div>
+                </div>
             </div>
 
             <div class="s-user-card s-user-card__deleted s-user-card__minimal mt16">
                 <time class="s-user-card--time">3 years ago</time>
                 <div class="s-avatar s-user-card--avatar demo-background"></div>
-                <div class="s-user-card--info">Paul Wright</div>
+                <div class="s-user-card--info">
+                    <div class="s-user-card--link">
+                        Paul Wright
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/lib/css/components/_stacks-user-cards.less
+++ b/lib/css/components/_stacks-user-cards.less
@@ -56,6 +56,15 @@
         align-items: center;
         grid-column-gap: unset; // Firefox flex layouts respect column gaps, so we need to reset this
 
+        .s-user-card--time {
+            margin-right: @su6;
+            margin-bottom: 0;
+        }
+
+        .s-user-card--link {
+            margin-right: @su6;
+        }
+
         .s-user-card--avatar {
             margin-right: @su6;
         }

--- a/lib/css/components/_stacks-user-cards.less
+++ b/lib/css/components/_stacks-user-cards.less
@@ -59,6 +59,12 @@
         .s-user-card--avatar {
             margin-right: @su6;
         }
+
+        .s-user-card--info {
+            display: flex;
+            align-items: center;
+            grid-column-gap: unset; // Firefox flex layouts respect column gaps, so we need to reset this
+        }
     }
 
     //  $$  A minimal presentation
@@ -84,6 +90,12 @@
         .s-user-card--rep {
             padding: 0;
             color: var(--black-600);
+        }
+
+        .s-user-card--info {
+            display: flex;
+            align-items: center;
+            grid-column-gap: unset; // Firefox flex layouts respect column gaps, so we need to reset this
         }
     }
 }


### PR DESCRIPTION
I was looking at a reusable component for `s-user-card` and ran into some issues:

- `s-user-card--info` doesn't reorient itself horizontally in small/minimal configurations, meaning we can't use the same structure for all sizes.
- `s-user-card--info` is `display: grid` so it shouldn't be used to hold deleted user usernames, in case we want to do markup annotations.
- `s-user-card__small` lacks margins provided by all other variants.

This addresses each by:

- Making `s-user-card--info` a `display: flex` in small/minimal, updating documentation to use `s-user-card--info`.  If we want to keep the info section optional here, I think we should explicitly say so.
- Making the documentation use `--link` for usernames even if they are deleted.
- Copying margins from minimal to small.

I would also argue that we should:

- Deprecate `s-user-card__minimal` since the only difference between small and minimal is that we unbold some text and decreases a margin by 2px.
- Rename `s-user-card--link` to `s-user-card--name` since it should always be a name but it might not always be a link.
- Radically, consider getting rid of `s-user-card__deleted` in place of `.s-user-card--name:not(:link) { color: var(--black-500); }` If people we're worried about selector priority and people want to go bananas with formatting they could do `<div class="s-user-card--link"><span class="s-btn s-btn__primary">🍌</span></div>`

## Preview

Identical cards with different size classes and avatar size classes:

![Screen Shot 2021-01-07 at 2 49 19 PM](https://user-images.githubusercontent.com/662837/103951158-69faf580-50fb-11eb-8a99-e5f850bedf36.png)
