### PR TITLE
Better darkmode override mixin and popover arrows

### DIFF
--- a/docs/assets/less/stacks-documentation.less
+++ b/docs/assets/less/stacks-documentation.less
@@ -26,11 +26,11 @@
     background-image: url("../img/illustration-crane.svg"), url("../img/illustration-field.svg");
     background-position: top -35% left 15%, bottom 10% right 8%;
     background-repeat: no-repeat, no-repeat;
-}
 
-#stacks-internals #darkmode('.stacks-intro', {
-    background-image: url("../img/illustration-crane-dark.svg"), url("../img/illustration-field-dark.svg");
-});
+    .dark-mode({
+        background-image: url("../img/illustration-crane-dark.svg"), url("../img/illustration-field-dark.svg");
+    });
+}
 
 .stacks-home-nav {
     margin-bottom: 316px;
@@ -227,16 +227,16 @@
         border-radius: @br-md @br-md 0 0;
         border: 1px solid var(--black-100);
         max-height: 24rem;
+
+        .dark-mode({
+            border-color: transparent;
+        });
     }
 
     &._preview-none pre.s-code-block {
         .bar-md;
     }
 }
-
-#stacks-internals #darkmode('.stacks-preview > pre.s-code-block', {
-    border-color: transparent;
-});
 
 //  Preview area
 .stacks-preview--example {
@@ -246,12 +246,12 @@
     border: 1px solid var(--black-100);
     border-top-width: 0;
     font-size: @fs-body1;
-}
 
-#stacks-internals #darkmode('.stacks-preview--example', {
-    border-color: transparent;
-    background: var(--black-025);
-});
+    .dark-mode({
+        border-color: transparent;
+        background: var(--black-025);
+    });
+}
 
 // Checkered background
 .bg-checkered {

--- a/docs/product/components/popovers.html
+++ b/docs/product/components/popovers.html
@@ -185,7 +185,7 @@ description: Popovers are small content containers that provide a contextual ove
             <div class="grid--cell ml-auto sm:ml0 sm:mt12"
                 data-controller="s-popover"
                 data-s-popover-reference-selector="#reference-element"
-                data-s-popover-placement="right">
+                data-s-popover-placement="auto">
                 <a id="reference-element" class="s-link s-link__inherit"
                     aria-controls="popover-example-3">
                     Follow question
@@ -567,7 +567,7 @@ Stacks.setTooltipHtml(el,
     <div class="stacks-preview">
 {% highlight html %}
 <div class="s-popover">
-    <div class="s-popover--arrow__tc"></div>
+    <div class="s-popover--arrow s-popover--arrow__tc"></div>
     …
 </div>
 {% endhighlight %}
@@ -575,84 +575,84 @@ Stacks.setTooltipHtml(el,
             <div class="grid gs16 grid__allcells4 fw-wrap">
                 <div class="grid--cell">
                     <div class="s-popover ps-relative z-base is-visible">
-                        <div class="s-popover--arrow__tc"></div>
+                        <div class="s-popover--arrow s-popover--arrow__tc"></div>
                         <p class="ff-mono mb8">.s-popover--arrow__tc</p>
                         <p class="mb0">Popover arrow appears top center</p>
                     </div>
                 </div>
                 <div class="grid--cell">
                     <div class="s-popover ps-relative z-base is-visible">
-                        <div class="s-popover--arrow__tl"></div>
+                        <div class="s-popover--arrow s-popover--arrow__tl"></div>
                         <p class="ff-mono mb8">.s-popover--arrow__tl</p>
                         <p class="mb0">Popover arrow appears top left</p>
                     </div>
                 </div>
                 <div class="grid--cell">
                     <div class="s-popover ps-relative z-base is-visible">
-                        <div class="s-popover--arrow__tr"></div>
+                        <div class="s-popover--arrow s-popover--arrow__tr"></div>
                         <p class="ff-mono mb8">.s-popover--arrow__tr</p>
                         <p class="mb0">Popover arrow appears top right</p>
                     </div>
                 </div>
                 <div class="grid--cell">
                     <div class="s-popover ps-relative z-base is-visible">
-                        <div class="s-popover--arrow__bc"></div>
+                        <div class="s-popover--arrow s-popover--arrow__bc"></div>
                         <p class="ff-mono mb8">.s-popover--arrow__bc</p>
                         <p class="mb0">Popover arrow appears bottom center</p>
                     </div>
                 </div>
                 <div class="grid--cell">
                     <div class="s-popover ps-relative z-base is-visible">
-                        <div class="s-popover--arrow__bl"></div>
+                        <div class="s-popover--arrow s-popover--arrow__bl"></div>
                         <p class="ff-mono mb8">.s-popover--arrow__bl</p>
                         <p class="mb0">Popover arrow appears bottom left</p>
                     </div>
                 </div>
                 <div class="grid--cell">
                     <div class="s-popover ps-relative z-base is-visible">
-                        <div class="s-popover--arrow__br"></div>
+                        <div class="s-popover--arrow s-popover--arrow__br"></div>
                         <p class="ff-mono mb8">.s-popover--arrow__br</p>
                         <p class="mb0">Popover arrow appears bottom right</p>
                     </div>
                 </div>
                 <div class="grid--cell">
                     <div class="s-popover ps-relative z-base is-visible">
-                        <div class="s-popover--arrow__rc"></div>
+                        <div class="s-popover--arrow s-popover--arrow__rc"></div>
                         <p class="ff-mono mb8">.s-popover--arrow__rc</p>
                         <p class="mb0">Popover arrow appears right center</p>
                     </div>
                 </div>
                 <div class="grid--cell">
                     <div class="s-popover ps-relative z-base is-visible">
-                        <div class="s-popover--arrow__rt"></div>
+                        <div class="s-popover--arrow s-popover--arrow__rt"></div>
                         <p class="ff-mono mb8">.s-popover--arrow__rt</p>
                         <p class="mb0">Popover arrow appears right top</p>
                     </div>
                 </div>
                 <div class="grid--cell">
                     <div class="s-popover ps-relative z-base is-visible">
-                        <div class="s-popover--arrow__rb"></div>
+                        <div class="s-popover--arrow s-popover--arrow__rb"></div>
                         <p class="ff-mono mb8">.s-popover--arrow__rb</p>
                         <p class="mb0">Popover arrow appears right bottom</p>
                     </div>
                 </div>
                 <div class="grid--cell">
                     <div class="s-popover ps-relative z-base is-visible">
-                        <div class="s-popover--arrow__lc"></div>
+                        <div class="s-popover--arrow s-popover--arrow__lc"></div>
                         <p class="ff-mono mb8">.s-popover--arrow__lc</p>
                         <p class="mb0">Popover arrow appears left center</p>
                     </div>
                 </div>
                 <div class="grid--cell">
                     <div class="s-popover ps-relative z-base is-visible">
-                        <div class="s-popover--arrow__lt"></div>
+                        <div class="s-popover--arrow s-popover--arrow__lt"></div>
                         <p class="ff-mono mb8">.s-popover--arrow__lt</p>
                         <p class="mb0">Popover arrow appears left top</p>
                     </div>
                 </div>
                 <div class="grid--cell">
                     <div class="s-popover ps-relative z-base is-visible">
-                        <div class="s-popover--arrow__lb"></div>
+                        <div class="s-popover--arrow s-popover--arrow__lb"></div>
                         <p class="ff-mono mb8">.s-popover--arrow__lb</p>
                         <p class="mb0">Popover arrow appears left bottom</p>
                     </div>

--- a/docs/product/components/popovers.html
+++ b/docs/product/components/popovers.html
@@ -275,7 +275,7 @@ description: Popovers are small content containers that provide a contextual ove
         <div class="stacks-preview--example bg-black-025">
             <div class="s-popover ps-relative is-visible">
                 <button class="s-popover--close s-btn s-btn__muted" aria-label="Close">{% icon "ClearSm" %}</button>
-                <div class="s-popover--arrow__bl"></div>
+                <div class="s-popover--arrow s-popover--arrow__bl"></div>
                 <p class="mb0">Dismissible persistent popover presented with a close button</p>
             </div>
         </div>

--- a/docs/product/components/popovers.html
+++ b/docs/product/components/popovers.html
@@ -185,7 +185,7 @@ description: Popovers are small content containers that provide a contextual ove
             <div class="grid--cell ml-auto sm:ml0 sm:mt12"
                 data-controller="s-popover"
                 data-s-popover-reference-selector="#reference-element"
-                data-s-popover-placement="auto">
+                data-s-popover-placement="right">
                 <a id="reference-element" class="s-link s-link__inherit"
                     aria-controls="popover-example-3">
                     Follow question

--- a/lib/css/atomic/_stacks-borders.less
+++ b/lib/css/atomic/_stacks-borders.less
@@ -320,4 +320,4 @@
 //  $$  TRANSPARENT
 //  ----------------------------------------------------------------------------
 .bc-transparent     { border-color: transparent !important; }
-#stacks-internals #darkmode('.d\:bc-transparent', { border-color: transparent !important; });
+.d\:bc-transparent  { .dark-mode({ border-color: transparent !important; }) }

--- a/lib/css/atomic/_stacks-colors.less
+++ b/lib/css/atomic/_stacks-colors.less
@@ -25,9 +25,11 @@
         .f\:fc-@{color-name}:focus-within {
             color: var(~"--@{color-name}") !important;
         }
-        #stacks-internals #darkmode('.d\:fc-@{color-name}', {
-            color: var(~"--@{color-name}") !important;
-        });
+        .d\:fc-@{color-name} {
+            .dark-mode({
+                color: var(~"--@{color-name}") !important;
+            });
+        }
 
         .bg-@{color-name},
         .h\:bg-@{color-name}:hover,
@@ -37,9 +39,11 @@
         .f\:bg-@{color-name}:focus-within {
             background-color: var(~"--@{color-name}") !important;
         }
-        #stacks-internals #darkmode('.d\:bg-@{color-name}', {
-            background-color: var(~"--@{color-name}") !important;
-        });
+        .d\:bg-@{color-name} {
+            .dark-mode({
+                background-color: var(~"--@{color-name}") !important;
+            });
+        }
     }
 
     .standard-weights(@color) {

--- a/lib/css/base/_stacks-internals.less
+++ b/lib/css/base/_stacks-internals.less
@@ -15,33 +15,6 @@
     }
 
     //  ===========================================================================
-    //  --  DARKMODE
-    //      #darkmode renders a dark mode override behind the
-    //      prefers-color-scheme: dark media query and .theme-system. It also
-    //      renders the same rules outside of the media query with .theme-dark
-    //
-    //      Usage example:
-    //
-    //      #stacks-internals #darkmode('.s-dialog', { background-color: var(--black-100); });
-    //
-    //  ---------------------------------------------------------------------------
-
-    #darkmode(@class, @rules) {
-        @classname: ~"@{class}"; // Interpolate the @class passed to us so we can generate proper CSS rules from it
-
-        body.theme-system @{classname} {
-            @media (prefers-color-scheme: dark) {
-                @rules();
-            }
-        }
-
-        body.theme-dark @{classname},
-        .theme-dark__forced @{classname} {
-            @rules();
-        }
-    }
-
-    //  ===========================================================================
     //  --  RESPONSIVE (modern)
     //      #responsify renders a plain class as well as its responsive counterparts.
     //

--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -188,7 +188,10 @@
     }
 }
 
-#stacks-internals #darkmode('.s-btn__primary:not(.is-selected) .s-btn--number, .s-btn__danger.s-btn__filled:not(.is-selected) .s-btn--number', { color: @black; });
+.s-btn__primary:not(.is-selected) .s-btn--number,
+.s-btn__danger.s-btn__filled:not(.is-selected) .s-btn--number {
+    .dark-mode({ color: @black; });
+}
 
 //  ============================================================================
 //  $   DEFAULT (SECONDARY) STYLES
@@ -214,6 +217,8 @@
     border-color: @button-filled-border-color;
     box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, .7);
 
+    .dark-mode({ box-shadow: none; });
+
     &:hover,
     &:focus,
     &:active {
@@ -234,8 +239,6 @@
         box-shadow: none;
     }
 }
-
-#stacks-internals #darkmode('.s-btn__filled', { box-shadow: none; });
 
 //  --  Muted Clear Style
 //      Creates a gray button style.
@@ -283,6 +286,8 @@
         border-color: transparent;
         box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, .4);
 
+        .dark-mode({ box-shadow: none; });
+
         &:hover,
         &:focus,
         &:active {
@@ -310,8 +315,6 @@
         }
     }
 }
-
-#stacks-internals #darkmode('.s-btn__muted.s-btn__filled', { box-shadow: none; });
 
 //  ============================================================================
 //  $   DANGER BUTTONS & STYLES
@@ -359,6 +362,8 @@
         border-color: transparent;
         box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, .4);
 
+        .dark-mode({ box-shadow: none; });
+
         &:hover,
         &:focus,
         &:active {
@@ -391,8 +396,6 @@
     }
 }
 
-#stacks-internals #darkmode('.s-btn__danger.s-btn__filled', { box-shadow: none; });
-
 //  ============================================================================
 //  $   PRIMARY STYLE
 //  ============================================================================
@@ -400,6 +403,8 @@
     color: @button-primary-color;
     background-color: @button-primary-background-color;
     box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, .4);
+
+    .dark-mode({ box-shadow: none; });
 
     &:hover,
     &:focus,
@@ -422,9 +427,6 @@
         color: @button-primary-number-color;
     }
 }
-
-#stacks-internals #darkmode('.s-btn__primary', { box-shadow: none; });
-
 
 //  ============================================================================
 //  $   MISC STYLES

--- a/lib/css/components/_stacks-code-blocks.less
+++ b/lib/css/components/_stacks-code-blocks.less
@@ -113,8 +113,9 @@ pre.s-code-block .s-code-block--line-numbers {
     padding: @su12;
     padding-right: @su6;
     background-color: var(--black-050);
+
+    .dark-mode({
+        background-color: var(--black-025);
+    });
 }
 
-#stacks-internals #darkmode('pre.s-code-block .s-code-block--line-numbers', {
-    background-color: var(--black-025);
-});

--- a/lib/css/components/_stacks-modals.less
+++ b/lib/css/components/_stacks-modals.less
@@ -56,6 +56,10 @@
     backface-visibility: hidden;
     transform: translate3d(0, 30%, 0) scale3d(0.6, 0.6, 0.6);
 
+    .dark-mode({
+        background-color: var(--black-100);
+    });
+
     @scrollbar-styles();
 
     transition: opacity 200ms @te-smooth 0s, z-index 0s 100ms, visibility 0s 100ms, transform 100ms @te-smooth 0s, transform 100ms @te-smooth 0s; // Transition out
@@ -65,8 +69,6 @@
         transform: translate3d(0, 0, 0) scale3d(1, 1, 1); // Transition in
     }
 }
-
-#stacks-internals #darkmode('.s-modal--dialog', { background-color: var(--black-100) });
 
 //  [1] To override .s-btn class attributes
 .s-modal--close {

--- a/lib/css/components/_stacks-notices.less
+++ b/lib/css/components/_stacks-notices.less
@@ -145,14 +145,14 @@
     color: var(--white);
 }
 
-#stacks-internals #darkmode('', {
-    .s-notice__info,
-    .s-notice__success,
-    .s-notice__warning,
-    .s-notice__danger {
+.s-notice__info,
+.s-notice__success,
+.s-notice__warning,
+.s-notice__danger {
+    .dark-mode({
         border-color: transparent;
-    }
-});
+    });
+}
 
 //  ============================================================================
 //  $   TOASTS

--- a/lib/css/components/_stacks-popovers.less
+++ b/lib/css/components/_stacks-popovers.less
@@ -45,7 +45,10 @@
         display: block;
     }
 
-    &[data-popper-placement^="top"] > .s-popover--arrow {
+    &[data-popper-placement^="top"] > .s-popover--arrow,
+    .s-popover--arrow__bc,
+    .s-popover--arrow__bl,
+    .s-popover--arrow__br {
         bottom: -@su6;
 
         &:after {
@@ -54,7 +57,10 @@
         }
     }
 
-    &[data-popper-placement^="bottom"] > .s-popover--arrow {
+    &[data-popper-placement^="bottom"] > .s-popover--arrow,
+    .s-popover--arrow__tc,
+    .s-popover--arrow__tl,
+    .s-popover--arrow__tr {
         top: -@su6;
 
         &:after {
@@ -63,7 +69,10 @@
         }
     }
 
-    &[data-popper-placement^="left"] > .s-popover--arrow {
+    &[data-popper-placement^="left"] > .s-popover--arrow,
+    .s-popover--arrow__rc,
+    .s-popover--arrow__rt,
+    .s-popover--arrow__rb {
         right: -@su6;
 
         &:after {
@@ -72,7 +81,10 @@
         }
     }
 
-    &[data-popper-placement^="right"] > .s-popover--arrow {
+    &[data-popper-placement^="right"] > .s-popover--arrow,
+    .s-popover--arrow__lc,
+    .s-popover--arrow__lt,
+    .s-popover--arrow__lb {
         left: -@su6;
 
         &:after {
@@ -134,11 +146,6 @@
     // This renders our border
     content: '';
     transform: rotate(45deg);
-    background: var(--black-150);
-
-    .dark-mode({
-        background: currentColor !important;
-    });
 }
 
 .s-popover--arrow:after {
@@ -146,173 +153,4 @@
     content: '';
     transform: rotate(45deg);
     background: currentColor;
-}
-
-.s-popover--arrow__tl,
-.s-popover--arrow__tc,
-.s-popover--arrow__tr,
-.s-popover--arrow__bl,
-.s-popover--arrow__bc,
-.s-popover--arrow__br,
-.s-popover--arrow__lt,
-.s-popover--arrow__lc,
-.s-popover--arrow__lb,
-.s-popover--arrow__rt,
-.s-popover--arrow__rc,
-.s-popover--arrow__rb {
-    color: var(--white);
-
-    .dark-mode({
-        color: var(--black-075);
-    });
-
-    &:before,
-    &:after {
-        content: "";
-        position: absolute;
-        border-width: @su8;
-        border-style: solid;
-        border-color: transparent;
-    }
-}
-
-//  ============================================================================
-//  $   ARROW LOCATIONS
-//  ============================================================================
-//  $$  TOP
-//  ----------------------------------------------------------------------------
-.s-popover--arrow__tl,
-.s-popover--arrow__tc,
-.s-popover--arrow__tr {
-    &:before,
-    &:after {
-        border-top: none;
-    }
-    &:before {
-        top: -(@su8);
-        border-bottom-color: var(--black-150);
-    }
-    &:after {
-        top: -(@su8 - 1);
-        border-bottom-color: currentColor;
-    }
-}
-
-//  $$  BOTTOM
-//  ----------------------------------------------------------------------------
-.s-popover--arrow__bl,
-.s-popover--arrow__bc,
-.s-popover--arrow__br {
-    &:before,
-    &:after {
-        border-bottom: none;
-    }
-    &:before {
-        bottom: -(@su8);
-        border-top-color: var(--black-150);
-    }
-    &:after {
-        bottom: -(@su8 - 1);
-        border-top-color: currentColor;
-    }
-}
-
-//  $$  TOP & BOTTOM LEFT
-//  ----------------------------------------------------------------------------
-.s-popover--arrow__tl,
-.s-popover--arrow__bl {
-    &:before,
-    &:after {
-        left: @su12;
-    }
-}
-
-//  $$  TOP & BOTTOM CENTER
-//  ----------------------------------------------------------------------------
-.s-popover--arrow__tc,
-.s-popover--arrow__bc {
-    &:before,
-    &:after {
-        left: 50%;
-        margin-left: -(@su8);
-    }
-}
-
-//  $$  TOP & BOTTOM RIGHT
-//  ----------------------------------------------------------------------------
-.s-popover--arrow__tr,
-.s-popover--arrow__br {
-    &:before,
-    &:after {
-        right: @su12;
-    }
-}
-
-//  $$  LEFT
-//  ----------------------------------------------------------------------------
-.s-popover--arrow__lt,
-.s-popover--arrow__lc,
-.s-popover--arrow__lb {
-    &:before,
-    &:after {
-        border-left: none;
-    }
-    &:before {
-        left: -(@su8);
-        border-right-color: var(--black-150);
-    }
-    &:after {
-        left: -(@su8 - 1);
-        border-right-color: currentColor;
-    }
-}
-
-//  $$  RIGHT
-//  ----------------------------------------------------------------------------
-.s-popover--arrow__rt,
-.s-popover--arrow__rc,
-.s-popover--arrow__rb {
-    &:before,
-    &:after {
-        border-right: none;
-    }
-    &:before {
-        right: -(@su8);
-        border-left-color: var(--black-150);
-    }
-    &:after {
-        right: -(@su8 - 1);
-        border-left-color: currentColor;
-    }
-}
-
-//  $$  LEFT & RIGHT TOP
-//  ----------------------------------------------------------------------------
-.s-popover--arrow__lt,
-.s-popover--arrow__rt {
-    &:before,
-    &:after {
-        top: @su12;
-    }
-}
-
-//  $$  LEFT & RIGHT CENTER
-//  ----------------------------------------------------------------------------
-.s-popover--arrow__lc,
-.s-popover--arrow__rc {
-    &:before,
-    &:after {
-        top: 50%;
-        margin-top: -(@su8);
-    }
-}
-
-//  $$  LEFT & RIGHT BOTTOM
-//  ----------------------------------------------------------------------------
-.s-popover--arrow__lb,
-.s-popover--arrow__rb {
-    &:before,
-    &:after {
-        bottom: @su12;
-    }
 }

--- a/lib/css/components/_stacks-popovers.less
+++ b/lib/css/components/_stacks-popovers.less
@@ -50,6 +50,7 @@
 
         &:after {
             bottom: 1px;
+            box-shadow: 2px 2px 5px 0 rgba(0, 0, 0, 0.07), 2px 2px 2px -1px rgba(0, 0, 0, .1);
         }
     }
 
@@ -58,6 +59,7 @@
 
         &:after {
             top: 1px;
+            box-shadow: -1px -1px 1px 0 rgba(0, 0, 0, 0.12);
         }
     }
 
@@ -66,6 +68,7 @@
 
         &:after {
             right: 1px;
+            box-shadow: 2px -2px 5px 0 rgba(0, 0, 0, 0.07), 2px -2px 2px -1px rgba(0, 0, 0, .1);
         }
     }
 
@@ -74,6 +77,7 @@
 
         &:after {
             left: 1px;
+            box-shadow: -2px 2px 5px 0 rgba(0, 0, 0, 0.07), -2px 2px 2px -1px rgba(0, 0, 0, .1);
         }
     }
 }

--- a/lib/css/components/_stacks-popovers.less
+++ b/lib/css/components/_stacks-popovers.less
@@ -95,12 +95,22 @@
 
     .s-popover--arrow__tc,
     .s-popover--arrow__bc {
-        left: calc(50% - @su12);
+        left: calc(50% - @su6);
     }
 
     .s-popover--arrow__lc,
     .s-popover--arrow__rc {
         top: calc(50% - @su6);
+    }
+
+    .s-popover--arrow__tr,
+    .s-popover--arrow__br {
+        right: @su12;
+    }
+
+    .s-popover--arrow__rb,
+    .s-popover--arrow__lb {
+        bottom: @su12;
     }
 }
 

--- a/lib/css/components/_stacks-popovers.less
+++ b/lib/css/components/_stacks-popovers.less
@@ -92,6 +92,16 @@
             box-shadow: -2px 2px 5px 0 rgba(0, 0, 0, 0.07), -2px 2px 2px -1px rgba(0, 0, 0, .1);
         }
     }
+
+    .s-popover--arrow__tc,
+    .s-popover--arrow__bc {
+        left: calc(50% - @su12);
+    }
+
+    .s-popover--arrow__lc,
+    .s-popover--arrow__rc {
+        top: calc(50% - @su6);
+    }
 }
 
 //  ============================================================================

--- a/lib/css/components/_stacks-popovers.less
+++ b/lib/css/components/_stacks-popovers.less
@@ -152,5 +152,6 @@
     // This renders our foreground color
     content: '';
     transform: rotate(45deg);
+    border-radius: 1.5px;
     background: currentColor;
 }

--- a/lib/css/components/_stacks-popovers.less
+++ b/lib/css/components/_stacks-popovers.less
@@ -30,6 +30,12 @@
     min-width: 12rem;
     width: 100%;
 
+    .dark-mode({
+        background-color: var(--black-075);
+        border-color: transparent;
+        box-shadow: var(--bs-lg);
+    });
+
     &.s-popover__tooltip {
         width: auto;
         min-width: unset;
@@ -71,12 +77,6 @@
         }
     }
 }
-
-#stacks-internals #darkmode('.s-popover', {
-    background-color: var(--black-075);
-    border-color: transparent;
-    box-shadow: var(--bs-lg);
-});
 
 //  ============================================================================
 //  $   CLOSE BUTTON
@@ -120,23 +120,21 @@
 
 .s-popover--arrow {
     color: var(--white);
-}
 
-#stacks-internals #darkmode('', {
-    .s-popover--arrow {
+    .dark-mode({
         color: var(--black-075);
-    }
-
-    .s-popover--arrow:before {
-        background: currentColor;
-    }
-});
+    });
+}
 
 .s-popover--arrow:before {
     // This renders our border
     content: '';
     transform: rotate(45deg);
     background: var(--black-150);
+
+    .dark-mode({
+        background: currentColor !important;
+    });
 }
 
 .s-popover--arrow:after {
@@ -160,6 +158,10 @@
 .s-popover--arrow__rb {
     color: var(--white);
 
+    .dark-mode({
+        color: var(--black-075);
+    });
+
     &:before,
     &:after {
         content: "";
@@ -169,23 +171,6 @@
         border-color: transparent;
     }
 }
-
-#stacks-internals #darkmode('', {
-    .s-popover--arrow__tl,
-    .s-popover--arrow__tc,
-    .s-popover--arrow__tr,
-    .s-popover--arrow__bl,
-    .s-popover--arrow__bc,
-    .s-popover--arrow__br,
-    .s-popover--arrow__lt,
-    .s-popover--arrow__lc,
-    .s-popover--arrow__lb,
-    .s-popover--arrow__rt,
-    .s-popover--arrow__rc,
-    .s-popover--arrow__rb {
-        color: var(--black-075);
-    }
-});
 
 //  ============================================================================
 //  $   ARROW LOCATIONS

--- a/lib/css/components/_stacks-prose.less
+++ b/lib/css/components/_stacks-prose.less
@@ -405,6 +405,12 @@
         border-radius: @br-sm;
         box-shadow: 0 1px 1px rgba(12, 13, 14, 0.15), inset 0 1px 0 0 @white;
         overflow-wrap: break-word;
+
+        .dark-mode({
+            box-shadow: 0 1px 1px rgba(12, 13, 14, 0.8);
+            border-color: transparent;
+            border-top-color: @black-500;
+        });
     }
 
     // ============================================================================
@@ -482,9 +488,3 @@
         }
     }
 }
-
-#stacks-internals #darkmode('.s-prose kbd', {
-    box-shadow: 0 1px 1px rgba(12, 13, 14, 0.8);
-    border-color: transparent;
-    border-top-color: @black-500;
-});

--- a/lib/css/exports/_stacks-mixins.less
+++ b/lib/css/exports/_stacks-mixins.less
@@ -18,6 +18,31 @@
     &:after { clear: both; }
 }
 
+//  ===========================================================================
+//  --  DARKMODE
+//      .darkmode renders a dark mode override behind the
+//      prefers-color-scheme: dark media query and .theme-system. It also
+//      renders the same rules outside of the media query with .theme-dark
+//
+//      Usage example:
+//
+//      .dark-mode({ background-color: var(--black-100); });
+//
+//  ---------------------------------------------------------------------------
+
+.dark-mode(@rules) {
+    body.theme-system & {
+        @media (prefers-color-scheme: dark) {
+            @rules();
+        }
+    }
+
+    body.theme-dark &,
+    .theme-dark__forced & {
+        @rules();
+    }
+}
+
 
 //  ===========================================================================
 //  --  APPEARANCE


### PR DESCRIPTION
This PR started as better syntax for dark-mode overrides, but morphed into some fixes for popover arrows as well. 

![image](https://user-images.githubusercontent.com/1369864/103954803-9c601f00-510a-11eb-8ada-505dcb0726db.png)

This:

- Moves the mixin to `mixins.less` so they're more widely available
- Switches to the `whatever &` syntax, so we can more easily use them within existing blocks
- Refines popover arrows to use stacked shadows instead of hard borders which allows us to remove some dark mode overrides, actually
- Breaks how manual arrows are marked up, by requiring `s-popover--arrow` first, but saves us lots of CSS.

@abovedave Will you double check that these popovers don't look worse to you?
@b-kelly Can you make sure I'm not committing anything stupid here?