### PR TITLE
Fix typo in auto-margin docs

### DIFF
--- a/docs/product/base/spacing.html
+++ b/docs/product/base/spacing.html
@@ -161,7 +161,7 @@ description: Stacks provides atomic classes to override margin and padding.
                 <tr>
                     <td>Left</td>
                     <td class="ff-mono">
-                        .mr-auto
+                        .ml-auto
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
Left margin should be `.ml-auto`, not `.mr-auto`