### PR TITLE
Fix typos on `s-sidebarwidget__small-bold-text`

### DIFF
--- a/docs/product/components/sidebar-widgets.html
+++ b/docs/product/components/sidebar-widgets.html
@@ -564,7 +564,7 @@ description: Sidebar widgets are flexible containers that provide a lot of patte
     <div class="stacks-preview">
 {% highlight html %}
 <div class="s-sidebarwidget">
-    <div class="s-sidebarwidget--header s-sidebarwidget__small-bold_text
+    <div class="s-sidebarwidget--header s-sidebarwidget__small-bold-text
                 s-sidebarwidget__expanding-control"
                 aria-expanded="true"
                 aria-controls="recent-searches"
@@ -598,7 +598,7 @@ description: Sidebar widgets are flexible containers that provide a lot of patte
 {% endhighlight %}
         <div class="stacks-preview--example overflow-x-auto">
             <div class="s-sidebarwidget ws3 mx-auto">
-                <div class="s-sidebarwidget--header s-sidebarwidget__small-bold_text
+                <div class="s-sidebarwidget--header s-sidebarwidget__small-bold-text
                             s-sidebarwidget__expanding-control"
                             aria-expanded="true"
                             aria-controls="recent-searches"


### PR DESCRIPTION
The documentation mistakenly lists it as `...small-bold_text` (with an underscore instead of hyphen) in a couple of places
It actually propagated to SO code in a few spots 😄