### PR TITLE
User card links should have overflow-wrap:break-word

### DIFF
--- a/lib/css/components/_stacks-user-cards.less
+++ b/lib/css/components/_stacks-user-cards.less
@@ -137,6 +137,7 @@
     font-size: @fs-caption;
     align-items: center;
     flex-wrap: wrap;
+    overflow-wrap: break-word;
 }
 
 //  $   AWARDS CONTAINER


### PR DESCRIPTION
- Addresses: https://meta.stackexchange.com/a/360268/51
- Applicable in other situations where we have a username that is many characters long with no spaces - as it is right now, this can extend the user name (inside `.s-user-card--link`) to overlap with content to the right (badge count, etc).