### PR TITLE
Ensure dispatcher is set on shown/hidden events

### DIFF
--- a/lib/ts/controllers/s-popover.ts
+++ b/lib/ts/controllers/s-popover.ts
@@ -82,7 +82,7 @@ namespace Stacks {
             // ensure the popper has been positioned correctly
             this.scheduleUpdate();
 
-            this.shown();
+            this.shown(dispatcherElement);
         }
 
         /**
@@ -105,7 +105,7 @@ namespace Stacks {
                 this.popper = null;
             }
 
-            this.hidden();
+            this.hidden(dispatcherElement);
         }
 
         /**


### PR DESCRIPTION
When calling `shown/hidden` from `show/hide`, we weren't passing the `dispatcher`, which caused the `e.details.dispatcher` to always be undefined.