### PR TITLE
Usercards: Move padding to main card

### DIFF
--- a/docs/product/components/user-cards.html
+++ b/docs/product/components/user-cards.html
@@ -129,22 +129,47 @@ description: User cards are a combination of a user and metadata about the user 
                 </div>
             </div>
 
-            <div class="mt16 s-user-card s-user-card__highlighted wmx2">
-                <time class="s-user-card--time">3 minutes ago</time>
-                <a href="#" class="s-avatar s-avatar__32 s-user-card--avatar">
-                    <img class="s-avatar--image" src="https://picsum.photos/64/64" />
-                </a>
-                <div class="s-user-card--info">
-                    <a href="#" class="s-user-card--link">Paul Wright</a>
-                    <ul class="s-user-card--awards">
-                        <li class="s-user-card--rep">2,500</li>
-                        <li class="s-award-bling s-award-bling__gold">5</li>
-                        <li class="s-award-bling s-award-bling__silver">9</li>
-                        <li class="s-award-bling s-award-bling__bronze">1</li>
-                    </ul>
+            <div class="grid gsx gs16 mt16">
+                <div class="grid--cell">
+                    <div class="s-user-card s-user-card__highlighted wmx2">
+                        <time class="s-user-card--time">3 minutes ago</time>
+                        <a href="#" class="s-avatar s-avatar__32 s-user-card--avatar">
+                            <img class="s-avatar--image" src="https://picsum.photos/64/64" />
+                        </a>
+                        <div class="s-user-card--info">
+                            <a href="#" class="s-user-card--link">Paul Wright</a>
+                            <ul class="s-user-card--awards">
+                                <li class="s-user-card--rep">2,500</li>
+                                <li class="s-award-bling s-award-bling__gold">5</li>
+                                <li class="s-award-bling s-award-bling__silver">9</li>
+                                <li class="s-award-bling s-award-bling__bronze">1</li>
+                            </ul>
+                        </div>
+                        <div class="s-user-card--type">
+                            {% icon "StarVerifiedSm" %} Star Wars Partner
+                        </div>
+                    </div>
                 </div>
-                <div class="s-user-card--type">
-                    {% icon "StarVerifiedSm" %} Star Wars Partner
+
+                <div class="grid--cell">
+                    <div class="s-user-card wmx2">
+                        <time class="s-user-card--time">3 minutes ago</time>
+                        <a href="#" class="s-avatar s-avatar__32 s-user-card--avatar">
+                            <img class="s-avatar--image" src="https://picsum.photos/64/64" />
+                        </a>
+                        <div class="s-user-card--info">
+                            <a href="#" class="s-user-card--link">Paul Wright</a>
+                            <ul class="s-user-card--awards">
+                                <li class="s-user-card--rep">2,500</li>
+                                <li class="s-award-bling s-award-bling__gold">5</li>
+                                <li class="s-award-bling s-award-bling__silver">9</li>
+                                <li class="s-award-bling s-award-bling__bronze">1</li>
+                            </ul>
+                        </div>
+                        <div class="s-user-card--type">
+                            {% icon "StarVerifiedSm" %} Star Wars Partner
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/lib/css/components/_stacks-user-cards.less
+++ b/lib/css/components/_stacks-user-cards.less
@@ -60,6 +60,7 @@
         display: flex;
         align-items: center;
         grid-column-gap: unset; // Firefox flex layouts respect column gaps, so we need to reset this
+        padding: 0;
 
         .s-user-card--time {
             margin-right: @su6;
@@ -87,6 +88,7 @@
         display: flex;
         align-items: center;
         grid-column-gap: unset; // Firefox flex layouts respect column gaps, so we need to reset this
+        padding: 0;
 
         .s-user-card--time {
             margin-right: @su6;

--- a/lib/css/components/_stacks-user-cards.less
+++ b/lib/css/components/_stacks-user-cards.less
@@ -16,6 +16,7 @@
     grid-column-gap: @su8;
     align-items: center;
     line-height: 1;
+    padding: @su8;
 
     //  ===========================================================================
     //  $   STYLE VARIATIONS
@@ -25,7 +26,6 @@
     //  ---------------------------------------------------------------------------
     &.s-user-card__highlighted {
         background-color: var(--powder-100);
-        padding: @su8;
         border-radius: @br-md;
 
         .s-user-card--type {


### PR DESCRIPTION
This moves padding to the main .user-card class instead of only on the highlighted card. This allows a highlighted and non highlighted card to sit side-by-side with the text aligned 

<img width="464" alt="Screen Shot 2021-02-22 at 1 38 00 PM" src="https://user-images.githubusercontent.com/371114/108753949-596bd680-7513-11eb-9bd5-b56501bb7abf.png">
