### PR TITLE
Segmented Progress Bars

### DIFF
--- a/docs/product/components/progress-bars.html
+++ b/docs/product/components/progress-bars.html
@@ -276,12 +276,22 @@ description: A component that visually communicates the completion of a task or 
             </svg>
         </div>
     </div>
+</div>
 
     <p class="stacks-copy">By default, the segmented progress bars are 256px wide. These dimensions can be modified by adding
         t-shirt sizing classes to <code class="stacks-code">.s-progress__segmented</code>: <code
             class="stacks-code">.s-progress__sm</code>, <code class="stacks-code">.s-progress__md</code>, and <code
             class="stacks-code">.s-progress__lg</code></p>
 
+<div class="stacks-preview">
+{% highlight html %}
+<div class="s-progress s-progress__segmented s-progress__sm" style="--progress-value-max: 4; --progress-value: 1;">
+    <svg viewBox="0 0 100 3">
+        <line x1="1" y1="1" x2="100" y2="1" />
+        <line x1="1" y1="1" x2="100" y2="1" />
+    </svg>
+</div>
+{% endhighlight %}
     <div class="stacks-preview--example">
         <div class="s-progress s-progress__segmented s-progress__sm" style="--progress-value-max: 4; --progress-value: 1;">
             <svg viewBox="0 0 100 3">
@@ -311,6 +321,7 @@ description: A component that visually communicates the completion of a task or 
             </svg>
         </div>
     </div>
+</div>
 </section>
 
 <section class="stacks-section">

--- a/docs/product/components/progress-bars.html
+++ b/docs/product/components/progress-bars.html
@@ -232,6 +232,88 @@ description: A component that visually communicates the completion of a task or 
 </section>
 
 <section class="stacks-section">
+    {% header "h2", "Segmented" %}
+    <p class="stacks-copy">For task tracking, switching to a segmented progress bar might be more appropriate. Our segmented
+        progress bar inherits the parent’s text color. You and your designer will need to choose an appropriate font
+        color. You’ll also need to pass the <code class="stacks-code">--s-progress-value-max</code> CSS variable the total number
+        of segments, and the <code class="stacks-code">--s-progress-value</code> CSS variable the number of completed segments..</p>
+
+<div class="stacks-preview">
+{% highlight html %}
+<div class="s-progress s-progress__segmented" style="--progress-value-max: 8; --progress-value: 4">
+    <svg viewBox="0 0 100 3" aria-valuemin="0" aria-valuemax="8" aria-valuenow="4">
+        <line x1="1" y1="1" x2="100" y2="1" />
+        <line x1="1" y1="1" x2="100" y2="1" />
+    </svg>
+</div>
+{% endhighlight %}
+    <div class="stacks-preview--example">
+        <div class="s-progress s-progress__segmented fc-blue-600" style="--progress-value: 1; --progress-value-max: 2;">
+            <svg viewBox="0 0 100 3">
+                <line x1="1" y1="1" x2="100" y2="1" />
+                <line x1="1" y1="1" x2="100" y2="1" />
+            </svg>
+        </div>
+
+        <div class="s-progress s-progress__segmented fc-orange-400" style="--progress-value: 1; --progress-value-max: 4;">
+            <svg viewBox="0 0 100 3">
+                <line x1="1" y1="1" x2="100" y2="1" />
+                <line x1="1" y1="1" x2="100" y2="1" />
+            </svg>
+        </div>
+
+        <div class="s-progress s-progress__segmented fc-green-400" style="--progress-value: 7; --progress-value-max: 10;">
+            <svg viewBox="0 0 100 3">
+                <line x1="1" y1="1" x2="100" y2="1" />
+                <line x1="1" y1="1" x2="100" y2="1" />
+            </svg>
+        </div>
+
+        <div class="s-progress s-progress__segmented fc-red-600" style="--progress-value: 18; --progress-value-max: 20;">
+            <svg viewBox="0 0 100 3">
+                <line x1="1" y1="1" x2="100" y2="1" />
+                <line x1="1" y1="1" x2="100" y2="1" />
+            </svg>
+        </div>
+    </div>
+
+    <p class="stacks-copy">By default, the segmented progress bars are 256px wide. These dimensions can be modified by adding
+        t-shirt sizing classes to <code class="stacks-code">.s-progress__segmented</code>: <code
+            class="stacks-code">.s-progress__sm</code>, <code class="stacks-code">.s-progress__md</code>, and <code
+            class="stacks-code">.s-progress__lg</code></p>
+
+    <div class="stacks-preview--example">
+        <div class="s-progress s-progress__segmented s-progress__sm" style="--progress-value-max: 4; --progress-value: 1;">
+            <svg viewBox="0 0 100 3">
+                <line x1="1" y1="1" x2="100" y2="1" />
+                <line x1="1" y1="1" x2="100" y2="1" />
+            </svg>
+        </div>
+
+        <div class="s-progress s-progress__segmented" style="--progress-value-max: 4; --progress-value: 1;">
+            <svg viewBox="0 0 100 3">
+                <line x1="1" y1="1" x2="100" y2="1" />
+                <line x1="1" y1="1" x2="100" y2="1" />
+            </svg>
+        </div>
+
+        <div class="s-progress s-progress__segmented s-progress__md" style="--progress-value-max: 4; --progress-value: 1;">
+            <svg viewBox="0 0 100 3">
+                <line x1="1" y1="1" x2="100" y2="1" />
+                <line x1="1" y1="1" x2="100" y2="1" />
+            </svg>
+        </div>
+
+        <div class="s-progress s-progress__segmented s-progress__lg" style="--progress-value-max: 4; --progress-value: 1;">
+            <svg viewBox="0 0 100 3">
+                <line x1="1" y1="1" x2="100" y2="1" />
+                <line x1="1" y1="1" x2="100" y2="1" />
+            </svg>
+        </div>
+    </div>
+</section>
+
+<section class="stacks-section">
     {% header "h2", "Privileges" %}
     <p class="stacks-copy">Taller progress bars used within Profiles to help users understand how close they are to achieving their next privilege.</p>
     <div class="stacks-preview">

--- a/lib/css/components/_stacks-progress-bars.less
+++ b/lib/css/components/_stacks-progress-bars.less
@@ -270,3 +270,61 @@
         height: 64px;
     }
 }
+
+
+//  ===========================================================================
+//  $   SEQUENTIAL
+//  ---------------------------------------------------------------------------
+.s-progress__segmented {
+    width: 256px;
+    height: 24px;
+    margin: 10px;
+    background: none;
+
+    --progress-value-total-width: 100;
+    --progress-value-spacer-width: 4;
+
+    /* Params */
+    --progress-value: 0;
+    --progress-value-max: 10;
+
+    /* End result */
+    --progress-value-width: calc(var(--progress-value-total-width) / var(--progress-value-max) - var(--progress-value-spacer-width));
+    --progress-value-empty: calc(var(--progress-value-max) - var(--progress-value));
+    --progress-combined-width: var(--progress-value-width) + var(--progress-value-spacer-width);
+    --progress-leftover: calc(var(--progress-value-max) - var(--progress-value));
+
+    line {
+        stroke-width: 2px;
+        stroke-linecap: round;
+        stroke-dasharray: var(--progress-value-width) var(--progress-value-spacer-width);
+    }
+
+    line:nth-of-type(1) {
+        stroke: currentColor;
+        opacity: .4;
+    }
+
+    line:nth-of-type(2) {
+        stroke: currentColor;
+        /* Dasharrays are pattern based and the line keeps going "infinitely".
+           As such, the only way to create a line with a big empty space at the end is to make a LONG pattern
+           that is long as you could possibly want, and then add an equivalent spacing to the end.
+           Then we can offset the array to hide the starting dashes.
+        */
+        stroke-dasharray: var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) var(--progress-value-spacer-width) var(--progress-value-width) 110;
+        stroke-dashoffset: calc((21 - var(--progress-value)) * (var(--progress-value-width) + var(--progress-value-spacer-width)));
+    }
+
+    &.s-progress__sm {
+        width: 128px;
+    }
+
+    &.s-progress__md {
+        width: 384px;
+    }
+
+    &.s-progress__lg {
+        width: 512px;
+    }
+}


### PR DESCRIPTION
This is working perfectly in Chrome, but it looks like there is an issue with Firefox.

This is similar to the circular progress bars but with a little twist. Currently limited to 20 segments given the way I needed to accomplish this. Relevant comment from the code about this:

`Dasharrays are pattern based and the line keeps going "infinitely".
As such, the only way to create a line with a big empty space at the end is to make a LONG pattern
that is long as you could possibly want, and then add an equivalent spacing to the end.
Then we can offset the array to hide the starting dashes.`

Would love some input on how to make this work in Firefox too. It looks like it should work, haven't tried any Firefox specific tests yet.

Chrome:

<img width="641" alt="2021-02-26 12_53_36-Progress bars - Stacks" src="https://user-images.githubusercontent.com/325529/109336640-b1674d80-7831-11eb-9718-77581f87bc30.png">

Firefox:

<img width="626" alt="2021-02-26 12_57_04-Progress bars - Stacks — Mozilla Firefox" src="https://user-images.githubusercontent.com/325529/109337019-2f2b5900-7832-11eb-932c-38a02c5df088.png">

