### PR TITLE
Fix `aria-expanded` in expandable example

### DIFF
--- a/docs/product/components/expandable.html
+++ b/docs/product/components/expandable.html
@@ -31,7 +31,7 @@ description: An expandable, sometimes called an accordion, is an element that ca
                 <button class="s-btn s-btn__filled mb8"
                     data-controller="s-expandable-control"
                     data-s-expandable-control-toggle-class="is-selected"
-                    aria-expanded="true"
+                    aria-expanded="false"
                     aria-controls="expandable-example">
                         Show first paragraph
                 </button>

--- a/docs/product/components/expandable.html
+++ b/docs/product/components/expandable.html
@@ -15,7 +15,7 @@ description: An expandable, sometimes called an accordion, is an element that ca
     <button class="s-btn s-btn__filled"
         data-controller="s-expandable-control"
         data-s-expandable-control-toggle-class="is-selected"
-        aria-expanded="true"
+        aria-expanded="false"
         aria-controls="expandable-example">
             Show first paragraph
     </button>


### PR DESCRIPTION
The example initial state is not expanded, but `aria-expanded` was set to `true`.