### PR TITLE
Add v-truncate-fade classes

### DIFF
--- a/docs/product/base/typography.html
+++ b/docs/product/base/typography.html
@@ -302,20 +302,20 @@ description: Stacks provides atomic classes to override default styling of typog
     <p class="stacks-copy">Alternatively, you can use a vertical fade that will set <code class="stacks-code">max-height</code> and sets a vertical <code class="stacks-code">mask-image</code>:</p>
     <div class="stacks-preview">
         {% highlight html %}
-<p class="v-truncate-fade-sm">…</p>
-<p class="v-truncate-fade-md">…</p>
-<p class="v-truncate-fade-lg">…</p>
+<p class="v-truncate-fade v-truncate-fade__sm">…</p>
+<p class="v-truncate-fade">…</p>
+<p class="v-truncate-fade v-truncate-fade__lg">…</p>
         {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="v-truncate-fade-sm wmx3 mb16">
+            <div class="v-truncate-fade v-truncate-fade__sm wmx3 mb16">
                 Regardless of length, this text will be this text will be truncated to 100px, vertically. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
             </div>
 
-            <div class="v-truncate-fade-md wmx3 mb16">
+            <div class="v-truncate-fade wmx3 mb16">
                 Regardless of length, this text will be this text will be truncated to 200px, vertically. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
             </div>
 
-            <div class="v-truncate-fade-lg wmx3 mb16">
+            <div class="v-truncate-fade v-truncate-fade__lg wmx3 mb16">
                 Regardless of length, this text will be this text will be truncated to 400px, vertically. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
             </div> 
         </div>

--- a/docs/product/base/typography.html
+++ b/docs/product/base/typography.html
@@ -299,6 +299,27 @@ description: Stacks provides atomic classes to override default styling of typog
             </div>
         </div>
     </div>
+    <p class="stacks-copy">Alternatively, you can use a vertical fade that will set <code>max-height</code> and sets a <code>vertical-mask</code>:</p>
+    <div class="stacks-preview">
+        {% highlight html %}
+<p class="v-truncate-fade-sm">…</p>
+<p class="v-truncate-fade-md">…</p>
+<p class="v-truncate-fade-lg">…</p>
+        {% endhighlight %}
+        <div class="stacks-preview--example">
+            <div class="v-truncate-fade-sm wmx3 mb16">
+                Regardless of length, this text will be this text will be truncated to 100px, vertically. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </div>
+
+            <div class="v-truncate-fade-md wmx3 mb16">
+                Regardless of length, this text will be this text will be truncated to 200px, vertically. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </div>
+
+            <div class="v-truncate-fade-lg wmx3 mb16">
+                Regardless of length, this text will be this text will be truncated to 400px, vertically. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </div> 
+        </div>
+    </div>
 </section>
 
 <section class="stacks-section">

--- a/docs/product/base/typography.html
+++ b/docs/product/base/typography.html
@@ -299,7 +299,7 @@ description: Stacks provides atomic classes to override default styling of typog
             </div>
         </div>
     </div>
-    <p class="stacks-copy">Alternatively, you can use a vertical fade that will set <code>max-height</code> and sets a <code>vertical-mask</code>:</p>
+    <p class="stacks-copy">Alternatively, you can use a vertical fade that will set <code class="stacks-code">max-height</code> and sets a vertical <code class="stacks-code">mask-image</code>:</p>
     <div class="stacks-preview">
         {% highlight html %}
 <p class="v-truncate-fade-sm">…</p>

--- a/lib/css/atomic/_stacks-typography.less
+++ b/lib/css/atomic/_stacks-typography.less
@@ -152,21 +152,22 @@ h1, h2, h3, h4, h5, h6, p {
 }
 
 .v-truncate-fade {
+    @one-lh: @lh-md * 1em;
     overflow: hidden; 
-    -webkit-mask-image: linear-gradient(180deg, #000 @lh-md * 1em * 9, transparent); 
-    mask-image: linear-gradient(180deg,#000 @lh-md * 1em * 9,transparent); 
-    max-height: @lh-md * 1em * 12;
+    -webkit-mask-image: linear-gradient(180deg, #000 @one-lh * 9, transparent); 
+    mask-image: linear-gradient(180deg,#000 @one-lh * 9,transparent); 
+    max-height: @one-lh * 12;
 
     &.v-truncate-fade__sm {
-        -webkit-mask-image: linear-gradient(180deg, #000 @lh-md * 1em * 3, transparent); 
-        mask-image: linear-gradient(180deg,#000 @lh-md * 1em * 3,transparent);
-        max-height: @lh-md * 1em * 6;
+        -webkit-mask-image: linear-gradient(180deg, #000 @one-lh * 3, transparent); 
+        mask-image: linear-gradient(180deg,#000 @one-lh * 3,transparent);
+        max-height: @one-lh * 6;
     }
 
     &.v-truncate-fade__lg {
-        -webkit-mask-image: linear-gradient(180deg, #000 @lh-md * 1em * 21, transparent); 
-        mask-image: linear-gradient(180deg,#000 @lh-md * 1em * 21,transparent); 
-        max-height: @lh-md * 1em * 24;
+        -webkit-mask-image: linear-gradient(180deg, #000 @one-lh * 21, transparent); 
+        mask-image: linear-gradient(180deg,#000 @one-lh * 21,transparent); 
+        max-height: @one-lh * 24;
     }
 }
 

--- a/lib/css/atomic/_stacks-typography.less
+++ b/lib/css/atomic/_stacks-typography.less
@@ -164,7 +164,7 @@ h1, h2, h3, h4, h5, h6, p {
 }
 
 .truncation-fade(@count) {
-    -webkit-mask-image: linear-gradient(180deg,#000 (pow(2, @count) * 100px - 50px),transparent); 
+    -webkit-mask-image: linear-gradient(180deg, #000 (pow(2, @count) * 100px - 50px), transparent); 
     mask-image: linear-gradient(180deg,#000 (pow(2, @count) * 100px - 50px)px,transparent); 
     overflow: hidden; 
     max-height: pow(2, @count) * 100px;

--- a/lib/css/atomic/_stacks-typography.less
+++ b/lib/css/atomic/_stacks-typography.less
@@ -155,18 +155,18 @@ h1, h2, h3, h4, h5, h6, p {
     @one-lh: @lh-md * 1em;
     overflow: hidden; 
     -webkit-mask-image: linear-gradient(180deg, #000 @one-lh * 9, transparent); 
-    mask-image: linear-gradient(180deg,#000 @one-lh * 9,transparent); 
+    mask-image: linear-gradient(180deg, #000 @one-lh * 9, transparent); 
     max-height: @one-lh * 12;
 
     &.v-truncate-fade__sm {
         -webkit-mask-image: linear-gradient(180deg, #000 @one-lh * 3, transparent); 
-        mask-image: linear-gradient(180deg,#000 @one-lh * 3,transparent);
+        mask-image: linear-gradient(180deg, #000 @one-lh * 3, transparent);
         max-height: @one-lh * 6;
     }
 
     &.v-truncate-fade__lg {
         -webkit-mask-image: linear-gradient(180deg, #000 @one-lh * 21, transparent); 
-        mask-image: linear-gradient(180deg,#000 @one-lh * 21,transparent); 
+        mask-image: linear-gradient(180deg, #000 @one-lh * 21, transparent); 
         max-height: @one-lh * 24;
     }
 }

--- a/lib/css/atomic/_stacks-typography.less
+++ b/lib/css/atomic/_stacks-typography.less
@@ -171,14 +171,6 @@ h1, h2, h3, h4, h5, h6, p {
     }
 }
 
-.v-truncate-fade-lg {
-    .truncation-fade(2)
-}
-
-.truncation-fade(@count) {
-}
-
-
 //  --  Whitespace
 .ws-normal        { white-space: normal !important; }
 .ws-nowrap        { white-space: nowrap !important; }

--- a/lib/css/atomic/_stacks-typography.less
+++ b/lib/css/atomic/_stacks-typography.less
@@ -151,12 +151,23 @@ h1, h2, h3, h4, h5, h6, p {
     overflow: hidden;
 }
 
-.v-truncate-fade-sm {
-    .truncation-fade(0)
-}
+.v-truncate-fade {
+    overflow: hidden; 
+    -webkit-mask-image: linear-gradient(180deg, #000 150px, transparent); 
+    mask-image: linear-gradient(180deg,#000 150px,transparent); 
+    max-height: 200px;
 
-.v-truncate-fade-md {
-    .truncation-fade(1)
+    &.v-truncate-fade__sm {
+        -webkit-mask-image: linear-gradient(180deg, #000 50px, transparent); 
+        mask-image: linear-gradient(180deg,#000 50px,transparent);
+        max-height: 100px;
+    }
+
+    &.v-truncate-fade__lg {
+        -webkit-mask-image: linear-gradient(180deg, #000 350px, transparent); 
+        mask-image: linear-gradient(180deg,#000 350px,transparent); 
+        max-height: 400px;
+    }
 }
 
 .v-truncate-fade-lg {
@@ -164,10 +175,6 @@ h1, h2, h3, h4, h5, h6, p {
 }
 
 .truncation-fade(@count) {
-    -webkit-mask-image: linear-gradient(180deg, #000 (pow(2, @count) * 100px - 50px), transparent); 
-    mask-image: linear-gradient(180deg,#000 (pow(2, @count) * 100px - 50px)px,transparent); 
-    overflow: hidden; 
-    max-height: pow(2, @count) * 100px;
 }
 
 

--- a/lib/css/atomic/_stacks-typography.less
+++ b/lib/css/atomic/_stacks-typography.less
@@ -151,6 +151,26 @@ h1, h2, h3, h4, h5, h6, p {
     overflow: hidden;
 }
 
+.v-truncate-fade-sm {
+    .truncation-fade(0)
+}
+
+.v-truncate-fade-md {
+    .truncation-fade(1)
+}
+
+.v-truncate-fade-lg {
+    .truncation-fade(2)
+}
+
+.truncation-fade(@count) {
+    -webkit-mask-image: linear-gradient(180deg,#000 (pow(2, @count) * 100px - 50px),transparent); 
+    mask-image: linear-gradient(180deg,#000 (pow(2, @count) * 100px - 50px)px,transparent); 
+    overflow: hidden; 
+    max-height: pow(2, @count) * 100px;
+}
+
+
 //  --  Whitespace
 .ws-normal        { white-space: normal !important; }
 .ws-nowrap        { white-space: nowrap !important; }

--- a/lib/css/atomic/_stacks-typography.less
+++ b/lib/css/atomic/_stacks-typography.less
@@ -153,20 +153,20 @@ h1, h2, h3, h4, h5, h6, p {
 
 .v-truncate-fade {
     overflow: hidden; 
-    -webkit-mask-image: linear-gradient(180deg, #000 150px, transparent); 
-    mask-image: linear-gradient(180deg,#000 150px,transparent); 
-    max-height: 200px;
+    -webkit-mask-image: linear-gradient(180deg, #000 @lh-md * 1em * 9, transparent); 
+    mask-image: linear-gradient(180deg,#000 @lh-md * 1em * 9,transparent); 
+    max-height: @lh-md * 1em * 12;
 
     &.v-truncate-fade__sm {
-        -webkit-mask-image: linear-gradient(180deg, #000 50px, transparent); 
-        mask-image: linear-gradient(180deg,#000 50px,transparent);
-        max-height: 100px;
+        -webkit-mask-image: linear-gradient(180deg, #000 @lh-md * 1em * 3, transparent); 
+        mask-image: linear-gradient(180deg,#000 @lh-md * 1em * 3,transparent);
+        max-height: @lh-md * 1em * 6;
     }
 
     &.v-truncate-fade__lg {
-        -webkit-mask-image: linear-gradient(180deg, #000 350px, transparent); 
-        mask-image: linear-gradient(180deg,#000 350px,transparent); 
-        max-height: 400px;
+        -webkit-mask-image: linear-gradient(180deg, #000 @lh-md * 1em * 21, transparent); 
+        mask-image: linear-gradient(180deg,#000 @lh-md * 1em * 21,transparent); 
+        max-height: @lh-md * 1em * 24;
     }
 }
 


### PR DESCRIPTION
Adds `v-truncate-fade-{sm|md|lg}` that adds a vertical fade out at a height of `100px`, `200px`, or `400px` using [`mask-image`](https://caniuse.com/mdn-css_properties_mask-image).

Some browsers require the `-webkit-mask-image` prefixed version for now.

The copy isn't anything special so feel free to request changes there!

![image](https://user-images.githubusercontent.com/6742479/109356355-7109ce80-7835-11eb-9db2-f8f273084362.png)
