### PR TITLE
Don't double grey-out `.s-description`

### DIFF
--- a/lib/css/components/_stacks-inputs.less
+++ b/lib/css/components/_stacks-inputs.less
@@ -546,6 +546,10 @@ fieldset {
     .s-label,
     .s-description {
         opacity: 0.5;
+
+        .s-description {
+            opacity: unset;
+        }
     }
 
     .s-input-icon {


### PR DESCRIPTION
`.s-description` is pretty much always hosted inside a `.s-label`, so greying them both out results in small text at 25% opacity.  This fixes that.