### PR TITLE
Add segmented progress bar

### DIFF
--- a/docs/product/components/progress-bars.html
+++ b/docs/product/components/progress-bars.html
@@ -331,6 +331,39 @@ description: A component that visually communicates the completion of a task or 
 </section>
 
 <section class="stacks-section">
+    {% header "h2", "Segmented" %}
+    <p class="stacks-copy">Stacks provides dividers to create segmented progress bars. The progess bar can be either independent of the dividers, or locked to them.</p>
+    <div class="stacks-preview">
+{% highlight html %}
+<div class="s-progress s-progress__segmented">
+    <div class="s-progress--bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" style="width: 75%;"></div>
+    <ol class="s-progress--segments">
+        <li></li>
+        <li></li>
+        <li></li>
+        <li></li>
+        <li></li>
+        <li></li>
+    </ol>
+</div>
+{% endhighlight %}
+        <div class="stacks-preview--example">
+            <div class="s-progress s-progress__segmented">
+                <div class="s-progress--bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" style="width: 75%;"></div>
+                <ol class="s-progress--segments">
+                    <li></li>
+                    <li></li>
+                    <li></li>
+                    <li></li>
+                    <li></li>
+                    <li></li>
+                </ol>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="stacks-section">
     {% header "h2", "Stepped" %}
     <p class="stacks-copy">If your experience has a small number of discrete steps, it might be appropriate to use a stepped progress bar.</p>
     <div class="stacks-preview">

--- a/lib/css/components/_stacks-progress-bars.less
+++ b/lib/css/components/_stacks-progress-bars.less
@@ -126,6 +126,43 @@
 }
 
 //  ===========================================================================
+//  $   SEGMENTED
+//  ---------------------------------------------------------------------------
+.s-progress.s-progress__segmented {
+    position: relative;
+
+    .s-progress--segments {
+        margin: 0;
+        padding: 0;
+        position: absolute;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        justify-content: space-between;
+        list-style: none;
+
+        li {
+            display: block;
+            padding-top: 4px;
+            position: relative;
+            text-align: center;
+
+            &:not(:first-child):not(:last-child):before {
+                display: block;
+                content: "";
+                height: 100%;
+                width: 4px;
+                position: absolute;
+                top: 0;
+                left: -1px;
+                background-color: var(--white);
+            }
+        }
+    }
+}
+
+//  ===========================================================================
 //  $   STEPPED
 //  ---------------------------------------------------------------------------
 .s-progress.s-progress__stepped {
@@ -188,7 +225,7 @@
             left: 50%;
         }
     }
-    
+
     .s-progress--step.is-active {
         .s-progress--bar.s-progress--bar__left {
             background: var(--blue-500);


### PR DESCRIPTION
This adds a way to build dividers on top of a progress bar using an ordered list. Optionally, you can add text between the dividers as a legend, but punting on this for now.