### PR TITLE
Add `s-progress__segmented` to the list classes in docs

### DIFF
--- a/docs/product/components/progress-bars.html
+++ b/docs/product/components/progress-bars.html
@@ -62,6 +62,10 @@ description: A component that visually communicates the completion of a task or 
                     <td>A modifying class applied to <code class="stacks-code">.s-progress__badge</code>, it is used when a bronze badge progress bar is desired.</td>
                 </tr>
                 <tr>
+                    <th scope="row"><code class="stacks-code">.s-progress__segmented</code></th>
+                    <td>A modifying class applied to <code class="stacks-code">.s-progress</code> for a segmented progress bar</td>
+                </tr>
+                <tr>
                     <th scope="row"><code class="stacks-code">.s-progress__stepped</code></th>
                     <td>A modifying class applied to <code class="stacks-code">.s-progress</code> for a stepped progress bar</td>
                 </tr>


### PR DESCRIPTION
We just added segmented progress bars (#610), but `.s-progress__segmented` was still missing from the list of classes in the docs