### PR TITLE
Refine circular progress bar math

### DIFF
--- a/docs/product/components/progress-bars.html
+++ b/docs/product/components/progress-bars.html
@@ -203,29 +203,36 @@ description: A component that visually communicates the completion of a task or 
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="grid fw-wrap gs16">
-                <div class="grid--cell s-progress s-progress__circular s-progress__sm fc-blue-600" style="--s-progress-value: .22">
-                    <svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="22">
+                <div class="grid--cell s-progress s-progress__circular s-progress__sm fc-blue-600" style="--s-progress-value: 0">
+                    <svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
                         <circle cx="16" cy="16" r="14"></circle>
                         <circle cx="16" cy="16" r="14"></circle>
                     </svg>
                 </div>
 
-                <div class="grid--cell s-progress s-progress__circular fc-orange-400" style="--s-progress-value: .75">
+                <div class="grid--cell s-progress s-progress__circular fc-orange-400" style="--s-progress-value: .5">
+                    <svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50">
+                        <circle cx="16" cy="16" r="14"></circle>
+                        <circle cx="16" cy="16" r="14"></circle>
+                    </svg>
+                </div>
+
+                <div class="grid--cell s-progress s-progress__circular s-progress__md fc-green-400" style="--s-progress-value: .75">
                     <svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75">
                         <circle cx="16" cy="16" r="14"></circle>
                         <circle cx="16" cy="16" r="14"></circle>
                     </svg>
                 </div>
 
-                <div class="grid--cell s-progress s-progress__circular s-progress__md fc-green-400" style="--s-progress-value: .48">
-                    <svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="48">
+                <div class="grid--cell s-progress s-progress__circular s-progress__lg fc-red-600" style="--s-progress-value: .94">
+                    <svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="94">
                         <circle cx="16" cy="16" r="14"></circle>
                         <circle cx="16" cy="16" r="14"></circle>
                     </svg>
                 </div>
 
-                <div class="grid--cell s-progress s-progress__circular s-progress__lg fc-red-600" style="--s-progress-value: .08">
-                    <svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="8">
+                <div class="grid--cell s-progress s-progress__circular s-progress__lg fc-blue-600" style="--s-progress-value: 1">
+                    <svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100">
                         <circle cx="16" cy="16" r="14"></circle>
                         <circle cx="16" cy="16" r="14"></circle>
                     </svg>

--- a/lib/css/components/_stacks-progress-bars.less
+++ b/lib/css/components/_stacks-progress-bars.less
@@ -287,8 +287,7 @@
             // Multiply the circle circumference by an the opposite percentage of what we want to display
             // For example 70%, represented as a decimal is 0.7
             // The opposite of that is 0.3 so ( 1 - 0.7 )
-            // Additionally, since the "round" linecap adds (width / 2)px length, adjust the total offset to compensate
-            stroke-dashoffset: calc( (((1 - var(--s-progress-value)) * @s-progress-circle-circumference) + @s-progress-stroke-width) * 1px); // Multiply everything by 1px since Safari and Firefox require these to be in pixels
+            stroke-dashoffset: calc( ((1 - var(--s-progress-value)) * @s-progress-circle-circumference) * 1px); // Multiply everything by 1px since Safari and Firefox require these to be in pixels
         }
     }
 


### PR DESCRIPTION
This PR cleans up the edge cases in the circular progress bar. This now updates the examples to show some of these edgecases and make sure they're lining up. Closes #622.