### PR TITLE
Remove `.s-btn__lg` and `.s-btn__xl`

### DIFF
--- a/docs/_data/buttons.json
+++ b/docs/_data/buttons.json
@@ -239,16 +239,6 @@
       "size": "Medium",
       "fs": "17px",
       "class": "s-btn__md"
-    },
-    {
-      "size": "Large",
-      "fs": "21px",
-      "class": "s-btn__lg"
-    },
-    {
-      "size": "Extra Large",
-      "fs": "27px",
-      "class": "s-btn__xl"
     }
   ]
 }

--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -137,42 +137,6 @@
         }
     }
 
-    &.s-btn__lg {
-        padding: 0.6em;
-        border-radius: @br-sm + 1;
-        font-size: @fs-headline1;
-
-        &.s-btn__dropdown {
-            padding-right: 1.5em;
-
-            &:after {
-                top: calc(~"50% - 2px");
-                right: 0.6em;
-                border-width: @su6;
-                border-top-width: @su6;
-                border-bottom-width: 0;
-            }
-        }
-    }
-
-    &.s-btn__xl {
-        padding: 0.5em;
-        border-radius: @br-sm + @br-sm;
-        font-size: @fs-headline2;
-
-        &.s-btn__dropdown {
-            padding-right: 1.3em;
-
-            &:after {
-                top: calc(~"50% - 4px");
-                right: 0.5em;
-                border-width: @su4 + 3px;
-                border-top-width: @su4 + 3px;
-                border-bottom-width: 0;
-            }
-        }
-    }
-
     .s-btn--badge {
         opacity: .5;
         display: inline-block;
@@ -582,20 +546,6 @@
             // If the first thing in the button is an icon, let's hide it on loading
             // We only want to modify the visibility, since we still want it to have shape and keep the same layout.
             opacity: 0;
-        }
-
-        &.s-btn__lg {
-            &:before,
-            &:after {
-                border-width: 3px;
-            }
-        }
-
-        &.s-btn__xl {
-            &:before,
-            &:after {
-                border-width: 4px;
-            }
         }
     }
 }


### PR DESCRIPTION
These button variations are not used in the product, and they're impractically / comically huge. This removes them in favor of just using `s-btn__md` when we need a little extra spacing.