### PR TITLE
Also force the font size on medium size inputs and textareas

### DIFF
--- a/lib/css/components/_stacks-inputs.less
+++ b/lib/css/components/_stacks-inputs.less
@@ -637,6 +637,20 @@ fieldset {
     border-radius: @br-md;
 }
 
+.s-input__md,
+.s-textarea__md {
+    //  --  INCREASE FONT SIZE FOR MOBILE SAFARI
+    //  This keeps our inputs from zooming the page while focused
+    //  ------------------------------------------------------------------------
+    @supports (-webkit-overflow-scrolling: touch) {
+        font-size: 17px;
+
+        // Compensate for the larger font size so we generally keep the input the same size
+        padding-top: .4em;
+        padding-bottom: .4em;
+    }
+}
+
 @autofill: {
     &::-webkit-contacts-auto-fill-button {
         background-color: var(--black); // In Safari, make the autocomplete button darkmode-aware


### PR DESCRIPTION
Closes #630 by forcing a font size of 17px on mobile devices and the medium sized input / textarea.

- [x] Double check that the input size doesn't change too much