### PR TITLE
Add appearance:button to s-btn

### DIFF
--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -34,7 +34,9 @@
     text-decoration: none;
     cursor: pointer;
     user-select: none;
-    
+
+    // Guard against the difference in configurable resets
+    // Eric Meyer's reset does not include this, while normalize.css does
     -webkit-appearance: button;
     -moz-appearance: button;
     appearance: button;

--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -34,6 +34,10 @@
     text-decoration: none;
     cursor: pointer;
     user-select: none;
+    
+    -webkit-appearance: button;
+    -moz-appearance: button;
+    appearance: button;
 
     // Override for buttons having inline-block by default
     &.grid {


### PR DESCRIPTION
`<input type="submit" class="s-btn s-btn__primary">` looks like this on my iphone:

![Untitled](https://user-images.githubusercontent.com/3857587/115438699-b4504000-a1db-11eb-85f7-d644abcf905f.jpg)

Looks like it's coming from the default `-webkit-appearance: push-button` in the user agent stylesheet.