### PR TITLE
Add font smoothing

### DIFF
--- a/lib/css/base/_stacks-body.less
+++ b/lib/css/base/_stacks-body.less
@@ -23,6 +23,10 @@ body {
     font-family: var(--theme-body-font-family);
     font-size: @fs-base;
     line-height: @lh-base;
+
+    // As of macOS 11.3, you can no longer disable font smoothing.
+    // This does it for us at the CSS-level.
+    -webkit-font-smoothing: antialiased;
 }
 
 #stacks-internals #screen-sm({


### PR DESCRIPTION
As of macOS 11.3, Safari no longer respects the workaround to disable font smoothing at the OS level. This does it for us at the CSS-level, forcing Stacks to make the opinionated choice to disable font smoothing via CSS.