### PR TITLE
Add an activity indicator

### DIFF
--- a/docs/_data/activity-indicator.json
+++ b/docs/_data/activity-indicator.json
@@ -1,0 +1,9 @@
+{
+  "indicator": [
+    {
+      "class": ".s-activity-indicator",
+      "applies": "N/A",
+      "description": "Base activity indicator element"
+    }
+  ]
+}

--- a/docs/_data/site-navigation.json
+++ b/docs/_data/site-navigation.json
@@ -151,6 +151,10 @@
           "title": "Components",
           "links": [
             {
+              "title": "Activity indicator",
+              "url": "/product/components/activity-indicator/"
+            },
+            {
               "title": "Avatars",
               "url": "/product/components/avatars/"
             },

--- a/docs/product/components/activity-indicator.html
+++ b/docs/product/components/activity-indicator.html
@@ -1,0 +1,77 @@
+---
+layout: page
+title: Activity indicator
+description: Stacks provides a small jewel for indicating new activity.
+---
+<section class="stacks-section">
+    {% header "h3", "Classes" %}
+    <div class="overflow-x-auto mb32">
+        <table class="wmn4 s-table s-table__bx-simple">
+            <thead>
+                <tr>
+                    <th scope="col">Class</th>
+                    <th scope="col">Applied to</th>
+                    <th scope="col">Description</th>
+                </tr>
+            </thead>
+            <tbody class="fs-caption">
+                {% for item in activity-indicator.indicator %}
+                    <tr>
+                        <td><code class="stacks-code">{{ item.class }}</code></td>
+                        <td>{% if item.applies == "N/A" %}<em class="fc-black-350">{{ item.applies }}</em>{% else %}<code class="stacks-code">{{ item.applies }}</code>{% endif %}</td>
+                        <td>{{ item.description }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+<section class="stacks-section">
+    {% header "h3", "Examples" %}
+    <p class="stacks-copy">By default, our indicator has no positioning attached to it. Depending on your context, you can modify the activity indicator’s positioning using any combination of atomic classes. Since our activity indicator has no inherent semantic meaning, make sure to include visually-hidden, screenreader-only text.</p>
+    <div class="stacks-preview">
+{% highlight html %}
+<div class="s-activity-indicator">
+    <div class="v-visible-sr">New activity</div>
+</div>
+
+<div class="ps-relative">
+    <div class="s-activity-indicator ps-absolute tn6 ln6">
+        <div class="v-visible-sr">New activity</div>
+    </div>
+</div>
+{% endhighlight %}
+        <div class="stacks-preview--example">
+            <div class="grid fd-column gs24">
+                <div class="grid--cell">
+                    <div class="s-activity-indicator">
+                        <div class="v-visible-sr">New activity</div>
+                    </div>
+                </div>
+
+                <div class="grid--cell">
+                    <a href="#" class="s-link s-link__muted">
+                        <div class="s-avatar bg-red-400 ps-relative">
+                            <div class="s-activity-indicator ps-absolute tn6 ln6">
+                                <div class="v-visible-sr">New activity</div>
+                            </div>
+                            <div class="s-avatar--letter">G</div>
+                            {% icon "ShieldXSm", "native s-avatar--badge" %}
+                        </div>
+                        <span class="pl4">Grayson</span>
+                    </a>
+                </div>
+
+                <div class="grid--cell">
+                    <div class="fc-medium ps-relative d-inline-block">
+                        {% icon "Bell" %}
+
+                        <div class="s-activity-indicator ps-absolute tn4 rn4">
+                            <div class="v-visible-sr">New activity</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/lib/css/components/_stacks-activity-indicator.less
+++ b/lib/css/components/_stacks-activity-indicator.less
@@ -1,0 +1,21 @@
+//
+//  STACK OVERFLOW
+//  ACTIVITY INDICATOR
+//
+//  This CSS comes from Stacks, our CSS & Pattern library for rapidly building
+//  Stack Overflow. For documentation of all these classes and how to contribute,
+//  visit https://stackoverflow.design/
+//
+
+//  ============================================================================
+//  $   ACTIVITY INDICATOR
+//  ----------------------------------------------------------------------------
+
+.s-activity-indicator {
+    display: inline-block;
+    width: @su12;
+    height: @su12;
+    background-color: var(--blue-400);
+    box-shadow: 0 0 0 @su4 var(--focus-ring);
+    border-radius: 100%;
+}

--- a/lib/css/stacks-static.less
+++ b/lib/css/stacks-static.less
@@ -17,6 +17,7 @@
 @import "base/_stacks-icons";
 
 //  --  COMPONENTS
+@import "components/_stacks-activity-indicator";
 @import "components/_stacks-avatars";
 @import "components/_stacks-badges";
 @import "components/_stacks-blank-states";


### PR DESCRIPTION
This PR formalizes how we indicate activity in Stacks. Creates a little gem / doodad that we can display wherever we need. Heck, maybe we even make it pulse.

![image](https://user-images.githubusercontent.com/1369864/117205798-b3acd180-adb7-11eb-8e0a-904639d2c809.png)