### PR TITLE
Update popover example to use info icon

### DIFF
--- a/docs/product/components/popovers.html
+++ b/docs/product/components/popovers.html
@@ -180,7 +180,7 @@ description: Popovers are small content containers that provide a contextual ove
                     data-s-popover-placement="top"
                     data-action="s-popover#toggle"
                     aria-controls="popover-example-4">
-                {% icon "HelpSm" %}
+                {% icon "InfoSm" %}
             </button>
             <div id="popover-example-4" class="s-popover" role="menu">
                 <div class="s-popover--arrow"></div>


### PR DESCRIPTION
We previously discussed using the info icon instead of the question icon for these types of popovers, I wanted to make sure the example on Stacks is more in line with our icon logic.

@aaronshekey 