### PR TITLE
Add file extensions for auto-linking

### DIFF
--- a/lib/css/exports/_stacks-exports.less
+++ b/lib/css/exports/_stacks-exports.less
@@ -9,7 +9,7 @@
 //  Wherein we establish a bunch of values to make our lives a lot easier.
 //
 //  ============================================================================
-@import "_stacks-constants-type";            // Type styles, sizes, and line-heights
-@import "_stacks-constants-helpers";         // Border radius, z-index, spacing, transitions, etc
-@import "_stacks-constants-colors";          // Colors
-@import "_stacks-mixins";
+@import "_stacks-constants-type.less";            // Type styles, sizes, and line-heights
+@import "_stacks-constants-helpers.less";         // Border radius, z-index, spacing, transitions, etc
+@import "_stacks-constants-colors.less";          // Colors
+@import "_stacks-mixins.less";

--- a/lib/css/stacks-dynamic.less
+++ b/lib/css/stacks-dynamic.less
@@ -15,21 +15,21 @@
 //      via variables.
 //  ----------------------------------------------------------------------------
 //  --  SET BASIC STYLES FOR BODY
-@import "base/_stacks-body";
+@import "base/_stacks-body.less";
 
 //  --  COMPONENTS
-@import "components/_stacks-banners";
-@import "components/_stacks-buttons";
-@import "components/_stacks-links";
-@import "components/_stacks-link-previews";
-@import "components/_stacks-navigation";
-@import "components/_stacks-notices";
-@import "components/_stacks-tags";
-@import "components/_stacks-pagination";
-@import "components/_stacks-widget-dynamic";
+@import "components/_stacks-banners.less";
+@import "components/_stacks-buttons.less";
+@import "components/_stacks-links.less";
+@import "components/_stacks-link-previews.less";
+@import "components/_stacks-navigation.less";
+@import "components/_stacks-notices.less";
+@import "components/_stacks-tags.less";
+@import "components/_stacks-pagination.less";
+@import "components/_stacks-widget-dynamic.less";
 
 //  --  LESS CONSTANTS AND MIXINS
-@import "exports/_stacks-exports";
+@import "exports/_stacks-exports.less";
 
 //  --  CONFIG
 @import "base/_stacks-configuration-static.less";

--- a/lib/css/stacks-static.less
+++ b/lib/css/stacks-static.less
@@ -13,45 +13,45 @@
 //      The following items are elements which we DO NOT allow communities
 //      to modify via variables.
 //  ----------------------------------------------------------------------------
-@import "base/_stacks-reset";
-@import "base/_stacks-icons";
+@import "base/_stacks-reset.less";
+@import "base/_stacks-icons.less";
 
 //  --  COMPONENTS
-@import "components/_stacks-activity-indicator";
-@import "components/_stacks-avatars";
-@import "components/_stacks-badges";
-@import "components/_stacks-blank-states";
-@import "components/_stacks-breadcrumbs";
-@import "components/_stacks-button-groups";
-@import "components/_stacks-cards";
-@import "components/_stacks-code-blocks";
-@import "components/_stacks-collapsible";
-@import "components/_stacks-inputs";
-@import "components/_stacks-menu";
-@import "components/_stacks-modals";
-@import "components/_stacks-page-titles";
-@import "components/_stacks-popovers";
-@import "components/_stacks-post-summary";
-@import "components/_stacks-progress-bars";
-@import "components/_stacks-prose";
-@import "components/_stacks-spinner";
-@import "components/_stacks-tables";
-@import "components/_stacks-toggle-switches";
-@import "components/_stacks-user-cards";
-@import "components/_stacks-widget-static";
+@import "components/_stacks-activity-indicator.less";
+@import "components/_stacks-avatars.less";
+@import "components/_stacks-badges.less";
+@import "components/_stacks-blank-states.less";
+@import "components/_stacks-breadcrumbs.less";
+@import "components/_stacks-button-groups.less";
+@import "components/_stacks-cards.less";
+@import "components/_stacks-code-blocks.less";
+@import "components/_stacks-collapsible.less";
+@import "components/_stacks-inputs.less";
+@import "components/_stacks-menu.less";
+@import "components/_stacks-modals.less";
+@import "components/_stacks-page-titles.less";
+@import "components/_stacks-popovers.less";
+@import "components/_stacks-post-summary.less";
+@import "components/_stacks-progress-bars.less";
+@import "components/_stacks-prose.less";
+@import "components/_stacks-spinner.less";
+@import "components/_stacks-tables.less";
+@import "components/_stacks-toggle-switches.less";
+@import "components/_stacks-user-cards.less";
+@import "components/_stacks-widget-static.less";
 
 //  --  LESS CONSTANTS AND MIXINS
-@import "exports/_stacks-exports";
+@import "exports/_stacks-exports.less";
 
 //  --  ATOMIC CLASSES
-@import "atomic/_stacks-borders";
-@import "atomic/_stacks-colors";
-@import "atomic/_stacks-flex";
-@import "atomic/_stacks-grid";
-@import "atomic/_stacks-spacing";
-@import "atomic/_stacks-typography";
-@import "atomic/_stacks-misc";
-@import "atomic/_stacks-width-height";
+@import "atomic/_stacks-borders.less";
+@import "atomic/_stacks-colors.less";
+@import "atomic/_stacks-flex.less";
+@import "atomic/_stacks-grid.less";
+@import "atomic/_stacks-spacing.less";
+@import "atomic/_stacks-typography.less";
+@import "atomic/_stacks-misc.less";
+@import "atomic/_stacks-width-height.less";
 
 #stacks-internals #screen-lg({
     #stacks-internals-collect-large();


### PR DESCRIPTION
This is a dumb chore I've been meaning to do. Adds file extensions for auto-linking in stock installs of VS Code