### PR TITLE
Switch to CSS variable on monospace font variables

### DIFF
--- a/docs/assets/less/stacks-documentation.less
+++ b/docs/assets/less/stacks-documentation.less
@@ -190,7 +190,7 @@
     background-color: var(--black-075);
 
     font-size: @fs-caption;
-    font-family: @ff-mono;
+    font-family: var(--ff-mono);
     color: var(--fc-dark);
     line-height: @lh-xs;
 
@@ -286,7 +286,7 @@
     padding: @su8;
     border: 1px solid var(--black-100);
     background-color: var(--black-075);
-    font-family: @ff-mono;
+    font-family: var(--ff-mono);
     font-size: @fs-caption;
     color: var(--fc-dark);
 }

--- a/lib/css/components/_stacks-code-blocks.less
+++ b/lib/css/components/_stacks-code-blocks.less
@@ -1,6 +1,6 @@
 pre.s-code-block {
     font-size: @fs-body1;
-    font-family: @ff-mono;
+    font-family: var(--ff-mono);
     line-height: @lh-md;
     color: var(--highlight-color);
     background-color: var(--highlight-bg);

--- a/lib/css/components/_stacks-prose.less
+++ b/lib/css/components/_stacks-prose.less
@@ -30,7 +30,7 @@
 
     code {
         font-size: @fs-body1;
-        font-family: @ff-mono;
+        font-family: var(--ff-mono);
     }
 
     sub,


### PR DESCRIPTION
Let's quit hardcoding the fonts and render them at runtime.