### PR TITLE
s-expandable: Prevent click after keydown on Firefox

### DIFF
--- a/lib/ts/controllers/s-expandable-control.ts
+++ b/lib/ts/controllers/s-expandable-control.ts
@@ -51,6 +51,7 @@
         private events!: string[];
         private isCheckable!: boolean;
         private isRadio!: boolean;
+        private lastKeydownClickTimestamp: number = 0;
 
         initialize() {
             if (this.element.nodeName === "INPUT" && ["radio", "checkbox"].indexOf((<HTMLInputElement>this.element).type) >= 0) {
@@ -120,8 +121,20 @@
                 if (e.target !== e.currentTarget && ["A", "BUTTON"].indexOf((<HTMLElement>e.target).nodeName) >= 0) {
                     return;
                 }
-                newCollapsed = this.element.getAttribute("aria-expanded") === "true";
+                
                 e.preventDefault();
+                                
+                // Prevent "click" events from toggling the expandable within 300ms of "keydown".
+                // e.preventDefault() should have done the same, but https://bugzilla.mozilla.org/show_bug.cgi?id=1487102
+                // doesn't guarantee it.
+                if (e.type == "keydown") {
+                    this.lastKeydownClickTimestamp = Date.now();
+                } else if (e.type == "click" && Date.now() - this.lastKeydownClickTimestamp < 300) {
+                    return;
+                }
+
+                
+                newCollapsed = this.element.getAttribute("aria-expanded") === "true";
                 if (e.type === "click") {
                     (<HTMLInputElement>this.element).blur();
                 }

--- a/lib/ts/controllers/s-expandable-control.ts
+++ b/lib/ts/controllers/s-expandable-control.ts
@@ -132,8 +132,6 @@
                 } else if (e.type == "click" && Date.now() - this.lastKeydownClickTimestamp < 300) {
                     return;
                 }
-
-                
                 newCollapsed = this.element.getAttribute("aria-expanded") === "true";
                 if (e.type === "click") {
                     (<HTMLInputElement>this.element).blur();


### PR DESCRIPTION
Closes #649.

The 300ms delay was chosen as an arbitrary number higher than the 160ms delay I observed in Firefox. If you keyboard click and then quickly mouse click, you'll see your mouse click get rejected (i.e., do nothing) but that's not typical user behavior.