### PR TITLE
s-modal: Fix keyboard focus on complex views

### DIFF
--- a/docs/product/components/modals.html
+++ b/docs/product/components/modals.html
@@ -85,22 +85,22 @@ description: Modals are dialog overlays that prevent the user from interacting w
             <tbody class="fs-caption">
                 <tr>
                     <th scope="row"><code class="stacks-code">s-modal:show</code></th>
-                    <td>Controller element</td>
+                    <td>Modal target</td>
                     <td><span class="s-label--status ml0">Default preventable</span> Fires immediately before showing the modal. Calling <code class="stacks-code">.preventDefault()</code> cancels the display of the modal.</td>
                 </tr>
                 <tr>
                     <th scope="row"><code class="stacks-code">s-modal:shown</code></th>
-                    <td>Controller element</td>
+                    <td>Modal target</td>
                     <td>Fires after the modal has been visually shown</td>
                 </tr>
                 <tr>
                     <th scope="row"><code class="stacks-code">s-modal:hide</code></th>
-                    <td>Controller element</td>
+                    <td>Modal target</td>
                     <td><span class="s-label--status ml0">Default preventable</span> Fires immediately before hiding the modal. Calling <code class="stacks-code">.preventDefault()</code> cancels the removal of the modal.</td>
                 </tr>
                 <tr>
                     <th scope="row"><code class="stacks-code">s-modal:hidden</code></th>
-                    <td>Controller element</td>
+                    <td>Modal target</td>
                     <td>Fires after the modal has been visually hidden</td>
                 </tr>
             </tbody>

--- a/lib/ts/controllers/s-modal.ts
+++ b/lib/ts/controllers/s-modal.ts
@@ -85,7 +85,7 @@ namespace Stacks {
             var triggeredEvent = this.triggerEvent(toShow ? "show" : "hide", {
                 returnElement: this.returnElement,
                 dispatcher: this.getDispatcher(dispatchingElement)
-            });
+            }, this.modalTarget);
 
             // if this pre-show/hide event was prevented, don't attempt to continue changing the modal state
             if (triggeredEvent.defaultPrevented) {
@@ -114,12 +114,12 @@ namespace Stacks {
                     //TODO this is firing waaay to soon?
                     this.triggerEvent(toShow ? "shown" : "hidden", {
                         dispatcher: dispatchingElement
-                    });
+                    }, this.modalTarget);
                 }, { once: true });
             } else {
                 this.triggerEvent(toShow ? "shown" : "hidden", {
                     dispatcher: dispatchingElement
-                });
+                }, this.modalTarget);
             }           
         }
 


### PR DESCRIPTION
Right now, we emit show/hide events on `this.element` but listen for them on `this.modalTarget`.  If those two properties aren't the same element, we fail to bring focus into the modal or return focus when hiding the modal (and probably other things).

This fixes it by emitting the event from `modalTarget`.  We could alternatively fix it by binding the events on `element`, but if we made this mistake it's only natural to think consumers would too.