### PR TITLE
Add `.is-selected` to tags

### DIFF
--- a/docs/_data/tags-component.json
+++ b/docs/_data/tags-component.json
@@ -29,6 +29,11 @@
       "class": ".s-tag--sponsor",
       "applies": "N/A",
       "description": "A child element within <code class=\"stacks-code\">.s-tag</code> that correctly positions a tag’s sponsor logo."
+    },
+    {
+      "class": ".is-selected",
+      "applies": ".s-tag",
+      "description": "Adds a currently selected / active aesthetic"
     }
   ],
   "sizes": [

--- a/docs/product/components/tags.html
+++ b/docs/product/components/tags.html
@@ -36,6 +36,7 @@ description: Tags are an interactive, community-generated keyword that allow com
     <a class="grid--cell s-tag" href="#">jquery</a>
     <a class="grid--cell s-tag" href="#">javascript <span class="s-tag--dismiss">@Svg.ClearSm</span></a>
     <a class="grid--cell s-tag" href="#"><img class="s-tag--sponsor" src="https://i.stack.imgur.com/tKsDb.png" width="16" height="18" alt="Google Android"> android</a>
+    <a class="grid--cell s-tag is-selected" href="#">razor <span class="s-tag--dismiss">@Svg.ClearSm</span></a>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
@@ -43,6 +44,7 @@ description: Tags are an interactive, community-generated keyword that allow com
                 <a class="grid--cell s-tag" href="#">jquery</a>
                 <a class="grid--cell s-tag" href="#">javascript <span class="s-tag--dismiss">{% icon "ClearSm" %}</span></a>
                 <a class="grid--cell s-tag" href="#"><img class="s-tag--sponsor" src="https://i.stack.imgur.com/tKsDb.png" width="16" height="18" alt="Google Android"> android</a>
+                <a class="grid--cell s-tag is-selected" href="#">razor <span class="s-tag--dismiss">{% icon "ClearSm" %} </span></a>
             </div>
         </div>
     </div>
@@ -54,6 +56,7 @@ description: Tags are an interactive, community-generated keyword that allow com
     <a class="grid--cell s-tag s-tag__moderator" href="#">status-completed</a>
     <a class="grid--cell s-tag s-tag__moderator" href="#">status-bydesign <span class="s-tag--dismiss">@Svg.ClearSm</span></a>
     <a class="grid--cell s-tag s-tag__moderator" href="#">status-planned</a>
+    <a class="grid--cell s-tag s-tag__moderator is-selected" href="#">status-deferred</a>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
@@ -61,6 +64,7 @@ description: Tags are an interactive, community-generated keyword that allow com
                 <a class="grid--cell s-tag s-tag__moderator" href="#">status-completed</a>
                 <a class="grid--cell s-tag s-tag__moderator" href="#">status-bydesign <span class="s-tag--dismiss">{% icon "ClearSm" %}</span></a>
                 <a class="grid--cell s-tag s-tag__moderator" href="#">status-planned</a>
+                <a class="grid--cell s-tag s-tag__moderator is-selected" href="#">status-deferred</a>
             </div>
         </div>
     </div>
@@ -72,6 +76,7 @@ description: Tags are an interactive, community-generated keyword that allow com
     <a class="grid--cell s-tag s-tag__required" href="#">discussion</a>
     <a class="grid--cell s-tag s-tag__required" href="#">feature-request <span class="s-tag--dismiss">@Svg.ClearSm</span></a>
     <a class="grid--cell s-tag s-tag__required" href="#">bug</a>
+    <a class="grid--cell s-tag s-tag__required is-selected" href="#">featured</a>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
@@ -79,6 +84,7 @@ description: Tags are an interactive, community-generated keyword that allow com
                 <a class="grid--cell s-tag s-tag__required" href="#">discussion</a>
                 <a class="grid--cell s-tag s-tag__required" href="#">feature-request <span class="s-tag--dismiss">{% icon "ClearSm" %}</span></a>
                 <a class="grid--cell s-tag s-tag__required" href="#">bug</a>
+                <a class="grid--cell s-tag s-tag__required is-selected" href="#">featured</a>
             </div>
         </div>
     </div>
@@ -90,6 +96,7 @@ description: Tags are an interactive, community-generated keyword that allow com
     <a class="grid--cell s-tag s-tag__muted" href="#">asp-net</a>
     <a class="grid--cell s-tag s-tag__muted" href="#">netscape <span class="s-tag--dismiss">@Svg.ClearSm</span></a>
     <a class="grid--cell s-tag s-tag__muted" href="#"><img class="s-tag--sponsor" src="https://i.stack.imgur.com/gfrSH.png" width="18" height="16" alt="SQL Server"> sql-server</a>
+    <a class="grid--cell s-tag s-tag__muted is-selected" href="#">razor <span class="s-tag--dismiss">@Svg.ClearSm</span></a>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
@@ -97,6 +104,7 @@ description: Tags are an interactive, community-generated keyword that allow com
                 <a class="grid--cell s-tag s-tag__muted" href="#">asp-net</a>
                 <a class="grid--cell s-tag s-tag__muted" href="#">netscape <span class="s-tag--dismiss">{% icon "ClearSm" %}</span></a>
                 <a class="grid--cell s-tag s-tag__muted" href="#"><img class="s-tag--sponsor" src="https://i.stack.imgur.com/gfrSH.png" width="18" height="16" alt="SQL Server"> sql-server</a>
+                <a class="grid--cell s-tag s-tag__muted is-selected" href="#">razor <span class="s-tag--dismiss">{% icon "ClearSm" %}</span></a>
             </div>
         </div>
     </div>

--- a/lib/css/base/_stacks-configuration-dynamic.less
+++ b/lib/css/base/_stacks-configuration-dynamic.less
@@ -112,30 +112,42 @@
     @tags-border:                                    transparent;
     @tags-background:                                var(--powder-100);
     @tags-color:                                     var(--powder-700);
-    @tags-border-hover:                              transparent;
-    @tags-background-hover:                          var(--powder-200);
-    @tags-color-hover:                               var(--powder-800);
+    @tags-hover-border:                              transparent;
+    @tags-hover-background:                          var(--powder-200);
+    @tags-hover-color:                               var(--powder-800);
+    @tags-selected-border:                           transparent;
+    @tags-selected-background:                       var(--powder-400);
+    @tags-selected-color:                            var(--powder-900);
 
     @tags-moderator-border:                          var(--red-100);
     @tags-moderator-background:                      var(--red-050);
     @tags-moderator-color:                           var(--red-600);
-    @tags-moderator-border-hover:                    var(--red-200);
-    @tags-moderator-background-hover:                var(--red-100);
-    @tags-moderator-color-hover:                     var(--red-700);
+    @tags-moderator-hover-border:                    var(--red-200);
+    @tags-moderator-hover-background:                var(--red-100);
+    @tags-moderator-hover-color:                     var(--red-700);
+    @tags-moderator-selected-border:                 var(--red-400);
+    @tags-moderator-selected-background:             var(--red-200);
+    @tags-moderator-selected-color:                  var(--red-800);
 
     @tags-required-border:                           var(--black-200);
     @tags-required-background:                       var(--black-075);
     @tags-required-color:                            var(--black-700);
-    @tags-required-border-hover:                     var(--black-300);
-    @tags-required-background-hover:                 var(--black-100);
-    @tags-required-color-hover:                      var(--black-800);
+    @tags-required-hover-border:                     var(--black-300);
+    @tags-required-hover-background:                 var(--black-100);
+    @tags-required-hover-color:                      var(--black-800);
+    @tags-required-selected-border:                  var(--black-500);
+    @tags-required-selected-background:              var(--black-200);
+    @tags-required-selected-color:                   var(--black-900);
 
     @tags-muted-border:                              transparent;
     @tags-muted-background:                          var(--black-075);
     @tags-muted-color:                               var(--black-700);
-    @tags-muted-border-hover:                        transparent;
-    @tags-muted-background-hover:                    var(--black-100);
-    @tags-muted-color-hover:                         var(--black-800);
+    @tags-muted-hover-border:                        transparent;
+    @tags-muted-hover-background:                    var(--black-100);
+    @tags-muted-hover-color:                         var(--black-800);
+    @tags-muted-selected-border:                      transparent;
+    @tags-muted-selected-background:                  var(--black-200);
+    @tags-muted-selected-color:                       var(--black-900);
 
     //  Pagination
     @pagination-select-background:                   var(--orange-500);

--- a/lib/css/components/_stacks-tags.less
+++ b/lib/css/components/_stacks-tags.less
@@ -28,6 +28,12 @@
     }
 }
 
+.s-tag-selected-styles(@border: transparent, @background: transparent, @color: inherit) {
+    border-color: @border;
+    background-color: @background;
+    color: @color;
+}
+
 .s-tag-hover-styles(@border-hover: transparent, @background-hover: transparent, @color-hover: inherit) {
     &:hover,
     &:focus,
@@ -62,6 +68,10 @@
 
     .s-tag-styles(@tags-border, @tags-background, @tags-color);
 
+    &.is-selected {
+        .s-tag-selected-styles(@tags-selected-border, @tags-selected-background, @tags-selected-color);
+    }
+
     //  -- SIZES
     &.s-tag__xs {
         font-size: @fs-fine;
@@ -88,13 +98,13 @@
     }
 }
 
-a.s-tag {
+a.s-tag:not(.is-selected) {
     #stacks-internals #load-config();
-    .s-tag-hover-styles(@tags-border-hover, @tags-background-hover, @tags-color-hover);
+    .s-tag-hover-styles(@tags-hover-border, @tags-hover-background, @tags-hover-color);
 }
 
 //  $$  DISMISS ICON
-//      Style adjument to @Svg.ClearSm
+//      Style adjustment to @Svg.ClearSm
 //  ---------------------------------------------------------------------------
 .s-tag--dismiss {
     display: flex;
@@ -140,10 +150,14 @@ a.s-tag {
 .s-tag__required {
     #stacks-internals #load-config();
     .s-tag-styles(@tags-required-border, @tags-required-background, @tags-required-color);
+
+    &.is-selected {
+        .s-tag-selected-styles(@tags-required-selected-border, @tags-required-selected-background, @tags-required-selected-color);
+    }
 }
-a.s-tag__required {
+a.s-tag__required:not(.is-selected) {
     #stacks-internals #load-config();
-    .s-tag-hover-styles(@tags-required-border-hover, @tags-required-background-hover, @tags-required-color-hover);
+    .s-tag-hover-styles(@tags-required-hover-border, @tags-required-hover-background, @tags-required-hover-color);
 }
 
 //  $$  Moderator Tag
@@ -151,10 +165,14 @@ a.s-tag__required {
 .s-tag__moderator {
     #stacks-internals #load-config();
     .s-tag-styles(@tags-moderator-border, @tags-moderator-background, @tags-moderator-color);
+
+    &.is-selected {
+        .s-tag-selected-styles(@tags-moderator-selected-border, @tags-moderator-selected-background, @tags-moderator-selected-color);
+    }
 }
-a.s-tag__moderator {
+a.s-tag__moderator:not(.is-selected) {
     #stacks-internals #load-config();
-    .s-tag-hover-styles(@tags-moderator-border-hover, @tags-moderator-background-hover, @tags-moderator-color-hover);
+    .s-tag-hover-styles(@tags-moderator-hover-border, @tags-moderator-hover-background, @tags-moderator-hover-color);
 }
 
 //  $$  Muted Tag
@@ -162,8 +180,12 @@ a.s-tag__moderator {
 .s-tag__muted {
     #stacks-internals #load-config();
     .s-tag-styles(@tags-muted-border, @tags-muted-background, @tags-muted-color);
+
+    &.is-selected {
+        .s-tag-selected-styles(@tags-muted-selected-border, @tags-muted-selected-background, @tags-muted-selected-color);
+    }
 }
-a.s-tag__muted {
+a.s-tag__muted:not(.is-selected) {
     #stacks-internals #load-config();
-    .s-tag-hover-styles(@tags-muted-border-hover, @tags-muted-background-hover, @tags-muted-color-hover);
+    .s-tag-hover-styles(@tags-muted-hover-border, @tags-muted-hover-background, @tags-muted-hover-color);
 }


### PR DESCRIPTION
Closes #663.

This adds an `.is-selected` state to `s-tag` for added interactivity e.g. managing tag autocomplete. Also makes the tag configuration variables more consistent with buttons, so we'll have to babysit this change in production. @taiwei426 does this satisfy the highlighted ads use case?