### PR TITLE
Adapt tab focus to changes in modals

### DIFF
--- a/docs/product/components/modals.html
+++ b/docs/product/components/modals.html
@@ -212,7 +212,7 @@ description: Modals are dialog overlays that prevent the user from interacting w
 </section>
 
 <!-- Example base modal content -->
-<aside class="s-modal" id="modal-base" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true" data-controller="s-modal" data-target="s-modal.modal" data-s-modal-remove-when-hidden="false">
+<aside class="s-modal" id="modal-base" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true" data-controller="s-modal" data-target="s-modal.modal" data-s-modal-return-element=".js-modal-open[data-target='#modal-base']" data-s-modal-remove-when-hidden="false">
     <div class="s-modal--dialog" role="document">
         <h1 class="s-modal--header" id="modal-title">Example title</h1>
         <p class="s-modal--body" id="modal-description">Nullam ornare lectus vitae lacus sagittis, at sodales leo viverra. Suspendisse nec nulla dignissim elit varius tempus. Cras viverra neque at imperdiet vehicula. Curabitur condimentum id dolor vitae ultrices. Pellentesque scelerisque nunc sit amet leo fringilla bibendum. Etiam feugiat imperdiet mi, eu blandit arcu cursus a. Pellentesque cursus massa id dolor ullamcorper, at condimentum nunc ultrices.</p>
@@ -227,7 +227,7 @@ description: Modals are dialog overlays that prevent the user from interacting w
 </aside>
 
 <!-- Example danger modal content -->
-<aside class="s-modal s-modal__danger" id="modal-danger" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true" data-controller="s-modal" data-target="s-modal.modal">
+<aside class="s-modal s-modal__danger" id="modal-danger" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true" data-controller="s-modal" data-target="s-modal.modal" data-s-modal-return-element=".js-modal-open[data-target='#modal-danger']">
     <div class="s-modal--dialog" role="document">
         <h1 class="s-modal--header" id="modal-title">Example danger title</h1>
         <p class="s-modal--body" id="modal-description">Nullam ornare lectus vitae lacus sagittis, at sodales leo viverra. Suspendisse nec nulla dignissim elit varius tempus. Cras viverra neque at imperdiet vehicula. Curabitur condimentum id dolor vitae ultrices. Pellentesque scelerisque nunc sit amet leo fringilla bibendum. Etiam feugiat imperdiet mi, eu blandit arcu cursus a. Pellentesque cursus massa id dolor ullamcorper, at condimentum nunc ultrices.</p>

--- a/lib/ts/controllers/s-modal.ts
+++ b/lib/ts/controllers/s-modal.ts
@@ -173,27 +173,16 @@ namespace Stacks {
          * Binds tab presses on tabbable items such that tabbing only works within the modal
          */
         private focusInsideModal() {
-
-            // get all tabbable items
-            var allTabbables = this.getAllTabbables();
-
-            if (!allTabbables.length) {
-                return;
-            }
-
-            // focus on the first focusable item within the modal, preferring targets explicitly provided by the DOM.
-
-            var initialFocus = this.firstVisible(this.initialFocusTargets) ?? this.firstVisible(allTabbables);
-            if (initialFocus) {
-                this.modalTarget.addEventListener("s-modal:shown", () => {
-                    // double check the element still exists when the event is called
-                    if (initialFocus && document.body.contains(initialFocus)) {
-                        initialFocus.focus()
-                    }
-                }, {once: true });
-            }
+            this.modalTarget.addEventListener("s-modal:shown", () => {
+                var initialFocus = this.firstVisible(this.initialFocusTargets) ?? this.firstVisible(this.getAllTabbables());
+                initialFocus?.focus();
+            }, {once: true });
         }
 
+
+        /**
+         * Returns keyboard focus to the modal if it has left or is about to leave.
+         */
         private keepFocusWithinModal(e: KeyboardEvent) {
 
             // If somehow the user has tabbed out of the modal or if focus started outside the modal, push them to the first item.

--- a/lib/ts/controllers/s-modal.ts
+++ b/lib/ts/controllers/s-modal.ts
@@ -196,7 +196,7 @@ namespace Stacks {
             }
 
             // If we observe a tab keydown and we're on an edge, cycle the focus to the other side.
-            if (e.keyCode === 9) {
+            if (e.key === "Tab") {
                 var tabbables = this.getAllTabbables();
 
                 var firstTabbable = this.firstVisible(tabbables);

--- a/lib/ts/controllers/s-modal.ts
+++ b/lib/ts/controllers/s-modal.ts
@@ -153,24 +153,32 @@ namespace Stacks {
         }
 
         /**
-         * Gets all elements that could be tabbed to in 
+         * Gets all elements within the modal that could receive keyboard focus.
          */
         private getAllTabbables() {
-            return <HTMLElement[]>Array.from(this.modalTarget.querySelectorAll("[href], input, select, textarea, button, [tabindex]"))
+            return Array.from(this.modalTarget.querySelectorAll<HTMLElement>("[href], input, select, textarea, button, [tabindex]"))
                 .filter((el: Element) => el.matches(":not([disabled]):not([tabindex='-1'])"));
         }
 
+        /**
+         * Returns the first visible element in an array or `undefined` if no elements are visible.
+         */
         private firstVisible(elements: HTMLElement[]) {
             // https://stackoverflow.com/a/21696585
             return elements.find(el => el.offsetParent !== null);
         }
 
+        /**
+         * Returns the last visible element in an array or `undefined` if no elements are visible.
+         */
         private lastVisible(elements: HTMLElement[]) {
-            return [...elements].reverse().find(el => el.offsetParent !== null);
+            return this.firstVisible([...elements].reverse());
         }
 
         /**
-         * Binds tab presses on tabbable items such that tabbing only works within the modal
+         * Attempts to shift keyboard focus into the modal.
+         * If elements with `data-s-modal-target="initialFocus"` are present and visible, one of those will be selected.
+         * Otherwise, the first visible focusable element will receive focus.
          */
         private focusInsideModal() {
             this.modalTarget.addEventListener("s-modal:shown", () => {

--- a/lib/ts/controllers/s-modal.ts
+++ b/lib/ts/controllers/s-modal.ts
@@ -179,7 +179,6 @@ namespace Stacks {
             }, {once: true });
         }
 
-
         /**
          * Returns keyboard focus to the modal if it has left or is about to leave.
          */


### PR DESCRIPTION
I have a reusable modal where a couple things can happen between shows:

- The body of the modal gets replaced with new contents, which may or may not contain a link.
- One of two elements that should receive initial focus is hidden.

This surfaces two problems with the current implementation of tab traps:

1. We only capture the list of tabbable elements once, the first time we bind document events.  After that, we just keep reusing that list no matter how the modal's content changes.
2. When using `initialFocusTarget`, Stimulus grabs the first matching element, but doesn't know or care if the element is visible.

To resolve 1, I'm no longer using a stored version of the tabbable list, instead fetching it each time a tab keydown is observed.  Given the nature of modals, I don't expect us to reach a scale where this really impacts users.

To resolve 2, I'm switching from `initialFocusTarget` to `initialFocusTargets` and finding the first visible one using a check from https://stackoverflow.com/a/21696585/860000.  If none is found, it falls back to the first tabbable as before.