### PR TITLE
Use opacity only for disabled states of checkbox, radio (take 2 🎬)

### DIFF
--- a/docs/product/components/checkbox.html
+++ b/docs/product/components/checkbox.html
@@ -47,6 +47,26 @@ description: A checkable input that visually shows if an option is true or false
                     <label class="grid--cell s-label fw-normal" for="example-item-disabled">Checkbox Label</label>
                 </div>
             </fieldset>
+
+            <!-- Checked -->
+            <fieldset class="mt8">
+                <div class="grid gs8">
+                    <div class="grid--cell">
+                        <input class="s-checkbox" type="checkbox" name="example-checked" id="example-item-checked" checked />
+                    </div>
+                    <label class="grid--cell s-label fw-normal" for="example-item-checked">Checkbox Label</label>
+                </div>
+            </fieldset>
+
+            <!-- Disabled and checked -->
+            <fieldset class="mt8">
+                <div class="grid gs8 is-disabled">
+                    <div class="grid--cell">
+                        <input class="s-checkbox" type="checkbox" name="example-checked-disabled" id="example-item-checked-disabled" disabled checked />
+                    </div>
+                    <label class="grid--cell s-label fw-normal" for="example-item-checked-disabled">Checkbox Label</label>
+                </div>
+            </fieldset>
         </div>
     </div>
 </section>

--- a/docs/product/components/radio.html
+++ b/docs/product/components/radio.html
@@ -47,6 +47,26 @@ description: An input group which can only have one entry selected at a time.
                     <label class="grid--cell s-label fw-normal" for="example-item-disabled">Radio Label</label>
                 </div>
             </fieldset>
+
+            <!-- Checked -->
+            <fieldset class="mt8">
+                <div class="grid gs8">
+                    <div class="grid--cell">
+                        <input class="s-radio" type="radio" name="example-radio-checked" id="example-item-checked" checked />
+                    </div>
+                    <label class="grid--cell s-label fw-normal" for="example-item-checked">Radio Label</label>
+                </div>
+            </fieldset>
+
+            <!-- Disabled and checked -->
+            <fieldset class="mt8">
+                <div class="grid gs8 is-disabled">
+                    <div class="grid--cell">
+                        <input class="s-radio" type="radio" name="example-radio-checked-disabled" id="example-item-checked-disabled" disabled checked />
+                    </div>
+                    <label class="grid--cell s-label fw-normal" for="example-item-checked-disabled">Radio Label</label>
+                </div>
+            </fieldset>
         </div>
     </div>
 </section>

--- a/lib/css/components/_stacks-inputs.less
+++ b/lib/css/components/_stacks-inputs.less
@@ -335,12 +335,6 @@ fieldset {
         background-repeat: no-repeat;
         background-size: contain;
 
-        //  Disabled
-        &[disabled] {
-            border-color: var(--black-200);
-            background-color: var(--black-075);
-        }
-
         &:checked {
             border-color: var(--blue-500) !important;
             background-color: var(--blue-500);
@@ -348,12 +342,6 @@ fieldset {
 
             &:focus {
                 border-color: var(--blue-500);
-            }
-
-            //  Disabled
-            &[disabled] {
-                border-color: var(--black-500) !important;
-                background-color: var(--black-400);
             }
         }
 


### PR DESCRIPTION
This PR addresses https://github.com/StackExchange/Stacks/issues/672 by removing color overrides for checkbox and radio inputs to solely use 50% opacity when disabled.

Take 1: https://github.com/StackExchange/Stacks/pull/674
