### PR TITLE
Update avatar letter line-height

### DIFF
--- a/lib/css/components/_stacks-avatars.less
+++ b/lib/css/components/_stacks-avatars.less
@@ -31,7 +31,7 @@
         color: @white; // Force a light appearance of text rendering
         font-size: 11px; // Force a font size so the avatar text doesn't get smaller as the window resizes
         font-weight: bold;
-        line-height: 1.4545455; // Guards against some line-height trolling from the parent
+        line-height: 1.4; // Guards against some line-height trolling from the parent
         text-align: center;
         text-transform: uppercase; // Force uppercase in avatars when team name is lowercase
         // We don't need text selection on our letter


### PR DESCRIPTION
Addresses https://github.com/StackExchange/Stacks/issues/676

This does what it says on the tin. 

A simple compromise to help `.s-avatar--letter` feel close to center in our font stack.

Gonna slam this one in w/o review to test my boundaries like a three year old. Yell if this one-liner needs a review.

# Segoe UI
![image](https://user-images.githubusercontent.com/647177/120383890-70307f00-c2f3-11eb-8a2a-5b98bfac953a.png)

# --apple-system
![image](https://user-images.githubusercontent.com/647177/120383945-82122200-c2f3-11eb-8ebe-04c84296e079.png)
