### PR TITLE
Restore deprecated grid classes

### DIFF
--- a/lib/css/atomic/_stacks-flex.less
+++ b/lib/css/atomic/_stacks-flex.less
@@ -13,6 +13,7 @@
 //  • GRID SPACING
 //  • MODIFICATIONS
 //  • ATOMIC
+//  • DEPRECATED
 //
 //  ============================================================================
 //  --  STACKS GRID MIXINS
@@ -177,6 +178,7 @@
 //  --  UNIVERSAL FLEX WIDTHS
 //      This applies a flex value it to all of a grid's direct children.
 //  --------------------------------------------------------------------------
+.grid__fl0,
 .grid__fl-shrink0,
 .flex__fl-shrink0 {
     &,
@@ -348,3 +350,62 @@
 //  ----------------------------------------------------------------------------
 #stacks-internals #responsify('.order-first', { order: -1 !important; });
 #stacks-internals #responsify('.order-last', { order: 1 !important; });
+
+
+//  ============================================================================
+//  $  DEPRECATED CLASSES
+//  ----------------------------------------------------------------------------
+
+//  --  FLEX FLOW
+//      This is another shorthand property for flex-direction and flex-wrap.
+//      Default value is "row nowrap".
+//  ----------------------------------------------------------------------------
+.ff-row-wrap { flex-flow: row wrap !important; }
+.ff-row-nowrap { flex-flow: row nowrap !important; }
+.ff-row-reverse-wrap { flex-flow: row-reverse wrap !important; }
+.ff-row-reverse-nowrap { flex-flow: row-reverse nowrap !important; }
+.ff-column-wrap { flex-flow: column wrap !important; }
+.ff-column-nowrap { flex-flow: column nowrap !important; }
+.ff-column-reverse-wrap { flex-flow: column-reverse wrap !important; }
+.ff-column-reverse-nowrap { flex-flow: column-reverse nowrap !important; }
+
+//  --  FLEX
+//      Graduating scale of flex-grow and flex-shrink values
+//  ----------------------------------------------------------------------------
+#stacks-internals #responsify('.fl0', { flex: 0 auto !important; });
+#stacks-internals #responsify('.fl1', { flex: 1 auto !important; });
+.fl2 { flex: 2 auto !important; }
+.fl3 { flex: 3 auto !important; }
+.fl4 { flex: 4 auto !important; }
+.fl5 { flex: 5 auto !important; }
+
+//  --  FLEX SHRINK
+//      Specifies the flex-shrink factor, which states how much an item will
+//      shrink relative to other flex items in the container when there isn't
+//      enough space in the row. Default value is 1.
+//  ----------------------------------------------------------------------------
+.fl-shrink2 { flex-shrink: 2; }
+.fl-shrink3 { flex-shrink: 3; }
+.fl-shrink4 { flex-shrink: 4; }
+.fl-shrink5 { flex-shrink: 5; }
+
+//  --  FLEX GROW
+//      Specifies the flex-shrink grow, which states how much an item will
+//      grow relative to other flex items in the container when there isn't
+//      enough space in the row. Default value is 1.
+//  ----------------------------------------------------------------------------
+.fl-grow2 { flex-grow: 2; }
+.fl-grow3 { flex-grow: 3; }
+.fl-grow4 { flex-grow: 4; }
+.fl-grow5 { flex-grow: 5; }
+
+
+.grid__fl1 {
+    &,
+    > .grid,
+    > .d-flex,
+    > .grid--cell,
+    > .flex--item {
+        flex: 1 auto;
+    }
+}


### PR DESCRIPTION
On second thought, let's keep these grid classes around while we remove them in production.