### PR TITLE
Fix whitesp ace issues in post summary

### DIFF
--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -46,15 +46,15 @@ description: The post summary component summarizes various content and associate
 <div class="s-post-summary">
     <div class="s-post-summary--stats">
         <div class="s-post-summary--stats-item has-answers has-accepted-answer">
-            @Svg.CheckmarkSm.With("va-text-bottom")
-            … answers
+            @Svg.CheckmarkSm
+            …answers
         </div>
         <div class="s-post-summary--stats-item">
-            … votes
+            …votes
         </div>
         <div class="s-post-summary--stats-item is-supernova">
-            @Svg.FireSm.With("va-text-bottom mrn2")
-            … views
+            @Svg.FireSm
+            …views
         </div>
     </div>
     <div class="s-post-summary--content">
@@ -91,14 +91,14 @@ description: The post summary component summarizes various content and associate
             <div class="s-post-summary">
                 <div class="s-post-summary--stats">
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
-                        {% icon "CheckmarkSm", "va-text-bottom" %}
+                        {% icon "CheckmarkSm" %}
                         5 answers
                     </div>
                     <div class="s-post-summary--stats-item">
                         95 votes
                     </div>
                     <div class="s-post-summary--stats-item is-supernova">
-                        {% icon "FireSm", "va-text-bottom mrn2" %}
+                        {% icon "FireSm" %}
                         104k views
                     </div>
                 </div>
@@ -283,7 +283,7 @@ description: The post summary component summarizes various content and associate
 <div class="s-post-summary s-post-summary__minimal">
     <div class="s-post-summary--stats">
         <div class="s-post-summary--stats-item">
-            @Svg.CheckmarkSm.With("va-text-bottom")
+            @Svg.CheckmarkSm
             … answers
         </div>
         <div class="s-post-summary--stats-item">
@@ -437,7 +437,7 @@ description: The post summary component summarizes various content and associate
 
 <!-- Has accepted answers -->
 <div class="s-post-summary--stats-item has-answers has-accepted-answer">
-    @Svg.CheckmarkSm.With("va-text-bottom")
+    @Svg.CheckmarkSm
     5 answers
 </div>
 {% endhighlight %}
@@ -469,7 +469,7 @@ description: The post summary component summarizes various content and associate
 
                 <div class="grid--cell w-auto s-post-summary--stats">
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
-                        {% icon "CheckmarkSm", "va-text-bottom" %}
+                        {% icon "CheckmarkSm" %}
                         5 answers
                     </div>
                     <div class="s-post-summary--stats-item">
@@ -510,7 +510,7 @@ description: The post summary component summarizes various content and associate
 
 <!-- Supernova -->
 <div class="s-post-summary--stats-item is-supernova">
-    @Svg.FireSm.With("va-text-bottom mrn2")
+    @Svg.FireSm
     100k views
 </div>
 {% endhighlight %}
@@ -530,7 +530,7 @@ description: The post summary component summarizes various content and associate
 
                 <div class="grid--cell w-auto s-post-summary--stats">
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
-                        {% icon "CheckmarkSm", "va-text-bottom" %}
+                        {% icon "CheckmarkSm" %}
                         3 answers
                     </div>
                     <div class="s-post-summary--stats-item">
@@ -543,7 +543,7 @@ description: The post summary component summarizes various content and associate
 
                 <div class="grid--cell w-auto s-post-summary--stats">
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
-                        {% icon "CheckmarkSm", "va-text-bottom" %}
+                        {% icon "CheckmarkSm" %}
                         10 answers
                     </div>
                     <div class="s-post-summary--stats-item">
@@ -556,14 +556,14 @@ description: The post summary component summarizes various content and associate
 
                 <div class="grid--cell w-auto s-post-summary--stats">
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
-                        {% icon "CheckmarkSm", "va-text-bottom" %}
+                        {% icon "CheckmarkSm" %}
                         18 answers
                     </div>
                     <div class="s-post-summary--stats-item">
                         126 votes
                     </div>
                     <div class="s-post-summary--stats-item is-supernova">
-                        {% icon "FireSm", "va-text-bottom" %}
+                        {% icon "FireSm" %}
                         100k views
                     </div>
                 </div>

--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -47,14 +47,14 @@ description: The post summary component summarizes various content and associate
     <div class="s-post-summary--stats">
         <div class="s-post-summary--stats-item has-answers has-accepted-answer">
             @Svg.CheckmarkSm
-            …answers
+            … answers
         </div>
         <div class="s-post-summary--stats-item">
-            …votes
+            … votes
         </div>
         <div class="s-post-summary--stats-item is-supernova">
             @Svg.FireSm
-            …views
+            … views
         </div>
     </div>
     <div class="s-post-summary--content">

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -64,10 +64,17 @@
     color: var(--fc-light);
 
     .s-post-summary--stats-item {
+        display: flex;
+        align-items: center;
         margin-right: var(--s-post-summary-stats-gap);
         margin-bottom: var(--s-post-summary-stats-gap);
         white-space: nowrap;
         border: 1px solid transparent;
+
+        .svg-icon {
+            // Add the equivalent to a single space of margin to accomodate when we can't have whitespace in our markup
+            margin-right: 3px;
+        }
 
         &.has-answers,
         &.has-bounty {


### PR DESCRIPTION
Switch to flex on .s-post-summary--stats-item to control for whitespace or the lack thereof. Also shifts some icon positioning to CSS instead of atomic classes.

Closes #686 

cc: @bnickel 