### PR TITLE
Fix js selector in stylelint

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -10,7 +10,7 @@
     "selector-pseudo-element-colon-notation": "single",
     "no-descending-specificity": null,
     "selector-disallowed-list": [
-      "/^[.#]js-/",
+      "/[.#]js-/",
       {
         "message": "js-* selectors can’t have visual styling. https://stackoverflow.design/product/guidelines/javascript/#javascript-classnames"
       }


### PR DESCRIPTION
`"/^[.#]js-/"` looks at the whole selector and fails to catch things like `div .js-foo`, `div.js-foo`, `.s-good, .js-bad`.