### PR TITLE
Apply `cursor: pointer` only to `.s-label[for]`

### DIFF
--- a/lib/css/components/_stacks-inputs.less
+++ b/lib/css/components/_stacks-inputs.less
@@ -119,10 +119,9 @@ fieldset {
     font-family: inherit;
     font-size: @fs-body2;
     font-weight: 600;
-    cursor: pointer;
 
-    legend& {
-        cursor: default; // Reset cursor when it's a legend
+    &[for] {
+        cursor: pointer;
     }
 }
 


### PR DESCRIPTION
Addresses https://github.com/StackExchange/Stacks/issues/694

### If we really wanna be picky...

@aaronshekey Only issue I can find is when using a label as an input + label text wrapper. Something like:

```
<label class="s-label">
  <div>Question title</div>
  <input class="s-input" type="text" placeholder="idk" />
</label>
```

In the above HTML, the `<div>` would focus the input but wouldn't have `cursor: pointer`. We don't suggest anyone structure HTML this way, but it is valid HTML. Not the biggest deal, just calling it out.

If it turns out to _be a big deal_, we could potentially address it with something like `.s-label > *:not(input):not(textarea):not(select)`.

### What other folks do

A quick glance around the web indicates that most forms are styled _without_ `cursor: pointer` on `label[for]`. This goes (at least) for [Tailwind UI](https://tailwindui.com/components/application-ui/forms/form-layouts), [Bootstrap](https://getbootstrap.com/docs/5.0/examples/checkout/), and [Wufoo](https://www.wufoo.com/gallery/templates/forms/employee-complaint-form/).

My opinion is that the cursor on the label is a worthwhile affordance. Just thought I'd note what I found regardless and give anyone that wants the world's most banal cursors flamewar some ammunition.