### PR TITLE
Replace placehold.it with fakeimg.pl

### DIFF
--- a/docs/email/base/snippets/border-radius.html
+++ b/docs/email/base/snippets/border-radius.html
@@ -44,10 +44,10 @@
 </head>
 <body style="background-color: #f3f3f5; text-align: center; height: 100%; padding: 16px 0; margin: 0;">
     <div class="email-container" style="max-width: 680px; margin: 0 auto;">
-        <div style="padding: 30px; margin-bottom: 30px; background-color: #ffffff;" class="bar">
-            <h2 class="ex-wide" style="font-family: arial, sans-serif; font-weight: bold; font-size: 21px; line-height: 21px; color: #0C0D0E; margin: 0 auto;">Round corners in wide viewports.</h2>
-            <h2 class="ex-narrow" style="font-family: arial, sans-serif; font-weight: bold; font-size: 21px; line-height: 21px; color: #0C0D0E; margin: 0 auto;">Square corners in narrow viewports.</h2>
+        <div style="padding: 30px; margin-bottom: 30px; background-color: #fff;" class="bar">
+            <h2 class="ex-wide" style="font-family: arial, sans-serif; font-weight: bold; font-size: 21px; line-height: 21px; color: #0c0d0e; margin: 0 auto;">Round corners in wide viewports.</h2>
+            <h2 class="ex-narrow" style="font-family: arial, sans-serif; font-weight: bold; font-size: 21px; line-height: 21px; color: #0c0d0e; margin: 0 auto;">Square corners in narrow viewports.</h2>
         </div>
-        <img src="https://placehold.it/1280x200?text=Works+on+Foreground+Images+Too" width="680" height="" alt="Works on Foreground Images Too" border="0" style="width: 100%; max-width: 680px; height: auto; display: block; margin: auto;" class="btr">
+        <img src="https://fakeimg.pl/1280x200?text=Works+on+Foreground+Images+Too" width="680" height="" alt="Works on Foreground Images Too" border="0" style="width: 100%; max-width: 680px; height: auto; display: block; margin: auto;" class="btr">
     </div>
 </body>

--- a/docs/email/components/images.html
+++ b/docs/email/components/images.html
@@ -79,15 +79,15 @@ description:
     <div class="stacks-preview">
 {% highlight html %}
 /* Responsive */
-<img src="https://placehold.it/1280x600" width="640" height="" alt="alt_text" border="0" style="width: 100%; max-width: 640px; height: auto; display: block;" class="g-img">
+<img src="https://fakeimg.pl/1280x600" width="640" height="" alt="alt_text" border="0" style="width: 100%; max-width: 640px; height: auto; display: block;" class="g-img">
 
 /* Static */
-<img src="https://placehold.it/256" width="128" height="128" alt="alt_text" border="0" style="display: block;">
+<img src="https://fakeimg.pl/256" width="128" height="128" alt="alt_text" border="0" style="display: block;">
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <img src="https://placehold.it/1280x600" width="640" height="" alt="alt_text" border="0" style="width: 100%; max-width: 640px; height: auto; display: block;" class="g-img">
+            <img src="https://fakeimg.pl/1280x600" width="640" height="" alt="alt_text" border="0" style="width: 100%; max-width: 640px; height: auto; display: block;" class="g-img">
             <br>
-            <img src="https://placehold.it/256" width="128" height="128" alt="alt_text" border="0" style="display: block;">
+            <img src="https://fakeimg.pl/256" width="128" height="128" alt="alt_text" border="0" style="display: block;">
         </div>
     </div>
     <div class="grid s-notice s-notice__info mb48">
@@ -162,7 +162,7 @@ description:
     {% header "h3", "Background image examples" %}
     <div class="stacks-preview mb24">
 {% highlight html %}
-<td valign="middle" style="background-image: url('https://d2axdqolvqmdvx.cloudfront.net/857c3f94-f791-401e-85a8-e041ec72569e/bgheropatternblue.png'); background-position: center center; background-size: cover; background-color: #117FF1; text-align: center;">
+<td valign="middle" style="background-image: url('https://d2axdqolvqmdvx.cloudfront.net/857c3f94-f791-401e-85a8-e041ec72569e/bgheropatternblue.png'); background-position: center center; background-size: cover; background-color: #117ff1; text-align: center;">
     <!--[if gte mso 9]>
     <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:680px;height:220px;">
     <v:fill type="tile" src="https://d2axdqolvqmdvx.cloudfront.net/857c3f94-f791-401e-85a8-e041ec72569e/bgheropatternblue.png" color="#117FF1"/>
@@ -172,7 +172,7 @@ description:
         <!-- Foreground Content : BEGIN -->
         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
             <tr>
-                <td style="padding: 60px; color: #ffffff; font-family: arial, sans-serif; font-size: 15px; text-align: center;">
+                <td style="padding: 60px; color: #fff; font-family: arial, sans-serif; font-size: 15px; text-align: center;">
                     Foreground HTML content.
                 </td>
             </tr>
@@ -188,12 +188,12 @@ description:
         <div class="stacks-preview--example">
             <table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation">
                 <tr>
-                    <td valign="middle" style="background-image: url('https://d2axdqolvqmdvx.cloudfront.net/857c3f94-f791-401e-85a8-e041ec72569e/bgheropatternblue.png'); background-position: center center; background-size: cover; background-color: #117FF1; text-align: center;">
+                    <td valign="middle" style="background-image: url('https://d2axdqolvqmdvx.cloudfront.net/857c3f94-f791-401e-85a8-e041ec72569e/bgheropatternblue.png'); background-position: center center; background-size: cover; background-color: #117ff1; text-align: center;">
                         <div>
                             <!-- Foreground Content : BEGIN -->
                             <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
                                 <tr>
-                                    <td style="padding: 60px; color: #ffffff; font-family: arial, sans-serif; font-size: 15px; text-align: center;">
+                                    <td style="padding: 60px; color: #fff; font-family: arial, sans-serif; font-size: 15px; text-align: center;">
                                         Foreground HTML content.
                                     </td>
                                 </tr>

--- a/docs/email/components/spacers.html
+++ b/docs/email/components/spacers.html
@@ -10,13 +10,13 @@ description: Spacers are used to add separation between table rows.
     <div class="stacks-preview mb24 bbr-sm">
 {% highlight html %}
 <tr>
-    <td aria-hidden="true" height="30" style="font-size: 0px; line-height: 0px;">
+    <td aria-hidden="true" height="30" style="font-size: 0; line-height: 0px;">
         &nbsp;
     </td>
 </tr>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="ba bc-black-5 bas-dashed fc-light fs-caption ta-center grid ai-center jc-center" style="height: 30px">
+            <div class="ba bc-black-5 bas-dashed fc-light fs-caption ta-center grid ai-center jc-center" style="height: 30px;">
                 (size of the spacer)
             </div>
         </div>
@@ -63,7 +63,7 @@ description: Spacers are used to add separation between table rows.
     <td> … </td>
 </tr>
 <tr>
-    <td aria-hidden="true" height="30" style="font-size: 0px; line-height: 0px;">
+    <td aria-hidden="true" height="30" style="font-size: 0; line-height: 0px;">
         &nbsp;
     </td>
 </tr>
@@ -73,17 +73,17 @@ description: Spacers are used to add separation between table rows.
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="grid ai-center">
-                <img src="https://placehold.it/192" width="96" height="96" alt="alt_text" border="0" class="mr16">
+                <img src="https://fakeimg.pl/192" width="96" height="96" alt="alt_text" border="0" class="mr16">
                 <div>
                     <h2 class="fs-body3 fw-bold fc-dark mt0 mb8">Are your preferences up to date?</h2>
                     <p class="fs-body2 fc-medium m0">Make sure we are recommending the best content for you.</p>
                 </div>
             </div>
-            <div class="ba bc-black-5 bas-dashed fc-light fs-caption ta-center grid ai-center jc-center" style="height: 30px">
+            <div class="ba bc-black-5 bas-dashed fc-light fs-caption ta-center grid ai-center jc-center" style="height: 30px;">
                 (spacer)
             </div>
             <div class="grid ai-center">
-                <img src="https://placehold.it/192" width="96" height="96" alt="alt_text" border="0" class="mr16">
+                <img src="https://fakeimg.pl/192" width="96" height="96" alt="alt_text" border="0" class="mr16">
                 <div>
                     <h2 class="fs-body3 fw-bold fc-dark mt0 mb8">Are your preferences up to date?</h2>
                     <p class="fs-body2 fc-medium m0">Make sure we are recommending the best content for you.</p>
@@ -96,30 +96,30 @@ description: Spacers are used to add separation between table rows.
     <div class="stacks-preview mb24">
 {% highlight html %}
 <tr>
-    <td style="background-color: #ffffff;" class="bar"> … </td>
+    <td style="background-color: #fff;" class="bar"> … </td>
 </tr>
 <tr>
-    <td aria-hidden="true" height="30" style="font-size: 0px; line-height: 0px;">
+    <td aria-hidden="true" height="30" style="font-size: 0; line-height: 0px;">
         &nbsp;
     </td>
 </tr>
 <tr>
-    <td style="background-color: #ffffff;" class="bar"> … </td>
+    <td style="background-color: #fff;" class="bar"> … </td>
 </tr>
 {% endhighlight %}
         <div class="stacks-preview--example bg-black-050">
             <div class="grid ai-center bg-white wmx5 mx-auto bar-md p16">
-                <img src="https://placehold.it/192" width="96" height="96" alt="alt_text" border="0" class="mr16">
+                <img src="https://fakeimg.pl/192" width="96" height="96" alt="alt_text" border="0" class="mr16">
                 <div>
                     <h2 class="fs-body3 fw-bold fc-dark mt0 mb8">Are your preferences up to date?</h2>
                     <p class="fs-body2 fc-medium m0">Make sure we are recommending the best content for you.</p>
                 </div>
             </div>
-            <div class="fc-light fs-caption ta-center grid ai-center jc-center" style="height: 30px">
+            <div class="fc-light fs-caption ta-center grid ai-center jc-center" style="height: 30px;">
                 (spacer)
             </div>
             <div class="grid ai-center bg-white wmx5 mx-auto bar-md p16">
-                <img src="https://placehold.it/192" width="96" height="96" alt="alt_text" border="0" class="mr16">
+                <img src="https://fakeimg.pl/192" width="96" height="96" alt="alt_text" border="0" class="mr16">
                 <div>
                     <h2 class="fs-body3 fw-bold fc-dark mt0 mb8">Are your preferences up to date?</h2>
                     <p class="fs-body2 fc-medium m0">Make sure we are recommending the best content for you.</p>


### PR DESCRIPTION
[Related discussion in Slack](https://stackexchange.slack.com/archives/C27RWNQN9/p1625140722450500)

> Nick Craver Today at 7:58 AM
Hey ya'll - dropping in a DM I got, bug report for docs site:
>>Hi Nick, I was watching your youtube interview with Jon Galloway (btw, it was great!) and, following the link on stackoverflow.design , I stumbled upon this page https://stackoverflow.design/email/components/images/ where I noticed you are using placehold.it images, but they are broken because their https certificate expired around 3 months ago.

I'm still receptive to the [kitten idea](https://placekitten.com/).