### PR TITLE
Full width email signatures

### DIFF
--- a/docs/email/components/signatures.html
+++ b/docs/email/components/signatures.html
@@ -12,7 +12,7 @@ description: Signatures are a useful option when you need to send more formal em
     {% header "h3", "Basic example" %}
     <div class="stacks-preview mb24">
 {% highlight html %}
-<table border="0" cellpadding="0" cellspacing="0">
+<table width="100%" border="0" cellpadding="0" cellspacing="0">
     <tbody>
         <tr>
             <td border="0" cellpadding="0" cellspacing="0" style="font-family:Arial, sans-serif; font-size:13px; font-style:bold; padding-bottom: 20px; color: #212325">
@@ -30,7 +30,7 @@ description: Signatures are a useful option when you need to send more formal em
 {% endhighlight %}
         <div class="stacks-preview--example theme-light__forced" style="font-family: arial, sans-serif; font-size: 15px; line-height: 19px; color: #54595F; text-align: left;">
             <div style="width: 100%; margin: 0 auto;">
-                <table border="0" cellpadding="0" cellspacing="0">
+                <table width="100%" border="0" cellpadding="0" cellspacing="0">
                     <tbody>
                         <tr>
                             <td border="0" cellpadding="0" cellspacing="0" style="font-family:Arial, sans-serif; font-size:13px; font-style:bold; padding-bottom: 20px; color: #212325">
@@ -52,7 +52,7 @@ description: Signatures are a useful option when you need to send more formal em
     {% header "h3", "Detailed example" %}
     <div class="stacks-preview mb24">
 {% highlight html %}
-<table border="0" cellpadding="0" cellspacing="0">
+<table width="100%" border="0" cellpadding="0" cellspacing="0">
     <tbody>
         <tr>
             <td border="0" cellpadding="0" cellspacing="0" style="font-family:Arial,sans-serif;font-size:13px;font-style:bold;padding-bottom:20px;color:#212325">
@@ -77,7 +77,7 @@ description: Signatures are a useful option when you need to send more formal em
 {% endhighlight %}
         <div class="stacks-preview--example theme-light__forced" style="font-family: arial, sans-serif; font-size: 15px; line-height: 19px; color: #54595F; text-align: left;">
             <div style="width: 100%; margin: 0 auto;">
-                <table border="0" cellpadding="0" cellspacing="0">
+                <table width="100%" border="0" cellpadding="0" cellspacing="0">
                     <tbody>
                         <tr>
                             <td border="0" cellpadding="0" cellspacing="0" style="font-family:Arial,sans-serif;font-size:13px;font-style:bold;padding-bottom:20px;color: #212325">


### PR DESCRIPTION
Fixes an issue where tables were collapsing to the width of the logo:

<img width="190" alt="Screenshot 2021-07-12 at 11 21 14" src="https://user-images.githubusercontent.com/649231/125272120-64c57000-e303-11eb-87a7-7c24b34c8b22.png">
