### PR TITLE
Menu docs - padding over negative margins

### DIFF
--- a/docs/product/components/menus.html
+++ b/docs/product/components/menus.html
@@ -38,8 +38,8 @@ description: A menu offers a contextual list of actions or functions.
     </p>
     <div class="stacks-preview">
 {% highlight html %}
-<div class="s-popover">
-    <ul class="s-menu mxn12 myn8" role="menu">
+<div class="s-popover px0 py4">
+    <ul class="s-menu" role="menu">
         <li role="menuitem">
             <a href="…" class="s-block-link">…</a>
         </li>
@@ -65,9 +65,9 @@ description: A menu offers a contextual list of actions or functions.
             <div class="d-flex gs32 fw-wrap">
                 <div class="flex--item">
                     <div class="ff-mono mb16">Within a popover</div>
-                    <div class="s-popover is-visible ps-relative ws2">
+                    <div class="s-popover is-visible ps-relative ws2 px0 py4">
                         <div class="s-popover--arrow s-popover--arrow__tc"></div>
-                        <ul class="s-menu mxn12 myn8" role="menu">
+                        <ul class="s-menu" role="menu">
                             <li role="menuitem">
                                 <a href="#" class="s-block-link">
                                     Share
@@ -138,8 +138,8 @@ description: A menu offers a contextual list of actions or functions.
     </p>
     <div class="stacks-preview">
 {% highlight html %}
-<div class="s-popover">
-    <ul class="s-menu mxn12 myn8" role="menu">
+<div class="s-popover px0 py4">
+    <ul class="s-menu" role="menu">
         <li class="s-menu--title" role="separator">…</li>
         <li role="menuitem">
             <a href="…" class="s-block-link">…</a>
@@ -152,9 +152,9 @@ description: A menu offers a contextual list of actions or functions.
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="s-popover is-visible ps-relative ws2">
+            <div class="s-popover is-visible ps-relative ws2 px0 py4">
                 <div class="s-popover--arrow s-popover--arrow__tc"></div>
-                <ul class="s-menu mxn12 myn8" role="menu">
+                <ul class="s-menu" role="menu">
                     <li class="s-menu--title" role="separator">
                         Share via
                     </li>
@@ -195,8 +195,8 @@ description: A menu offers a contextual list of actions or functions.
     </p>
     <div class="stacks-preview">
 {% highlight html %}
-<div class="s-popover">
-    <ul class="s-menu mxn12 myn8" role="menu">
+<div class="s-popover px0 py4">
+    <ul class="s-menu" role="menu">
         <li role="menuitem">
             <a href="…" class="s-block-link s-block-link__left is-selected">…</a>
         </li>
@@ -204,9 +204,9 @@ description: A menu offers a contextual list of actions or functions.
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="s-popover is-visible ps-relative ws2">
+            <div class="s-popover is-visible ps-relative ws2 px0 py4">
                 <div class="s-popover--arrow s-popover--arrow__tc"></div>
-                <ul class="s-menu mxn12 myn8" role="menu">
+                <ul class="s-menu" role="menu">
                     <li role="menuitem">
                         <a href="#" class="s-block-link">
                             Frequent
@@ -246,8 +246,8 @@ description: A menu offers a contextual list of actions or functions.
     </p>
     <div class="stacks-preview">
 {% highlight html %}
-<div class="s-popover">
-    <fieldset class="s-menu mxn12 myn8" role="menu">
+<div class="s-popover px0 py4">
+    <fieldset class="s-menu" role="menu">
         <legend class="s-menu--title">…</legend>
         <label class="s-menu--label d-flex" for="…">
             <div class="flex--item mr8">
@@ -271,9 +271,9 @@ description: A menu offers a contextual list of actions or functions.
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="s-popover is-visible ps-relative ws3">
+            <div class="s-popover is-visible ps-relative ws3 px0 py4">
                 <div class="s-popover--arrow s-popover--arrow__tc"></div>
-                <fieldset class="s-menu mxn12 myn8" role="menu">
+                <fieldset class="s-menu" role="menu">
                     <legend class="s-menu--title">Roles</legend>
                     <label class="s-menu--label d-flex" for="choice-user-34">
                         <div class="flex--item mr8">


### PR DESCRIPTION
Updates menu docs to recommend using padding on the parent popover instead of negative margins on the child component.

Adding classes to the child to dictate styles on the parent is a tad wonky. Additionally, if the parent's styles ever changed (e.g. from 12px to 8px), then the layout will be visibly broken in a way that is hard to search for.