### PR TITLE
Use the same `:hover` color on `:focus` in Notices

### DIFF
--- a/lib/css/components/_stacks-notices.less
+++ b/lib/css/components/_stacks-notices.less
@@ -53,6 +53,7 @@
 
     // Improve the presentation of buttons
     .s-notice--btn {
+        &:focus,
         &:hover {
             background-color: var(--theme-secondary-300);
         }
@@ -82,6 +83,7 @@
 
     // Improve the presentation of buttons
     .s-notice--btn {
+        &:focus,
         &:hover {
             background-color: var(--green-100);
         }
@@ -107,6 +109,7 @@
 
     // Improve the presentation of buttons
     .s-notice--btn {
+        &:focus,
         &:hover {
             background-color: var(--yellow-200);
         }
@@ -131,6 +134,7 @@
 
     // Improve the presentation of buttons
     .s-notice--btn {
+        &:focus,
         &:hover {
             background-color: var(--red-100);
         }


### PR DESCRIPTION
**Currently**

![wrong-color-for-notices](https://user-images.githubusercontent.com/1246453/126562637-ef92a861-6011-42aa-8a05-d22ae09c3755.gif)

**Fixed**

![right-color-for-notices](https://user-images.githubusercontent.com/1246453/126562638-f288be80-1f8b-4b9f-bb1d-4d4359191725.gif)
