### PR TITLE
Respect `prefers-reduced-motion` for toast animations

### DIFF
--- a/lib/css/components/_stacks-notices.less
+++ b/lib/css/components/_stacks-notices.less
@@ -189,4 +189,12 @@
         transform: translate3d(0, 0, 0);
         transition: visibility 0s 0s, opacity 100ms @te-smooth 0s, transform 100ms @te-smooth 0s;
     }
+
+    @media (prefers-reduced-motion) {
+        transition: none;
+
+        &[aria-hidden="false"] {
+            transition: none;
+        }
+    }
 }


### PR DESCRIPTION
**With animations (untouched)**
![with-animations](https://user-images.githubusercontent.com/1246453/126822029-767c5ed7-9cf1-4496-bd2b-6ec239604c8c.gif)

**Prefers reduced motion (no animation)**
![reduced-motion](https://user-images.githubusercontent.com/1246453/126822021-3b66ca50-a011-4b33-994b-9eaab0c85a8e.gif)
