### PR TITLE
Retain `.s-toast` transition while respecting prefers-reduced-motion

### DIFF
--- a/lib/css/components/_stacks-notices.less
+++ b/lib/css/components/_stacks-notices.less
@@ -189,12 +189,4 @@
         transform: translate3d(0, 0, 0);
         transition: visibility 0s 0s, opacity 100ms @te-smooth 0s, transform 100ms @te-smooth 0s;
     }
-
-    @media (prefers-reduced-motion) {
-        transition: none;
-
-        &[aria-hidden="false"] {
-            transition: none;
-        }
-    }
 }

--- a/lib/css/components/_stacks-notices.less
+++ b/lib/css/components/_stacks-notices.less
@@ -189,4 +189,8 @@
         transform: translate3d(0, 0, 0);
         transition: visibility 0s 0s, opacity 100ms @te-smooth 0s, transform 100ms @te-smooth 0s;
     }
+
+    @media (prefers-reduced-motion) {
+        transform: none;
+    }
 }


### PR DESCRIPTION
@bnickel pointed out that our `.s-toast` component has JS that relies on the a CSS transition.

This PR builds on top of @allejo's work in https://github.com/StackExchange/Stacks/pull/720