### PR TITLE
Add `.fc-inherit`, `.bc-inherit`, and `.bg-inherit`

### DIFF
--- a/docs/_data/colors.json
+++ b/docs/_data/colors.json
@@ -4,6 +4,7 @@
     "primary": 500,
     "white": true,
     "flip": true,
+    "include": true,
     "stops": [
       {
         "stop": 900,
@@ -61,6 +62,7 @@
     "name": "orange",
     "primary": 400,
     "white": true,
+    "include": true,
     "stops": [
       {
         "stop": 900,
@@ -114,6 +116,7 @@
   {
     "name": "yellow",
     "primary": 400,
+    "include": true,
     "stops": [
       {
         "stop": 900,
@@ -167,6 +170,7 @@
     "name": "green",
     "primary": 500,
     "white": true,
+    "include": true,
     "stops": [
       {
         "stop": 900,
@@ -227,6 +231,7 @@
     "name": "blue",
     "primary": 600,
     "white": true,
+    "include": true,
     "stops": [
       {
         "stop": 900,
@@ -285,6 +290,7 @@
     "name": "powder",
     "primary": 600,
     "white": true,
+    "include": true,
     "stops": [
       {
         "stop": 900,
@@ -338,6 +344,7 @@
     "name": "black",
     "primary": 800,
     "white": true,
+    "include": true,
     "stops": [
       {
         "stop": 900,

--- a/docs/product/base/colors.html
+++ b/docs/product/base/colors.html
@@ -92,7 +92,7 @@ description: To avoid specifying color values by hand, we’ve included a robust
                         {% for stop in color.stops %}
                         <tr>
                             <th scope="row">
-                            <div class="stacks-swatch bar-sm bg-{{ color.name }}-{{ stop.stop }}"></div>
+                            <div class="stacks-swatch bar-sm bs-sm bg-{{ color.name }}-{{ stop.stop }}"></div>
                             </th>
                             <td class="ff-mono">.fc-{{ color.name }}-{{ stop.stop }}</td>
                             <td class="ff-mono">.bg-{{ color.name }}-{{ stop.stop }}</td>
@@ -104,7 +104,7 @@ description: To avoid specifying color values by hand, we’ve included a robust
                         {% endfor %}
                         <tr class="ff-mono">
                             <th scope="row">
-                            <div class="stacks-swatch bar-sm bg-white"></div>
+                            <div class="stacks-swatch bar-sm bs-sm bg-white"></div>
                             </th>
                             <td class="ff-mono">.fc-white</td>
                             <td class="ff-mono">.bg-white</td>
@@ -115,12 +115,23 @@ description: To avoid specifying color values by hand, we’ve included a robust
                         </tr>
                         <tr class="ff-mono">
                             <th scope="row">
-                            <div class="stacks-swatch bar-sm bg-transparent"></div>
+                            <div class="stacks-swatch bar-sm bs-sm bg-transparent"></div>
                             </th>
                             <td class="fc-light">N/A</td>
                             <td>.bg-transparent</td>
                             <td>.bc-transparent</td>
                             <td class="ta-center">{% icon "Checkmark", "fc-green-500" %}</td>
+                            <td></td>
+                            <td class="ta-center">{% icon "Checkmark", "fc-green-500" %}</td>
+                        </tr>
+                        <tr class="ff-mono">
+                            <th scope="row">
+                            <div class="stacks-swatch bar-sm bs-sm bg-inherit"></div>
+                            </th>
+                            <td>.fc-inherit</td>
+                            <td>.bg-inherit</td>
+                            <td>.bc-inherit</td>
+                            <td></td>
                             <td></td>
                             <td></td>
                         </tr>

--- a/lib/css/atomic/_stacks-borders.less
+++ b/lib/css/atomic/_stacks-borders.less
@@ -354,3 +354,7 @@
 //  ----------------------------------------------------------------------------
 .bc-transparent { border-color: transparent !important; }
 .d\:bc-transparent { .dark-mode({ border-color: transparent !important; }); }
+
+//  $$  INHERIT
+//  ----------------------------------------------------------------------------
+.bc-inherit { border-color: inherit !important; }

--- a/lib/css/atomic/_stacks-colors.less
+++ b/lib/css/atomic/_stacks-colors.less
@@ -199,3 +199,7 @@
     background-color: transparent !important;
     background-image: none !important;
 }
+
+.bg-inherit {
+    background-color: inherit !important;
+}

--- a/lib/css/atomic/_stacks-colors.less
+++ b/lib/css/atomic/_stacks-colors.less
@@ -203,3 +203,7 @@
 .bg-inherit {
     background-color: inherit !important;
 }
+
+.fc-inherit {
+    color: inherit !important;
+}


### PR DESCRIPTION
This PR also restores the full list of classes across the colors docs which was messed up in #552.