### PR TITLE
Remove `grid` and `grid--cell`

### DIFF
--- a/docs/_data/flex.json
+++ b/docs/_data/flex.json
@@ -2,62 +2,62 @@
   "flex-item": [
     {
       "class": ".flex--item1",
-      "all": ".flex__allcells1",
+      "all": ".flex__allitems1",
       "output": "flex-basis: 8.333333333%;"
     },
     {
       "class": ".flex--item2",
-      "all": ".flex__allcells2",
+      "all": ".flex__allitems2",
       "output": "flex-basis: 16.666666667%;"
     },
     {
       "class": ".flex--item3",
-      "all": ".flex__allcells3",
+      "all": ".flex__allitems3",
       "output": "flex-basis: 24.999999999%;"
     },
     {
       "class": ".flex--item4",
-      "all": ".flex__allcells4",
+      "all": ".flex__allitems4",
       "output": "flex-basis: 33.333333332%;"
     },
     {
       "class": ".flex--item5",
-      "all": ".flex__allcells5",
+      "all": ".flex__allitems5",
       "output": "flex-basis: 41.666666665%;"
     },
     {
       "class": ".flex--item6",
-      "all": ".flex__allcells6",
+      "all": ".flex__allitems6",
       "output": "flex-basis: 50%;"
     },
     {
       "class": ".flex--item7",
-      "all": ".flex__allcells7",
+      "all": ".flex__allitems7",
       "output": "flex-basis: 58.333333331%;"
     },
     {
       "class": ".flex--item8",
-      "all": ".flex__allcells8",
+      "all": ".flex__allitems8",
       "output": "flex-basis: 66.666666664%;"
     },
     {
       "class": ".flex--item9",
-      "all": ".flex__allcells9",
+      "all": ".flex__allitems9",
       "output": "flex-basis: 74.999999997%;"
     },
     {
       "class": ".flex--item10",
-      "all": ".flex__allcells10",
+      "all": ".flex__allitems10",
       "output": "flex-basis: 83.33333333%;"
     },
     {
       "class": ".flex--item11",
-      "all": ".flex__allcells11",
+      "all": ".flex__allitems11",
       "output": "flex-basis: 91.666666663%;"
     },
     {
       "class": ".flex--item12",
-      "all": ".flex__allcells12",
+      "all": ".flex__allitems12",
       "output": "flex-basis: 100%;"
     }
   ],

--- a/docs/brand/colors.html
+++ b/docs/brand/colors.html
@@ -8,7 +8,7 @@ description: See the <a href="/product/base/colors/">Product</a> section for col
 
 <section class="stacks-section">
     {% header "h2", "Primary" %}
-    <div class="d-flex flex__allcells4 gs32 ff-row-wrap">
+    <div class="d-flex flex__allitems4 gs32 ff-row-wrap">
         <div class="flex--item s-card wmn2 bs-sm p0 mb24">
             <div class="h96 bg-orange-400 mln1 mrn1 mtn1 btr-sm"></div>
             <div class="p12">
@@ -68,7 +68,7 @@ description: See the <a href="/product/base/colors/">Product</a> section for col
 
 <section class="stacks-section">
     {% header "h2", "Secondary" %}
-    <div class="d-flex flex__allcells4 gs32 ff-row-wrap">
+    <div class="d-flex flex__allitems4 gs32 ff-row-wrap">
         <div class="flex--item s-card wmn2 bs-sm p0 mb24">
             <div class="h96 mln1 mrn1 mtn1 btr-sm" style="background:#0095FF"></div>
             <div class="p12">
@@ -110,7 +110,7 @@ description: See the <a href="/product/base/colors/">Product</a> section for col
 
 <section class="stacks-section">
     {% header "h2", "Verticals" %}
-    <div class="d-flex flex__allcells4 gs32 ff-row-wrap">
+    <div class="d-flex flex__allitems4 gs32 ff-row-wrap">
         <div class="flex--item s-card wmn2 bs-sm p0 mb24">
             <div class="h96 mln1 mrn1 mtn1 btr-sm" style="background:#2B2D6E"></div>
             <div class="p12">

--- a/docs/brand/logo.html
+++ b/docs/brand/logo.html
@@ -24,7 +24,7 @@ description: Guidelines and resources for using our logos. By downloading these,
     </p>
 
     {% header "h3", "Color alternatives" %}
-    <div class="d-flex flex__allcells6 ta-center sm:fd-column w100">
+    <div class="d-flex flex__allitems6 ta-center sm:fd-column w100">
         <div class="flex--item p64">
             {% icon "LogoMd", "native wmx100" %}
         </div>
@@ -32,7 +32,7 @@ description: Guidelines and resources for using our logos. By downloading these,
             {% icon "LogoMd", "native wmx100" %}
         </div>
     </div>
-    <div class="d-flex flex__allcells6 ta-center sm:fd-column w100 mb32">
+    <div class="d-flex flex__allitems6 ta-center sm:fd-column w100 mb32">
         <div class="flex--item bg-orange-400 fc-white p64">
             {% icon "LogoMd", "wmx100" %}
         </div>

--- a/docs/email/guidelines/getting-started.html
+++ b/docs/email/guidelines/getting-started.html
@@ -11,7 +11,7 @@ menu: false
             <p class="stacks-copy m0">Starting points for creating new emails.</p>
         </div>
     </div>
-    <div class="d-flex flex__allcells4 sm:fd-column jc-space-between gs16 gsx">
+    <div class="d-flex flex__allitems4 sm:fd-column jc-space-between gs16 gsx">
         <a href="{{ "/email/templates/short-transactional" | relative_url }}" class="flex--item s-card bs-sm h:bs-md mb16">
             <img src="/assets/img/preview-short-transactional.svg" alt="short transactional preview" class="w100">
             <h3 class="my8">Short Transactional</h3>
@@ -35,7 +35,7 @@ menu: false
         <h2 class="d-flex jc-space-between ai-center stacks-h2">Customizing email</h2>
         <p class="stacks-copy m0">Design and code guidelines for how we create and customize emails.</p>
     </div>
-    <div class="d-flex flex__allcells6 sm:fd-column jc-space-between gs16 gsx">
+    <div class="d-flex flex__allitems6 sm:fd-column jc-space-between gs16 gsx">
         <div class="d-flex jc-space-between ai-start s-card mb16">
             <div class="flex--item fl-shrink0 fc-orange-400 mr16">
                 <svg aria-hidden="true" class="svg-spot spotPuzzleAlt" width="48" height="48" viewBox="0 0 48 48"><path opacity=".2" d="M3.83 30.27a1.94 1.94 0 01.04-2.78l6.42-6.13c.63-.64 1.64-.38 2.02.39a4.94 4.94 0 005.8 2.97 5.13 5.13 0 00.89-9.68c-.76-.39-1.01-1.42-.38-2.06l4.02-4.21a2 2 0 012.85-.05l4.68 4.61c.63.65 1.51.39 1.9-.26a4.98 4.98 0 015.42-2.32 4.97 4.97 0 013.66 3.74 5.1 5.1 0 01-2.27 5.55c-.64.39-.89 1.42-.26 1.94l5.25 5.32a2 2 0 01.01 2.8L29 45.4a7 7 0 01-10 .01C14.27 40.58 7.05 33.5 3.84 30.27z"/><path d="M45.7 23.3v-.01l-5.66-5.67a1 1 0 00-.08-.07.2.2 0 010-.06l.06-.15a.29.29 0 01.08-.08 6.05 6.05 0 002.77-6.66 6.13 6.13 0 00-11.23-1.8.3.3 0 01-.19.14h-.06a.27.27 0 01-.11-.08L24.7 2.3a1 1 0 00-1.42 0l-6.22 6.23a1.98 1.98 0 00-.65 1.88c.1.6.47 1.2 1.05 1.56h.02a3.8 3.8 0 011.73 4.18 4.09 4.09 0 01-2.91 2.94h-.01a3.89 3.89 0 01-4.21-1.76 2.24 2.24 0 00-1.5-1.04 2.12 2.12 0 00-1.9.61l-6.4 6.4a1 1 0 00-.29.74 1 1 0 00.29.74l17.25 17.38a6.23 6.23 0 008.86 0l17.3-17.44a.7.7 0 00.14-.16 1 1 0 00-.13-1.26zM18.46 9.95L24 4.41l5.86 5.87a2.2 2.2 0 001.95.63 2.3 2.3 0 001.54-1.07 4.13 4.13 0 014.48-1.87c1.4.3 2.67 1.53 3.1 3.13a4.05 4.05 0 01-1.84 4.43l-.02.01c-.59.36-.97.98-1.08 1.6-.1.64.04 1.4.67 1.93L43.59 24 26.98 40.74a4.23 4.23 0 01-6.02 0L4.38 24.04l5.73-5.73a.22.22 0 01.08-.06h.04c.05 0 .11.04.15.11v.01l.02.02a5.89 5.89 0 0010.77-1.8 5.8 5.8 0 00-2.67-6.35.23.23 0 01-.06-.07.33.33 0 01-.05-.15l.06-.06zM8.47 6.53a1.37 1.37 0 11-1.94 1.94 1.37 1.37 0 011.94-1.94zm33 33a1.38 1.38 0 11-1.94 1.94 1.38 1.38 0 011.94-1.94zm-33 0a1.38 1.38 0 10-1.94 1.94 1.38 1.38 0 001.94-1.94z"/></svg>
@@ -61,7 +61,7 @@ menu: false
     <div class="mb16">
         <h2 class="d-flex jc-space-between ai-center stacks-h2">Knowledge and resources</h2>
     </div>
-    <div class="d-flex flex__allcells6 sm:fd-column jc-space-between gs16 gsx">
+    <div class="d-flex flex__allitems6 sm:fd-column jc-space-between gs16 gsx">
         <div class="flex--item pr48">
             <div class="mb48">
                 <h3 class="mb8 stacks-h3">Design best practices</h3>

--- a/docs/email/templates/major-announcements.html
+++ b/docs/email/templates/major-announcements.html
@@ -8,7 +8,7 @@ menu: false
     <strong>Note:</strong> The source for these emails is provided for historical purposes only. It’s ok to grab <strong>parts</strong> of a design, but these templates should not be used as a starting point because the code is likely outdated.
 {% endtip %}
 <section data-controller="docs-resizer">
-    <div class="d-flex flex__allcells4 ai-stretch gs16 gsx sm:fd-column">
+    <div class="d-flex flex__allitems4 ai-stretch gs16 gsx sm:fd-column">
         <a href="{{ "/email/templates/examples/integrations.html" | relative_url }}" class="flex--item s-card mb16 bs-sm h:bs-md">
             <img src="{{ "/email/templates/examples/integrations.png" | relative_url }}" alt="Integrations for Stack Overflow for Teams announcement" class="w100">
             <h3 class="my8">Integrations Announcement</h3>
@@ -27,7 +27,7 @@ menu: false
     </div>
 </section>
 <section data-controller="docs-resizer">
-    <div class="d-flex flex__allcells4 ai-stretch gs16 gsx sm:fd-column">
+    <div class="d-flex flex__allitems4 ai-stretch gs16 gsx sm:fd-column">
         <a href="{{ "/email/templates/examples/coc.html" | relative_url }}" class="flex--item s-card mb16 bs-sm h:bs-md">
             <img src="{{ "/email/templates/examples/coc.png" | relative_url }}" alt="Code of Conduct announcement" class="w100">
             <h3 class="my8">Code of Conduct</h3>

--- a/docs/product/base/backgrounds.html
+++ b/docs/product/base/backgrounds.html
@@ -86,7 +86,7 @@ description: Atomic classes for controlling the background properties of an elem
 <div class="bg-no-repeat bg-top">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="d-flex flex__allcells3 w100 gs8 fc-black-800 ff-mono fw-wrap">
+            <div class="d-flex flex__allitems3 w100 gs8 fc-black-800 ff-mono fw-wrap">
                 <div class="flex--item p12 bg-black-075 hs1 ba bc-black-3 stacks-bg-img bg-no-repeat bg-bottom">.bg-bottom</div>
                 <div class="flex--item p12 bg-black-075 hs1 ba bc-black-3 stacks-bg-img bg-no-repeat bg-center">.bg-center</div>
                 <div class="flex--item p12 bg-black-075 hs1 ba bc-black-3 stacks-bg-img bg-no-repeat bg-left">.bg-left</div>

--- a/docs/product/base/box-shadow.html
+++ b/docs/product/base/box-shadow.html
@@ -50,7 +50,7 @@ description: Box shadow atomic classes allow you to change an element’s box sh
 <div class="bs-lg">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example fs-caption ff-mono">
-            <div class="d-flex jc-space-between flex__allcells3 mb16">
+            <div class="d-flex jc-space-between flex__allitems3 mb16">
                 <div class="flex--item fd-column p12 bs-sm bar-sm h96">
                     .bs-sm
                 </div>
@@ -62,7 +62,7 @@ description: Box shadow atomic classes allow you to change an element’s box sh
                 </div>
             </div>
 
-            <div class="d-flex jc-space-between flex__allcells3">
+            <div class="d-flex jc-space-between flex__allitems3">
                 <div class="flex--item fd-column p12 bs-ring bar-sm h96">
                     .bs-ring
                 </div>

--- a/docs/product/base/flex.html
+++ b/docs/product/base/flex.html
@@ -111,7 +111,7 @@ description: Stacks provides extensive utility and helper classes for flex layou
     <div class="flex--item6">…</div>
     <div class="flex--item">…</div>
 </div>
-<div class="d-flex flex__allcells4">
+<div class="d-flex flex__allitems4">
     <div class="flex--item">…</div>
     <div class="flex--item">…</div>
     <div class="flex--item">…</div>
@@ -140,9 +140,9 @@ description: Stacks provides extensive utility and helper classes for flex layou
                     </div>
                 </div>
                 <div class="flex--item">
-                    <div class="mb8 ff-mono">.d-flex.flex__allcells4</div>
+                    <div class="mb8 ff-mono">.d-flex.flex__allitems4</div>
                     <div class="bar-sm bg-black-025 ba bc-black-075 p8">
-                        <div class="d-flex gs4 flex__allcells4 fw-wrap">
+                        <div class="d-flex gs4 flex__allitems4 fw-wrap">
                             <div class="flex--item stacks-flex-example--item">.flex--item</div>
                             <div class="flex--item stacks-flex-example--item">.flex--item</div>
                             <div class="flex--item stacks-flex-example--item">.flex--item</div>
@@ -305,7 +305,7 @@ description: Stacks provides extensive utility and helper classes for flex layou
         <div class="stacks-preview--example">
             <div class="d-flex gs32 gsy fd-column">
                 <div class="flex--item bg-orange-050">
-                    <div class="d-flex flex__allcells6 gs16 fw-wrap">
+                    <div class="d-flex flex__allitems6 gs16 fw-wrap">
                         <div class="flex--item"><div class="stacks-flex-example--item">.gs16</div></div>
                         <div class="flex--item"><div class="stacks-flex-example--item">.gs16</div></div>
                         <div class="flex--item"><div class="stacks-flex-example--item">.gs16</div></div>
@@ -313,7 +313,7 @@ description: Stacks provides extensive utility and helper classes for flex layou
                     </div>
                 </div>
                 <div class="flex--item bg-orange-050">
-                    <div class="d-flex flex__allcells6 gs16 gsx fw-wrap">
+                    <div class="d-flex flex__allitems6 gs16 gsx fw-wrap">
                         <div class="flex--item"><div class="stacks-flex-example--item">.gs16.gsx -- Row gutters only</div></div>
                         <div class="flex--item"><div class="stacks-flex-example--item">.gs16.gsx -- Row gutters only</div></div>
                         <div class="flex--item"><div class="stacks-flex-example--item">.gs16.gsx -- Row gutters only</div></div>

--- a/docs/product/base/overflow.html
+++ b/docs/product/base/overflow.html
@@ -41,7 +41,7 @@ description: Atomic overflow classes allow you to change an element’s overflow
 <div class="overflow-visible">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example overflow-x-auto fs-caption ff-mono">
-            <div class="d-flex flex__allcells3 gs16 fw-wrap wmn7">
+            <div class="d-flex flex__allitems3 gs16 fw-wrap wmn7">
                 <div class="flex--item bg-black-050 p12 ba bc-black-3 ws-nowrap overflow-auto hs2">
                     <div class="mb12">.overflow-auto</div>
                     <div class="bg-black-075 ba baw1 bc-black-3 hs2 ws2"></div>

--- a/docs/product/components/popovers.html
+++ b/docs/product/components/popovers.html
@@ -655,7 +655,7 @@ Stacks.setTooltipHtml(el,
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example bg-black-025">
-            <div class="d-flex gs16 flex__allcells4 fw-wrap">
+            <div class="d-flex gs16 flex__allitems4 fw-wrap">
                 <div class="flex--item">
                     <div class="s-popover ps-relative z-base is-visible">
                         <div class="s-popover--arrow s-popover--arrow__tc"></div>

--- a/docs/product/components/sidebar-widgets.html
+++ b/docs/product/components/sidebar-widgets.html
@@ -281,7 +281,7 @@ description: Sidebar widgets are flexible containers that provide a lot of patte
 <div class="s-sidebarwidget s-sidebarwidget__blue">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example overflow-x-auto">
-            <div class="d-flex flex__allcells6 gs16 md:fd-column">
+            <div class="d-flex flex__allitems6 gs16 md:fd-column">
                 <div class="flex--item">
                     <div class="s-sidebarwidget s-sidebarwidget__yellow">
                         <div class="s-sidebarwidget--header s-sidebarwidget__small-bold-text">Featured on Meta</div>

--- a/docs/product/resources/icons.html
+++ b/docs/product/resources/icons.html
@@ -103,7 +103,7 @@ description: Stacks provides a complete icon set, managed separately in the <a h
         <button class="s-btn s-btn__filled ws-nowrap js-color-toggle-btn ml8">Toggle native colors</button>
         {% icon "Search", "s-input-icon s-input-icon__search" %}
     </div>
-    <div class="d-flex fw-wrap sm:fd-column gs16 flex__allcells4 list js-icon-list">
+    <div class="d-flex fw-wrap sm:fd-column gs16 flex__allitems4 list js-icon-list">
         {% for iconName in stacks-icons.icons %}
             <div class="flex--item">
                 <div id="{{ iconName | downcase }}" class="d-flex fd-column p0 s-card stacks-icon-container">

--- a/docs/product/resources/spots.html
+++ b/docs/product/resources/spots.html
@@ -52,7 +52,7 @@ description: Spot illustrations are the slightly grown up version of icons with 
         <input type="text" class="flex--item fuzzy-search s-input s-input__search" placeholder="Search spot illustrations…" />
         {% icon "Search", "s-input-icon s-input-icon__search" %}
     </div>
-    <div class="d-flex fw-wrap sm:fd-column gs16 flex__allcells4 list js-icon-list">
+    <div class="d-flex fw-wrap sm:fd-column gs16 flex__allitems4 list js-icon-list">
         {% for spotName in stacks-icons.spots %}
             <div class="flex--item">
                 <div id="{{ spotName | downcase }}" class="d-flex fd-column p0 s-card h100 stacks-icon-container">

--- a/lib/css/atomic/_stacks-flex.less
+++ b/lib/css/atomic/_stacks-flex.less
@@ -29,7 +29,6 @@
         #stacks-internals #grid-builder-settings();
 
         .create-fixed-cells(@num, @count: 1) when (@count =< @num) {
-            .grid--cell@{count},
             .flex--item@{count} {
                 flex-basis: ((@count * 100%) / @num);
             }
@@ -45,11 +44,8 @@
         //      all child elements will automatically be sized.
         //  ----------------------------------------------------------------------------
         .create-grid-count-cols(@num, @count: 1) when (@count =< @num) {
-            .grid__allcells@{count},
             .flex__allcells@{count} {
-                > .grid,
                 > .d-flex,
-                > .grid--cell,
                 > .flex--item {
                     flex-basis: ((@count * 100%) / @num);
                 }
@@ -106,7 +102,6 @@
         .grid-fixed-cell-spacing(@spacing, @num, @count: 1) when (@count =< @num) {
             @cell-width: (@count * 100% / @num);
 
-            > .grid--cell@{count},
             > .flex--item@{count} {
                 margin: (@spacing / 2);
             }
@@ -116,16 +111,13 @@
             //      This makes the fixed width cells to account for gutters.
             //
             //  [2] UNIFORM CHILD GRID CELLS
-            //      This class allows you to uniformly state the width of `.grid--cell`
-            //      divs within a `.grid` element. In particular we adjust the flex-basis
+            //      This class allows you to uniformly state the width of `.flex--item`
+            //      divs within a `.d-flex` element. In particular we adjust the flex-basis
             //      and max-width here to account for gutters.
             //  ------------------------------------------------------------------------
-            > .grid--cell@{count},                                  // [1]
-            > .flex--item@{count},
-            &.grid__allcells@{count} > .grid,                       // [2]
-            &.flex__allcells@{count} > .d-flex,
-            &.grid__allcells@{count} > .grid--cell,                 // [2]
-            &.flex__allcells@{count} > .flex--item {
+            > .flex--item@{count},                                  // [1]
+            &.flex__allcells@{count} > .d-flex,                     // [2]
+            &.flex__allcells@{count} > .flex--item {                // [2]
                 flex-basis: calc(~"@{cell-width} - @{spacing}");
             }
 
@@ -149,9 +141,7 @@
             margin: -(@spacing / 2);
 
             //  --  FLUID CELLS
-            > .grid,
             > .d-flex,
-            > .grid--cell,
             > .flex--item {
                 margin: (@spacing / 2);
             }
@@ -164,51 +154,30 @@
     }
 }
 
-
-//  ============================================================================
-//  $   GRID ELEMENTS
-//  ============================================================================
-//      To help simplify our CSS, we create a generic box container. By default
-//      this is a row container, but we can modify the box to become a column.
-//  ----------------------------------------------------------------------------
-.grid {
-    display: flex;
-}
-
 //  --  UNIVERSAL FLEX WIDTHS
 //      This applies a flex value it to all of a grid's direct children.
 //  --------------------------------------------------------------------------
-.grid__fl0,
 .flex__fl0,
-.grid__fl-shrink0,
 .flex__fl-shrink0 {
     &,
-    > .grid,
     > .d-flex,
-    > .grid--cell,
     > .flex--item {
         flex: 0 auto;
     }
 }
 
-.grid__fl-equal,
 .flex__fl-equal {
     &,
-    > .grid,
     > .d-flex,
-    > .grid--cell,
     > .flex--item {
         flex: 1 1 0%;
     }
 }
 
-// Deprecated in favor of .flex__fl-equal
-.grid__fl1,
-.flex__fl1 {
+.flex__fl1,
+.flex__fl-grow1 {
     &,
-    > .grid,
     > .d-flex,
-    > .grid--cell,
     > .flex--item {
         flex: 1 auto;
     }
@@ -243,9 +212,7 @@
 //  On rows, remove top and bottom margins
 .gsx {
     &,
-    > .grid,
     > .d-flex,
-    > [class*="grid--cell"],
     > [class*="flex--item"] {
         margin-top: 0;
         margin-bottom: 0;
@@ -255,9 +222,7 @@
 //  On columns, remove left and right margins
 .gsy {
     &,
-    > .grid,
     > .d-flex,
-    > [class*="grid--cell"],
     > [class*="flex--item"] {
         margin-right: 0;
         margin-left: 0;
@@ -325,7 +290,6 @@
 //      A common combination of classes is .jc-center and .ai-center.
 //      Use this class when you want both.
 //  ----------------------------------------------------------------------------
-.grid__center,
 .flex__center {
     .jc-center;
     .ai-center;

--- a/lib/css/atomic/_stacks-flex.less
+++ b/lib/css/atomic/_stacks-flex.less
@@ -9,54 +9,55 @@
 //  TABLE OF CONTENTS
 //  • VARIABLES
 //  • MIXINS
-//  • GRID ELEMENTS
-//  • GRID SPACING
+//  • FLEX ELEMENTS
+//  • FLEX SPACING
 //  • MODIFICATIONS
 //  • ATOMIC
 //  • DEPRECATED
 //
 //  ============================================================================
-//  --  STACKS GRID MIXINS
+//  --  STACKS FLEX LAYOUT MIXINS
 //  ============================================================================
 //  --  FIXED COLUMN WIDTHS
 //  ----------------------------------------------------------------------------
 
 #stacks-internals() {
-    #grid-builder-settings() {
-        @grid-cols: 12; // Desired grid columns
+    #flex-builder-settings() {
+        @flex-cols: 12; // Desired flex columns
     }
-    #grid-builder-helpers() {
-        #stacks-internals #grid-builder-settings();
+    #flex-builder-helpers() {
+        #stacks-internals #flex-builder-settings();
 
-        .create-fixed-cells(@num, @count: 1) when (@count =< @num) {
+        .create-fixed-items(@num, @count: 1) when (@count =< @num) {
             .flex--item@{count} {
                 flex-basis: ((@count * 100%) / @num);
             }
 
-            #stacks-internals #grid-builder-helpers .create-fixed-cells(@num, (@count + 1));
+            #stacks-internals #flex-builder-helpers .create-fixed-items(@num, (@count + 1));
         }
 
-        //  --  AUTO FIXED WIDTH CELLS
-        //      Automatic adjusting width cells are great. And being able to specify a
-        //      cell's width is equally amazing. But sometimes you want to be able to
-        //      have all cell's within a box container to be the same width. Instead
-        //      stating a fixed cell width, apply a modifying to the box container and
+        //  --  AUTO FIXED WIDTH ITEMS
+        //      Automatic adjusting width items are great. And being able to specify an
+        //      item's width is equally amazing. But sometimes you want to be able to
+        //      have all items within a box container to be the same width. Instead
+        //      stating a fixed item width, apply a modifying to the box container and
         //      all child elements will automatically be sized.
         //  ----------------------------------------------------------------------------
-        .create-grid-count-cols(@num, @count: 1) when (@count =< @num) {
-            .flex__allcells@{count} {
+        .create-flex-count-cols(@num, @count: 1) when (@count =< @num) {
+            .flex__allcells@{count},
+            .flex__allitems@{count} {
                 > .d-flex,
                 > .flex--item {
                     flex-basis: ((@count * 100%) / @num);
                 }
             }
 
-            #stacks-internals #grid-builder-helpers .create-grid-count-cols(@num, (@count + 1));
+            #stacks-internals #flex-builder-helpers .create-flex-count-cols(@num, (@count + 1));
         }
 
-        //  --  GRID GUTTERS
+        //  --  FLEX GUTTERS
         //  ============================================================================
-        //      We need two mixins to properly generate grid gutters:
+        //      We need two mixins to properly generate flex gutters:
         //
         //      [1]  Adjusts the fixed column max-width / flex-basis if gutters are present.
         //      [2]  Generate the desired gutters.
@@ -66,7 +67,7 @@
         //
         //      HOW IT WORKS:
         //      A quick primer on how this mixin works. The TL;DR is we're using a mixin
-        //      guard to start a loop that'll create all the desired `> .grid--cell@{count}`
+        //      guard to start a loop that'll create all the desired `> .flex--item@{count}`
         //      classes.
         //
         //      The three mixin parameters are:
@@ -82,10 +83,10 @@
         //      it's checking to see if the current @count is equal to (=) or less
         //      than (<) the desired @num total. If it is, run the mixin.
         //
-        //      Next the mixin runs as normal. Using the @cell-width variable, we
-        //      calculate the cell's width. We do this here because we need to use the
+        //      Next the mixin runs as normal. Using the @item-width variable, we
+        //      calculate the item's width. We do this here because we need to use the
         //      CSS calc function and this makes the code a little prettier. Using the
-        //      variable, we then update the fixed cell's flex-basis and width.
+        //      variable, we then update the fixed item's flex-basis and width.
         //
         //      Finally we call for the mixin again within itself, assigning a new
         //      @count value: the current value + 1. This then fires off the mixin
@@ -93,42 +94,44 @@
         //      of our desired @num.
         //
         //      There are two mixins here:
-        //          • "grid-fixed-cell-row" -- This is the baseline mixin.
-        //          • "grid-fixed-cell-column" -- When the ".grid" is a column, change
+        //          • "flex-fixed-item-row" -- This is the baseline mixin.
+        //          • "flex-fixed-item-column" -- When the ".d-flex" is a column, change
         //             the margins, setting a top and bottom margin instead of left
         //             and right.
         //
         //  ----------------------------------------------------------------------------
-        .grid-fixed-cell-spacing(@spacing, @num, @count: 1) when (@count =< @num) {
-            @cell-width: (@count * 100% / @num);
+        .flex-fixed-item-spacing(@spacing, @num, @count: 1) when (@count =< @num) {
+            @item-width: (@count * 100% / @num);
 
             > .flex--item@{count} {
                 margin: (@spacing / 2);
             }
 
             //  ------------------------------------------------------------------------
-            //  [1] FIXED WIDTH CELLS
-            //      This makes the fixed width cells to account for gutters.
+            //  [1] FIXED WIDTH ITEMS
+            //      This makes the fixed width items to account for gutters.
             //
-            //  [2] UNIFORM CHILD GRID CELLS
+            //  [2] UNIFORM CHILD FLEX ITEMS
             //      This class allows you to uniformly state the width of `.flex--item`
             //      divs within a `.d-flex` element. In particular we adjust the flex-basis
             //      and max-width here to account for gutters.
             //  ------------------------------------------------------------------------
             > .flex--item@{count},                                  // [1]
             &.flex__allcells@{count} > .d-flex,                     // [2]
-            &.flex__allcells@{count} > .flex--item {                // [2]
-                flex-basis: calc(~"@{cell-width} - @{spacing}");
+            &.flex__allitemss@{count} > .d-flex,                    // [2]
+            &.flex__allcells@{count} > .flex--item                  // [2]
+            &.flex__allitems@{count} > .flex--item {                // [2]
+                flex-basis: calc(~"@{item-width} - @{spacing}");
             }
 
-            #stacks-internals #grid-builder-helpers .grid-fixed-cell-spacing(@spacing, @num, (@count + 1));
+            #stacks-internals #flex-builder-helpers .flex-fixed-item-spacing(@spacing, @num, (@count + 1));
         }
 
 
         //  ----------------------------------------------------------------------------
         //      2.  Generate the desired gutters
         //          We halve the spacing value because the spacing value should be the
-        //          total space between cells--not the total applied to each cell,
+        //          total space between items--not the total applied to each item,
         //          which would effectively double the desired total.
         //
         //          The "when" statements here refer to when we declare it's for a
@@ -136,26 +139,26 @@
         //          left and right margins and add in top and bottom margins.
         //  ----------------------------------------------------------------------------
         .gutter-spacing(@spacing) {
-            #stacks-internals #grid-builder-settings();
+            #stacks-internals #flex-builder-settings();
 
             margin: -(@spacing / 2);
 
-            //  --  FLUID CELLS
+            //  --  FLUID ITEMS
             > .d-flex,
             > .flex--item {
                 margin: (@spacing / 2);
             }
 
-            //  --  FIXED WIDTH CELLS
+            //  --  FIXED WIDTH ITEMS
             //      Now we call for the above mixin [1] to make sure we adjust the default
             //      widths for the new gutters.
-            #stacks-internals #grid-builder-helpers .grid-fixed-cell-spacing(@spacing, @grid-cols);
+            #stacks-internals #flex-builder-helpers .flex-fixed-item-spacing(@spacing, @flex-cols);
         }
     }
 }
 
 //  --  UNIVERSAL FLEX WIDTHS
-//      This applies a flex value it to all of a grid's direct children.
+//      This applies a flex value it to all of a flex's direct children.
 //  --------------------------------------------------------------------------
 .flex__fl0,
 .flex__fl-shrink0 {
@@ -184,30 +187,30 @@
 }
 
 & {
-    #stacks-internals #grid-builder-settings(); // load @grid-cols
+    #stacks-internals #flex-builder-settings(); // load @flex-cols
 
-    //  $$  FIXED WIDTH CELLS
+    //  $$  FIXED WIDTH ITEMS
     //  ----------------------------------------------------------------------------
-    #stacks-internals #grid-builder-helpers .create-fixed-cells(@grid-cols);
+    #stacks-internals #flex-builder-helpers .create-fixed-items(@flex-cols);
 
-    //  $$  AUTO FIXED WIDTH CELLS
+    //  $$  AUTO FIXED WIDTH ITEMS
     //  ----------------------------------------------------------------------------
-    #stacks-internals #grid-builder-helpers .create-grid-count-cols(@grid-cols);
+    #stacks-internals #flex-builder-helpers .create-flex-count-cols(@flex-cols);
 }
 //  ============================================================================
-//  $   GRID SPACING
-//      Insert spaces or gutters in between grid cells
+//  $   FLEX SPACING
+//      Insert spaces or gutters in between flex items
 //  ----------------------------------------------------------------------------
-.gs2 { #stacks-internals #grid-builder-helpers .gutter-spacing(@su2); }
-.gs4 { #stacks-internals #grid-builder-helpers .gutter-spacing(@su4); }
-.gs6 { #stacks-internals #grid-builder-helpers .gutter-spacing(@su6); }
-.gs8 { #stacks-internals #grid-builder-helpers .gutter-spacing(@su8); }
-.gs12 { #stacks-internals #grid-builder-helpers .gutter-spacing(@su12); }
-.gs16 { #stacks-internals #grid-builder-helpers .gutter-spacing(@su16); }
-.gs24 { #stacks-internals #grid-builder-helpers .gutter-spacing(@su24); }
-.gs32 { #stacks-internals #grid-builder-helpers .gutter-spacing(@su32); }
-.gs48 { #stacks-internals #grid-builder-helpers .gutter-spacing(@su48); }
-.gs64 { #stacks-internals #grid-builder-helpers .gutter-spacing(@su64); }
+.gs2 { #stacks-internals #flex-builder-helpers .gutter-spacing(@su2); }
+.gs4 { #stacks-internals #flex-builder-helpers .gutter-spacing(@su4); }
+.gs6 { #stacks-internals #flex-builder-helpers .gutter-spacing(@su6); }
+.gs8 { #stacks-internals #flex-builder-helpers .gutter-spacing(@su8); }
+.gs12 { #stacks-internals #flex-builder-helpers .gutter-spacing(@su12); }
+.gs16 { #stacks-internals #flex-builder-helpers .gutter-spacing(@su16); }
+.gs24 { #stacks-internals #flex-builder-helpers .gutter-spacing(@su24); }
+.gs32 { #stacks-internals #flex-builder-helpers .gutter-spacing(@su32); }
+.gs48 { #stacks-internals #flex-builder-helpers .gutter-spacing(@su48); }
+.gs64 { #stacks-internals #flex-builder-helpers .gutter-spacing(@su64); }
 
 //  On rows, remove top and bottom margins
 .gsx {


### PR DESCRIPTION
A bit more housekeeping around the grid rename / deprecation. This removes the `grid` and `grid--cell` classes. It also deprecates `flex__allcells[x]` and introduces `flex__allitems[x]` while cleaning up internal documentation and variables.

These can all be deleted since we're shipping that old grid shim in `0.69.0`