### PR TITLE
Add a navigation dropdown

### DIFF
--- a/docs/_data/navigation.json
+++ b/docs/_data/navigation.json
@@ -34,6 +34,11 @@
       "class": ".is-selected",
       "applies": "<code class=\"stacks-code\">.s-navigation--item</code>",
       "description": "Applies to a navigation item that’s currently selected / active"
+    },
+    {
+      "class": ".s-navigation--item__dropdown",
+      "applies": "<code class=\"stacks-code\">.s-navigation--item</code>",
+      "description": "Adds a small caret that indicates a dropdown"
     }
   ]
 }

--- a/docs/product/components/navigation.html
+++ b/docs/product/components/navigation.html
@@ -176,7 +176,7 @@ description: Our navigation component is a collection of pill-shaped buttons tha
                     <li><a href="#" class="s-navigation--item">Email</a></li>
                     <li><a href="#" class="s-navigation--item">Content</a></li>
                     <li><a href="#" class="s-navigation--item">Brand</a></li>
-                    <li><a href="#" class="s-navigation--item s-navigation--item__dropdown">Marketing</a></li>
+                    <li><a href="#" class="s-navigation--item">Marketing</a></li>
                 </ul>
             </nav>
         </div>

--- a/docs/product/components/navigation.html
+++ b/docs/product/components/navigation.html
@@ -134,6 +134,28 @@ description: Our navigation component is a collection of pill-shaped buttons tha
         </div>
     </div>
 
+    {% header "h3", "Dropdown" %}
+    <div class="stacks-preview">
+{% highlight html %}
+<nav>
+    <ul class="s-navigation s-navigation__scroll">
+        <li><a href="…" class="s-navigation--item is-selected">…</a></li>
+        <li><a href="…" class="s-navigation--item">…</a></li>
+        <li><a href="…" class="s-navigation--item s-navigation--item__dropdown">…</a></li>
+    </ul>
+</nav>
+{% endhighlight %}
+        <div class="stacks-preview--example">
+            <nav class="wmx3">
+                <ul class="s-navigation s-navigation__scroll">
+                    <li><a href="#" class="s-navigation--item is-selected">Product</a></li>
+                    <li><a href="#" class="s-navigation--item">Email</a></li>
+                    <li><a href="#" class="s-navigation--item s-navigation--item__dropdown">More</a></li>
+                </ul>
+            </nav>
+        </div>
+    </div>
+
     {% header "h3", "Small" %}
     <div class="stacks-preview">
 {% highlight html %}
@@ -154,7 +176,7 @@ description: Our navigation component is a collection of pill-shaped buttons tha
                     <li><a href="#" class="s-navigation--item">Email</a></li>
                     <li><a href="#" class="s-navigation--item">Content</a></li>
                     <li><a href="#" class="s-navigation--item">Brand</a></li>
-                    <li><a href="#" class="s-navigation--item">Marketing</a></li>
+                    <li><a href="#" class="s-navigation--item s-navigation--item__dropdown">Marketing</a></li>
                 </ul>
             </nav>
         </div>

--- a/lib/css/components/_stacks-navigation.less
+++ b/lib/css/components/_stacks-navigation.less
@@ -26,6 +26,7 @@
         display: flex;
         align-items: center;
         padding: @su6 @su12;
+        position: relative;
 
         // Reset some things for when the navigation item is also a button
         border: none;
@@ -49,6 +50,24 @@
         &.is-selected {
             background: var(--theme-primary-color);
             color: var(--white);
+        }
+
+        &.s-navigation--item__dropdown {
+            padding-right: 2em;
+
+            &:after {
+                content: "";
+                position: absolute;
+                z-index: @zi-active;
+                top: calc(50% - 2px);
+                right: 0.9em;
+                border-style: solid;
+                border-width: @su4;
+                border-top-width: @su4;
+                border-bottom-width: 0;
+                border-color: currentColor transparent;
+                pointer-events: none;
+            }
         }
     }
 
@@ -98,6 +117,10 @@
         .s-navigation--item {
             padding: @su4 @su12;
             font-size: @fs-caption;
+
+            &.s-navigation--item__dropdown {
+                padding-right: 2em;
+            }
         }
     }
 }


### PR DESCRIPTION
Look, sometimes you just have so many links you've gotta drop a bunch of them into a `More` button and call it a day. I don't make the rules.

This can be done responsively, wrapping any of those last elements in an `s-menu`.

<img width="546" alt="image" src="https://user-images.githubusercontent.com/1369864/129214155-fc50c387-8608-4b79-b305-5dc9e515c019.png">