### PR TITLE
Control word wrapping in navigations

### DIFF
--- a/lib/css/components/_stacks-navigation.less
+++ b/lib/css/components/_stacks-navigation.less
@@ -36,6 +36,7 @@
         user-select: auto;
         border-radius: 1000px;
         margin: @su2;
+        white-space: nowrap;
         color: var(--black-600);
 
         &:hover,
@@ -66,6 +67,7 @@
 
         .s-navigation--item {
             margin: 0;
+            white-space: normal;
         }
     }
 


### PR DESCRIPTION
This makes sure that our words don't wrap in horizontal navigations. This becomes especially important if you force scrolling