### PR TITLE
Responsify .bg-inherit

### DIFF
--- a/lib/css/atomic/_stacks-colors.less
+++ b/lib/css/atomic/_stacks-colors.less
@@ -200,9 +200,7 @@
     background-image: none !important;
 }
 
-.bg-inherit {
-    background-color: inherit !important;
-}
+#stacks-internals #responsify('.bg-inherit', { background-color: inherit !important; });
 
 .fc-inherit {
     color: inherit !important;


### PR DESCRIPTION
This came up today in a profiles refactor as a way to remove a background color at a smaller breakpoint.