### PR TITLE
Additional staff / moderator badge tweaks

### DIFF
--- a/lib/css/components/_stacks-badges.less
+++ b/lib/css/components/_stacks-badges.less
@@ -118,10 +118,10 @@
 //  $$  Users
 //  ---------------------------------------------------------------------------
 .s-badge__admin {
-    .badge-styles(transparent, var(--theme-primary-075), var(--theme-primary-800));
+    .badge-styles(var(--theme-primary-200), var(--theme-primary-075), var(--theme-primary-800));
 }
 .s-badge__moderator {
-    .badge-styles(transparent, var(--theme-secondary-075), var(--theme-secondary-800));
+    .badge-styles(var(--theme-secondary-200), var(--theme-secondary-075), var(--theme-secondary-800));
 
     &:before {
         --s-badge-moderator-icon: url("data:image/svg+xml,%3Csvg width='12' height='14' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.528.746c.257-.329.675-.327.93 0l4.42 5.66c.258.329.257.864 0 1.192l-4.42 5.66c-.256.328-.674.327-.93 0l-4.42-5.66c-.257-.329-.256-.865 0-1.192l4.42-5.66z' fill='%23fff'/%3E%3C/svg%3E");
@@ -159,7 +159,7 @@
 }
 .s-badge__staff {
     // Staff badges are always "Stack Overflow Orange"
-    .badge-styles(transparent, var(--orange-100), var(--orange-900));
+    .badge-styles(var(--orange-200), var(--orange-100), var(--orange-900));
 }
 
 //  $$  Award Count

--- a/lib/css/components/_stacks-badges.less
+++ b/lib/css/components/_stacks-badges.less
@@ -150,7 +150,7 @@
     }
 
     &.s-badge__xs:before {
-        --s-badge-moderator-icon: url("data:image/svg+xml,%3Csvg width='7' height='9' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2.798.246c.3-.329 1.1-.327 1.399 0l2.579 3.66c.3.329.298.864 0 1.192L4.196 8.75c-.299.329-1.1.327-1.398 0L.224 5.098a.904.904 0 010-1.192L2.798.246z' fill='%23fff'/%3E%3C/svg%3E");
+        --s-badge-moderator-icon: url("data:image/svg+xml,%3Csvg width='7' height='9' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3 .246c.3-.329.701-.327 1 0L6.776 4c.3.329.298.672 0 1L4 8.75c-.299.329-.702.327-1 0L.224 5c-.284-.324-.285-.675 0-1L3 .246z' fill='%23fff'/%3E%3C/svg%3E");
 
         width: 7px;
         height: 9px;


### PR DESCRIPTION
This improves the rendering of the moderator badge when it's against a background of similar color. It also sharpens up the tiniest `s-badge__xs` diamond.