### PR TITLE
Kill some Less color vars

### DIFF
--- a/lib/css/exports/_stacks-constants-colors.less
+++ b/lib/css/exports/_stacks-constants-colors.less
@@ -368,9 +368,9 @@
 
     // Focus rings
     --focus-ring-success: hsla(@green-h, 40%, 75%, 40%);
-    --focus-ring-warning: hsla(@yellow-h, 79%, 58%);
-    --focus-ring-error: hsla(@red-h, 62%, 47%);
-    --focus-ring-muted: hsla(@black-h, @black-s, 15%);
+    --focus-ring-warning: hsla(@yellow-h, 79%, 58%, 40%);
+    --focus-ring-error: hsla(@red-h, 62%, 47%, 15%);
+    --focus-ring-muted: hsla(@black-h, @black-s, 15%, 10%);
 
     // Shadows
     --bs-sm: @bs-sm;
@@ -566,9 +566,9 @@
 
     // Focus rings
     --focus-ring-success: hsla(@green-h, 40%, 75%, 40%);
-    --focus-ring-warning: hsla(@yellow-h, 79%, 58%, 0.4);
-    --focus-ring-error: hsla(@red-h, 62%, 52%, 0.3);
-    --focus-ring-muted: hsla(@black-h, @black-s, 100%, 0.1);
+    --focus-ring-warning: hsla(@yellow-h, 79%, 58%, 40%);
+    --focus-ring-error: hsla(@red-h, 62%, 52%, 30%);
+    --focus-ring-muted: hsla(@black-h, @black-s, 100%, 10%);
 
     // Shadows
     --bs-sm: 0 1px 2px hsla(0, 0%, 0%, 0.1), 0 1px 4px hsla(0, 0%, 0%, 0.1), 0 2px 8px hsla(0, 0%, 0%, 0.1);

--- a/lib/css/exports/_stacks-constants-colors.less
+++ b/lib/css/exports/_stacks-constants-colors.less
@@ -374,7 +374,7 @@
 
     // Syntax highlighting
     --highlight-bg: hsl(0, 0%, 96.5%); // Between black-025 and black-050
-    --highlight-color: @black-750; // AAA 11.78
+    --highlight-color: var(--black-750); // AAA 11.78
     --highlight-comment: hsl(@black-h, 8%, 43.5%); // ~black-500 AA 4.80
     --highlight-punctuation: var(--black-600); // AA 6.48
     --highlight-namespace: hsl(@orange-h, 99%, 36%); // Custom orange AA 4.51
@@ -383,8 +383,8 @@
     --highlight-symbol: hsl(306, 43%, 35%); // Custom purple AAA 7.30
     --highlight-keyword: hsl(@blue-h, 98.5%, 29%); // Custom blue AAA 7.07
     --highlight-variable: hsl(80, 80.5%, 26.5%); // Custom green AAA 7.25
-    --highlight-addition: @green-700; // AA 5.59
-    --highlight-deletion: @red-600; // AA 5.31
+    --highlight-addition: var(--green-700); // AA 5.59
+    --highlight-deletion: var(--red-600); // AA 5.31
 }
 
 .light-themed-colors() {
@@ -564,7 +564,7 @@
 
     // Syntax highlighting
     --highlight-bg: hsl(0, 2%, 11%);
-    --highlight-color: @white; // AAA 17.19
+    --highlight-color: var(--black); // AAA 17.19
     --highlight-comment: hsl(0, 0%, 60%); // AA 6.03
     --highlight-punctuation: hsl(0, 0%, 80%); // AAA 10.70
     --highlight-namespace: hsl(@orange-h, 85%, 61.5%); // Custom orange AAA 7.05

--- a/lib/css/exports/_stacks-constants-colors.less
+++ b/lib/css/exports/_stacks-constants-colors.less
@@ -143,14 +143,6 @@
 @bronze-lighter: hsl(@bronze-h, 40%, 92%);
 @bronze-darker: hsl(@bronze-h, 31%, 52%);
 
-//  $  RINGS
-//  ----------------------------------------------------------------------------
-@focus-ring: fade(@blue-500, 15%);
-@focus-ring-success: fade(@green-200, 40%);
-@focus-ring-warning: fade(@yellow-400, 40%);
-@focus-ring-error: fade(@red-600, 15%);
-@focus-ring-muted: fade(@black-800, 10%);
-
 //  $  SHADOWS
 //  ----------------------------------------------------------------------------
 @bs-sm: 0 1px 2px hsla(0, 0, 0, 0.05), 0 1px 4px hsla(0, 0, 0, 0.05), 0 2px 8px hsla(0, 0, 0, 0.05);
@@ -367,10 +359,10 @@
     --fc-light: @black-500;
 
     // Focus rings
-    --focus-ring-success: @focus-ring-success;
-    --focus-ring-warning: @focus-ring-warning;
-    --focus-ring-error: @focus-ring-error;
-    --focus-ring-muted: @focus-ring-muted;
+    --focus-ring-success: hsla(@green-h, 40%, 75%, 40%);
+    --focus-ring-warning: hsla(@yellow-h, 79%, 58%);
+    --focus-ring-error: hsla(@red-h, 62%, 47%);
+    --focus-ring-muted: hsla(@black-h, @black-s, 15%);
 
     // Shadows
     --bs-sm: @bs-sm;
@@ -557,10 +549,10 @@
     --fc-light: var(--black-500);
 
     // Focus rings
-    --focus-ring-success: fade(@green-200, 40%);
-    --focus-ring-warning: fade(@yellow-400, 40%);
-    --focus-ring-error: fade(@red-500, 30%);
-    --focus-ring-muted: fade(@black-800, 10%);
+    --focus-ring-success: hsla(@green-h, 40%, 75%, 40%);
+    --focus-ring-warning: hsla(@yellow-h, 79%, 58%, 0.4);
+    --focus-ring-error: hsla(@red-h, 62%, 52%, 0.3);
+    --focus-ring-muted: hsla(@black-h, @black-s, 100%, 0.1);
 
     // Shadows
     --bs-sm: 0 1px 2px hsla(0, 0, 0, 0.1), 0 1px 4px hsla(0, 0, 0, 0.1), 0 2px 8px hsla(0, 0, 0, 0.1);


### PR DESCRIPTION
This PR moves us a tiny step closer to independence from Less.

- I got rid of any `@focus-ring` Less variables.
    - We only reference them in `_stacks-constants-colors.less`
- I updated the dark theme `--focus-ring-muted` value to be visible (thanks @allejo [for pointing out this issue](https://stackexchange.slack.com/archives/C27RWNQN9/p1631740546149600))
- I replaced `--highlight-*` references to Less color variables with CSS variables.