### PR TITLE
Add table layout atomic classes

### DIFF
--- a/docs/_data/tables.json
+++ b/docs/_data/tables.json
@@ -83,14 +83,6 @@
   ],
   "atomic": [
     {
-      "class": ".d-table",
-      "output": "display: table;"
-    },
-    {
-      "class": ".d-table-cell",
-      "output": "display: table-cell;"
-    },
-    {
       "class": ".tl-auto",
       "output": "table-layout: auto;"
     },

--- a/docs/_data/tables.json
+++ b/docs/_data/tables.json
@@ -80,5 +80,23 @@
       "applies": "td",
       "description": "Optionally use a custom value for sorting instead of the cell’s text content"
     }
+  ],
+  "atomic": [
+    {
+      "class": ".d-table",
+      "output": "display: table;"
+    },
+    {
+      "class": ".d-table-cell",
+      "output": "display: table-cell;"
+    },
+    {
+      "class": ".tl-auto",
+      "output": "table-layout: auto;"
+    },
+    {
+      "class": ".tl-fixed",
+      "output": "table-layout: fixed;"
+    }
   ]
 }

--- a/docs/product/components/tables.html
+++ b/docs/product/components/tables.html
@@ -1084,4 +1084,23 @@ description: Tables are used to list all information from a data set. The base s
             </table>
         </div>
     </div>
+
+    {% header "h2", "Atomic classes" %}
+    <p class="stacks-copy">Further control of table behavior is possible with atomic classes. For example, you can make non-table markup display as a table layout with <code class="stacks-code">.d-table</code> and <code class="stacks-code">.d-table-cell</code>.</p>
+    <table class="s-table s-table__bx-simple">
+        <thead>
+            <tr>
+                <th scope="col" class="s-table--cell3">Class</th>
+                <th scope="col">Output</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for item in tables.atomic %}
+            <tr>
+                <td><code class="stacks-code">{{ item.class }}</code></td>
+                <td class="ff-mono">{{ item.output }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
 </section>

--- a/docs/product/components/tables.html
+++ b/docs/product/components/tables.html
@@ -1086,7 +1086,7 @@ description: Tables are used to list all information from a data set. The base s
     </div>
 
     {% header "h2", "Atomic classes" %}
-    <p class="stacks-copy">Further control of table behavior is possible with atomic classes. For example, you can make non-table markup display as a table layout with <code class="stacks-code">.d-table</code> and <code class="stacks-code">.d-table-cell</code>.</p>
+    <p class="stacks-copy">Further control of table behavior is possible with atomic classes. For example, you can make non-table markup display as a table layout by pairing <code class="stacks-code">.d-table</code>, <code class="stacks-code">.d-table-cell</code> and <code class="stacks-code">.tl-fixed</code>.</p>
     <table class="s-table s-table__bx-simple">
         <thead>
             <tr>

--- a/lib/css/atomic/_stacks-misc.less
+++ b/lib/css/atomic/_stacks-misc.less
@@ -334,3 +334,9 @@
 // -- Delays
 .t-delay { transition-delay: 0.25s !important; }
 .t-delay-unset { transition-delay: 0s !important; }
+
+//  ============================================================================
+//  $  TABLE LAYOUT
+//  ----------------------------------------------------------------------------
+.tl-fixed { table-layout: fixed !important; }
+.tl-auto { table-layout: auto !important; }


### PR DESCRIPTION
This PR adds 2 table layout atomic classes while documenting the `display: table` on the tables page as well. They already appeared on the Display page, but the redundancy can't hurt.