### PR TITLE
Color `code` elements as links when they're links

### DIFF
--- a/docs/_includes/markdown-prose.md
+++ b/docs/_includes/markdown-prose.md
@@ -183,7 +183,7 @@ We also need to make sure inline code looks good, like if I wanted to talk about
 
 ### Sometimes I even use `code` in headings
 
-Another thing I’ve done in the past is put a `code` tag inside of a link, like if I wanted to tell you about the [`stackexchange/stacks`](https://github.com/stackexchange/stacks) repository. I don’t love that there is an underline below the backticks but it is absolutely not worth the madness it would require to avoid it.
+Another thing I’ve done in the past is put a `code` tag inside of a link, like if I wanted to tell you about the [`stackexchange/stacks`](https://github.com/stackexchange/stacks) repository.
 
 ### We still need to think about stacked headings though.
 

--- a/lib/css/components/_stacks-prose.less
+++ b/lib/css/components/_stacks-prose.less
@@ -431,6 +431,11 @@
         border-radius: @br-sm;
     }
 
+    // When contained within a link, we want the code to be link-colored
+    *:not(.s-code-block) > a code {
+        color: var(--theme-link-color);
+    }
+
     pre {
         margin-top: 0;
         margin-bottom: calc(var(--s-prose-spacing) + 0.4em); // Increase this spacing for better optical alignment


### PR DESCRIPTION
Tiny thing I noticed when looking at #9535. This makes code elements look like links when they're linked.