### PR TITLE
Add Stacks color stops indicators to /brand/data-visualization

### DIFF
--- a/docs/brand/data-visualization.html
+++ b/docs/brand/data-visualization.html
@@ -122,24 +122,30 @@ description: Tell a story with data visualizations. Use this section for guidanc
     {% header "h3", "Blue" %}
     <p class="stacks-copy">Useful for denoting neutral related metrics.</p>
 
-    <div class="overflow-hidden bar-lg ff-mono mb32">
-        <div style="background:#004487; color: rgb(255, 255, 255);" class="flex--item p12">
-            #004487
+    <div class="overflow-hidden bar-lg ff-mono mb32 theme-light__forced">
+        <div class="flex--item bg-blue-900 p12 fc-white d-flex jc-space-between">
+            <span>#004487</span>
+            <span>blue-900</span>
         </div>
-        <div style="background:#0077cc; color: rgb(255, 255, 255);" class="flex--item p12">
-            #0077cc
+        <div class="flex--item bg-blue-600 p12 fc-white d-flex jc-space-between">
+            <span>#0077cc</span>
+            <span>blue-600</span>
         </div>
-        <div style="background:#379fef; color: rgb(255, 255, 255);" class="flex--item p12">
-            #379fef
+        <div class="flex--item bg-blue-400 p12 fc-white d-flex jc-space-between">
+            <span>#379fef</span>
+            <span>blue-400</span>
         </div>
-        <div style="background:#0095ff; color: rgb(35, 38, 41);" class="flex--item p12">
-            #0095ff
+        <div class="flex--item bg-blue-500 p12 fc-dark d-flex jc-space-between">
+            <span>#0095ff</span>
+            <span>blue-500</span>
         </div>
-        <div style="background:#cfeafe; color: rgb(35, 38, 41);" class="flex--item p12">
-            #cfeafe
+        <div class="flex--item bg-blue-100 p12 fc-dark d-flex jc-space-between">
+            <span>#cfeafe</span>
+            <span>blue-100</span>
         </div>
-        <div style="background:#f2f9ff; color: rgb(35, 38, 41);" class="flex--item p12">
-            #f2f9ff
+        <div class="flex--item bg-blue-050 p12 fc-dark d-flex jc-space-between">
+            <span>#f2f9ff</span>
+            <span>blue-050</span>
         </div>
     </div>
 
@@ -151,72 +157,88 @@ description: Tell a story with data visualizations. Use this section for guidanc
     {% header "h3", "Green" %}
     <p class="stacks-copy">Useful for denoting positive related metrics.</p>
 
-    <div class="overflow-hidden bar-lg ff-mono mb32">
-        <div style="background:#1e472c; color: rgb(255, 255, 255);" class="flex--item p12">
-            #1e472c
+    <div class="overflow-hidden bar-lg ff-mono mb32 theme-light__forced">
+        <div class="flex--item p12 bg-green-900 fc-white d-flex jc-space-between">
+            <span>#1e472c</span>
+            <span>color-900</span>
         </div>
-        <div style="background:#29603b; color: rgb(255, 255, 255);" class="flex--item p12">
-            #29603b
+        <div class="flex--item p12 bg-green-800 fc-white d-flex jc-space-between">
+            <span>#29603b</span>
+            <span>color-800</span>
         </div>
-        <div style="background:#2f6f44; color: rgb(255, 255, 255);" class="flex--item p12">
-            #2f6f44
+        <div class="flex--item p12 bg-green-700 fc-white d-flex jc-space-between">
+            <span>#2f6f44</span>
+            <span>color-700</span>
         </div>
-        <div style="background:#48a868; color: rgb(35, 38, 41);" class="flex--item p12">
-            #48a868
+        <div class="flex--item p12 bg-green-500 fc-dark d-flex jc-space-between">
+            <span>#48a868</span>
+            <span>color-500</span>
         </div>
-        <div style="background:#a6d9b7; color: rgb(35, 38, 41);" class="flex--item p12">
-            #a6d9b7
+        <div class="flex--item p12 bg-green-200 fc-dark d-flex jc-space-between">
+            <span>#a6d9b7</span>
+            <span>color-200</span>
         </div>
-        <div style="background:#eef8f1; color: rgb(35, 38, 41);" class="flex--item p12">
-            #eef8f1
+        <div class="flex--item p12 bg-green-025 fc-dark d-flex jc-space-between">
+            <span>#eef8f1</span>
+            <span>color-025</span>
         </div>
     </div>
 
     {% header "h3", "Red" %}
     <p class="stacks-copy">Using for denoting negative metrics.</p>
 
-    <div class="overflow-hidden bar-lg ff-mono mb32">
-        <div style="background:#7a1819; color: rgb(255, 255, 255);" class="flex--item p12">
-            #7a1819
+    <div class="overflow-hidden bar-lg ff-mono mb32 theme-light__forced">
+        <div class="flex--item p12 bg-red-900 fc-white d-flex jc-space-between">
+            <span>#7a1819</span>
+            <span>red-900</span>
         </div>
-        <div style="background:#ac2726; color: rgb(255, 255, 255);" class="flex--item p12">
-            #ac2726
+        <div class="flex--item p12 bg-red-700 fc-white d-flex jc-space-between">
+            <span>#ac2726</span>
+            <span>red-700</span>
         </div>
-        <div style="background:#d1383d; color: rgb(255, 255, 255);" class="flex--item p12">
-            #d1383d
+        <div class="flex--item p12 bg-red-500 fc-white d-flex jc-space-between">
+            <span>#d1383d</span>
+            <span>red-500</span>
         </div>
-        <div style="background:#de535e; color: rgb(35, 38, 41);" class="flex--item p12">
-            #de535e
+        <div class="flex--item p12 bg-red-400 fc-dark d-flex jc-space-between">
+            <span>#de535e</span>
+            <span>red-400</span>
         </div>
-        <div style="background:#f4b4bb; color: rgb(35, 38, 41);" class="flex--item p12">
-            #f4b4bb
+        <div class="flex--item p12 bg-red-200 fc-dark d-flex jc-space-between">
+            <span>#f4b4bb</span>
+            <span>red-200</span>
         </div>
-        <div style="background:#fdf3f4; color: rgb(35, 38, 41);" class="flex--item p12">
-            #fdf3f4
+        <div class="flex--item p12 bg-red-050 fc-dark d-flex jc-space-between">
+            <span>#fdf3f4</span>
+            <span>red-050</span>
         </div>
     </div>
 
     {% header "h3", "Multi-colored" %}
     <p class="stacks-copy">Useful for denoting unrelated metrics.</p>
-    
-    <div class="overflow-hidden ff-mono mb32">
-        <div style="background:#27348b; color: rgb(255, 255, 255);" class="flex--item p12 mb6 bar-lg">
-            #27348b
+
+    <div class="overflow-hidden ff-mono mb32 theme-light__forced">
+        <div style="background: #27348b;" class="flex--item p12 fc-white d-flex jc-space-between mb6 bar-lg">
+            <span>#27348b</span>
         </div>
-        <div style="background:#f2720c; color: rgb(35, 38, 41);" class="flex--item p12 mb6 bar-lg">
-            #f2720c
+        <div class="flex--item p12 bg-orange-500 fc-dark d-flex jc-space-between mb6 bar-lg">
+            <span>#f2720c</span>
+            <span>orange-500</span>
         </div>
-        <div style="background:#48a868; color: rgb(35, 38, 41);" class="flex--item p12 mb6 bar-lg">
-            #48a868
+        <div class="flex--item p12 bg-green-500 fc-dark d-flex jc-space-between mb6 bar-lg">
+            <span>#48a868</span>
+            <span>green-500</span>
         </div>
-        <div style="background:#379fef; color: rgb(35, 38, 41);" class="flex--item p12 mb6 bar-lg">
-            #379fef
+        <div class="flex--item p12 bg-blue-400 fc-dark d-flex jc-space-between mb6 bar-lg">
+            <span>#379fef</span>
+            <span>blue-400</span>
         </div>
-        <div style="background:#f7cc46; color: rgb(35, 38, 41);" class="flex--item p12 mb6 bar-lg">
-            #f7cc46
+        <div style="background: #f7cc46;" class="flex--item p12 fc-dark d-flex jc-space-between mb6 bar-lg">
+            <span>#f7cc46</span>
         </div>
-        <div style="background:#fee3cf; color: rgb(35, 38, 41);" class="flex--item p12 mb6 bar-lg">
-            #fee3cf
+        <div class="flex--item p12 bg-orange-100 fc-dark d-flex jc-space-between mb6 bar-lg">
+            <span>#fee3cf</span>
+            <span>orange-100</span>
         </div>
     </div>
 </section>


### PR DESCRIPTION
What it says in the title. With this extra data, developers won't need to manually match the values up when implementing in a web context.