### PR TITLE
Add answer previews to post summaries

### DIFF
--- a/docs/_data/post-summary.json
+++ b/docs/_data/post-summary.json
@@ -66,6 +66,16 @@
       "description": "An optional content excerpt truncated at 2 lines."
     },
     {
+      "class": ".s-post-summary--answer",
+      "applies": ".s-post-summary--content",
+      "description": "Adds blockquote styling and spacing for answer previews"
+    },
+    {
+      "class": ".s-post-summary--answer-excerpt",
+      "applies": ".s-post-summary--content",
+      "description": "Provides padding, and truncation to 4 lines."
+    },
+    {
       "class": ".s-post-summary--content-menu-button",
       "applies": ".s-post-summary--content",
       "description": "An optional button for displaying a post-specific menu."

--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -415,6 +415,133 @@ description: The post summary component summarizes various content and associate
 </section>
 
 <section class="stacks-section">
+    {% header "h2", "Answers" %}
+    <p class="stacks-copy">Previews of answers can also be attached to the post summary as needed.</p>
+    <div class="stacks-preview">
+{% highlight html %}
+<div class="s-post-summary">
+    …
+    <div class="s-post-summary--content">
+        <a href="…" class="s-post-summary--content-title s-link">…</a>
+        <div class="s-post-summary--meta">…</div>
+
+        <div class="s-post-summary--answer">
+            <div class="s-post-summary--stats">
+                <div class="s-post-summary--stats-item has-answers has-accepted-answer">
+                    @Svg.CheckmarkSm.With("va-text-bottom") Accepted answer
+                </div>
+                <div class="s-post-summary--stats-item">
+                    … votes
+                </div>
+            </div>
+            <p class="s-post-summary--answer-excerpt">
+                …
+            </p>
+            <div class="s-post-summary--meta">
+                <a class="s-link" href="…">
+                    View answer
+                </a>
+
+                <div class="s-user-card s-user-card__minimal">
+                    <a href="…" class="s-avatar s-user-card--avatar">
+                        <img class="s-avatar--image" src="…" />
+                    </a>
+                    <a href="…" class="s-user-card--link">…</a>
+                    <time class="s-user-card--time">…</time>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endhighlight %}
+        <div class="stacks-preview--example p0">
+            <div class="s-post-summary">
+                <div class="s-post-summary--stats">
+                    <div class="s-post-summary--stats-item has-answers has-accepted-answer">
+                        {% icon "CheckmarkSm", "va-text-bottom" %} 2 answers
+                    </div>
+                    <div class="s-post-summary--stats-item">
+                        2 votes
+                    </div>
+                    <div class="s-post-summary--stats-item">
+                        1k views
+                    </div>
+                </div>
+                <div class="s-post-summary--content">
+                    <a class="s-post-summary--content-title s-link">
+                        Azure API Management and Backend Web API
+                    </a>
+                    <p class="s-post-summary--content-excerpt">
+                        Right now, I have enabled basic authentication to the developer portal in API Management. Also, I have enabled OAuth 2.0 authentication for the back end server (user Authorization). So, if i login to the developer portal, i can see two fields - Subscription Key and Authorization. The Subscription key will be the developer's subscription to the portal and the Authorization will be the OAuth authorization which is required for the back end server.
+                    </p>
+                    <div class="s-post-summary--meta">
+                        <div class="s-post-summary--meta-tags">
+                            <a class="s-tag" href="#">azure</a>
+                            <a class="s-tag" href="#">asp.net-web-api</a>
+                            <a class="s-tag" href="#">oauth-2.0</a>
+                            <a class="s-tag" href="#">azure-active-directory</a>
+                        </div>
+
+                        <div class="s-user-card s-user-card__minimal">
+                            <a href="…" class="s-avatar s-user-card--avatar">
+                                <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
+                            </a>
+                            <a href="#" class="s-user-card--link">karel</a>
+                            <time class="s-user-card--time">asked 3 minutes ago</time>
+                        </div>
+                    </div>
+                    <div class="s-post-summary--answer">
+                        <div class="s-post-summary--stats">
+                            <div class="s-post-summary--stats-item has-answers has-accepted-answer">
+                                {% icon "CheckmarkSm", "va-text-bottom" %} Accepted answer
+                            </div>
+                            <div class="s-post-summary--stats-item">
+                                2 votes
+                            </div>
+                        </div>
+                        <p class="s-post-summary--answer-excerpt">Subscription keys in APIM are tied to a user and product, thus if you change (or create new one) product to not require subscription (option available at creation time or in product settings) no subscription key would be needed to call any API included into such products. The downside is that all such calls would be treated by APIM as anonymous and shown in analytics as such.</p>
+                        <div class="s-post-summary--meta">
+                            <a class="s-link" href="#">
+                                View answer
+                            </a>
+
+                            <div class="s-user-card s-user-card__minimal">
+                                <a href="…" class="s-avatar s-user-card--avatar">
+                                    <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
+                                </a>
+                                <a href="#" class="s-user-card--link">Aaron Shekey</a>
+                                <time class="s-user-card--time">answered 1 minute ago</time>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="s-post-summary--answer">
+                        <div class="s-post-summary--stats">
+                            <div class="s-post-summary--stats-item">
+                                2 votes
+                            </div>
+                        </div>
+                        <p class="s-post-summary--answer-excerpt">Yeah, you can do that (a bit of a hack). You have to use REST Api for that, specifically this call. For me it didn't work to edit the existing API (they key was still there), but when I've created new API, key wasn't there:</p>
+                        <div class="s-post-summary--meta">
+                            <a class="s-link" href="#">
+                                View answer
+                            </a>
+
+                            <div class="s-user-card s-user-card__minimal">
+                                <a href="…" class="s-avatar s-user-card--avatar">
+                                    <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
+                                </a>
+                                <a href="#" class="s-user-card--link">4c74356b41</a>
+                                <time class="s-user-card--time">answered 3 minutes ago</time>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="stacks-section">
     {% header "h2", "Stats examples" %}
     {% header "h3", "Answered status" %}
     <p class="stacks-copy">Within the stats section of the post summary, posts can have various answered states. A checkmark icon is displayed in questions that have accepted answers.</p>

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -182,3 +182,42 @@
         margin-left: auto;
     }
 }
+
+.s-post-summary--answer {
+    position: relative;
+    margin: @su16 1em 0 1em;
+    padding: 0.5em 0 0.5em calc(1em + @su4);
+
+    + .s-post-summary--answer {
+        margin-top: @su16;
+    }
+
+    &:before {
+        content: "";
+        display: block;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: @su4;
+        border-radius: @su8;
+        background: var(--black-150);
+
+        .highcontrast-mode({
+            background: var(--black-600);
+        });
+    }
+
+    .s-post-summary--stats {
+        width: auto;
+        flex-direction: row;
+        align-items: center;
+        margin-bottom: @su4;
+    }
+
+    .s-post-summary--answer-excerpt {
+        color: var(--black-600);
+        margin-bottom: @su8;
+        .v-truncate4;
+    }
+}

--- a/lib/css/components/_stacks-prose.less
+++ b/lib/css/components/_stacks-prose.less
@@ -322,8 +322,8 @@
             top: 0;
             bottom: 0;
             left: 0;
-            width: 4px;
-            border-radius: 8px;
+            width: @su4;
+            border-radius: @su8;
             background: var(--black-150);
 
             .highcontrast-mode({


### PR DESCRIPTION
<img width="824" alt="image" src="https://user-images.githubusercontent.com/1369864/141396444-498ec9c7-0a82-410d-8f74-dc2be5432e75.png">

This lets us preview the content of answers alongside our post summaries. This work was punted on in #547 