### PR TITLE
Various buttons and links improvements

### DIFF
--- a/docs/_data/links.json
+++ b/docs/_data/links.json
@@ -34,6 +34,11 @@
       "class": ".s-link__visited",
       "applies": "all",
       "description": "Applies the hover / active state styling to links that have been visited."
+    },
+    {
+      "class": ".s-link__dropdown",
+      "applies": ".s-link",
+      "description": "Applies a caret for dropdowns and additional interactivity."
     }
   ],
   "descendent-anchors": [

--- a/docs/product/components/buttons.html
+++ b/docs/product/components/buttons.html
@@ -483,7 +483,7 @@ description: Buttons are user interface elements which allows users to take acti
                     <td class="va-middle">
                         <code class="flex--item stacks-code">.s-btn__link</code>
                     </td>
-                    <td class="va-middle">Styles a button element as though it were a link.</td>
+                    <td class="va-middle">Styles a button element as though it were a link. Instead of transforming an <code class="stacks-code">s-btn</code> to a link, you most likely want to style a <code class="stacks-code">button</code> as a <a href="{{ "/product/components/links/#single-link-examples" | relative_url }}">link</a>.</td>
                     <td class="va-middle"><button class="s-btn s-btn__link ws-nowrap" type="button">Link button</button></td>
                 </tr>
             </tbody>

--- a/docs/product/components/links.html
+++ b/docs/product/components/links.html
@@ -50,6 +50,7 @@ description: Links are lightly styled via the <code class="stacks-code">a</code>
                 <a class="flex--item s-link s-link__underlined" href="#">Underlined</a>
                 <button class="flex--item s-link">Button Link</button>
                 <a class="flex--item s-link s-link__visited" href="https://stackoverflow.design">Visited</a>
+                <a class="flex--item s-link s-link__dropdown" href="#">Links</a>
             </div>
         </div>
     </div>

--- a/docs/product/components/links.html
+++ b/docs/product/components/links.html
@@ -39,6 +39,7 @@ description: Links are lightly styled via the <code class="stacks-code">a</code>
 <a class="s-link s-link__underlined" href="#">Underlined</a>
 <button class="s-link">Button Link</button>
 <a class="s-link s-link__visited" href="#">Visited</a>
+<a class="s-link s-link__dropdown" href="#">Links</a>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="d-flex gs16 fw-wrap">

--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -576,6 +576,8 @@
         &:focus,
         &[disabled] {
             background: none;
+            box-shadow: none;
+        }
         }
     }
 

--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -585,6 +585,13 @@
             background: none;
             box-shadow: none;
         }
+
+        &.s-btn__dropdown {
+            padding-right: .9em;
+
+            &:after {
+                right: 0;
+            }
         }
     }
 

--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -401,7 +401,6 @@
             &:active {
                 color: @button-danger-filled-hover-color;
                 background-color: @button-danger-filled-hover-background-color;
-                box-shadow: 0 0 0 @su4 var(--focus-ring-error);
             }
 
             &:active {

--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -544,7 +544,8 @@
 
     .s-btn__unset,
     .s-btn__unset:hover,
-    .s-btn__unset:active {
+    .s-btn__unset:active,
+    .s-btn__unset:focus {
         padding: 0;
         border: none;
         outline: none;
@@ -555,10 +556,6 @@
         box-shadow: none;
         cursor: default;
         user-select: auto;
-    }
-
-    .s-btn__unset:focus {
-        color: unset;
     }
 
     .s-btn__link {

--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -587,7 +587,7 @@
         }
 
         &.s-btn__dropdown {
-            padding-right: .9em;
+            padding-right: 0.9em;
 
             &:after {
                 right: 0;

--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -499,9 +499,12 @@
         }
 
         &:active {
-            border-color: var(--bc-darkest);
             background-color: var(--black-050);
             color: var(--black-900);
+        }
+
+        &:focus {
+            box-shadow: 0 0 0 @su4 var(--focus-ring-muted);
         }
     }
 
@@ -539,6 +542,10 @@
         &:active {
             background-color: var(--black-900);
             color: var(--white);
+        }
+
+        &:focus {
+            box-shadow: 0 0 0 @su4 var(--focus-ring-muted);
         }
     }
 

--- a/lib/css/components/_stacks-links.less
+++ b/lib/css/components/_stacks-links.less
@@ -94,6 +94,25 @@ a,
     &.s-link__underlined {
         text-decoration: underline !important;
     }
+
+    &.s-link__dropdown {
+        position: relative;
+        padding-right: 0.9em;
+
+        &:after {
+            content: "";
+            position: absolute;
+            z-index: @zi-active;
+            top: calc(50% - 2px);
+            right: 0;
+            border-style: solid;
+            border-width: @su4;
+            border-top-width: @su4;
+            border-bottom-width: 0;
+            border-color: currentColor transparent;
+            pointer-events: none;
+        }
+    }
 }
 
 button.s-link {

--- a/lib/css/components/_stacks-links.less
+++ b/lib/css/components/_stacks-links.less
@@ -104,6 +104,7 @@ button.s-link {
     padding: 0;
     line-height: inherit;
     user-select: auto;
+    font-family: inherit;
 
     &:focus {
         outline: none;


### PR DESCRIPTION
The biggest feature here is adding `s-link__dropdown` and making sure `s-btn s-btn__dropdown` combines with `s-btn__link`. The other improvements are described in commit messages :v:

<img width="603" alt="image" src="https://user-images.githubusercontent.com/1369864/141692554-eb521ca8-816c-4248-9c82-429f14be345e.png">

Closes #783 