### PR TITLE
Badge and privilege progress bar refinements

### DIFF
--- a/docs/product/components/progress-bars.html
+++ b/docs/product/components/progress-bars.html
@@ -290,25 +290,25 @@ description: A component that visually communicates the completion of a task or 
 {% highlight html %}
 <!-- Gold Badge -->
 <div class="s-progress s-progress__badge s-progress__gold">
-    <label class="d-flex gs4 gsx m0 s-progress--label" for="badgegold-progress">
-        <img class="flex--item s-badge--image" src="BadgeGold.svg" aria-hidden="true">
-        <div class="d-flex flex__center fl-grow1 s-badge--label">Electorate</div>
+    <label class="s-progress--label" for="badgegold-progress">
+        <img class="s-badge--image" src="BadgeGold.svg" aria-hidden="true">
+        <div class="s-badge--label">Electorate</div>
     </label>
     <div class="s-progress--bar" id="badgegold-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="25" style="width: 25%;"></div>
 </div>
 <!-- Silver Badge -->
 <div class="s-progress s-progress__badge s-progress__silver">
-    <label class="d-flex gs4 gsx m0 s-progress--label" for="badgesilver-progress">
-        <img class="flex--item s-badge--image" src="BadgeSilver.svg" aria-hidden="true">
-        <div class="d-flex flex__center fl-grow1 s-badge--label">Civic Duty - 162/300</div>
+    <label class="s-progress--label" for="badgesilver-progress">
+        <img class="s-badge--image" src="BadgeSilver.svg" aria-hidden="true">
+        <div class="s-badge--label">Civic Duty - 162/300</div>
     </label>
     <div class="s-progress--bar" id="badgegold-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" style="width: 50%;"></div>
 </div>
 <!-- Bronze Badge -->
 <div class="s-progress s-progress__badge s-progress__bronze">
-    <label class="d-flex gs4 gsx m0 s-progress--label" for="badgebronze-progress">
-        <img class="flex--item s-badge--image" src="BadgeBronze.svg" aria-hidden="true">
-        <div class="d-flex flex__center fl-grow1 s-badge--label">Proofreader - 16/100</div>
+    <label class="s-progress--label" for="badgebronze-progress">
+        <img class="s-badge--image" src="BadgeBronze.svg" aria-hidden="true">
+        <div class="s-badge--label">Proofreader - 16/100</div>
     </label>
     <div class="s-progress--bar" id="badgegold-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" style="width: 75%;"></div>
 </div>
@@ -316,23 +316,23 @@ description: A component that visually communicates the completion of a task or 
         <div class="stacks-preview--example">
             <div class="d-flex gs16">
                 <div class="flex--item s-progress s-progress__badge s-progress__gold">
-                    <label class="d-flex gs4 gsx m0 s-progress--label" for="badgegold-progress">
-                        <img class="flex--item s-badge--image" src="/assets/img/BadgeGold.svg" aria-hidden="true">
-                        <div class="d-flex flex__center fl-grow1 s-badge--label">Electorate</div>
+                    <label class="s-progress--label" for="badgegold-progress">
+                        <img class="s-badge--image" src="/assets/img/BadgeGold.svg" aria-hidden="true">
+                        <div class="s-badge--label">Electorate</div>
                     </label>
                     <div class="s-progress--bar" id="badgegold-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="25" style="width: 25%;"></div>
                 </div>
                 <div class="flex--item s-progress s-progress__badge s-progress__silver">
-                    <label class="d-flex gs4 gsx m0 s-progress--label" for="badgesilver-progress">
-                        <img class="flex--item s-badge--image" src="/assets/img/BadgeSilver.svg" aria-hidden="true">
-                        <div class="d-flex flex__center fl-grow1 s-badge--label">Civic Duty - 162/300</div>
+                    <label class="s-progress--label" for="badgesilver-progress">
+                        <img class="s-badge--image" src="/assets/img/BadgeSilver.svg" aria-hidden="true">
+                        <div class="s-badge--label">Civic Duty - 162/300</div>
                     </label>
                     <div class="s-progress--bar" id="badgegold-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" style="width: 50%;"></div>
                 </div>
                 <div class="flex--item s-progress s-progress__badge s-progress__bronze">
-                    <label class="d-flex gs4 gsx m0 s-progress--label" for="badgebronze-progress">
-                        <img class="flex--item s-badge--image" src="/assets/img/BadgeBronze.svg" aria-hidden="true">
-                        <div class="d-flex flex__center fl-grow1 s-badge--label">Proofreader - 16/100</div>
+                    <label class="s-progress--label" for="badgebronze-progress">
+                        <img class="s-badge--image" src="/assets/img/BadgeBronze.svg" aria-hidden="true">
+                        <div class="s-badge--label">Proofreader - 16/100</div>
                     </label>
                     <div class="s-progress--bar" id="badgegold-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" style="width: 75%;"></div>
                 </div>

--- a/docs/product/components/progress-bars.html
+++ b/docs/product/components/progress-bars.html
@@ -248,9 +248,9 @@ description: A component that visually communicates the completion of a task or 
     <div class="stacks-preview">
 {% highlight html %}
 <div class="s-progress s-progress__privilege">
-    <label class="d-flex gs4 gsx flex__center m0 s-progress--label" for="badgegold-progress">
-        @Svg.PromoteDemote.With("flex--item")
-        <div class="flex--item">Access Review Queues</div>
+    <label class="s-progress--label" for="badgegold-progress">
+        @Svg.PromoteDemote
+        Access Review Queues
     </label>
     <div class="s-progress--bar" id="badgegold-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="25" style="width: 25%;"></div>
 </div>
@@ -258,23 +258,23 @@ description: A component that visually communicates the completion of a task or 
         <div class="stacks-preview--example">
             <div class="d-flex gs8">
                 <div class="flex--item s-progress s-progress__privilege">
-                    <label class="d-flex gs4 gsx flex__center m0 s-progress--label" for="badgegold-progress">
-                        {% icon "PromoteDemote", "flex--item" %}
-                        <div class="flex--item">Access Review Queues</div>
+                    <label class="s-progress--label" for="badgegold-progress">
+                        {% icon "PromoteDemote" %}
+                        Access Review Queues
                     </label>
                     <div class="s-progress--bar" id="badgegold-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="25" style="width: 25%;"></div>
                 </div>
                 <div class="flex--item s-progress s-progress__privilege">
-                    <label class="d-flex gs4 gsx flex__center m0 s-progress--label" for="badgesilver-progress">
-                        {% icon "AchievementsSm", "flex--item" %}
-                        <div class="flex--item">Trusted user</div>
+                    <label class="s-progress--label" for="badgesilver-progress">
+                        {% icon "AchievementsSm" %}
+                        Trusted user
                     </label>
                     <div class="s-progress--bar" id="badgegold-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50" style="width: 50%;"></div>
                 </div>
                 <div class="flex--item s-progress s-progress__privilege">
-                    <label class="d-flex gs4 gsx flex__center m0 s-progress--label" for="badgebronze-progress">
-                        {% icon "PromoteDemote", "flex--item" %}
-                        <div class="flex--item">Protect questions</div>
+                    <label class="s-progress--label" for="badgebronze-progress">
+                        {% icon "PromoteDemote" %}
+                        Protect questions
                     </label>
                     <div class="s-progress--bar" id="badgegold-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" style="width: 75%;"></div>
                 </div>

--- a/lib/css/components/_stacks-progress-bars.less
+++ b/lib/css/components/_stacks-progress-bars.less
@@ -92,6 +92,21 @@
     background-color: transparent;
 }
 
+.s-progress__badge {
+    .s-progress--label {
+        display: flex;
+        gap: @su4;
+        align-items: center;
+        padding-left: 1em;
+        padding-right: 1em;
+
+        .s-badge--label {
+            text-align: center;
+            flex-grow: 1;
+        }
+    }
+}
+
 //  $$  GOLD
 //  ---------------------------------------------------------------------------
 .s-progress__gold {

--- a/lib/css/components/_stacks-progress-bars.less
+++ b/lib/css/components/_stacks-progress-bars.less
@@ -73,6 +73,10 @@
     }
     .s-progress--label {
         border-color: var(--green-400);
+        display: flex;
+        gap: @su4;
+        align-items: center;
+        justify-content: center;
     }
 }
 


### PR DESCRIPTION
There are a lot of atomic classes in this component. This PR cleans up our approach and is a bit more opinionated. This would fix the issue with bling as [reported on Meta](https://codegolf.meta.stackexchange.com/questions/24166/badge-progress-circle-misalinged).

## Before
<img width="812" alt="image" src="https://user-images.githubusercontent.com/1369864/146431830-b5434ee0-11b2-4f93-b61b-3fe23f40661a.png">


## After
<img width="815" alt="image" src="https://user-images.githubusercontent.com/1369864/146431798-dcccba2a-2e8c-4cae-ab1a-3bd0a5f4e359.png">
