### PR TITLE
Guard against parent white space in popovers

### DIFF
--- a/lib/css/components/_stacks-popovers.less
+++ b/lib/css/components/_stacks-popovers.less
@@ -30,6 +30,10 @@
     min-width: 12rem;
     width: 100%;
 
+    // Guard against popovers being in a container with white-space: nowrap
+    // Without this, the content pops *out* of the popover.
+    white-space: normal; 
+
     .dark-mode({
         background-color: var(--black-075);
         border-color: var(--bc-light);


### PR DESCRIPTION
Without this, the content pops *out* of the popover if the parent has `ws-nowrap`. For tooltips, this can be a tricky interaction.