### PR TITLE
Switch to native gaps on user cards

### DIFF
--- a/docs/product/components/user-cards.html
+++ b/docs/product/components/user-cards.html
@@ -131,7 +131,7 @@ description: User cards are a combination of a user and metadata about the user 
 
             <div class="d-flex gsx gs16 mt16">
                 <div class="flex--item">
-                    <div class="s-user-card s-user-card__highlighted wmx2">
+                    <div class="s-user-card s-user-card__highlighted fw-wrap wmx2">
                         <time class="s-user-card--time">3 minutes ago</time>
                         <a href="#" class="s-avatar s-avatar__32 s-user-card--avatar">
                             <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />

--- a/docs/product/components/user-cards.html
+++ b/docs/product/components/user-cards.html
@@ -343,20 +343,22 @@ description: User cards are a combination of a user and metadata about the user 
 
 <section class="stacks-section">
     {% header "h3", "Minimal" %}
+    <p class="stacks-copy">
+        Minimal user cards reduce the amount of information down to who asked the question, how much rep they have, and when the action was taken. To read as plainly as possible, e.g. “Paul Wright modified 3 minutes ago,” we change the positioning of the time, and remove any reputation bling, leaving just the aggregated reputation.
+    </p>
     <div class="stacks-preview">
 {% highlight html %}
 <div class="s-user-card s-user-card__minimal">
-    <time class="s-user-card--time">…</time>
     <div class="s-user-card--info">
         <a href="…" class="s-user-card--link">…</a>
         <ul class="s-user-card--awards">
             <li class="s-user-card--rep">…</li>
         </ul>
     </div>
+    <time class="s-user-card--time">…</time>
 </div>
 
 <div class="s-user-card s-user-card__minimal">
-    <time class="s-user-card--time">…</time>
     <a href="…" class="s-avatar s-user-card--avatar">
         <img class="s-avatar--image" src="…" />
     </a>
@@ -366,23 +368,11 @@ description: User cards are a combination of a user and metadata about the user 
             <li class="s-user-card--rep">…</li>
         </ul>
     </div>
+    <time class="s-user-card--time">…</time>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="s-user-card s-user-card__minimal">
-                <time class="s-user-card--time">3 minutes ago</time>
-                <div class="s-user-card--info">
-                    <a href="#" class="s-user-card--link">
-                        Paul Wright
-                    </a>
-                    <ul class="s-user-card--awards">
-                        <li class="s-user-card--rep">2,500</li>
-                    </ul>
-                </div>
-            </div>
-
             <div class="s-user-card s-user-card__minimal mt16">
-                <time class="s-user-card--time">3 minutes ago</time>
                 <a href="#" class="s-avatar s-user-card--avatar">
                     <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
                 </a>
@@ -394,6 +384,19 @@ description: User cards are a combination of a user and metadata about the user 
                         <li class="s-user-card--rep">2,500</li>
                     </ul>
                 </div>
+                <time class="s-user-card--time">asked 3 minutes ago</time>
+            </div>
+
+            <div class="s-user-card s-user-card__minimal mt16">
+                <div class="s-user-card--info">
+                    <a href="#" class="s-user-card--link">
+                        Paul Wright
+                    </a>
+                    <ul class="s-user-card--awards">
+                        <li class="s-user-card--rep">2,500</li>
+                    </ul>
+                </div>
+                <time class="s-user-card--time">asked 3 minutes ago</time>
             </div>
         </div>
     </div>

--- a/docs/product/components/user-cards.html
+++ b/docs/product/components/user-cards.html
@@ -51,7 +51,7 @@ description: User cards are a combination of a user and metadata about the user 
             <div class="s-user-card">
                 <time class="s-user-card--time">3 minutes ago</time>
                 <a href="#" class="s-avatar s-avatar__32 s-user-card--avatar">
-                    <img class="s-avatar--image" src="https://picsum.photos/64" />
+                    <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
                 </a>
                 <div class="s-user-card--info">
                     <a href="#" class="s-user-card--link">Paul Wright</a>
@@ -67,7 +67,7 @@ description: User cards are a combination of a user and metadata about the user 
             <div class="s-user-card mt16">
                 <time class="s-user-card--time">3 minutes ago</time>
                 <a href="#" class="s-avatar s-avatar__32 s-user-card--avatar">
-                    <img class="s-avatar--image" src="https://picsum.photos/64" />
+                    <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
                 </a>
                 <div class="s-user-card--info">
                     <a href="#" class="s-user-card--link d-flex gs4">
@@ -116,7 +116,7 @@ description: User cards are a combination of a user and metadata about the user 
             <div class="s-user-card s-user-card__highlighted wmx2">
                 <time class="s-user-card--time">3 minutes ago</time>
                 <a href="#" class="s-avatar s-avatar__32 s-user-card--avatar">
-                    <img class="s-avatar--image" src="https://picsum.photos/64/64" />
+                    <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
                 </a>
                 <div class="s-user-card--info">
                     <a href="#" class="s-user-card--link">Paul Wright</a>
@@ -134,7 +134,7 @@ description: User cards are a combination of a user and metadata about the user 
                     <div class="s-user-card s-user-card__highlighted wmx2">
                         <time class="s-user-card--time">3 minutes ago</time>
                         <a href="#" class="s-avatar s-avatar__32 s-user-card--avatar">
-                            <img class="s-avatar--image" src="https://picsum.photos/64/64" />
+                            <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
                         </a>
                         <div class="s-user-card--info">
                             <a href="#" class="s-user-card--link">Paul Wright</a>
@@ -155,7 +155,7 @@ description: User cards are a combination of a user and metadata about the user 
                     <div class="s-user-card wmx2">
                         <time class="s-user-card--time">3 minutes ago</time>
                         <a href="#" class="s-avatar s-avatar__32 s-user-card--avatar">
-                            <img class="s-avatar--image" src="https://picsum.photos/64/64" />
+                            <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
                         </a>
                         <div class="s-user-card--info">
                             <a href="#" class="s-user-card--link">Paul Wright</a>
@@ -213,7 +213,7 @@ description: User cards are a combination of a user and metadata about the user 
     <div class="stacks-preview--example">
         <div class="s-user-card s-user-card__full">
             <a href="#" class="s-avatar s-avatar__48 s-user-card--avatar">
-                <img class="s-avatar--image" src="https://picsum.photos/128" />
+                <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
             </a>
             <div class="s-user-card--info">
                 <a href="#" class="s-user-card--link d-flex gs4">
@@ -238,7 +238,7 @@ description: User cards are a combination of a user and metadata about the user 
 
         <div class="s-user-card s-user-card__full mt16">
             <a href="#" class="s-avatar s-avatar__48 s-user-card--avatar">
-                <img class="s-avatar--image" src="https://picsum.photos/128" />
+                <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
             </a>
             <div class="s-user-card--info">
                 <a href="#" class="s-user-card--link d-flex gs4">
@@ -262,7 +262,7 @@ description: User cards are a combination of a user and metadata about the user 
 
         <div class="s-user-card s-user-card__full mt16">
             <a href="#" class="s-avatar s-avatar__48 s-user-card--avatar">
-                <img class="s-avatar--image" src="https://picsum.photos/128" />
+                <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
             </a>
             <div class="s-user-card--info">
                 <a href="#" class="s-user-card--link">
@@ -285,7 +285,7 @@ description: User cards are a combination of a user and metadata about the user 
 
         <div class="s-user-card s-user-card__full mt16">
             <a href="#" class="s-avatar s-avatar__48 s-user-card--avatar">
-                <img class="s-avatar--image" src="https://picsum.photos/128" />
+                <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
             </a>
             <div class="s-user-card--info">
                 <a href="#" class="s-user-card--link">
@@ -326,7 +326,7 @@ description: User cards are a combination of a user and metadata about the user 
         <div class="stacks-preview--example">
             <div class="s-user-card s-user-card__small">
                 <a href="#" class="s-avatar s-avatar__24 s-user-card--avatar">
-                    <img class="s-avatar--image" src="https://picsum.photos/48" />
+                    <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
                 </a>
                 <div class="s-user-card--info">
                     <ul class="s-user-card--awards">
@@ -384,7 +384,7 @@ description: User cards are a combination of a user and metadata about the user 
             <div class="s-user-card s-user-card__minimal mt16">
                 <time class="s-user-card--time">3 minutes ago</time>
                 <a href="#" class="s-avatar s-user-card--avatar">
-                    <img class="s-avatar--image" src="https://picsum.photos/32" />
+                    <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
                 </a>
                 <div class="s-user-card--info">
                     <a href="#" class="s-user-card--link">

--- a/docs/product/components/user-cards.html
+++ b/docs/product/components/user-cards.html
@@ -190,13 +190,13 @@ description: User cards are a combination of a user and metadata about the user 
             <div class="flex--item">…</div>
             <div class="flex--item s-badge s-badge__staff s-badge__xs">…</div>
         </a>
-        <div class="s-user-card--location">…</div>
         <ul class="s-user-card--awards">
             <li class="s-user-card--rep">…</li>
             <li class="s-award-bling s-award-bling__gold">…</li>
             <li class="s-award-bling s-award-bling__silver">…</li>
             <li class="s-award-bling s-award-bling__bronze">…</li>
         </ul>
+        <div class="s-user-card--location">…</div>
         <div class="s-user-card--tags d-flex g4">
             <a href="…" class="flex--item s-tag s-tag__xs">…</a>
             <a href="…" class="flex--item s-tag s-tag__xs">…</a>
@@ -206,7 +206,7 @@ description: User cards are a combination of a user and metadata about the user 
 
     <!-- Optional -->
     <div class="s-user-card--type">
-        @Svg.StarVerifiedSm Partner
+        @Svg.StarVerifiedSm Recognized by <a href="…">…</a>
     </div>
 </div>
 {% endhighlight %}
@@ -221,13 +221,13 @@ description: User cards are a combination of a user and metadata about the user 
                     <div class="flex--item s-badge s-badge__staff s-badge__xs">Staff</div>
                     <div class="flex--item s-badge s-badge__admin s-badge__xs">Admin</div>
                 </a>
-                <div class="s-user-card--location">Paris, France</div>
                 <ul class="s-user-card--awards">
                     <li class="s-user-card--rep">2,500</li>
                     <li class="s-award-bling s-award-bling__gold">5</li>
                     <li class="s-award-bling s-award-bling__silver">9</li>
                     <li class="s-award-bling s-award-bling__bronze">1</li>
                 </ul>
+                <div class="s-user-card--location">Paris, France</div>
                 <div class="s-user-card--tags d-flex g4">
                     <a href="#" class="flex--item s-tag s-tag__xs">javascript</a>
                     <a href="#" class="flex--item s-tag s-tag__xs">node.js</a>
@@ -245,14 +245,14 @@ description: User cards are a combination of a user and metadata about the user 
                     <div class="flex--item">Nick Craver</div>
                     <div class="flex--item s-badge s-badge__moderator s-badge__xs">Mod</div>
                 </a>
-                <div class="s-user-card--role">Architecture Lead</div>
-                <div class="s-user-card--location">North Carolina</div>
                 <ul class="s-user-card--awards">
                     <li class="s-user-card--rep">17k</li>
                     <li class="s-award-bling s-award-bling__gold">108</li>
                     <li class="s-award-bling s-award-bling__silver">265</li>
                     <li class="s-award-bling s-award-bling__bronze">812</li>
                 </ul>
+                <div class="s-user-card--role">Architecture Lead</div>
+                <div class="s-user-card--location">North Carolina</div>
                 <div class="s-user-card--tags d-flex g4">
                     <a href="#" class="flex--item s-tag s-tag__xs">.net</a>
                     <a href="#" class="flex--item s-tag s-tag__xs">sre</a>
@@ -268,13 +268,13 @@ description: User cards are a combination of a user and metadata about the user 
                 <a href="#" class="s-user-card--link">
                     Aaron Shekey
                 </a>
-                <div class="s-user-card--role">Senior Product Designer</div>
-                <div class="s-user-card--location">Minneapolis, MN</div>
                 <ul class="s-user-card--awards">
                     <li class="s-user-card--rep">768</li>
                     <li class="s-award-bling s-award-bling__silver">9</li>
                     <li class="s-award-bling s-award-bling__bronze">1</li>
                 </ul>
+                <div class="s-user-card--role">Senior Product Designer</div>
+                <div class="s-user-card--location">Minneapolis, MN</div>
                 <div class="s-user-card--tags d-flex g4">
                     <a href="#" class="flex--item s-tag s-tag__xs">css</a>
                     <a href="#" class="flex--item s-tag s-tag__xs">javascript</a>
@@ -291,15 +291,15 @@ description: User cards are a combination of a user and metadata about the user 
                 <a href="#" class="s-user-card--link">
                     Aaron Shekey
                 </a>
-                <div class="s-user-card--location">Minneapolis, MN</div>
                 <ul class="s-user-card--awards">
                     <li class="s-user-card--rep">768</li>
                     <li class="s-award-bling s-award-bling__silver">9</li>
                     <li class="s-award-bling s-award-bling__bronze">1</li>
                 </ul>
+                <div class="s-user-card--location">Minneapolis, MN</div>
             </div>
             <div class="s-user-card--type">
-                {% icon "StarVerifiedSm" %} Star Wars Partner
+                {% icon "StarVerifiedSm" %} Recognized by <a href="#">Hum</a>
             </div>
         </div>
     </div>

--- a/docs/product/components/user-cards.html
+++ b/docs/product/components/user-cards.html
@@ -428,9 +428,11 @@ description: User cards are a combination of a user and metadata about the user 
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="s-user-card s-user-card__deleted">
+            <div class="s-user-card s-user-card__deleted p0">
                 <time class="s-user-card--time">3 minutes ago</time>
-                <div class="s-avatar s-avatar__32 s-user-card--avatar demo-background"></div>
+                <div class="s-avatar s-avatar__32 s-user-card--avatar">
+                    <img class="s-avatar--image" src="{{ "/assets/img/anonymous-user.svg" | relative_url }}" />
+                </div>
                 <div class="s-user-card--info">
                     <div class="s-user-card--link">
                         Paul Wright
@@ -440,7 +442,9 @@ description: User cards are a combination of a user and metadata about the user 
 
             <div class="s-user-card s-user-card__deleted s-user-card__minimal mt16">
                 <time class="s-user-card--time">3 years ago</time>
-                <div class="s-avatar s-user-card--avatar demo-background"></div>
+                <div class="s-avatar s-user-card--avatar">
+                    <img class="s-avatar--image" src="{{ "/assets/img/anonymous-user.svg" | relative_url }}" />
+                </div>
                 <div class="s-user-card--info">
                     <div class="s-user-card--link">
                         Paul Wright
@@ -450,9 +454,3 @@ description: User cards are a combination of a user and metadata about the user 
         </div>
     </div>
 </section>
-
-<style>
-    .demo-background {
-        background-image: url("{{ "/assets/img/anonymous-user.svg" | relative_url }}");
-    }
-</style>

--- a/docs/product/components/user-cards.html
+++ b/docs/product/components/user-cards.html
@@ -70,7 +70,7 @@ description: User cards are a combination of a user and metadata about the user 
                     <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
                 </a>
                 <div class="s-user-card--info">
-                    <a href="#" class="s-user-card--link d-flex gs4">
+                    <a href="#" class="s-user-card--link d-flex g4">
                         <div class="flex--item">Paul Wright</div>
                         <div class="flex--item s-badge s-badge__moderator s-badge__xs">Mod</div>
                     </a>
@@ -186,7 +186,7 @@ description: User cards are a combination of a user and metadata about the user 
         <img class="s-avatar--image" src="…" />
     </a>
     <div class="s-user-card--info">
-        <a href="#" class="s-user-card--link d-flex gs4">
+        <a href="#" class="s-user-card--link d-flex g4">
             <div class="flex--item">…</div>
             <div class="flex--item s-badge s-badge__staff s-badge__xs">…</div>
         </a>
@@ -197,7 +197,7 @@ description: User cards are a combination of a user and metadata about the user 
             <li class="s-award-bling s-award-bling__silver">…</li>
             <li class="s-award-bling s-award-bling__bronze">…</li>
         </ul>
-        <div class="s-user-card--tags d-flex gs4">
+        <div class="s-user-card--tags d-flex g4">
             <a href="…" class="flex--item s-tag s-tag__xs">…</a>
             <a href="…" class="flex--item s-tag s-tag__xs">…</a>
             <a href="…" class="flex--item s-tag s-tag__xs">…</a>
@@ -216,7 +216,7 @@ description: User cards are a combination of a user and metadata about the user 
                 <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
             </a>
             <div class="s-user-card--info">
-                <a href="#" class="s-user-card--link d-flex gs4">
+                <a href="#" class="s-user-card--link d-flex g4">
                     <div class="flex--item">Paul Wright</div>
                     <div class="flex--item s-badge s-badge__staff s-badge__xs">Staff</div>
                     <div class="flex--item s-badge s-badge__admin s-badge__xs">Admin</div>
@@ -228,7 +228,7 @@ description: User cards are a combination of a user and metadata about the user 
                     <li class="s-award-bling s-award-bling__silver">9</li>
                     <li class="s-award-bling s-award-bling__bronze">1</li>
                 </ul>
-                <div class="s-user-card--tags d-flex gs4">
+                <div class="s-user-card--tags d-flex g4">
                     <a href="#" class="flex--item s-tag s-tag__xs">javascript</a>
                     <a href="#" class="flex--item s-tag s-tag__xs">node.js</a>
                     <a href="#" class="flex--item s-tag s-tag__xs">graphQL</a>
@@ -241,7 +241,7 @@ description: User cards are a combination of a user and metadata about the user 
                 <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
             </a>
             <div class="s-user-card--info">
-                <a href="#" class="s-user-card--link d-flex gs4">
+                <a href="#" class="s-user-card--link d-flex g4">
                     <div class="flex--item">Nick Craver</div>
                     <div class="flex--item s-badge s-badge__moderator s-badge__xs">Mod</div>
                 </a>
@@ -253,7 +253,7 @@ description: User cards are a combination of a user and metadata about the user 
                     <li class="s-award-bling s-award-bling__silver">265</li>
                     <li class="s-award-bling s-award-bling__bronze">812</li>
                 </ul>
-                <div class="s-user-card--tags d-flex gs4">
+                <div class="s-user-card--tags d-flex g4">
                     <a href="#" class="flex--item s-tag s-tag__xs">.net</a>
                     <a href="#" class="flex--item s-tag s-tag__xs">sre</a>
                 </div>
@@ -275,7 +275,7 @@ description: User cards are a combination of a user and metadata about the user 
                     <li class="s-award-bling s-award-bling__silver">9</li>
                     <li class="s-award-bling s-award-bling__bronze">1</li>
                 </ul>
-                <div class="s-user-card--tags d-flex gs4">
+                <div class="s-user-card--tags d-flex g4">
                     <a href="#" class="flex--item s-tag s-tag__xs">css</a>
                     <a href="#" class="flex--item s-tag s-tag__xs">javascript</a>
                     <a href="#" class="flex--item s-tag s-tag__xs">html</a>

--- a/docs/product/components/user-cards.html
+++ b/docs/product/components/user-cards.html
@@ -146,7 +146,7 @@ description: User cards are a combination of a user and metadata about the user 
                             </ul>
                         </div>
                         <div class="s-user-card--type">
-                            {% icon "StarVerifiedSm" %} Star Wars Partner
+                            {% icon "StarVerifiedSm" %} Recognized by <a href="#">Hum</a>
                         </div>
                     </div>
                 </div>
@@ -167,7 +167,7 @@ description: User cards are a combination of a user and metadata about the user 
                             </ul>
                         </div>
                         <div class="s-user-card--type">
-                            {% icon "StarVerifiedSm" %} Star Wars Partner
+                            {% icon "StarVerifiedSm" %} Recognized by <a href="#">Hum</a>
                         </div>
                     </div>
                 </div>
@@ -372,7 +372,7 @@ description: User cards are a combination of a user and metadata about the user 
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
-            <div class="s-user-card s-user-card__minimal mt16">
+            <div class="s-user-card s-user-card__minimal">
                 <a href="#" class="s-avatar s-user-card--avatar">
                     <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
                 </a>
@@ -441,7 +441,6 @@ description: User cards are a combination of a user and metadata about the user 
             </div>
 
             <div class="s-user-card s-user-card__deleted s-user-card__minimal mt16">
-                <time class="s-user-card--time">3 years ago</time>
                 <div class="s-avatar s-user-card--avatar">
                     <img class="s-avatar--image" src="{{ "/assets/img/anonymous-user.svg" | relative_url }}" />
                 </div>
@@ -450,6 +449,7 @@ description: User cards are a combination of a user and metadata about the user 
                         Paul Wright
                     </div>
                 </div>
+                <time class="s-user-card--time">asked 3 years ago</time>
             </div>
         </div>
     </div>

--- a/docs/product/components/user-cards.html
+++ b/docs/product/components/user-cards.html
@@ -416,15 +416,15 @@ description: User cards are a combination of a user and metadata about the user 
 </div>
 
 <div class="s-user-card s-user-card__deleted s-user-card__minimal">
-    <time class="s-user-card--time">3 years ago</time>
     <div class="s-avatar s-avatar__32 s-user-card--avatar">
         <img class="s-avatar--image" src="…" />
     </div>
     <div class="s-user-card--info">
         <div class="s-user-card--link">
-            Paul Wright
+            …
         </div>
     </div>
+    <time class="s-user-card--time">…</time>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">

--- a/lib/css/components/_stacks-user-cards.less
+++ b/lib/css/components/_stacks-user-cards.less
@@ -99,6 +99,10 @@
         grid-column: ~"1 / 3";
         font-size: @fs-caption;
         color: var(--theme-primary-400);
+
+        a {
+            color: inherit;
+        }
     }
 }
 

--- a/lib/css/components/_stacks-user-cards.less
+++ b/lib/css/components/_stacks-user-cards.less
@@ -13,7 +13,8 @@
 .s-user-card {
     display: grid;
     grid-template-columns: auto 1fr;
-    grid-column-gap: @su8;
+    column-gap: @su8;
+    row-gap: @su4;
     align-items: center;
     line-height: 1;
     padding: @su8;
@@ -39,7 +40,7 @@
         align-items: start;
 
         .s-user-card--info {
-            grid-gap: @su4;
+            gap: @su4;
         }
 
         .s-user-card--link {
@@ -58,26 +59,12 @@
     &.s-user-card__small {
         display: flex;
         align-items: center;
-        grid-column-gap: unset; // Firefox flex layouts respect column gaps, so we need to reset this
+        gap: @su4;
         padding: 0;
-
-        .s-user-card--time {
-            margin-right: @su6;
-            margin-bottom: 0;
-        }
-
-        .s-user-card--link {
-            margin-right: @su6;
-        }
-
-        .s-user-card--avatar {
-            margin-right: @su6;
-        }
 
         .s-user-card--info {
             display: flex;
             align-items: center;
-            grid-column-gap: unset; // Firefox flex layouts respect column gaps, so we need to reset this
         }
     }
 
@@ -86,39 +73,30 @@
     &.s-user-card__minimal {
         display: flex;
         align-items: center;
-        grid-column-gap: unset; // Firefox flex layouts respect column gaps, so we need to reset this
+        gap: @su4;
         padding: 0;
 
         .s-user-card--time {
-            margin-right: @su4;
-            margin-bottom: 0;
             white-space: nowrap;
         }
 
         .s-user-card--link {
-            margin-right: @su4;
             white-space: nowrap;
         }
 
-        .s-user-card--avatar {
-            margin-right: @su4;
-        }
-
         .s-user-card--rep {
-            padding: 0;
             color: var(--black-600);
         }
 
         .s-user-card--info {
             display: flex;
             align-items: center;
-            grid-column-gap: unset; // Firefox flex layouts respect column gaps, so we need to reset this
+            gap: @su4;
         }
     }
 
     .s-user-card--type {
         grid-column: ~"1 / 3";
-        padding-top: @su4;
         font-size: @fs-caption;
         color: var(--theme-primary-400);
     }
@@ -132,7 +110,6 @@
     grid-row: ~"1 / 2";
     color: var(--black-500);
     font-size: @fs-caption;
-    margin-bottom: @su4;
 }
 
 //  $   USER INFO CONTAINER
@@ -141,7 +118,7 @@
 //  ---------------------------------------------------------------------------
 .s-user-card--info {
     display: grid;
-    grid-gap: @su2;
+    gap: @su2;
 }
 
 //  $   USER LINK
@@ -162,9 +139,9 @@
     .list-reset;
     display: flex;
     align-items: center;
+    gap: @su6;
 
     li {
-        margin-right: @su6;
         font-size: @fs-caption;
     }
 }

--- a/lib/css/components/_stacks-user-cards.less
+++ b/lib/css/components/_stacks-user-cards.less
@@ -39,10 +39,6 @@
     &.s-user-card__full {
         align-items: start;
 
-        .s-user-card--info {
-            gap: @su4;
-        }
-
         .s-user-card--link {
             font-size: @fs-body2;
         }
@@ -63,7 +59,7 @@
         padding: 0;
 
         .s-user-card--info {
-            display: flex;
+            flex-direction: row;
             align-items: center;
         }
     }
@@ -89,9 +85,8 @@
         }
 
         .s-user-card--info {
-            display: flex;
+            flex-direction: row;
             align-items: center;
-            gap: @su4;
         }
     }
 
@@ -121,8 +116,9 @@
 //      vertical grid layout
 //  ---------------------------------------------------------------------------
 .s-user-card--info {
-    display: grid;
-    gap: @su2;
+    display: flex;
+    flex-direction: column;
+    gap: @su4;
 }
 
 //  $   USER LINK
@@ -167,7 +163,6 @@
 //      Apply layout to a bunch of child tags
 //  ---------------------------------------------------------------------------
 .s-user-card--tags {
-    padding-top: (@su2 / 2); // Optically align these a bit, but we can't use margin because of `gs[x]` being applied
     min-width: 0; // Allow things to wrap
     align-items: center;
     flex-wrap: wrap;


### PR DESCRIPTION
This reduces some CSS and simplifies our presentation of user cards by switching to native gaps. This will require some scrutiny in production, but should allow us to drop a bunch of margin overrides, and rearrange things more easily.

This also cleans up some documentation.