### PR TITLE
Bump required label contrast in dark mode

### DIFF
--- a/lib/css/components/_stacks-inputs.less
+++ b/lib/css/components/_stacks-inputs.less
@@ -181,6 +181,10 @@ fieldset {
     &.s-label--status__required {
         background-color: var(--red-100);
         color: var(--red-600);
+
+        .dark-mode({
+            color: var(--red-800);
+        });
     }
 
     &.s-label--status__new {

--- a/lib/css/components/_stacks-inputs.less
+++ b/lib/css/components/_stacks-inputs.less
@@ -183,7 +183,7 @@ fieldset {
         color: var(--red-600);
 
         .dark-mode({
-            color: var(--red-800);
+            color: var(--red-700);
         });
     }
 


### PR DESCRIPTION
https://stackexchange.slack.com/archives/C27RWNQN9/p1642098605278100

### Before

![20220113-133729](https://user-images.githubusercontent.com/647177/149389470-b47872e3-aad0-45a9-bb84-c620b62c1016.png)

### After

![20220113-134111](https://user-images.githubusercontent.com/647177/149389968-da232324-0a88-4908-9135-0332eb932635.png)

---

### That one time I tried `--red-800` but found it too contrast-y
![20220113-133741](https://user-images.githubusercontent.com/647177/149389486-ddac3b0c-054f-4b6f-bf2f-49d510b705ae.png)
