### PR TITLE
Add links to Figma components

### DIFF
--- a/docs/_includes/layouts/page.html
+++ b/docs/_includes/layouts/page.html
@@ -19,17 +19,29 @@
                 </div>
             {% endif %}
             {% comment %}
-                This container’s .fl-grow1 doesn't behave properly unless we add an explicit width.
+                This container’s .fl-grow1 doesn’t behave properly unless we add an explicit width.
                 https://stackoverflow.com/questions/38723559/flex-item-exceeds-its-container
             {% endcomment %}
             <div class="flex--item fl-grow1 ws1">
-                {% if js %}
-                    <div class="stacks-badged d-flex ai-center sm:jc-space-between">
-                        <h1 class="stacks-h1 flex--item mb0">{{ title }}</h1>
-                        <a href="{{ "/product/guidelines/javascript" | relative_url }}" class="d-flex p8 fc-white ml6">
-                            <div class="bg-green-700 blr-sm p4">{% icon "Checkmark" %}</div>
-                            <div class="bg-green-500 brr-sm px8 py4">javascript</div>
-                        </a>
+                {% if js or figma %}
+                    <div class="stacks-badged d-flex g8 ai-center">
+                        <h1 class="stacks-h1 flex--item mb0 mr-auto">{{ title }}</h1>
+
+                        {% if js %}
+                            <a href="{{ "/product/guidelines/javascript" | relative_url }}" class="d-flex fc-white">
+                                <div class="bg-green-700 blr-sm p4">{% icon "Checkmark" %}</div>
+                                <div class="d-flex flex__center bg-green-500 brr-sm px8 py4">JavaScript</div>
+                            </a>
+                        {% endif %}
+
+                        {% if figma %}
+                            <a href="{{ figma }}" class="d-flex fc-white theme-light__forced">
+                                <div class="bg-black-700 blr-sm p4">
+                                    <svg aria-hidden="true" class="svg-icon iconFigma native" width="18" height="18" viewBox="0 0 18 18"><path d="M6 18a3 3 0 0 0 3-3v-3H6a3 3 0 0 0 0 6Z" fill="#0ACF83"/><path d="M3 9a3 3 0 0 1 3-3h3v6H6a3 3 0 0 1-3-3Z" fill="#A259FF"/><path d="M3 3a3 3 0 0 1 3-3h3v6H6a3 3 0 0 1-3-3Z" fill="#F24E1E"/><path d="M9 0h3a3 3 0 0 1 0 6H9V0Z" fill="#FF7262"/><path d="M15 9a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" fill="#1ABCFE"/></svg>
+                                </div>
+                                <div class="d-flex flex__center bg-black-500 brr-sm px8 py4">Figma</div>
+                            </a>
+                        {% endif %}
                     </div>
                 {% else %}
                     <h1 class="stacks-h1">{{ title }}</h1>

--- a/docs/product/base/box-shadow.html
+++ b/docs/product/base/box-shadow.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Box shadow
+figma: https://www.figma.com/file/BKF0Bk7gymjt8cAdQcPtF7/Box-Shadows
 description: Box shadow atomic classes allow you to change an element’s box shadow quickly.
 ---
 <section class="stacks-section">

--- a/docs/product/base/colors.html
+++ b/docs/product/base/colors.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Colors
+figma: https://www.figma.com/file/KL7VJKlVDqpxgaP1UP4xxQ3U/Colors
 description: To avoid specifying color values by hand, we’ve included a robust set of color variables. For maintainability, please use these instead of hardcoding color values.
 ---
 

--- a/docs/product/base/typography.html
+++ b/docs/product/base/typography.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Typography
+figma: https://www.figma.com/file/x5Q2TKTuTcFhK1FIeCq9dk/Typography
 description: Stacks provides atomic classes to override default styling of typography. Change typographic weights, styles, and alignment with these atomic styles.
 ---
 <section class="stacks-section">

--- a/docs/product/components/avatars.html
+++ b/docs/product/components/avatars.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Avatars
+figma: https://www.figma.com/file/BJRlHasCR6r9hgszE95hJm/Avatars
 description: Avatars are used to quickly identify users or teams.
 ---
 <section class="stacks-section">

--- a/docs/product/components/badges.html
+++ b/docs/product/components/badges.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Badges
+figma: https://www.figma.com/file/i2HeoRFKn6MXAWn2UuTDHc/Badges
 description: Badges are labels used for flags, earned achievements, and number totals.
 ---
 <section class="stacks-section">

--- a/docs/product/components/banners.html
+++ b/docs/product/components/banners.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Banners
+figma: https://www.figma.com/file/9MG6BQ5X0FlHV0rQ3c9ugA/Banners
 description: Banners are a type of <a href="/product/components/notices">notice</a>, delivering both system and engagement messaging. These are highly intrusive messaging methods and so should be used appropriately.
 ---
 <!-- Additional javascript -->

--- a/docs/product/components/breadcrumbs.html
+++ b/docs/product/components/breadcrumbs.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Breadcrumbs
+figma: https://www.figma.com/file/Anwb7zgxxeMm7Sw7vbaukq/Breadcrumbs
 description: Breadcrumbs are used to provide context for the currently-viewed page.
 ---
 <section class="stacks-section">

--- a/docs/product/components/button-groups.html
+++ b/docs/product/components/button-groups.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Button groups
+figma: https://www.figma.com/file/9p5HuZwl9KXP9HpBZuvBoT/Button-Groups
 description: Button groups are a collection of buttons. This component is used in our questions view, and is frequently used in conjunction with other form elements such as search fields and sorting dropdowns. If the content you’re interacting with is a simple paring down or filter of the current view, it’s appropriate to use the <code class="stacks-code">.s-btn-group</code> component. Add the class <code class="stacks-code">.is-selected</code> to show the currently-selected button.
 ---
 <section class="stacks-section">

--- a/docs/product/components/buttons.html
+++ b/docs/product/components/buttons.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Buttons
+figma: https://www.figma.com/file/rknusKtqsY7iUI9Ng7PNDS/Buttons
 description: Buttons are user interface elements which allows users to take actions throughout the project. It is important that they have ample click space and help communicate the importance of their actions.
 ---
 <section class="stacks-section">

--- a/docs/product/components/cards.html
+++ b/docs/product/components/cards.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Cards
+figma: https://www.figma.com/file/ZidBnnDAVwYUnL0TvGWnTa/Cards
 description: Cards are used to group similar concepts and tasks together to make information easier to scan, read, and act on. Cards should use a heading that sets clear expectations about the card’s purpose, paragraphs that put the most critical information first, and (optionally) calls to action on the bottom to direct user action.
 ---
 <section class="stacks-section">

--- a/docs/product/components/checkbox.html
+++ b/docs/product/components/checkbox.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Checkbox
+figma: https://www.figma.com/file/GQB9GupHvraMioGRPbwKhO/Form-Elements
 description: A checkable input that visually shows if an option is true or false.
 ---
 <section class="stacks-section">

--- a/docs/product/components/editor.html
+++ b/docs/product/components/editor.html
@@ -2,6 +2,7 @@
 layout: page
 title: Editor
 js: true
+figma: https://www.figma.com/file/aUvZ3KmZN4oYrMBJ5AroKV/Editor
 description: The Stacks editor adds “what you see is what you get” and Markdown capabilities to textareas. It is available as a separate <a href="https://github.com/StackExchange/Stacks-Editor">Editor</a> repository, but requires Stacks’ CSS for styling.
 ---
 <section class="stacks-section">

--- a/docs/product/components/inputs.html
+++ b/docs/product/components/inputs.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Inputs
+figma: https://www.figma.com/file/GQB9GupHvraMioGRPbwKhO/Form-Elements
 description: Input elements are used to gather information from users.
 ---
 <section id="inputs" class="stacks-section">

--- a/docs/product/components/labels.html
+++ b/docs/product/components/labels.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Labels
+figma: https://www.figma.com/file/UMVHhcJjTqHgqn7wJkr5f6/Labels
 description: Labels are used to describe inputs, select menus, textareas, radio buttons, and checkboxes.
 ---
 <section class="stacks-section">

--- a/docs/product/components/modals.html
+++ b/docs/product/components/modals.html
@@ -2,6 +2,7 @@
 layout: page
 title: Modals
 js: true
+figma: https://www.figma.com/file/B1IIlRbtGvReNCILI7HNVL/Modals
 description: Modals are dialog overlays that prevent the user from interacting with the rest of the website until an action is taken or the dialog is dismissed. Modals are purposefully disruptive and should be used thoughtfully and sparingly.
 ---
 <section class="stacks-section">

--- a/docs/product/components/navigation.html
+++ b/docs/product/components/navigation.html
@@ -2,6 +2,7 @@
 layout: page
 title: Navigation
 js: true
+figma: https://www.figma.com/file/Hei0vYDqdyrjZR9laRdZCm/Navigation
 description: Our navigation component is a collection of pill-shaped buttons that respond gracefully to various window sizes and parent containers.
 ---
 <section class="stacks-section">

--- a/docs/product/components/notices.html
+++ b/docs/product/components/notices.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Notices
+figma: https://www.figma.com/file/WYBYiGnyr5qemIm93ZcTf8/Notices
 description: Notices deliver <strong>System</strong> and <strong>Engagement</strong> messaging, informing the user about product or account statuses and related actions.
 ---
 <!-- Example notice content -->

--- a/docs/product/components/popovers.html
+++ b/docs/product/components/popovers.html
@@ -2,6 +2,7 @@
 layout: page
 title: Popovers
 js: true
+figma: https://www.figma.com/file/LLHB9oIQ6DmOHQNVbGYrH4/Popovers
 description: Popovers are small content containers that provide a contextual overlay. They can be used as in-context feature explanations, dropdowns, or tooltips.
 ---
 <section class="stacks-section">

--- a/docs/product/components/radio.html
+++ b/docs/product/components/radio.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Radio
+figma: https://www.figma.com/file/GQB9GupHvraMioGRPbwKhO/Form-Elements
 description: An input group which can only have one entry selected at a time.
 ---
 <section class="stacks-section">

--- a/docs/product/components/select.html
+++ b/docs/product/components/select.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Select
+figma: https://www.figma.com/file/GQB9GupHvraMioGRPbwKhO/Form-Elements
 description: A selectable menu list from which a user can make a single selection. Typically they are used when there are more than four possible options. The custom select menu styling is achieved by wrapping the <code class="stacks-code">select</code> tag within the <code class="stacks-code">.s-select</code> class.
 ---
 <section class="stacks-section">

--- a/docs/product/components/tags.html
+++ b/docs/product/components/tags.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Tags
+figma: https://www.figma.com/file/pjrkFIbNIOWb8zhdJB7Aon/Tags
 description: Tags are an interactive, community-generated keyword that allow communities to label, organize, and discover related content. Tags are maintained by their respective communities
 ---
 <section class="stacks-section">

--- a/docs/product/components/textarea.html
+++ b/docs/product/components/textarea.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Textarea
+figma: https://www.figma.com/file/GQB9GupHvraMioGRPbwKhO/Form-Elements
 description: Multi-line inputs used by users to enter longer text portions.
 ---
 <section id="inputs" class="stacks-section">

--- a/docs/product/components/toggle-switch.html
+++ b/docs/product/components/toggle-switch.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Toggle switch
+figma: https://www.figma.com/file/DhmEdwQjfSugeNAfDSnbJa/Toggle-Switches
 description: A toggle is used to quickly switch between two or more possible states. They are most commonly used for simple “on/off” switches, but can contain multiple options.
 ---
 <section class="stacks-section">

--- a/docs/product/resources/icons.html
+++ b/docs/product/resources/icons.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Icons
+figma: https://www.figma.com/file/NxAqQAi9i5XsrZSm1WYj6tsM/Icons-and-Spot-Illustrations
 description: Stacks provides a complete icon set, managed separately in the <a href="https://github.com/StackExchange/Stacks-Icons">Stacks-Icons</a> repository. There you’ll find deeper documentation on the various uses as well as the icons’ source in our design tool Figma.
 ---
 

--- a/docs/product/resources/spots.html
+++ b/docs/product/resources/spots.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Spot illustrations
+figma: https://www.figma.com/file/NxAqQAi9i5XsrZSm1WYj6tsM/Icons-and-Spot-Illustrations
 description: Spot illustrations are the slightly grown up version of icons with a little more detail. They’re most often used in empty states and new product announcements. They’re built externally on the <a href="https://github.com/StackExchange/Stacks-Icons">Icons</a> repository.
 ---
 


### PR DESCRIPTION
Where they exist, let’s link to our Figma components in our documentation.

<img width="556" alt="image" src="https://user-images.githubusercontent.com/1369864/149669472-eebb6a48-7c8d-49df-9ac4-31004b6425dc.png">