### PR TITLE
Remove flex start from post summaries

### DIFF
--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -19,12 +19,10 @@
 
     #stacks-internals #screen-md({
         flex-direction: column;
-        align-items: flex-start;
     });
 
     &.s-post-summary__minimal {
         flex-direction: column;
-        align-items: flex-start;
 
         .s-post-summary--stats {
             width: auto;


### PR DESCRIPTION
I believe these were originally added in defense of a now-removed `align-items: center;` on the `post-summary` container.

This was causing a display issue in questions lists where the user card would be shoved to the left.

<img width="1560" alt="150200857-5d4107b7-f4fc-4b3b-96f4-e23ba6c1f596" src="https://user-images.githubusercontent.com/1369864/150218895-d3cde08c-3f32-4e81-818a-3936f8e66a37.png">

<img width="1591" alt="150200768-76ba4f11-4b81-4f80-b36c-113c86337741" src="https://user-images.githubusercontent.com/1369864/150218913-6458679d-48ff-4371-a27b-441f5332ebf1.png">
