### PR TITLE
Fix stateful title color specificity

### DIFF
--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -301,14 +301,16 @@
     }
 
     .s-post-summary--content-title {
-        color: var(--black-600);
+        &, & .s-link {
+            color: var(--black-600);
 
-        &:hover {
-            color: var(--black-500);
-        }
+            &:hover {
+                color: var(--black-500);
+            }
 
-        &:visited {
-            color: var(--black-700);
+            &:visited {
+                color: var(--black-700);
+            }
         }
     }
 


### PR DESCRIPTION
The way we're using the post summary titles in core looks like this: `.s-post-summary--content-title > a.s-link` (as opposed to the recommended `a.s-post-summary--content-title.s-link`). This fix makes the stateful title overrides more specific to include this use case.