### PR TITLE
Add focus states to multiple options toggle switch

### DIFF
--- a/lib/css/components/_stacks-toggle-switches.less
+++ b/lib/css/components/_stacks-toggle-switches.less
@@ -112,7 +112,6 @@
         //  If the input is selected, style its label accordingly.
         input[type="radio"]:checked {
             + label {
-                // Color activated options green
                 &.s-toggle-switch--label-off {
                     background-color: var(--black-300);
                     color: @white;
@@ -131,6 +130,14 @@
                         color: var(--white);
                     });
                 }
+            }
+
+            &:focus + label.s-toggle-switch--label-off {
+                box-shadow: 0 0 0 @su4 var(--focus-ring-muted);
+            }
+
+            &:focus + label:not(.s-toggle-switch--label-off) {
+                box-shadow: 0 0 0 @su4 var(--focus-ring-success);
             }
         }
     }


### PR DESCRIPTION
Closes #840

With your keyboard, tab to the multiple toggles, then move between options with your arrow keys like a radio group :v:

<img width="338" alt="image" src="https://user-images.githubusercontent.com/1369864/151100606-e655dca0-3681-4371-a510-0faa9a605410.png">
