### PR TITLE
Post summary refinements

### DIFF
--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -953,7 +953,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
 
 <div class="s-post-summary s-post-summary__ignored">
     …
-    <a class="s-tag s-tag__ignored">
+    <a class="s-tag">
         @Svg.EyeOffSm
         …
     </a>
@@ -994,7 +994,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </p>
                     <div class="s-post-summary--meta">
                         <div class="s-post-summary--meta-tags">
-                            <a class="s-tag s-tag__watched" href="#">{% icon "EyeSm" %} asp</a>
+                            <a class="s-tag s-tag__watched" href="#">{% icon "EyeSm", "mr4" %} asp</a>
                             <a class="s-tag" href="#">asp.net</a>
                             <a class="s-tag" href="#">asp.net-mvc</a>
                         </div>
@@ -1037,7 +1037,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </p>
                     <div class="s-post-summary--meta">
                         <div class="s-post-summary--meta-tags">
-                            <a class="s-tag s-tag__ignored" href="#">{% icon "EyeOffSm" %} regex</a>
+                            <a class="s-tag" href="#">{% icon "EyeOffSm", "mr4" %} regex</a>
                             <a class="s-tag" href="#">php</a>
                             <a class="s-tag" href="#">redirect</a>
                             <a class="s-tag" href="#">parameters</a>

--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -53,7 +53,6 @@ description: The post summary component summarizes various content and associate
             … answers
         </div>
         <div class="s-post-summary--stats-item is-supernova">
-            @Svg.FireSm.With("mrn2")
             … views
         </div>
     </div>
@@ -98,7 +97,6 @@ description: The post summary component summarizes various content and associate
                         5 answers
                     </div>
                     <div class="s-post-summary--stats-item is-supernova">
-                        {% icon "FireSm", "va-text-bottom mrn2" %}
                         104k views
                     </div>
                 </div>
@@ -434,7 +432,6 @@ description: The post summary component summarizes various content and associate
                         5 answers
                     </div>
                     <div class="s-post-summary--stats-item is-supernova">
-                        {% icon "FireSm", "va-text-bottom mrn2" %}
                         104k views
                     </div>
                 </div>
@@ -478,7 +475,6 @@ description: The post summary component summarizes various content and associate
                         5 answers
                     </div>
                     <div class="s-post-summary--stats-item is-supernova">
-                        {% icon "FireSm", "va-text-bottom mrn2" %}
                         104k views
                     </div>
                 </div>
@@ -527,7 +523,6 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                         5 answers
                     </div>
                     <div class="s-post-summary--stats-item is-supernova">
-                        {% icon "FireSm", "va-text-bottom mrn2" %}
                         104k views
                     </div>
                 </div>
@@ -574,7 +569,6 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                         5 answers
                     </div>
                     <div class="s-post-summary--stats-item is-supernova">
-                        {% icon "FireSm", "va-text-bottom mrn2" %}
                         104k views
                     </div>
                 </div>
@@ -621,7 +615,6 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                         5 answers
                     </div>
                     <div class="s-post-summary--stats-item is-supernova">
-                        {% icon "FireSm", "va-text-bottom mrn2" %}
                         104k views
                     </div>
                 </div>
@@ -858,7 +851,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
     </div>
 
     {% header "h3", "Hotness" %}
-    <p class="stacks-copy">Post stats also have various states of hotness and display in corresponding shades of orange. A fire icon is added in the supernova level of popularity.</p>
+    <p class="stacks-copy">Post stats also have various states of hotness and display in corresponding shades of orange.</p>
     <ul class="stacks-list">
         <li>Default</li>
         <li>Warm</li>
@@ -884,7 +877,6 @@ Is anyone aware of a fully functional implementation of this API (to generate th
 
 <!-- Supernova -->
 <div class="s-post-summary--stats-item is-supernova">
-    @Svg.FireSm.With("mrn2")
     100k views
 </div>
 {% endhighlight %}
@@ -937,7 +929,6 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                         18 answers
                     </div>
                     <div class="s-post-summary--stats-item is-supernova">
-                        {% icon "FireSm" %}
                         100k views
                     </div>
                 </div>

--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -945,7 +945,6 @@ Is anyone aware of a fully functional implementation of this API (to generate th
 <div class="s-post-summary s-post-summary__watched">
     …
     <a class="s-tag s-tag__watched">
-        @Svg.EyeSm
         …
     </a>
     …
@@ -953,8 +952,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
 
 <div class="s-post-summary s-post-summary__ignored">
     …
-    <a class="s-tag">
-        @Svg.EyeOffSm
+    <a class="s-tag s-tag__ignored">
         …
     </a>
     …
@@ -994,7 +992,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </p>
                     <div class="s-post-summary--meta">
                         <div class="s-post-summary--meta-tags">
-                            <a class="s-tag s-tag__watched" href="#">{% icon "EyeSm" %} asp</a>
+                            <a class="s-tag s-tag__watched" href="#">asp</a>
                             <a class="s-tag" href="#">asp.net</a>
                             <a class="s-tag" href="#">asp.net-mvc</a>
                         </div>
@@ -1037,7 +1035,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </p>
                     <div class="s-post-summary--meta">
                         <div class="s-post-summary--meta-tags">
-                            <a class="s-tag" href="#">{% icon "EyeOffSm" %} regex</a>
+                            <a class="s-tag s-tag__ignored" href="#">regex</a>
                             <a class="s-tag" href="#">php</a>
                             <a class="s-tag" href="#">redirect</a>
                             <a class="s-tag" href="#">parameters</a>

--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -90,7 +90,7 @@ description: The post summary component summarizes various content and associate
         <div class="stacks-preview--example p0">
             <div class="s-post-summary">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         95 votes
                     </div>
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
@@ -137,7 +137,7 @@ description: The post summary component summarizes various content and associate
 
             <div class="s-post-summary">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         280 votes
                     </div>
                     <div class="s-post-summary--stats-item has-answers">
@@ -184,7 +184,7 @@ description: The post summary component summarizes various content and associate
 
             <div class="s-post-summary">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         1 vote
                     </div>
                     <div class="s-post-summary--stats-item">
@@ -231,7 +231,7 @@ description: The post summary component summarizes various content and associate
 
             <div class="s-post-summary">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         1 vote
                     </div>
                     <div class="s-post-summary--stats-item has-answers">
@@ -282,7 +282,7 @@ description: The post summary component summarizes various content and associate
 {% highlight html %}
 <div class="s-post-summary s-post-summary__minimal">
     <div class="s-post-summary--stats">
-        <div class="s-post-summary--stats-item">
+        <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
             … votes
         </div>
         <div class="s-post-summary--stats-item">
@@ -314,7 +314,7 @@ description: The post summary component summarizes various content and associate
         <div class="stacks-preview--example p0">
             <div class="s-post-summary s-post-summary__minimal">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         0 votes
                     </div>
                     <div class="s-post-summary--stats-item">
@@ -347,7 +347,7 @@ description: The post summary component summarizes various content and associate
             </div>
             <div class="s-post-summary s-post-summary__minimal">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         0 votes
                     </div>
                     <div class="s-post-summary--stats-item has-answers">
@@ -378,7 +378,7 @@ description: The post summary component summarizes various content and associate
             </div>
             <div class="s-post-summary s-post-summary__minimal">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         0 votes
                     </div>
                     <div class="s-post-summary--stats-item">
@@ -426,7 +426,7 @@ description: The post summary component summarizes various content and associate
         <div class="stacks-preview--example p0">
             <div class="s-post-summary">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         95 votes
                     </div>
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
@@ -470,7 +470,7 @@ description: The post summary component summarizes various content and associate
 
             <div class="s-post-summary">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         95 votes
                     </div>
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
@@ -519,7 +519,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
 
             <div class="s-post-summary">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         95 votes
                     </div>
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
@@ -566,7 +566,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
 
             <div class="s-post-summary">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         95 votes
                     </div>
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
@@ -613,7 +613,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
 
             <div class="s-post-summary">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         95 votes
                     </div>
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
@@ -674,7 +674,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
 
         <div class="s-post-summary--answer">
             <div class="s-post-summary--stats">
-                <div class="s-post-summary--stats-item">
+                <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                     … votes
                 </div>
                 <div class="s-post-summary--stats-item has-answers has-accepted-answer">
@@ -704,7 +704,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
         <div class="stacks-preview--example p0">
             <div class="s-post-summary">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         2 votes
                     </div>
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
@@ -739,7 +739,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </div>
                     <div class="s-post-summary--answer">
                         <div class="s-post-summary--stats">
-                            <div class="s-post-summary--stats-item">
+                            <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                                 2 votes
                             </div>
                             <div class="s-post-summary--stats-item has-answers has-accepted-answer">
@@ -763,7 +763,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </div>
                     <div class="s-post-summary--answer">
                         <div class="s-post-summary--stats">
-                            <div class="s-post-summary--stats-item">
+                            <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                                 2 votes
                             </div>
                         </div>
@@ -818,7 +818,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
         <div class="stacks-preview--example">
             <div class="d-flex ai-center gs24 fw-wrap">
                 <div class="flex--item w-auto s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         3 votes
                     </div>
                     <div class="s-post-summary--stats-item">
@@ -830,7 +830,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                 </div>
 
                 <div class="flex--item w-auto s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         12 votes
                     </div>
                     <div class="s-post-summary--stats-item has-answers">
@@ -842,7 +842,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                 </div>
 
                 <div class="flex--item w-auto s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         95 votes
                     </div>
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
@@ -891,7 +891,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
         <div class="stacks-preview--example">
             <div class="d-flex ai-center gs24 fw-wrap">
                 <div class="flex--item w-auto s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         3 votes
                     </div>
                     <div class="s-post-summary--stats-item">
@@ -903,7 +903,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                 </div>
 
                 <div class="flex--item w-auto s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         28 votes
                     </div>
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
@@ -916,7 +916,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                 </div>
 
                 <div class="flex--item w-auto s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         92 votes
                     </div>
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
@@ -929,7 +929,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                 </div>
 
                 <div class="flex--item w-auto s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         126 votes
                     </div>
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
@@ -980,7 +980,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
         <div class="stacks-preview--example p0">
             <div class="s-post-summary s-post-summary__watched">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         10 votes
                     </div>
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
@@ -1024,7 +1024,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
 
             <div class="s-post-summary s-post-summary__ignored">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         3 votes
                     </div>
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
@@ -1069,7 +1069,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
 
             <div class="s-post-summary s-post-summary__deleted">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         0 votes
                     </div>
                     <div class="s-post-summary--stats-item">
@@ -1121,7 +1121,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                         {% icon "PencilSm" %}
                         Draft
                     </div>
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         -3 votes
                     </div>
                     <div class="s-post-summary--stats-item">
@@ -1174,7 +1174,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                         {% icon "EyeSm" %}
                         Review
                     </div>
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         26 votes
                     </div>
                     <div class="s-post-summary--stats-item is-warm">
@@ -1226,7 +1226,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                         {% icon "NotInterestedSm" %}
                         Closed
                     </div>
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         0 votes
                     </div>
                     <div class="s-post-summary--stats-item">
@@ -1272,7 +1272,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                         {% icon "ArchiveSm" %}
                         Archived
                     </div>
-                    <div class="s-post-summary--stats-item">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
                         -22 votes
                     </div>
                     <div class="s-post-summary--stats-item is-warm">

--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -45,12 +45,12 @@ description: The post summary component summarizes various content and associate
 {% highlight html %}
 <div class="s-post-summary">
     <div class="s-post-summary--stats">
+        <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
+            … votes
+        </div>
         <div class="s-post-summary--stats-item has-answers has-accepted-answer">
             @Svg.CheckmarkSm
             … answers
-        </div>
-        <div class="s-post-summary--stats-item">
-            … votes
         </div>
         <div class="s-post-summary--stats-item is-supernova">
             @Svg.FireSm.With("mrn2")

--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -961,12 +961,15 @@ Is anyone aware of a fully functional implementation of this API (to generate th
 </div>
 
 <div class="s-post-summary s-post-summary__deleted">
-    …
-    <div class="is-deleted">
-        @Svg.TrashSm
+    <div class="s-post-summary--stats">
+        <div class="s-post-summary--stats-item is-deleted">
+            @Svg.TrashSm
+            Deleted
+        </div>
+        …
     </div>
     …
-</div>
+ </div>
 {% endhighlight %}
         <div class="stacks-preview--example p0">
             <div class="s-post-summary s-post-summary__watched">
@@ -1060,7 +1063,11 @@ Is anyone aware of a fully functional implementation of this API (to generate th
 
             <div class="s-post-summary s-post-summary__deleted">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
+                    <div class="s-post-summary--stats-item is-deleted">
+                        {% icon "TrashSm" %}
+                        Deleted
+                    </div>
+                    <div class="s-post-summary--stats-item">
                         0 votes
                     </div>
                     <div class="s-post-summary--stats-item">
@@ -1079,9 +1086,6 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </p>
                     <div class="s-post-summary--meta">
                         <div class="s-post-summary--meta-tags">
-                            <div class="s-tag bg-red-600 fc-white d-flex flex__center g2" title="This post has been deleted">
-                                {% icon "TrashSm" %}
-                            </div>
                             <a class="s-tag" href="#">spring</a>
                             <a class="s-tag" href="#">spring-boot</a>
                             <a class="s-tag" href="#">authentication</a>

--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -994,7 +994,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </p>
                     <div class="s-post-summary--meta">
                         <div class="s-post-summary--meta-tags">
-                            <a class="s-tag s-tag__watched" href="#">{% icon "EyeSm", "mr4" %} asp</a>
+                            <a class="s-tag s-tag__watched" href="#">{% icon "EyeSm" %} asp</a>
                             <a class="s-tag" href="#">asp.net</a>
                             <a class="s-tag" href="#">asp.net-mvc</a>
                         </div>
@@ -1037,7 +1037,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </p>
                     <div class="s-post-summary--meta">
                         <div class="s-post-summary--meta-tags">
-                            <a class="s-tag" href="#">{% icon "EyeOffSm", "mr4" %} regex</a>
+                            <a class="s-tag" href="#">{% icon "EyeOffSm" %} regex</a>
                             <a class="s-tag" href="#">php</a>
                             <a class="s-tag" href="#">redirect</a>
                             <a class="s-tag" href="#">parameters</a>

--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -952,34 +952,27 @@ Is anyone aware of a fully functional implementation of this API (to generate th
     <div class="stacks-preview">
 {% highlight html %}
 <div class="s-post-summary s-post-summary__watched">
-    <div class="s-post-summary--stats">
-        <div class="s-post-summary--stats-item is-watched">
-            @Svg.EyeSm
-            Watched
-        </div>
+    …
+    <a class="s-tag s-tag__watched">
+        @Svg.EyeSm
         …
-    </div>
+    </a>
     …
 </div>
 
 <div class="s-post-summary s-post-summary__ignored">
-    <div class="s-post-summary--stats">
-        <div class="s-post-summary--stats-item is-ignored">
-            @Svg.EyeOffSm
-            Ignored
-        </div>
+    …
+    <a class="s-tag s-tag__ignored">
+        @Svg.EyeOffSm
         …
-    </div>
+    </a>
     …
 </div>
 
 <div class="s-post-summary s-post-summary__deleted">
-    <div class="s-post-summary--stats">
-        <div class="s-post-summary--stats-item is-deleted">
-            @Svg.TrashSm
-            Deleted
-        </div>
-        …
+    …
+    <div class="is-deleted">
+        @Svg.TrashSm
     </div>
     …
 </div>
@@ -987,10 +980,6 @@ Is anyone aware of a fully functional implementation of this API (to generate th
         <div class="stacks-preview--example p0">
             <div class="s-post-summary s-post-summary__watched">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item is-watched">
-                        {% icon "EyeSm" %}
-                        Watched
-                    </div>
                     <div class="s-post-summary--stats-item">
                         10 votes
                     </div>
@@ -1011,6 +1000,7 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </p>
                     <div class="s-post-summary--meta">
                         <div class="s-post-summary--meta-tags">
+                            <a class="s-tag s-tag__watched" href="#">{% icon "EyeSm" %} asp</a>
                             <a class="s-tag" href="#">asp.net</a>
                             <a class="s-tag" href="#">asp.net-mvc</a>
                         </div>
@@ -1034,10 +1024,6 @@ Is anyone aware of a fully functional implementation of this API (to generate th
 
             <div class="s-post-summary s-post-summary__ignored">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item is-ignored">
-                        {% icon "EyeOffSm" %}
-                        Ignored
-                    </div>
                     <div class="s-post-summary--stats-item">
                         3 votes
                     </div>
@@ -1057,8 +1043,8 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </p>
                     <div class="s-post-summary--meta">
                         <div class="s-post-summary--meta-tags">
+                            <a class="s-tag s-tag__ignored" href="#">{% icon "EyeOffSm" %} regex</a>
                             <a class="s-tag" href="#">php</a>
-                            <a class="s-tag" href="#">regex</a>
                             <a class="s-tag" href="#">redirect</a>
                             <a class="s-tag" href="#">parameters</a>
                             <a class="s-tag" href="#">wildcard</a>
@@ -1083,10 +1069,6 @@ Is anyone aware of a fully functional implementation of this API (to generate th
 
             <div class="s-post-summary s-post-summary__deleted">
                 <div class="s-post-summary--stats">
-                    <div class="s-post-summary--stats-item is-deleted">
-                        {% icon "TrashSm" %}
-                        Deleted
-                    </div>
                     <div class="s-post-summary--stats-item">
                         0 votes
                     </div>
@@ -1106,6 +1088,9 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </p>
                     <div class="s-post-summary--meta">
                         <div class="s-post-summary--meta-tags">
+                            <div class="s-tag bg-red-600 fc-white d-flex flex__center g2" title="This post has been deleted">
+                                {% icon "TrashSm" %}
+                            </div>
                             <a class="s-tag" href="#">spring</a>
                             <a class="s-tag" href="#">spring-boot</a>
                             <a class="s-tag" href="#">authentication</a>

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -52,13 +52,13 @@
     --s-post-summary-stats-gap: @su6; // Replace with gap property as soon as browser support makes sense.
     margin-right: @su8;
     margin-bottom: -@su2;
-    width: @su96;
+    width: @su96 + @su12;
     display: flex;
     flex-direction: column;
     flex-shrink: 0;
     flex-wrap: wrap;
     align-items: flex-end;
-    font-size: @fs-caption;
+    font-size: @fs-body1;
     color: var(--fc-light);
 
     .s-post-summary--stats-item {

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -73,9 +73,6 @@
 
         &.has-answers,
         &.has-bounty,
-        &.is-watched,
-        &.is-ignored,
-        &.is-deleted,
         &.is-published,
         &.is-draft,
         &.is-review,

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -160,10 +160,10 @@
     max-width: 100%;
 
     .s-post-summary--content-title {
-        display: inline-block;
+        display: block;
         font-size: @fs-body3;
         margin-top: -0.15rem; // Optical alignment to compensate for title's containing block
-        margin-bottom: @su4;
+        margin-bottom: @su6;
         overflow-wrap: break-word;
         word-wrap: break-word;
         padding-right: @su24;

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -301,7 +301,7 @@
         opacity: 0.6;
     }
 
-    .s-post-summary--stats-item:not(.is-ignored):not(.is-deleted) {
+    .s-post-summary--stats-item:not(.is-deleted) {
         opacity: 0.6;
         filter: grayscale(100%);
     }

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -51,7 +51,7 @@
 .s-post-summary--stats {
     --s-post-summary-stats-gap: @su6; // Replace with gap property as soon as browser support makes sense.
     margin-right: @su8;
-    margin-bottom: -@su2;
+    margin-bottom: -@su4;
     width: @su96 + @su12;
     display: flex;
     flex-direction: column;
@@ -161,7 +161,7 @@
     .s-post-summary--content-title {
         display: inline-block;
         font-size: @fs-subheading;
-        margin-bottom: @su6;
+        margin-bottom: @su4;
         overflow-wrap: break-word;
         word-wrap: break-word;
         padding-right: @su24;

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -160,7 +160,7 @@
 
     .s-post-summary--content-title {
         display: inline-block;
-        font-size: @fs-body3;
+        font-size: @fs-subheading;
         margin-bottom: @su6;
         overflow-wrap: break-word;
         word-wrap: break-word;

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -161,8 +161,8 @@
 
     .s-post-summary--content-title {
         display: inline-block;
-        font-size: @fs-subheading;
-        margin-top: -0.23rem; // Optical alignment to compensate for title's containing block
+        font-size: @fs-body3;
+        margin-top: -0.15rem; // Optical alignment to compensate for title's containing block
         margin-bottom: @su4;
         overflow-wrap: break-word;
         word-wrap: break-word;

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -298,11 +298,11 @@
 .s-post-summary__ignored,
 .s-post-summary__deleted {
     .s-post-summary--content {
-        opacity: 0.7;
+        opacity: 0.6;
     }
 
     .s-post-summary--stats-item:not(.is-ignored):not(.is-deleted) {
-        opacity: 0.7;
+        opacity: 0.6;
         filter: grayscale(100%);
     }
 

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -161,6 +161,7 @@
     .s-post-summary--content-title {
         display: inline-block;
         font-size: @fs-subheading;
+        margin-top: -0.23rem; // Optical alignment to compensate for title's containing block
         margin-bottom: @su4;
         overflow-wrap: break-word;
         word-wrap: break-word;
@@ -181,7 +182,7 @@
 
     .s-post-summary--content-type {
         color: var(--fc-medium);
-        margin-bottom: @su2;
+        margin-bottom: @su4;
 
         .svg-icon {
             margin-left: -@su2;

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -71,6 +71,10 @@
             vertical-align: text-bottom;
         }
 
+        &.s-post-summary--stats-item__emphasized {
+            color: var(--fc-dark);
+        }
+
         &.has-answers,
         &.has-bounty,
         &.is-published,

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -77,6 +77,7 @@
 
         &.has-answers,
         &.has-bounty,
+        &.is-deleted,
         &.is-published,
         &.is-draft,
         &.is-review,
@@ -286,17 +287,13 @@
     background-color: var(--red-050);
 
     .is-deleted {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        gap: @su2;
-        border-radius: var(--bs-sm);
-        background-color: var(--red-600);
-        color: var(--white);
+        color: @white;
+        background-color: var(--red-500);
     }
 }
 
-.s-post-summary__ignored {
+.s-post-summary__ignored,
+.s-post-summary__deleted {
     .s-post-summary--content {
         opacity: 0.7;
     }

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -277,23 +277,25 @@
     }
 }
 
-.s-post-summary__watched .is-watched {
-    color: var(--white);
-    background-color: var(--yellow-600);
+.s-post-summary__watched {
+    background-color: var(--yellow-050);
 }
 
-.s-post-summary__ignored .is-ignored {
-    color: var(--white);
-    background-color: var(--black-600);
-}
-
-.s-post-summary__deleted .is-deleted {
-    color: @white;
-    background-color: var(--red-500);
-}
-
-.s-post-summary__ignored,
 .s-post-summary__deleted {
+    background-color: var(--red-050);
+
+    .is-deleted {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: @su2;
+        border-radius: var(--bs-sm);
+        background-color: var(--red-600);
+        color: var(--white);
+    }
+}
+
+.s-post-summary__ignored {
     .s-post-summary--content {
         opacity: 0.7;
     }

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -192,6 +192,7 @@
     .s-post-summary--content-excerpt {
         margin-top: -@su2;
         margin-bottom: @su8;
+        color: var(--fc-medium);
         .v-truncate2;
 
         &.s-post-summary--content-excerpt__sm {

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -62,13 +62,16 @@
     color: var(--fc-light);
 
     .s-post-summary--stats-item {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
         margin-right: var(--s-post-summary-stats-gap);
         margin-bottom: var(--s-post-summary-stats-gap);
         white-space: nowrap;
         border: 1px solid transparent;
 
         .svg-icon {
-            vertical-align: text-bottom;
+            margin-right: @su4;
         }
 
         &.s-post-summary--stats-item__emphasized {

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -51,7 +51,7 @@
 .s-post-summary--stats {
     --s-post-summary-stats-gap: @su6; // Replace with gap property as soon as browser support makes sense.
     margin-right: @su8;
-    margin-bottom: -@su4;
+    margin-bottom: -@su2;
     width: @su96 + @su12;
     display: flex;
     flex-direction: column;

--- a/lib/css/components/_stacks-tags.less
+++ b/lib/css/components/_stacks-tags.less
@@ -82,6 +82,10 @@
     vertical-align: middle;
     white-space: nowrap;
 
+    .svg-icon {
+        margin-right: @su4;
+    }
+
     .s-tag-styles(var(--theme-tag-border-color), var(--theme-tag-background-color), var(--theme-tag-color));
 
     .highcontrast-mode({ text-decoration: none; });

--- a/lib/css/components/_stacks-tags.less
+++ b/lib/css/components/_stacks-tags.less
@@ -68,7 +68,7 @@
 .s-tag {
     #stacks-internals #load-config();
     display: inline-flex;
-    align-content: center;
+    align-items: center;
     justify-content: center;
     min-width: 0;
     padding-left: @su4;
@@ -213,29 +213,8 @@ a.s-tag__muted:not(.is-selected) {
 .s-tag__watched {
     #stacks-internals #load-config();
     .s-tag-styles(transparent, var(--yellow-600), var(--white));
-
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: @su2;
 }
 a.s-tag__watched:not(.is-selected) {
     #stacks-internals #load-config();
     .s-tag-hover-styles(transparent, var(--yellow-700), var(--white));
-}
-
-//  $$  Ignored Tag
-//  ---------------------------------------------------------------------------
-.s-tag__ignored {
-    #stacks-internals #load-config();
-    .s-tag-styles(transparent, var(--black-600), var(--white));
-
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: @su2;
-}
-a.s-tag__ignored:not(.is-selected) {
-    #stacks-internals #load-config();
-    .s-tag-hover-styles(transparent, var(--black-700), var(--white));
 }

--- a/lib/css/components/_stacks-tags.less
+++ b/lib/css/components/_stacks-tags.less
@@ -239,10 +239,18 @@ a.s-tag__muted:not(.is-selected) {
 
     #stacks-internals #load-config();
     .s-tag-styles(transparent, var(--yellow-600), var(--white));
+
+    .dark-mode({
+        .s-tag-styles(transparent, var(--yellow-400), var(--white));
+    });
 }
 a.s-tag__watched:not(.is-selected) {
     #stacks-internals #load-config();
-    .s-tag-hover-styles(transparent, var(--yellow-700), var(--white));
+    .s-tag-hover-styles(transparent, var(--yellow-600), var(--white));
+
+    .dark-mode({
+        .s-tag-styles(transparent, var(--yellow-400), var(--white));
+    });
 }
 
 //  $$  Ignored Tag

--- a/lib/css/components/_stacks-tags.less
+++ b/lib/css/components/_stacks-tags.less
@@ -207,3 +207,35 @@ a.s-tag__muted:not(.is-selected) {
     #stacks-internals #load-config();
     .s-tag-hover-styles(@tags-muted-hover-border, @tags-muted-hover-background, @tags-muted-hover-color);
 }
+
+//  $$  Watched Tag
+//  ---------------------------------------------------------------------------
+.s-tag__watched {
+    #stacks-internals #load-config();
+    .s-tag-styles(transparent, var(--yellow-600), var(--white));
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: @su2;
+}
+a.s-tag__watched:not(.is-selected) {
+    #stacks-internals #load-config();
+    .s-tag-hover-styles(transparent, var(--yellow-700), var(--white));
+}
+
+//  $$  Ignored Tag
+//  ---------------------------------------------------------------------------
+.s-tag__ignored {
+    #stacks-internals #load-config();
+    .s-tag-styles(transparent, var(--black-600), var(--white));
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: @su2;
+}
+a.s-tag__ignored:not(.is-selected) {
+    #stacks-internals #load-config();
+    .s-tag-hover-styles(transparent, var(--black-700), var(--white));
+}

--- a/lib/css/components/_stacks-tags.less
+++ b/lib/css/components/_stacks-tags.less
@@ -215,10 +215,62 @@ a.s-tag__muted:not(.is-selected) {
 //  $$  Watched Tag
 //  ---------------------------------------------------------------------------
 .s-tag__watched {
+    position: relative;
+    padding-left: 22px;
+
+    --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M7.05 1C2.63 1 0 6.5 0 6.5S2.63 12 7.05 12C11.38 12 14 6.5 14 6.5S11.37 1 7.05 1ZM7 10.17A3.59 3.59 0 0 1 3.5 6.5 3.6 3.6 0 0 1 7 2.83c1.94 0 3.5 1.65 3.5 3.67A3.57 3.57 0 0 1 7 10.17Zm0-1.84c.97 0 1.75-.81 1.75-1.83S7.97 4.67 7 4.67s-1.75.81-1.75 1.83S6.03 8.33 7 8.33Z'/%3E%3C/svg%3E");
+
+    &:before,
+    &:after {
+        content: "";
+        display: block;
+        position: absolute;
+        left: 4px;
+        top: calc(50% - 7px);
+        height: 14px;
+        width: 14px;
+    }
+
+    &:after {
+        background-color: currentColor;
+        -webkit-mask: var(--bg-icon) no-repeat center;
+        mask: var(--bg-icon) no-repeat center;
+        -webkit-mask-size: contain;
+        mask-size: contain;
+    }
+
     #stacks-internals #load-config();
     .s-tag-styles(transparent, var(--yellow-600), var(--white));
 }
 a.s-tag__watched:not(.is-selected) {
     #stacks-internals #load-config();
     .s-tag-hover-styles(transparent, var(--yellow-700), var(--white));
+}
+
+//  $$  Watched Tag
+//  ---------------------------------------------------------------------------
+.s-tag__ignored {
+    position: relative;
+    padding-left: 22px;
+
+    --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M3.52 7.38 1.58 9.26A12.38 12.38 0 0 1 0 7s2.63-5.14 7.05-5.14c.66 0 1.28.12 1.86.32L7.44 3.6a3.48 3.48 0 0 0-3.92 3.78ZM5.3 9.99c.5.28 1.1.44 1.71.44 1.94 0 3.5-1.53 3.5-3.43 0-.62-.17-1.21-.47-1.72L8.7 6.6a1.73 1.73 0 0 1-2.08 2.07L5.29 10Zm6.23-6.19A12.7 12.7 0 0 1 14 7s-2.63 5.14-6.95 5.14A6.1 6.1 0 0 1 4 11.3L2.27 13l-1.4-1.36L11.9 1l1.23 1.2-1.6 1.6Z'/%3E%3C/svg%3E");
+
+    &:before,
+    &:after {
+        content: "";
+        display: block;
+        position: absolute;
+        left: 4px;
+        top: calc(50% - 7px);
+        height: 14px;
+        width: 14px;
+    }
+
+    &:after {
+        background-color: currentColor;
+        -webkit-mask: var(--bg-icon) no-repeat center;
+        mask: var(--bg-icon) no-repeat center;
+        -webkit-mask-size: contain;
+        mask-size: contain;
+    }
 }

--- a/lib/css/components/_stacks-tags.less
+++ b/lib/css/components/_stacks-tags.less
@@ -225,8 +225,8 @@ a.s-tag__muted:not(.is-selected) {
         position: absolute;
         left: 4px;
         top: calc(50% - 7px);
-        -webkit-mask: var(--bg-icon) no-repeat center;
-        mask: var(--bg-icon) no-repeat center;
+        -webkit-mask: var(--s-tag-icon) no-repeat center;
+        mask: var(--s-tag-icon) no-repeat center;
         -webkit-mask-size: contain;
         mask-size: contain;
     }
@@ -235,26 +235,11 @@ a.s-tag__muted:not(.is-selected) {
 //  $$  Watched Tag
 //  ---------------------------------------------------------------------------
 .s-tag__watched {
-    --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M7.05 1C2.63 1 0 6.5 0 6.5S2.63 12 7.05 12C11.38 12 14 6.5 14 6.5S11.37 1 7.05 1ZM7 10.17A3.59 3.59 0 0 1 3.5 6.5 3.6 3.6 0 0 1 7 2.83c1.94 0 3.5 1.65 3.5 3.67A3.57 3.57 0 0 1 7 10.17Zm0-1.84c.97 0 1.75-.81 1.75-1.83S7.97 4.67 7 4.67s-1.75.81-1.75 1.83S6.03 8.33 7 8.33Z'/%3E%3C/svg%3E");
-
-    #stacks-internals #load-config();
-    .s-tag-styles(transparent, var(--yellow-600), var(--white));
-
-    .dark-mode({
-        .s-tag-styles(transparent, var(--yellow-400), var(--white));
-    });
-}
-a.s-tag__watched:not(.is-selected) {
-    #stacks-internals #load-config();
-    .s-tag-hover-styles(transparent, var(--yellow-600), var(--white));
-
-    .dark-mode({
-        .s-tag-styles(transparent, var(--yellow-400), var(--white));
-    });
+    --s-tag-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M7.05 1C2.63 1 0 6.5 0 6.5S2.63 12 7.05 12C11.38 12 14 6.5 14 6.5S11.37 1 7.05 1ZM7 10.17A3.59 3.59 0 0 1 3.5 6.5 3.6 3.6 0 0 1 7 2.83c1.94 0 3.5 1.65 3.5 3.67A3.57 3.57 0 0 1 7 10.17Zm0-1.84c.97 0 1.75-.81 1.75-1.83S7.97 4.67 7 4.67s-1.75.81-1.75 1.83S6.03 8.33 7 8.33Z'/%3E%3C/svg%3E");
 }
 
 //  $$  Ignored Tag
 //  ---------------------------------------------------------------------------
 .s-tag__ignored {
-    --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M3.52 7.38 1.58 9.26A12.38 12.38 0 0 1 0 7s2.63-5.14 7.05-5.14c.66 0 1.28.12 1.86.32L7.44 3.6a3.48 3.48 0 0 0-3.92 3.78ZM5.3 9.99c.5.28 1.1.44 1.71.44 1.94 0 3.5-1.53 3.5-3.43 0-.62-.17-1.21-.47-1.72L8.7 6.6a1.73 1.73 0 0 1-2.08 2.07L5.29 10Zm6.23-6.19A12.7 12.7 0 0 1 14 7s-2.63 5.14-6.95 5.14A6.1 6.1 0 0 1 4 11.3L2.27 13l-1.4-1.36L11.9 1l1.23 1.2-1.6 1.6Z'/%3E%3C/svg%3E");
+    --s-tag-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M3.52 7.38 1.58 9.26A12.38 12.38 0 0 1 0 7s2.63-5.14 7.05-5.14c.66 0 1.28.12 1.86.32L7.44 3.6a3.48 3.48 0 0 0-3.92 3.78ZM5.3 9.99c.5.28 1.1.44 1.71.44 1.94 0 3.5-1.53 3.5-3.43 0-.62-.17-1.21-.47-1.72L8.7 6.6a1.73 1.73 0 0 1-2.08 2.07L5.29 10Zm6.23-6.19A12.7 12.7 0 0 1 14 7s-2.63 5.14-6.95 5.14A6.1 6.1 0 0 1 4 11.3L2.27 13l-1.4-1.36L11.9 1l1.23 1.2-1.6 1.6Z'/%3E%3C/svg%3E");
 }

--- a/lib/css/components/_stacks-tags.less
+++ b/lib/css/components/_stacks-tags.less
@@ -208,10 +208,12 @@ a.s-tag__muted:not(.is-selected) {
     .s-tag-hover-styles(@tags-muted-hover-border, @tags-muted-hover-background, @tags-muted-hover-color);
 }
 
-//  $$  Watched Tag
+//  $$  Tag with Icons (watched, ignored)
 //  ---------------------------------------------------------------------------
-.s-tag__watched {
-    --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M7.05 1C2.63 1 0 6.5 0 6.5S2.63 12 7.05 12C11.38 12 14 6.5 14 6.5S11.37 1 7.05 1ZM7 10.17A3.59 3.59 0 0 1 3.5 6.5 3.6 3.6 0 0 1 7 2.83c1.94 0 3.5 1.65 3.5 3.67A3.57 3.57 0 0 1 7 10.17Zm0-1.84c.97 0 1.75-.81 1.75-1.83S7.97 4.67 7 4.67s-1.75.81-1.75 1.83S6.03 8.33 7 8.33Z'/%3E%3C/svg%3E");
+.s-tag__watched,
+.s-tag__ignored {
+    position: relative;
+    padding-left: 22px;
 
     &:before {
         content: "";
@@ -220,11 +222,21 @@ a.s-tag__muted:not(.is-selected) {
         height: 14px;
         margin-right: @su2;
         background-color: currentColor;
+        mask-size: contain;
+        position: absolute;
+        left: 4px;
+        top: calc(50% - 7px);
         -webkit-mask: var(--bg-icon) no-repeat center;
         mask: var(--bg-icon) no-repeat center;
         -webkit-mask-size: contain;
         mask-size: contain;
     }
+}
+
+//  $$  Watched Tag
+//  ---------------------------------------------------------------------------
+.s-tag__watched {
+    --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M7.05 1C2.63 1 0 6.5 0 6.5S2.63 12 7.05 12C11.38 12 14 6.5 14 6.5S11.37 1 7.05 1ZM7 10.17A3.59 3.59 0 0 1 3.5 6.5 3.6 3.6 0 0 1 7 2.83c1.94 0 3.5 1.65 3.5 3.67A3.57 3.57 0 0 1 7 10.17Zm0-1.84c.97 0 1.75-.81 1.75-1.83S7.97 4.67 7 4.67s-1.75.81-1.75 1.83S6.03 8.33 7 8.33Z'/%3E%3C/svg%3E");
 
     #stacks-internals #load-config();
     .s-tag-styles(transparent, var(--yellow-600), var(--white));
@@ -234,30 +246,8 @@ a.s-tag__watched:not(.is-selected) {
     .s-tag-hover-styles(transparent, var(--yellow-700), var(--white));
 }
 
-//  $$  Watched Tag
+//  $$  Ignored Tag
 //  ---------------------------------------------------------------------------
 .s-tag__ignored {
-    position: relative;
-    padding-left: 22px;
-
     --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M3.52 7.38 1.58 9.26A12.38 12.38 0 0 1 0 7s2.63-5.14 7.05-5.14c.66 0 1.28.12 1.86.32L7.44 3.6a3.48 3.48 0 0 0-3.92 3.78ZM5.3 9.99c.5.28 1.1.44 1.71.44 1.94 0 3.5-1.53 3.5-3.43 0-.62-.17-1.21-.47-1.72L8.7 6.6a1.73 1.73 0 0 1-2.08 2.07L5.29 10Zm6.23-6.19A12.7 12.7 0 0 1 14 7s-2.63 5.14-6.95 5.14A6.1 6.1 0 0 1 4 11.3L2.27 13l-1.4-1.36L11.9 1l1.23 1.2-1.6 1.6Z'/%3E%3C/svg%3E");
-
-    &:before,
-    &:after {
-        content: "";
-        display: block;
-        position: absolute;
-        left: 4px;
-        top: calc(50% - 7px);
-        height: 14px;
-        width: 14px;
-    }
-
-    &:after {
-        background-color: currentColor;
-        -webkit-mask: var(--bg-icon) no-repeat center;
-        mask: var(--bg-icon) no-repeat center;
-        -webkit-mask-size: contain;
-        mask-size: contain;
-    }
 }

--- a/lib/css/components/_stacks-tags.less
+++ b/lib/css/components/_stacks-tags.less
@@ -222,7 +222,6 @@ a.s-tag__muted:not(.is-selected) {
         height: 14px;
         margin-right: @su2;
         background-color: currentColor;
-        mask-size: contain;
         position: absolute;
         left: 4px;
         top: calc(50% - 7px);

--- a/lib/css/components/_stacks-tags.less
+++ b/lib/css/components/_stacks-tags.less
@@ -82,10 +82,6 @@
     vertical-align: middle;
     white-space: nowrap;
 
-    .svg-icon {
-        margin-right: @su4;
-    }
-
     .s-tag-styles(var(--theme-tag-border-color), var(--theme-tag-background-color), var(--theme-tag-color));
 
     .highcontrast-mode({ text-decoration: none; });

--- a/lib/css/components/_stacks-tags.less
+++ b/lib/css/components/_stacks-tags.less
@@ -215,23 +215,14 @@ a.s-tag__muted:not(.is-selected) {
 //  $$  Watched Tag
 //  ---------------------------------------------------------------------------
 .s-tag__watched {
-    position: relative;
-    padding-left: 22px;
-
     --bg-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M7.05 1C2.63 1 0 6.5 0 6.5S2.63 12 7.05 12C11.38 12 14 6.5 14 6.5S11.37 1 7.05 1ZM7 10.17A3.59 3.59 0 0 1 3.5 6.5 3.6 3.6 0 0 1 7 2.83c1.94 0 3.5 1.65 3.5 3.67A3.57 3.57 0 0 1 7 10.17Zm0-1.84c.97 0 1.75-.81 1.75-1.83S7.97 4.67 7 4.67s-1.75.81-1.75 1.83S6.03 8.33 7 8.33Z'/%3E%3C/svg%3E");
 
-    &:before,
-    &:after {
+    &:before {
         content: "";
         display: block;
-        position: absolute;
-        left: 4px;
-        top: calc(50% - 7px);
-        height: 14px;
         width: 14px;
-    }
-
-    &:after {
+        height: 14px;
+        margin-right: @su2;
         background-color: currentColor;
         -webkit-mask: var(--bg-icon) no-repeat center;
         mask: var(--bg-icon) no-repeat center;


### PR DESCRIPTION
This PR explores some changes based on feedback. More description to come.

1. Increases font size overall on stats
2. Moves watched and ignored to the tags themselves
4. Highlights various states in a way that looks closer to the status quo
5. Aligns post titles better with the view stats
6. Adds an `s-post-summary-stats--item__emphasized` for when we need to add emphasis to voting or views, etc.
7. Removes the fire icon
8. Makes the post title a block level element so it can render mathjax