### PR TITLE
Add brand/copywriting/concepts

### DIFF
--- a/docs/_data/site-navigation.json
+++ b/docs/_data/site-navigation.json
@@ -488,6 +488,10 @@
             {
               "title": "Naming guidelines",
               "url": "/brand/copywriting/naming/"
+            },
+            {
+              "title": "Concepts",
+              "url": "/brand/copywriting/concepts/"
             }
           ]
         },

--- a/docs/brand/copywriting/concepts.html
+++ b/docs/brand/copywriting/concepts.html
@@ -1,0 +1,54 @@
+---
+layout: page
+title: Concepts guidelines
+description: Quick guidelines for how to identify and refer to different conceptual units present on Stack Overflow
+---
+
+<section class="stacks-section">
+    {% header "h2", "Post scores" %}
+    <ul class="stacks-list">
+        <li>Questions, answers, and other types of Posts have <em>scores</em>.</li>
+        <li>A post’s <em>score</em> is calculated by subtracting the total number of downvotes from the total number of upvotes.</li>
+        <li>In almost all cases when referring to the sum of votes, we will use the term <em>score</em>.</li>
+        <li>
+            Use of the  term <em>votes</em> to refer to the post’s score is only acceptable in cases where we need to present the data in the format 
+            <code>{ScoreValue} votes</code> (as is done in the <a href="/product/components/post-summary/">Post summary</a>). In this case, "votes" 
+            stands in for the "balance of votes (up minus down)" on the post.
+        </li>
+        <li><em>Upvote</em> and <em>downvote</em> (one word, no hyphen) should be used when referring to the individual types of votes cast on a post.</li>
+        <li>While the unit for score is obstensibly "points", use of this unit in reference to score or votes is not encouraged.</li>
+    </ul>
+    <table class="s-table s-table__lg fs-body2 va-top w100 wmx6 mb48">
+        <thead>
+            <th class="btw0 bxw0 bbw3 bbw3 bc-red-2 fc-red-500 bg-transparent fs-body1 s-table--cell6">{% icon "Clear", "mtn1 mbn1" %} Incorrect</th>
+            <th class="btw0 bxw0 bbw3 bc-green-2 fc-green-500 bg-transparent fs-body1 s-table--cell6">{% icon "Checkmark", "mtn1 mbn1" %} Correct</th>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Highest voted posts</td>
+                <td>Highest scored posts</td>
+            </tr>
+            <tr>
+                <td>Total number of votes for this answer</td>
+                <td>Total score for this answer</td>
+            </tr>
+            <tr>
+                <td>Only top voted answers are eligible</td>
+                <td>Only top scored answers are eligible</td>
+            </tr>
+            <tr>
+                <td colspan="2" class="ta-center fw-bold">When in the Post Summary only:</td>
+            </tr>
+            <tr>
+                <td>8 score</td>
+                <td rowspan="3" class="ta-center va-middle">8 votes</td>
+            </tr>
+            <tr>
+                <td>Score: 8</td>
+            </tr>
+            <tr>
+                <td>8 points</td>
+            </tr>
+        </tbody>
+    </table>
+</section>

--- a/docs/brand/copywriting/concepts.html
+++ b/docs/brand/copywriting/concepts.html
@@ -41,7 +41,7 @@ description: Quick guidelines for how to identify and refer to different concept
             </tr>
             <tr>
                 <td>8 score</td>
-                <td rowspan="3" class="ta-center va-middle">8 votes</td>
+                <td rowspan="3" class="ta-center va-middle bb bbw1 bc-black-3">8 votes</td>
             </tr>
             <tr>
                 <td>Score: 8</td>

--- a/docs/brand/copywriting/concepts.html
+++ b/docs/brand/copywriting/concepts.html
@@ -12,7 +12,7 @@ description: Quick guidelines for how to identify and refer to different concept
         <li>In almost all cases when referring to the sum of votes, we will use the term <em>score</em>.</li>
         <li>
             Use of the  term <em>votes</em> to refer to the post’s score is only acceptable in cases where we need to present the data in the format 
-            <code>{ScoreValue} votes</code> (as is done in the <a href="/product/components/post-summary/">Post summary</a>). In this case, "votes" 
+            <code>{ScoreValue} votes</code> (as is done in the <a href="/product/components/post-summary/">post summary component</a>). In this case, "votes" 
             stands in for the "balance of votes (up minus down)" on the post.
         </li>
         <li><em>Upvote</em> and <em>downvote</em> (one word, no hyphen) should be used when referring to the individual types of votes cast on a post.</li>


### PR DESCRIPTION
Adding branding/terminology guidelines for the use of terms like "score", "votes", "upvote", "downvote" when referencing these concepts in relation to Posts. This page can be used for other similar conceptual definitions-of-record in the future. Addresses #818.