### PR TITLE
Add `.bs-xl` XL box-shadow atomic class

### DIFF
--- a/docs/_data/atomics.json
+++ b/docs/_data/atomics.json
@@ -21,6 +21,11 @@
       "hover": true
     },
     {
+      "class": "bs-xl",
+      "output": "TODO: Add output here. BTW, pretty sure the above outputs are way off.",
+      "hover": false
+    },
+    {
       "class": "bs-ring",
       "output": "box-shadow: 0 0 0 @su4 var(--focus-ring);",
       "hover": true,

--- a/docs/_data/atomics.json
+++ b/docs/_data/atomics.json
@@ -7,23 +7,22 @@
     },
     {
       "class": "bs-sm",
-      "output": "box-shadow: 0 @su2 @su8 fade(@black-700, 10%);",
+      "output": "box-shadow: 0 1px 2px hsla(0, 0%, 0%, 0.05),<br>0 1px 4px hsla(0, 0%, 0%, 0.05),<br>0 2px 8px hsla(0, 0%, 0%, 0.05)",
       "hover": true
     },
     {
       "class": "bs-md",
-      "output": "box-shadow: 0 @su4 @su8 fade(@black-700, 20%);",
+      "output": "box-shadow: 0 1px 3px hsla(0, 0%, 0%, 0.06),<br>0 2px 6px hsla(0, 0%, 0%, 0.06),<br>0 3px 8px hsla(0, 0%, 0%, 0.09)",
       "hover": true
     },
     {
       "class": "bs-lg",
-      "output": "box-shadow: 0 @su4 @su12 fade(@black-800, 20%);",
+      "output": "box-shadow: 0 1px 4px hsla(0, 0%, 0%, 0.09),<br>0 3px 8px hsla(0, 0%, 0%, 0.09),<br>0 4px 13px hsla(0, 0%, 0%, 0.13)",
       "hover": true
     },
     {
       "class": "bs-xl",
-      "output": "TODO: Add output here. BTW, pretty sure the above outputs are way off.",
-      "hover": false
+      "output": "box-shadow: 0 10px 24px hsla(0, 0%, 0%, 0.05),<br>0 20px 48px hsla(0, 0%, 0%, 0.05),<br>0 1px 4px hsla(0, 0%, 0%, 0.1)"
     },
     {
       "class": "bs-ring",

--- a/docs/product/base/box-shadow.html
+++ b/docs/product/base/box-shadow.html
@@ -49,9 +49,11 @@ description: Box shadow atomic classes allow you to change an element’s box sh
 <div class="bs-sm">…</div>
 <div class="bs-md">…</div>
 <div class="bs-lg">…</div>
+<div class="bs-xl">…</div>
+<div class="bs-ring">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example fs-caption ff-mono">
-            <div class="d-flex jc-space-between flex__allitems3 mb16">
+            <div class="d-grid grid__4 lg:grid__3 sm:grid__2 g16">
                 <div class="flex--item fd-column p12 bs-sm bar-sm h96">
                     .bs-sm
                 </div>
@@ -61,9 +63,9 @@ description: Box shadow atomic classes allow you to change an element’s box sh
                 <div class="flex--item fd-column p12 bs-lg bar-sm h96">
                     .bs-lg
                 </div>
-            </div>
-
-            <div class="d-flex jc-space-between flex__allitems3">
+                <div class="flex--item fd-column p12 bs-xl bar-sm h96">
+                    .bs-xl
+                </div>
                 <div class="flex--item fd-column p12 bs-ring bar-sm h96">
                     .bs-ring
                 </div>

--- a/docs/product/base/box-shadow.html
+++ b/docs/product/base/box-shadow.html
@@ -21,7 +21,7 @@ description: Box shadow atomic classes allow you to change an element’s box sh
                 {% for atomic in atomics.box-shadow %}
                     <tr class="fs-caption">
                         <th scope="row"><code class="stacks-code">.{{ atomic.class }}</code></th>
-                        <td><code class="stacks-code bg-white">{{ atomic.output }}</code></td>
+                        <td><code class="stacks-code bg-white pl0">{{ atomic.output }}</code></td>
                         <td class="ta-center">
                             {% if atomic.hover %}
                                 {% icon "Checkmark", "fc-green-500" %}

--- a/lib/css/atomic/_stacks-misc.less
+++ b/lib/css/atomic/_stacks-misc.less
@@ -292,6 +292,7 @@
 .h\:bs-md:hover { .bs-md; }
 .bs-lg { box-shadow: var(--bs-lg) !important; }
 .h\:bs-lg:hover { .bs-lg; }
+.bs-xl { box-shadow: var(--bs-xl) !important; }
 .bs-ring { box-shadow: 0 0 0 @su4 var(--focus-ring); }
 .h\:bs-ring:hover { .bs-ring; }
 .f\:bs-ring {

--- a/lib/css/exports/_stacks-constants-colors.less
+++ b/lib/css/exports/_stacks-constants-colors.less
@@ -150,6 +150,7 @@
 @bs-sm: 0 1px 2px hsla(0, 0%, 0%, 0.05), 0 1px 4px hsla(0, 0%, 0%, 0.05), 0 2px 8px hsla(0, 0%, 0%, 0.05);
 @bs-md: 0 1px 3px hsla(0, 0%, 0%, 0.06), 0 2px 6px hsla(0, 0%, 0%, 0.06), 0 3px 8px hsla(0, 0%, 0%, 0.09);
 @bs-lg: 0 1px 4px hsla(0, 0%, 0%, 0.09), 0 3px 8px hsla(0, 0%, 0%, 0.09), 0 4px 13px hsla(0, 0%, 0%, 0.13);
+@bs-xl: 0 10px 24px hsla(0, 0%, 0%, 0.05), 0 20px 48px hsla(0, 0%, 0%, 0.05), 0 1px 4px hsla(0, 0%, 0%, 0.1);
 
 //  $  SCROLLBARS
 //  ----------------------------------------------------------------------------
@@ -412,6 +413,7 @@
     --bs-sm: @bs-sm;
     --bs-md: @bs-md;
     --bs-lg: @bs-lg;
+    --bs-xl: @bs-xl;
 
     // Scrollbars
     --scrollbar: hsla(0, 0, 0, 0.2);
@@ -610,7 +612,8 @@
     --bs-sm: 0 1px 2px hsla(0, 0%, 0%, 0.1), 0 1px 4px hsla(0, 0%, 0%, 0.1), 0 2px 8px hsla(0, 0%, 0%, 0.1);
     --bs-md: 0 1px 3px hsla(0, 0%, 0%, 0.11), 0 2px 6px hsla(0, 0%, 0%, 0.11), 0 3px 8px hsla(0, 0%, 0%, 0.14);
     --bs-lg: 0 1px 4px hsla(0, 0%, 0%, 0.14), 0 3px 8px hsla(0, 0%, 0%, 0.14), 0 4px 13px hsla(0, 0%, 0%, 0.18);
-
+    --bs-xl: 0 10px 24px hsla(0, 0%, 0%, 0.1), 0 20px 48px hsla(0, 0%, 0%, 0.1), 0 1px 4px hsla(0, 0%, 0%, 0.15);
+    
     // Scrollbars
     --scrollbar: hsla(0, 0%, 100%, 0.2);
 
@@ -825,6 +828,7 @@
     --bs-sm: none;
     --bs-md: none;
     --bs-lg: none;
+    --bs-xl: none;
 
     // Scrollbars
     --scrollbar: var(--black);
@@ -980,6 +984,7 @@
     --bs-sm: none;
     --bs-md: none;
     --bs-lg: none;
+    --bs-xl: none;
 
     // Scrollbars
     --scrollbar: var(--black);


### PR DESCRIPTION
@aaronshekey a couple questions:

- The docs "output" for box-shadow look incorrect. The actual styles are combinations of multiple shadows (and they're different in dark mode). Feels a little wordy to stick the entire output of each box-shadow in the docs. Any better alternative in mind or should I just update to have the long rule in there?
- Are we cool with `.bs-xl` not being responsive?