### PR TITLE
Additional post summary refinements

### DIFF
--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -1335,6 +1335,17 @@ Is anyone aware of a fully functional implementation of this API (to generate th
     <p class="stacks-copy">Post summaries change their appearance based on being watched, ignored, or deleted. Articles can also have varying draft states.</p>
     <div class="stacks-preview">
 {% highlight html %}
+<div class="s-post-summary s-post-summary__pinned">
+    <div class="s-post-summary--stats">
+        <div class="s-post-summary--stats-item is-pinned">
+            @Svg.TackSm
+            Pinned
+        </div>
+        …
+    </div>
+    …
+ </div>
+
 <div class="s-post-summary s-post-summary__watched">
     …
     <a class="s-tag s-tag__watched">
@@ -1363,6 +1374,70 @@ Is anyone aware of a fully functional implementation of this API (to generate th
  </div>
 {% endhighlight %}
         <div class="stacks-preview--example p0">
+            <div class="s-post-summary s-post-summary__pinned">
+                <div class="s-post-summary--stats">
+                    <div class="s-post-summary--stats-item is-pinned">
+                        {% icon "TackSm" %}
+                        Pinned
+                    </div>
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
+                        <span class="s-post-summary--stats-item-number">
+                            10
+                        </span>
+                        <span class="s-post-summary--stats-item-unit">
+                            votes
+                        </span>
+                    </div>
+                    <div class="s-post-summary--stats-item">
+                        <span class="s-post-summary--stats-item-number">
+                            12
+                        </span>
+                        <span class="s-post-summary--stats-item-unit">
+                            views
+                        </span>
+                    </div>
+                    <div class="s-post-summary--stats-item">
+                        <span class="s-post-summary--stats-item-number">
+                            1
+                        </span>
+                        <span class="s-post-summary--stats-item-unit">
+                            minute read
+                        </span>
+                    </div>
+                </div>
+                <div class="s-post-summary--content">
+                    <div class="s-post-summary--content-type">
+                        <a href="#" class="s-link s-link__grayscale">{% icon "DocumentAlt" %} Knowledge Article</a>
+                    </div>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">Network graph of popular tags on Stack Overflow</a>
+                    </h3>
+                    <p class="s-post-summary--content-excerpt">
+                        I wanted to see how different tags related to each other. The below graph depicts associations between popular tags on our site. Description of analysis: I started looking at the 1000 most popular tags on questions in 2021. I created a list of tags cross joined by the question ID (so if a question contains tags for both Python and Numpy, it would show up in my list). I scaled up by the number of answers each question received (noting that some tag combos had 0 answers) -and then counted each distinct combination of each tag. Due to limitations in graphing, I only displayed the top ~2500 tag combinations - which accounts for tags combos that had more than 40 answers over the entire year.
+                    </p>
+                    <div class="s-post-summary--meta">
+                        <div class="s-post-summary--meta-tags">
+                            <a class="s-tag" href="#">data</a>
+                            <a class="s-tag" href="#">data-insights</a>
+                        </div>
+
+                        <div class="s-user-card s-user-card__minimal">
+                            <a href="#" class="s-avatar s-user-card--avatar">
+                                <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
+                            </a>
+                            <a href="#" class="s-user-card--link">Nimantha</a>
+                            <ul class="s-user-card--awards">
+                                <li class="s-user-card--rep">5,337</li>
+                            </ul>
+                            <time class="s-user-card--time">modified 18 minutes ago</time>
+                        </div>
+                    </div>
+                    <a href="#" class="s-btn s-btn__muted s-post-summary--content-menu-button">
+                        {% icon "EllipsisVertical" %}
+                    </a>
+                </div>
+            </div>
+
             <div class="s-post-summary s-post-summary__watched">
                 <div class="s-post-summary--stats">
                     <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">

--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -77,7 +77,9 @@ description: The post summary component summarizes various content and associate
                 @Svg… …
             </a>
         </div>
-        <a href="…" class="s-post-summary--content-title s-link">…</a>
+        <h3 class="s-post-summary--content-title">
+            <a href="…" class="s-link">…</a>
+        </h3>
         <p class="s-post-summary--content-excerpt">…</p>
         <div class="s-post-summary--meta">
             <div class="s-post-summary--meta-tags">
@@ -131,9 +133,9 @@ description: The post summary component summarizes various content and associate
                     </div>
                 </div>
                 <div class="s-post-summary--content">
-                    <a href="#" class="s-post-summary--content-title s-link">
-                        How to generate the JPA entity Metamodel?
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">How to generate the JPA entity Metamodel?</a>
+                    </h3>
                     <p class="s-post-summary--content-excerpt">
                         In the spirit of type safety associated with the CriteriaQuery JPA 2.0 also has an API to support Metamodel representation of entities.
                     </p>
@@ -194,9 +196,9 @@ description: The post summary component summarizes various content and associate
                     </div>
                 </div>
                 <div class="s-post-summary--content">
-                    <a class="s-post-summary--content-title s-link">
-                        Cannot read property 'startsWith' of null in npm install
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">Cannot read property 'startsWith' of null in npm install</a>
+                    </h3>
                     <p class="s-post-summary--content-excerpt">
                         I am creating my first react-native app. I am attempting to install the react-native command line interface as shown here. I keep getting an error when I type the command to initiate the react-native command line
                     </p>
@@ -264,9 +266,9 @@ description: The post summary component summarizes various content and associate
                     <div class="s-post-summary--content-type">
                         <a href="#" class="s-link s-link__grayscale">{% icon "DocumentAlt" %} How-to guide</a>
                     </div>
-                    <a href="#" class="s-post-summary--content-title s-link">
-                        How to run a product research study
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">How to run a product research study</a>
+                    </h3>
                     <p class="s-post-summary--content-excerpt">
                         This article aims to guide you through the steps and processes you may want to consider when running research at Stack Overflow. While there are obviously many methods, this guide will focus more interview-style research. For a full list of Product Research templates, guides, and links, see this article.
                     </p>
@@ -320,10 +322,12 @@ description: The post summary component summarizes various content and associate
                     </div>
                 </div>
                 <div class="s-post-summary--content">
-                    <a href="#" class="s-post-summary--content-title s-link">
-                        {% icon "Shield", "fc-light" %}
-                        EF core 3.1 - common table for entity and owned type
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">
+                            {% icon "Shield", "fc-light" %}
+                            EF core 3.1 - common table for entity and owned type
+                        </a>
+                    </h3>
                     <p class="s-post-summary--content-excerpt">
                         I’m trying to implement DDD approach in my project but realized that I have too big aggregates and trying to minimize the amount of data loaded from the database. I have an aggregate Order which
                     </p>
@@ -387,7 +391,9 @@ description: The post summary component summarizes various content and associate
         </div>
     </div>
     <div class="s-post-summary--content">
-        <a href="…" class="s-post-summary--content-title s-link">…</a>
+        <h3 class="s-post-summary--content-title">
+            <a href="…">…</a>
+        </h3>
         <div class="s-post-summary--meta">
             <div class="s-post-summary--meta-tags">
                 <a class="s-tag" href="…">…</a>
@@ -433,9 +439,9 @@ description: The post summary component summarizes various content and associate
                     </div>
                 </div>
                 <div class="s-post-summary--content">
-                    <a class="s-post-summary--content-title s-link">
-                        Clicking through a viewpager2?
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">Clicking through a viewpager2?</a>
+                    </h3>
                     <div class="s-post-summary--meta">
                         <div class="s-post-summary--meta-tags">
                             <a class="s-tag" href="#">android</a>
@@ -481,9 +487,9 @@ description: The post summary component summarizes various content and associate
                     </div>
                 </div>
                 <div class="s-post-summary--content">
-                    <a class="s-post-summary--content-title s-link">
-                        What permissions does github_token require for releases from a github action
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">What permissions does github_token require for releases from a github action</a>
+                    </h3>
                     <div class="s-post-summary--meta">
                         <div class="s-post-summary--meta-tags">
                             <a class="s-tag" href="#">github-actions</a>
@@ -527,9 +533,9 @@ description: The post summary component summarizes various content and associate
                     </div>
                 </div>
                 <div class="s-post-summary--content">
-                    <a class="s-post-summary--content-title s-link">
-                        Parentheses is Invalid Bash
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">Parentheses is Invalid Bash</a>
+                    </h3>
                     <div class="s-post-summary--meta">
                         <div class="s-post-summary--meta-tags">
                             <a class="s-tag" href="#">linux</a>
@@ -591,9 +597,9 @@ description: The post summary component summarizes various content and associate
                     </div>
                 </div>
                 <div class="s-post-summary--content">
-                    <a href="#" class="s-post-summary--content-title s-link">
-                        How to generate the JPA entity Metamodel?
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">How to generate the JPA entity Metamodel?</a>
+                    </h3>
                     <div class="s-post-summary--meta">
                         <div class="s-post-summary--meta-tags">
                             <a class="s-tag" href="#">java</a>
@@ -649,9 +655,9 @@ description: The post summary component summarizes various content and associate
                     </div>
                 </div>
                 <div class="s-post-summary--content">
-                    <a href="#" class="s-post-summary--content-title s-link">
-                        How to generate the JPA entity Metamodel?
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">How to generate the JPA entity Metamodel?</a>
+                    </h3>
                     <p class="s-post-summary--content-excerpt s-post-summary--content-excerpt__sm">
                         In the spirit of type safety associated with the CriteriaQuery JPA 2.0 also has an API to support Metamodel representation of entities.
 
@@ -712,9 +718,9 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </div>
                 </div>
                 <div class="s-post-summary--content">
-                    <a href="#" class="s-post-summary--content-title s-link">
-                        How to generate the JPA entity Metamodel?
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">How to generate the JPA entity Metamodel?</a>
+                    </h3>
                     <p class="s-post-summary--content-excerpt">
                         In the spirit of type safety associated with the CriteriaQuery JPA 2.0 also has an API to support Metamodel representation of entities. Is anyone aware of a fully functional implementation of this API (to generate the Metamodel as opposed to creating the metamodel classes manually)? It would be awesome if someone also knows the steps for setting this up in Eclipse (I assume it's as simple as setting up an annotation processor, but you never know).
                     </p>
@@ -773,9 +779,9 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </div>
                 </div>
                 <div class="s-post-summary--content">
-                    <a href="#" class="s-post-summary--content-title s-link">
-                        How to generate the JPA entity Metamodel?
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">How to generate the JPA entity Metamodel?</a>
+                    </h3>
                     <p class="s-post-summary--content-excerpt s-post-summary--content-excerpt__md">
                         In the spirit of type safety associated with the CriteriaQuery JPA 2.0 also has an API to support Metamodel representation of entities. Is anyone aware of a fully functional implementation of this API (to generate the Metamodel as opposed to creating the metamodel classes manually)? It would be awesome if someone also knows the steps for setting this up in Eclipse (I assume it's as simple as setting up an annotation processor, but you never know).
                     </p>
@@ -834,9 +840,9 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </div>
                 </div>
                 <div class="s-post-summary--content">
-                    <a href="#" class="s-post-summary--content-title s-link">
-                        How to generate the JPA entity Metamodel?
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">How to generate the JPA entity Metamodel?</a>
+                    </h3>
                     <p class="s-post-summary--content-excerpt s-post-summary--content-excerpt__lg">
                         In the spirit of type safety associated with the CriteriaQuery JPA 2.0 also has an API to support Metamodel representation of entities. Is anyone aware of a fully functional implementation of this API (to generate the Metamodel as opposed to creating the metamodel classes manually)? It would be awesome if someone also knows the steps for setting this up in Eclipse (I assume it's as simple as setting up an annotation processor, but you never know).
                     </p>
@@ -877,9 +883,10 @@ Is anyone aware of a fully functional implementation of this API (to generate th
 <div class="s-post-summary">
     …
     <div class="s-post-summary--content">
-        <a href="…" class="s-post-summary--content-title s-link">…</a>
+        <h3 class="s-post-summary--content-title">
+            <a href="…">…</a>
+        </h3>
         <div class="s-post-summary--meta">…</div>
-
         <div class="s-post-summary--answer">
             <div class="s-post-summary--stats">
                 <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
@@ -944,9 +951,9 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </div>
                 </div>
                 <div class="s-post-summary--content">
-                    <a class="s-post-summary--content-title s-link">
-                        Azure API Management and Backend Web API
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">Azure API Management and Backend Web API</a>
+                    </h3>
                     <p class="s-post-summary--content-excerpt">
                         Right now, I have enabled basic authentication to the developer portal in API Management. Also, I have enabled OAuth 2.0 authentication for the back end server (user Authorization). So, if i login to the developer portal, i can see two fields - Subscription Key and Authorization. The Subscription key will be the developer's subscription to the portal and the Authorization will be the OAuth authorization which is required for the back end server.
                     </p>
@@ -1385,9 +1392,9 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </div>
                 </div>
                 <div class="s-post-summary--content">
-                    <a class="s-post-summary--content-title s-link">
-                        Could not load type 'System.Web.Optimization.StyleBundle'
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">Could not load type 'System.Web.Optimization.StyleBundle'</a>
+                    </h3>
                     <p class="s-post-summary--content-excerpt">
                         Sometimes after build and launch my MVC4 web app I got this error. It can dissapear after rebuild or not. Same issue I got after publish to Windows Azure. Does anybody know how to fix this error?
                     </p>
@@ -1443,9 +1450,9 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </div>
                 </div>
                 <div class="s-post-summary--content">
-                    <a class="s-post-summary--content-title s-link">
-                        PHP URL Param redirects - with wildcards/regex
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">PHP URL Param redirects - with wildcards/regex</a>
+                    </h3>
                     <p class="s-post-summary--content-excerpt">
                         I recently found this solution for doing php url variable to header location redirects. It's so much more manageable compared to htaccess for mass redirects, however one thing I want to next work out templates, guides, and links, see this article.
                     </p>
@@ -1507,9 +1514,9 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     </div>
                 </div>
                 <div class="s-post-summary--content">
-                    <a class="s-post-summary--content-title s-link">
-                        Adding authentication based on API key and API secret to APIs in Spring Boot application
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">Adding authentication based on API key and API secret to APIs in Spring Boot application</a>
+                    </h3>
                     <p class="s-post-summary--content-excerpt">
                         I am working on a Spring Boot application with user authentication is based on Oauth2 2ith 2FA. Now, I would like to call the APIs in my application from the third-party client as well, say from another service.
                     </p>
@@ -1582,9 +1589,9 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     <div class="s-post-summary--content-type">
                         <a href="#" class="s-link s-link__grayscale">{% icon "DocumentAlt" %} How-to guide</a>
                     </div>
-                    <a class="s-post-summary--content-title s-link">
-                        How to make sql_mode empty on Cloud SQL
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">How to make sql_mode empty on Cloud SQL</a>
+                    </h3>
                     <p class="s-post-summary--content-excerpt">
                         Cloud SQL allows users to customize several flags that allow you to adjust options and configure and tune a database instance. In the case of the sql_mode flag, there are several options that are
                     </p>
@@ -1655,9 +1662,9 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     <div class="s-post-summary--content-type">
                         <a href="#" class="s-link s-link__grayscale">{% icon "DocumentAlt" %} How-to Guide</a>
                     </div>
-                    <a class="s-post-summary--content-title s-link">
-                        How to make sql_mode empty on Cloud SQL
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">How to make sql_mode empty on Cloud SQL</a>
+                    </h3>
                     <p class="s-post-summary--content-excerpt">
                         In Android apps that use Firebase Authentication, you can always get the user who is currently signed in with code like: FirebaseAuth auth = FirebaseAuth.getInstance(); FirebaseUser user = auth.get
                     </p>
@@ -1711,9 +1718,9 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     <div class="s-post-summary--content-type">
                         <a href="#" class="s-link s-link__grayscale">{% icon "DocumentAlt" %} How-to Guide</a>
                     </div>
-                    <a class="s-post-summary--content-title s-link">
-                        How to make sql_mode empty on Cloud SQL
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">How to make sql_mode empty on Cloud SQL</a>
+                    </h3>
                     <p class="s-post-summary--content-excerpt">
                         In Android apps that use Firebase Authentication, you can always get the user who is currently signed in with code like: FirebaseAuth auth = FirebaseAuth.getInstance(); FirebaseUser user = auth.get
                     </p>
@@ -1783,9 +1790,9 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                     <div class="s-post-summary--content-type">
                         <a href="#" class="s-link s-link__grayscale">{% icon "DocumentAlt" %} Announcement</a>
                     </div>
-                    <a class="s-post-summary--content-title s-link">
-                        Faster Cloud Storage transfers using the gcloud command-line
-                    </a>
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">Faster Cloud Storage transfers using the gcloud command-line</a>
+                    </h3>
                     <p class="s-post-summary--content-excerpt">
                         We’re pleased to announce gcloud storage, a new set of Cloud Storage commands in Cloud SDK that includes a new approach to parallelization that can accelerate both small and large data migrations.
                     </p>

--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -1596,11 +1596,11 @@ Is anyone aware of a fully functional implementation of this API (to generate th
                             <a href="#" class="s-avatar s-user-card--avatar">
                                 <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
                             </a>
-                            <a href="#" class="s-user-card--link">Nimantha</a>
+                            <a href="#" class="s-user-card--link">Aaron Shekey</a>
                             <ul class="s-user-card--awards">
-                                <li class="s-user-card--rep">5,337</li>
+                                <li class="s-user-card--rep">1,025</li>
                             </ul>
-                            <time class="s-user-card--time">modified 18 minutes ago</time>
+                            <time class="s-user-card--time">posted 1 minute ago</time>
                         </div>
                     </div>
                     <a href="#" class="s-btn s-btn__muted s-post-summary--content-menu-button">

--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -557,6 +557,177 @@ description: The post summary component summarizes various content and associate
         </div>
     </div>
 
+    {% header "h3", "Legacy" %}
+    <p class="stacks-copy">If you only need to display the original three stats and don’t need to interleave different content types, a legacy layout may be appropriate. This view is considered deprecated and will not receive updates. Care will be needed to move bounties to within the title block.</p>
+    <div class="stacks-preview">
+{% highlight html %}
+<div class="s-post-summary s-post-summary__legacy">
+    <div class="s-post-summary--stats">
+        <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
+            <div class="s-post-summary--stats-item-number">
+                …
+            </div>
+            votes
+        </div>
+        <div class="s-post-summary--stats-item">
+            @Svg.CheckmarkSm
+            <div class="s-post-summary--stats-item-number">…</div>
+            answers
+        </div>
+        <div class="s-post-summary--stats-item">
+            <div class="s-post-summary--stats-item-number">…</div>
+            views
+        </div>
+    </div>
+    <div class="s-post-summary--content">
+        <a href="…" class="s-post-summary--content-title s-link">…</a>
+        <div class="s-post-summary--meta">
+            <div class="s-post-summary--meta-tags">
+                <a class="s-tag" href="…">…</a>
+            </div>
+
+            <div class="s-user-card s-user-card__minimal">
+                <a href="…" class="s-avatar s-user-card--avatar">
+                    <img class="s-avatar--image" src="…" />
+                </a>
+                <a href="…" class="s-user-card--link">…</a>
+                <time class="s-user-card--time">…</time>
+            </div>
+        </div>
+    </div>
+</div>
+{% endhighlight %}
+        <div class="stacks-preview--example p0">
+            <div class="s-post-summary s-post-summary__legacy">
+                <div class="s-post-summary--stats">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
+                        <div class="s-post-summary--stats-item-number">
+                            0
+                        </div>
+                        votes
+                    </div>
+                    <div class="s-post-summary--stats-item">
+                        <div class="s-post-summary--stats-item-number">
+                            0
+                        </div>
+                        answers
+                    </div>
+                    <div class="s-post-summary--stats-item">
+                        <div class="s-post-summary--stats-item-number">
+                            2
+                        </div>
+                        views
+                    </div>
+                </div>
+                <div class="s-post-summary--content">
+                    <a class="s-post-summary--content-title s-link">
+                        Clicking through a viewpager2?
+                    </a>
+                    <div class="s-post-summary--meta">
+                        <div class="s-post-summary--meta-tags">
+                            <a class="s-tag" href="#">android</a>
+                            <a class="s-tag" href="#">android-studio</a>
+                            <a class="s-tag" href="#">android-viewpager2</a>
+                        </div>
+
+                        <div class="s-user-card s-user-card__minimal">
+                            <a href="…" class="s-avatar s-user-card--avatar">
+                                <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
+                            </a>
+                            <a href="#" class="s-user-card--link">Callum Osborne</a>
+                            <time class="s-user-card--time">asked about 1 minute ago</time>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="s-post-summary s-post-summary__legacy">
+                <div class="s-post-summary--stats">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
+                        <div class="s-post-summary--stats-item-number">
+                            0
+                        </div>
+                        votes
+                    </div>
+                    <div class="s-post-summary--stats-item has-answers has-accepted-answer">
+                        {% icon "CheckmarkSm" %}
+                        <div class="s-post-summary--stats-item-number">
+                            1
+                        </div>
+                        answer
+                    </div>
+                    <div class="s-post-summary--stats-item">
+                        <div class="s-post-summary--stats-item-number">
+                            3
+                        </div>
+                        views
+                    </div>
+                </div>
+                <div class="s-post-summary--content">
+                    <a class="s-post-summary--content-title s-link">
+                        <span class="s-badge s-badge__bounty s-badge__sm va-text-bottom">+100</span>
+                        What permissions does github_token require for releases from a github action
+                    </a>
+                    <div class="s-post-summary--meta">
+                        <div class="s-post-summary--meta-tags">
+                            <a class="s-tag" href="#">github-actions</a>
+                        </div>
+
+                        <div class="s-user-card s-user-card__minimal">
+                            <a href="…" class="s-avatar s-user-card--avatar">
+                                <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
+                            </a>
+                            <a href="#" class="s-user-card--link">GuiFalourd</a>
+                            <time class="s-user-card--time">answered 4 minutes ago</time>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="s-post-summary s-post-summary__legacy">
+                <div class="s-post-summary--stats">
+                    <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
+                        <div class="s-post-summary--stats-item-number">
+                            0
+                        </div>
+                        votes
+                    </div>
+                    <div class="s-post-summary--stats-item">
+                        <div class="s-post-summary--stats-item-number">
+                            0
+                        </div>
+                        answers
+                    </div>
+                    <div class="s-post-summary--stats-item">
+                        <div class="s-post-summary--stats-item-number">
+                            5
+                        </div>
+                        views
+                    </div>
+                </div>
+                <div class="s-post-summary--content">
+                    <a class="s-post-summary--content-title s-link">
+                        Parentheses is Invalid Bash
+                    </a>
+                    <div class="s-post-summary--meta">
+                        <div class="s-post-summary--meta-tags">
+                            <a class="s-tag" href="#">linux</a>
+                            <a class="s-tag" href="#">bash</a>
+                            <a class="s-tag" href="#">docker</a>
+                            <a class="s-tag" href="#">shell</a>
+                        </div>
+
+                        <div class="s-user-card s-user-card__minimal">
+                            <a href="…" class="s-avatar s-user-card--avatar">
+                                <img class="s-avatar--image" src="{{ "/assets/img/placeholder.svg" | relative_url }}" />
+                            </a>
+                            <a href="#" class="s-user-card--link">thatkingguy_</a>
+                            <time class="s-user-card--time">asked 8 minutes ago</time>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     {% header "h3", "Excerpts" %}
     <p class="stacks-copy">Posts can be shown with or without excerpts. Stacks also provides various size </p>
     <div class="stacks-preview">

--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -564,19 +564,29 @@ description: The post summary component summarizes various content and associate
 <div class="s-post-summary s-post-summary__legacy">
     <div class="s-post-summary--stats">
         <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
-            <div class="s-post-summary--stats-item-number">
+            <span class="s-post-summary--stats-item-number">
                 …
-            </div>
-            votes
+            </span>
+            <span class="s-post-summary--stats-item-unit">
+                votes
+            </span>
         </div>
         <div class="s-post-summary--stats-item">
             @Svg.CheckmarkSm
-            <div class="s-post-summary--stats-item-number">…</div>
-            answers
+            <span class="s-post-summary--stats-item-number">
+                …
+            </span>
+            <span class="s-post-summary--stats-item-unit">
+                answers
+            </span>
         </div>
         <div class="s-post-summary--stats-item">
-            <div class="s-post-summary--stats-item-number">…</div>
-            views
+            <span class="s-post-summary--stats-item-number">
+                …
+            </span>
+            <span class="s-post-summary--stats-item-unit">
+                views
+            </span>
         </div>
     </div>
     <div class="s-post-summary--content">
@@ -601,22 +611,28 @@ description: The post summary component summarizes various content and associate
             <div class="s-post-summary s-post-summary__legacy">
                 <div class="s-post-summary--stats">
                     <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
-                        <div class="s-post-summary--stats-item-number">
+                        <span class="s-post-summary--stats-item-number">
                             0
-                        </div>
-                        votes
+                        </span>
+                        <span class="s-post-summary--stats-item-unit">
+                            votes
+                        </span>
                     </div>
                     <div class="s-post-summary--stats-item">
-                        <div class="s-post-summary--stats-item-number">
+                        <span class="s-post-summary--stats-item-number">
                             0
-                        </div>
-                        answers
+                        </span>
+                        <span class="s-post-summary--stats-item-unit">
+                            answers
+                        </span>
                     </div>
                     <div class="s-post-summary--stats-item">
-                        <div class="s-post-summary--stats-item-number">
+                        <span class="s-post-summary--stats-item-number">
                             2
-                        </div>
-                        views
+                        </span>
+                        <span class="s-post-summary--stats-item-unit">
+                            views
+                        </span>
                     </div>
                 </div>
                 <div class="s-post-summary--content">
@@ -643,23 +659,29 @@ description: The post summary component summarizes various content and associate
             <div class="s-post-summary s-post-summary__legacy">
                 <div class="s-post-summary--stats">
                     <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
-                        <div class="s-post-summary--stats-item-number">
+                        <span class="s-post-summary--stats-item-number">
                             0
-                        </div>
-                        votes
+                        </span>
+                        <span class="s-post-summary--stats-item-unit">
+                            votes
+                        </span>
                     </div>
                     <div class="s-post-summary--stats-item has-answers has-accepted-answer">
                         {% icon "CheckmarkSm" %}
-                        <div class="s-post-summary--stats-item-number">
+                        <span class="s-post-summary--stats-item-number">
                             1
-                        </div>
-                        answer
+                        </span>
+                        <span class="s-post-summary--stats-item-unit">
+                            answer
+                        </span>
                     </div>
                     <div class="s-post-summary--stats-item">
-                        <div class="s-post-summary--stats-item-number">
+                        <span class="s-post-summary--stats-item-number">
                             3
-                        </div>
-                        views
+                        </span>
+                        <span class="s-post-summary--stats-item-unit">
+                            views
+                        </span>
                     </div>
                 </div>
                 <div class="s-post-summary--content">
@@ -685,22 +707,28 @@ description: The post summary component summarizes various content and associate
             <div class="s-post-summary s-post-summary__legacy">
                 <div class="s-post-summary--stats">
                     <div class="s-post-summary--stats-item s-post-summary--stats-item__emphasized">
-                        <div class="s-post-summary--stats-item-number">
+                        <span class="s-post-summary--stats-item-number">
                             0
-                        </div>
-                        votes
+                        </span>
+                        <span class="s-post-summary--stats-item-unit">
+                            votes
+                        </span>
                     </div>
                     <div class="s-post-summary--stats-item">
-                        <div class="s-post-summary--stats-item-number">
+                        <span class="s-post-summary--stats-item-number">
                             0
-                        </div>
-                        answers
+                        </span>
+                        <span class="s-post-summary--stats-item-unit">
+                            answers
+                        </span>
                     </div>
                     <div class="s-post-summary--stats-item">
-                        <div class="s-post-summary--stats-item-number">
+                        <span class="s-post-summary--stats-item-number">
                             5
-                        </div>
-                        views
+                        </span>
+                        <span class="s-post-summary--stats-item-unit">
+                            views
+                        </span>
                     </div>
                 </div>
                 <div class="s-post-summary--content">

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -199,6 +199,7 @@
         margin-bottom: @su8;
         color: var(--fc-medium);
         .v-truncate2;
+        .break-word;
 
         &.s-post-summary--content-excerpt__sm {
             .v-truncate1;

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -182,6 +182,21 @@
                 bottom: 0;
             });
         }
+
+        &.s-link,
+        & .s-link {
+            color: var(--theme-question-title-color);
+            font-family: var(--theme-question-title-font-family);
+
+            &:visited {
+                color: var(--theme-question-title-color-visited);
+            }
+
+            &:hover,
+            &:active {
+                color: var(--theme-question-title-color-hover);
+            }
+        }
     }
 
     .s-post-summary--content-type {
@@ -197,6 +212,7 @@
     .s-post-summary--content-excerpt {
         margin-top: -@su2;
         margin-bottom: @su8;
+        font-family: var(--theme-question-body-font-family);
         color: var(--fc-medium);
         .v-truncate2;
         .break-word;

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -67,6 +67,16 @@
                     font-weight: normal;
                     font-size: @fs-body3;
                 }
+
+                &.is-deleted,
+                &.is-published,
+                &.is-draft,
+                &.is-review,
+                &.is-closed,
+                &.is-archived,
+                &.is-pinned {
+                    display: none;
+                }
             }
 
             #stacks-internals #screen-md({
@@ -91,6 +101,16 @@
                     &.has-accepted-answer .svg-icon {
                         display: block;
                     }
+                }
+
+                &.is-deleted,
+                &.is-published,
+                &.is-draft,
+                &.is-review,
+                &.is-closed,
+                &.is-archived,
+                &.is-pinned {
+                    display: block;
                 }
             });
         }

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -84,7 +84,8 @@
         &.is-draft,
         &.is-review,
         &.is-closed,
-        &.is-archived {
+        &.is-archived,
+        &.is-pinned {
             border-radius: @br-sm;
             padding: @su2 @su4;
         }
@@ -148,6 +149,11 @@
             color: var(--black-900);
             background-color: var(--black-100);
             border-color: var(--black-600);
+        }
+
+        &.is-pinned {
+            color: var(--white);
+            background-color: var(--black-800);
         }
     }
 
@@ -306,6 +312,10 @@
     }
 }
 
+.s-post-summary__pinned {
+    background-color: var(--black-025);
+}
+
 .s-post-summary__ignored,
 .s-post-summary__deleted {
     .s-post-summary--content {
@@ -318,7 +328,8 @@
     }
 
     .s-post-summary--content-title {
-        &, & .s-link {
+        &,
+        & .s-link {
             color: var(--black-600);
 
             &:hover {

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -34,6 +34,65 @@
             width: 100%;
         }
     }
+
+    &.s-post-summary__legacy {
+        padding-left: 0; // Since stats have padding, we don't need it on the parent
+        column-gap: @su8;
+
+        .s-post-summary--stats {
+            width: auto;
+            flex-direction: row;
+            align-items: center;
+            gap: @su2;
+            margin: 0;
+
+            .s-post-summary--stats-item {
+                min-width: @su64;
+                height: @su48;
+                flex-direction: column;
+                gap: 0;
+                font-size: @fs-caption;
+
+                &.s-post-summary--stats-item__emphasized {
+                    color: inherit;
+                }
+
+                &.has-accepted-answer .svg-icon {
+                    display: none;
+                }
+
+                .s-post-summary--stats-item-number {
+                    font-weight: normal;
+                    font-size: @fs-body3;
+                }
+            }
+
+            #stacks-internals #screen-md({
+                flex-direction: row;
+                align-items: center;
+                gap: @su8;
+
+                .s-post-summary--stats-item {
+                    min-width: auto;
+                    height: auto;
+                    flex-direction: row;
+                    gap: 3px; // HTML spacing
+
+                    .s-post-summary--stats-item-number {
+                        font-size: inherit;
+                    }
+
+                    &.s-post-summary--stats-item__emphasized {
+                        color: var(--fc-dark);
+                    }
+
+                    &.has-accepted-answer .svg-icon {
+                        display: block;
+                    }
+                }
+            });
+        }
+    }
 }
 
 //  [1] To override .s-btn class attributes

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -170,6 +170,8 @@
         overflow-wrap: break-word;
         word-wrap: break-word;
         padding-right: @su24;
+        line-height: @lh-md;
+        font-weight: normal;
 
         .iconShield {
             color: var(--black-600);

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -167,11 +167,10 @@
         font-size: @fs-body3;
         margin-top: -0.15rem; // Optical alignment to compensate for title's containing block
         margin-bottom: @su6;
-        overflow-wrap: break-word;
-        word-wrap: break-word;
         padding-right: @su24;
         line-height: @lh-md;
         font-weight: normal;
+        .break-word;
 
         .iconShield {
             color: var(--black-600);
@@ -186,6 +185,8 @@
         }
 
         a {
+            .break-word;
+
             color: var(--theme-question-title-color);
             font-family: var(--theme-question-title-font-family);
 

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -185,8 +185,7 @@
             });
         }
 
-        &.s-link,
-        & .s-link {
+        a {
             color: var(--theme-question-title-color);
             font-family: var(--theme-question-title-font-family);
 

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -101,16 +101,16 @@
                     &.has-accepted-answer .svg-icon {
                         display: block;
                     }
-                }
 
-                &.is-deleted,
-                &.is-published,
-                &.is-draft,
-                &.is-review,
-                &.is-closed,
-                &.is-archived,
-                &.is-pinned {
-                    display: block;
+                    &.is-deleted,
+                    &.is-published,
+                    &.is-draft,
+                    &.is-review,
+                    &.is-closed,
+                    &.is-archived,
+                    &.is-pinned {
+                        display: block;
+                    }
                 }
             });
         }

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -47,7 +47,6 @@
             flex-direction: row;
             align-items: center;
             gap: @su2;
-            margin: 0;
 
             .s-post-summary--stats-item {
                 min-width: @su64;

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -37,7 +37,10 @@
 
     &.s-post-summary__legacy {
         padding-left: 0; // Since stats have padding, we don't need it on the parent
-        column-gap: @su8;
+
+        #stacks-internals #screen-md({
+            padding-left: @su16;
+        });
 
         .s-post-summary--stats {
             width: auto;

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -274,16 +274,16 @@
         a {
             .break-word;
 
-            color: var(--theme-question-title-color);
-            font-family: var(--theme-question-title-font-family);
+            color: var(--theme-post-title-color);
+            font-family: var(--theme-post-title-font-family);
 
             &:visited {
-                color: var(--theme-question-title-color-visited);
+                color: var(--theme-post-title-color-visited);
             }
 
             &:hover,
             &:active {
-                color: var(--theme-question-title-color-hover);
+                color: var(--theme-post-title-color-hover);
             }
         }
     }
@@ -301,7 +301,7 @@
     .s-post-summary--content-excerpt {
         margin-top: -@su2;
         margin-bottom: @su8;
-        font-family: var(--theme-question-body-font-family);
+        font-family: var(--theme-post-body-font-family);
         color: var(--fc-medium);
         .v-truncate2;
         .break-word;

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -327,18 +327,16 @@
         filter: grayscale(100%);
     }
 
-    .s-post-summary--content-title {
-        &,
-        & .s-link {
-            color: var(--black-600);
+    .s-post-summary--content-title a {
+        color: var(--black-600);
 
-            &:hover {
-                color: var(--black-500);
-            }
+        &:hover,
+        &:active {
+            color: var(--black-500);
+        }
 
-            &:visited {
-                color: var(--black-700);
-            }
+        &:visited {
+            color: var(--black-700);
         }
     }
 

--- a/lib/css/exports/_stacks-constants-colors.less
+++ b/lib/css/exports/_stacks-constants-colors.less
@@ -272,10 +272,12 @@
     // Topbar themed border accent
     --theme-topbar-accent-border: 3px solid var(--theme-primary-color);
 
-    // Post summaries
-    --theme-question-title-color: var(--theme-secondary-400);
-    --theme-question-title-color-visited: var(--theme-secondary-350);
-    --theme-question-title-color-hover: var(--theme-secondary-500);
+    // Post summary
+    --theme-post-title-color: var(--theme-link-color);
+    --theme-post-title-color-hover: var(--theme-link-color-hover);
+    --theme-post-title-color-visited: var(--theme-link-color-visited);
+    --theme-post-title-font-family: var(--theme-body-font-family);
+    --theme-post-body-font-family: var(--theme-body-font-family);
 }
 
 //  --  Light mode

--- a/lib/css/exports/_stacks-constants-colors.less
+++ b/lib/css/exports/_stacks-constants-colors.less
@@ -271,6 +271,11 @@
 
     // Topbar themed border accent
     --theme-topbar-accent-border: 3px solid var(--theme-primary-color);
+
+    // Post summaries
+    --theme-question-title-color: var(--theme-secondary-400);
+    --theme-question-title-color-visited: var(--theme-secondary-350);
+    --theme-question-title-color-hover: var(--theme-secondary-500);
 }
 
 //  --  Light mode

--- a/lib/css/exports/_stacks-constants-type.less
+++ b/lib/css/exports/_stacks-constants-type.less
@@ -31,9 +31,6 @@ body {
     --ff-serif: @ff-serif;
     --ff-mono: @ff-mono;
     --theme-body-font-family: var(--ff-sans);
-
-    --theme-question-title-font-family: var(--ff-sans);
-    --theme-question-body-font-family: var(--ff-sans);
 }
 
 //  ============================================================================

--- a/lib/css/exports/_stacks-constants-type.less
+++ b/lib/css/exports/_stacks-constants-type.less
@@ -31,6 +31,9 @@ body {
     --ff-serif: @ff-serif;
     --ff-mono: @ff-mono;
     --theme-body-font-family: var(--ff-sans);
+
+    --theme-question-title-font-family: var(--ff-sans);
+    --theme-question-body-font-family: var(--ff-sans);
 }
 
 //  ============================================================================


### PR DESCRIPTION
- [x] Upstreams breaking words in excerpts
- [x] Switches to `h3` for post titles
- [x] Guards against various environment differences in post titles
- [x] Removes reliance on `s-link`
- [x] Introduces new theming variables in the post summary
- [x] Adds deprecated "Legacy" layout
- [x] Adds pinned state

To manage in production:

- Add the prop for legacy layout and handle markup moving around based on that state
- Add prop for pinned
- Configure theming variables in production