### PR TITLE
Add link to the W3C's alt-text decision tree

### DIFF
--- a/docs/content/examples/alt-text.html
+++ b/docs/content/examples/alt-text.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Alt-text
-description: Everything we know about alt-texts, when to use them, and how to craft them.
+description: Everything we know about alt-texts, when to use them, and how to craft them. For a helpful decision tree on how and when to write alt-text, check out the W3C's <a href="https://www.w3.org/WAI/tutorials/images/decision-tree/"> alt-text decision tree</a>.
 ---
 <section class="stacks-section">
     {% header "h2", "How to write alt-text" %}

--- a/docs/content/examples/alt-text.html
+++ b/docs/content/examples/alt-text.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Alt-text
-description: Everything we know about alt-texts, when to use them, and how to craft them. For a helpful decision tree on how and when to write alt-text, check out the W3C's <a href="https://www.w3.org/WAI/tutorials/images/decision-tree/"> alt-text decision tree</a>.
+description: Everything we know about alt-texts, when to use them, and how to craft them. For a helpful decision tree on how and when to write alt-text, check out the W3C’s <a href="https://www.w3.org/WAI/tutorials/images/decision-tree/">alt-text decision tree</a>.
 ---
 <section class="stacks-section">
     {% header "h2", "How to write alt-text" %}


### PR DESCRIPTION
I added a link to https://www.w3.org/WAI/tutorials/images/decision-tree/ to the [alt-text docs page](http://localhost:8080/content/examples/alt-text/). How about it?