### PR TITLE
Refine the spacing under Post Summary titles

### DIFF
--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -253,7 +253,7 @@
         display: block;
         font-size: @fs-body3;
         margin-top: -0.15rem; // Optical alignment to compensate for title's containing block
-        margin-bottom: @su6;
+        margin-bottom: 0.3846rem;
         padding-right: @su24;
         line-height: @lh-md;
         font-weight: normal;


### PR DESCRIPTION
When there isn't an excerpt, this makes sure the tags and various stats items line up.