### PR TITLE
Update .s-post-summary__pinned styling

### DIFF
--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -393,15 +393,6 @@
     }
 }
 
-.s-post-summary__pinned {
-    background-color: var(--black-025);
-    border: 1px solid var(--black-075);
-
-    & + & {
-        border-top-width: 0;
-    }
-}
-
 .s-post-summary__ignored,
 .s-post-summary__deleted {
     .s-post-summary--content {

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -395,6 +395,11 @@
 
 .s-post-summary__pinned {
     background-color: var(--black-025);
+    border: 1px solid var(--black-075);
+
+    & + & {
+        border-top-width: 0px;
+    }
 }
 
 .s-post-summary__ignored,

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -398,7 +398,7 @@
     border: 1px solid var(--black-075);
 
     & + & {
-        border-top-width: 0px;
+        border-top-width: 0;
     }
 }
 

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -235,7 +235,6 @@
         &.is-pinned {
             color: var(--white);
             background-color: var(--black-700);
-            border-color: var(--black-075);
         }
     }
 

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -234,7 +234,8 @@
 
         &.is-pinned {
             color: var(--white);
-            background-color: var(--black-800);
+            background-color: var(--black-700);
+            border-color: var(--black-075);
         }
     }
 


### PR DESCRIPTION
1. Updates the `.s-post-summary--stats-item.is-pinned` background color from `--black-800` to `--black-700`.
2. Removes all `.s-post-summary__pinned` styling (We will not have a background color for pinned posts at this time)