### PR TITLE
Add `*-screen` atomic width/height classes

### DIFF
--- a/docs/_data/atomics.json
+++ b/docs/_data/atomics.json
@@ -419,6 +419,11 @@
       "class": "w100",
       "output": "width: 100%;",
       "responsive": true
+    },
+    {
+      "class": "w-screen",
+      "output": "width: 100vw;",
+      "responsive": true
     }
   ],
   "width-static": [
@@ -568,6 +573,11 @@
       "class": "wmx100",
       "output": "max-width: 100%;",
       "responsive": true
+    },
+    {
+      "class": "wmx-screen",
+      "output": "max-width: 100vw;",
+      "responsive": true
     }
   ],
   "width-min": [
@@ -675,6 +685,11 @@
     {
       "class": "h100",
       "output": "height: 100%;",
+      "responsive": true
+    },
+    {
+      "class": "h-screen",
+      "output": "height: 100vh;",
       "responsive": true
     }
   ],
@@ -877,6 +892,11 @@
       "class": "hmx100",
       "output": "max-height: 100%;",
       "responsive": true
+    },
+    {
+      "class": "hmx-initial",
+      "output": "max-height: 100vh;",
+      "responsive": true
     }
   ],
   "height-min": [
@@ -953,6 +973,11 @@
     {
       "class": "hmn100",
       "output": "min-height: 100%;",
+      "responsive": true
+    },
+    {
+      "class": "hmx-screen",
+      "output": "min-height: 100vh;",
       "responsive": true
     }
   ],

--- a/docs/_data/atomics.json
+++ b/docs/_data/atomics.json
@@ -976,7 +976,7 @@
       "responsive": true
     },
     {
-      "class": "hmx-screen",
+      "class": "hmn-screen",
       "output": "min-height: 100vh;",
       "responsive": true
     }

--- a/docs/product/base/width-height.html
+++ b/docs/product/base/width-height.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Width & height
-description: Stacks provides atomic sizing classes for percentage-based widths & heights, static widths & heights, max-widths & heights, and min-widths & heights.
+description: Stacks provides atomic sizing classes for percentage-based widths & heights, viewport-based widths & heights, static widths & heights, max-widths & heights, and min-widths & heights.
 ---
 <section class="stacks-section">
     {% header "h2", "Widths" %}
@@ -147,6 +147,7 @@ description: Stacks provides atomic sizing classes for percentage-based widths &
 <div class="w80">…</div>
 <div class="w90">…</div>
 <div class="w100">…</div>
+<div class="w-screen">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example ps-relative fs-caption ff-mono">
             <div class="d-flex gs2 fd-column w100">
@@ -180,6 +181,9 @@ description: Stacks provides atomic sizing classes for percentage-based widths &
                 <div class="d-flex">
                     <div class="p16 mr2 w50 bg-black-075 ba bc-black-3">.w50</div>
                     <div class="p16 ml2 w50 bg-black-075 ba bc-black-3">.w50</div>
+                </div>
+                <div class="d-flex">
+                    <div class="p16 w-screen bg-black-075 ba bc-black-3">.w-screen</div>
                 </div>
             </div>
         </div>
@@ -302,6 +306,7 @@ description: Stacks provides atomic sizing classes for percentage-based widths &
 <div class="wmx11">…</div>
 <div class="wmx12">…</div>
 <div class="wmx100">…</div>
+<div class="wmx-screen">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example ps-relative fs-caption ff-mono overflow-x-scroll">
             <div class="d-flex gs2 fd-column ws12">
@@ -320,6 +325,7 @@ description: Stacks provides atomic sizing classes for percentage-based widths &
                 <div class="flex--item p16 wmx10 bg-black-075 ba bc-black-3">.wmx10</div>
                 <div class="flex--item p16 wmx11 bg-black-075 ba bc-black-3">.wmx11</div>
                 <div class="flex--item p16 wmx12 bg-black-075 ba bc-black-3">.wmx12</div>
+                <div class="flex--item p16 wmx-screen bg-black-075 ba bc-black-3">.wmx-screen</div>
             </div>
         </div>
     </div>

--- a/docs/product/base/width-height.html
+++ b/docs/product/base/width-height.html
@@ -49,52 +49,52 @@ description: Stacks provides atomic sizing classes for percentage-based widths &
 <div class="w128">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example ps-relative fs-caption ff-mono">
-            <div class="d-flex gs2 fd-column">
-                <div class="d-flex gs4">
+            <div class="d-flex g2 fd-column">
+                <div class="d-flex g4">
                     <div class="flex--item w2 bg-black-075 ba bc-black-3"></div>
                     <div class="flex--item">.w2</div>
                 </div>
-                <div class="d-flex gs4">
+                <div class="d-flex g4">
                     <div class="flex--item w4 bg-black-075 ba bc-black-3"></div>
                     <div class="flex--item">.w4</div>
                 </div>
-                <div class="d-flex gs4">
+                <div class="d-flex g4">
                     <div class="flex--item w6 bg-black-075 ba bc-black-3"></div>
                     <div class="flex--item">.w6</div>
                 </div>
-                <div class="d-flex gs4">
+                <div class="d-flex g4">
                     <div class="flex--item w8 bg-black-075 ba bc-black-3"></div>
                     <div class="flex--item">.w8</div>
                 </div>
-                <div class="d-flex gs4">
+                <div class="d-flex g4">
                     <div class="flex--item w12 bg-black-075 ba bc-black-3"></div>
                     <div class="flex--item">.w12</div>
                 </div>
-                <div class="d-flex gs4">
+                <div class="d-flex g4">
                     <div class="flex--item w16 bg-black-075 ba bc-black-3"></div>
                     <div class="flex--item">.w16</div>
                 </div>
-                <div class="d-flex gs4">
+                <div class="d-flex g4">
                     <div class="flex--item w24 bg-black-075 ba bc-black-3"></div>
                     <div class="flex--item">.w24</div>
                 </div>
-                <div class="d-flex gs4">
+                <div class="d-flex g4">
                     <div class="flex--item w32 bg-black-075 ba bc-black-3"></div>
                     <div class="flex--item">.w32</div>
                 </div>
-                <div class="d-flex gs4">
+                <div class="d-flex g4">
                     <div class="flex--item w48 bg-black-075 ba bc-black-3"></div>
                     <div class="flex--item">.w48</div>
                 </div>
-                <div class="d-flex gs4">
+                <div class="d-flex g4">
                     <div class="flex--item w64 bg-black-075 ba bc-black-3"></div>
                     <div class="flex--item">.w64</div>
                 </div>
-                <div class="d-flex gs4">
+                <div class="d-flex g4">
                     <div class="flex--item w96 bg-black-075 ba bc-black-3"></div>
                     <div class="flex--item">.w96</div>
                 </div>
-                <div class="d-flex gs4">
+                <div class="d-flex g4">
                     <div class="flex--item w128 bg-black-075 ba bc-black-3"></div>
                     <div class="flex--item">.w128</div>
                 </div>
@@ -150,37 +150,37 @@ description: Stacks provides atomic sizing classes for percentage-based widths &
 <div class="w-screen">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example ps-relative fs-caption ff-mono">
-            <div class="d-flex gs2 fd-column w100">
+            <div class="d-flex g2 fd-column w100">
                 <div class="d-flex">
                     <div class="p16 w100 bg-black-075 ba bc-black-3">.w100</div>
                 </div>
-                <div class="d-flex">
-                    <div class="p16 mr2 w10 bg-black-075 ba bc-black-3">.w10</div>
-                    <div class="p16 ml2 w90 bg-black-075 ba bc-black-3">.w90</div>
+                <div class="d-flex g4">
+                    <div class="p16 w10 bg-black-075 ba bc-black-3">.w10</div>
+                    <div class="p16 w90 bg-black-075 ba bc-black-3">.w90</div>
                 </div>
-                <div class="d-flex">
-                    <div class="p16 mr2 w20 bg-black-075 ba bc-black-3">.w20</div>
-                    <div class="p16 ml2 w80 bg-black-075 ba bc-black-3">.w80</div>
+                <div class="d-flex g4">
+                    <div class="p16 w20 bg-black-075 ba bc-black-3">.w20</div>
+                    <div class="p16 w80 bg-black-075 ba bc-black-3">.w80</div>
                 </div>
-                <div class="d-flex">
-                    <div class="p16 mr2 w25 bg-black-075 ba bc-black-3">.w25</div>
-                    <div class="p16 ml2 w75 bg-black-075 ba bc-black-3">.w75</div>
+                <div class="d-flex g4">
+                    <div class="p16 w25 bg-black-075 ba bc-black-3">.w25</div>
+                    <div class="p16 w75 bg-black-075 ba bc-black-3">.w75</div>
                 </div>
-                <div class="d-flex">
-                    <div class="p16 mr2 w30 bg-black-075 ba bc-black-3">.w30</div>
-                    <div class="p16 ml2 w70 bg-black-075 ba bc-black-3">.w70</div>
+                <div class="d-flex g4">
+                    <div class="p16 w30 bg-black-075 ba bc-black-3">.w30</div>
+                    <div class="p16 w70 bg-black-075 ba bc-black-3">.w70</div>
                 </div>
-                <div class="d-flex">
-                    <div class="p16 mr2 w33 bg-black-075 ba bc-black-3">.w33</div>
-                    <div class="p16 ml2 w66 bg-black-075 ba bc-black-3">.w66</div>
+                <div class="d-flex g4">
+                    <div class="p16 w33 bg-black-075 ba bc-black-3">.w33</div>
+                    <div class="p16 w66 bg-black-075 ba bc-black-3">.w66</div>
                 </div>
-                <div class="d-flex">
-                    <div class="p16 mr2 w40 bg-black-075 ba bc-black-3">.w40</div>
-                    <div class="p16 ml2 w60 bg-black-075 ba bc-black-3">.w60</div>
+                <div class="d-flex g4">
+                    <div class="p16 w40 bg-black-075 ba bc-black-3">.w40</div>
+                    <div class="p16 w60 bg-black-075 ba bc-black-3">.w60</div>
                 </div>
-                <div class="d-flex">
-                    <div class="p16 mr2 w50 bg-black-075 ba bc-black-3">.w50</div>
-                    <div class="p16 ml2 w50 bg-black-075 ba bc-black-3">.w50</div>
+                <div class="d-flex g4">
+                    <div class="p16 w50 bg-black-075 ba bc-black-3">.w50</div>
+                    <div class="p16 w50 bg-black-075 ba bc-black-3">.w50</div>
                 </div>
                 <div class="d-flex">
                     <div class="p16 w-screen bg-black-075 ba bc-black-3">.w-screen</div>
@@ -240,7 +240,7 @@ description: Stacks provides atomic sizing classes for percentage-based widths &
 <div class="ws12">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example ps-relative fs-caption ff-mono overflow-x-scroll">
-            <div class="d-flex gs2 fd-column ws12">
+            <div class="d-flex g2 fd-column ws12">
                 <div class="flex--item p16 ws1 bg-black-075 ba bc-black-3">.ws1</div>
                 <div class="flex--item p16 ws2 bg-black-075 ba bc-black-3">.ws2</div>
                 <div class="flex--item p16 ws3 bg-black-075 ba bc-black-3">.ws3</div>
@@ -309,7 +309,7 @@ description: Stacks provides atomic sizing classes for percentage-based widths &
 <div class="wmx-screen">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example ps-relative fs-caption ff-mono overflow-x-scroll">
-            <div class="d-flex gs2 fd-column ws12">
+            <div class="d-flex g2 fd-column ws12">
                 <div class="flex--item p16 wmx1 bg-black-075 ba bc-black-3">.wmx1</div>
                 <div class="flex--item p16 wmx2 bg-black-075 ba bc-black-3">.wmx2</div>
                 <div class="flex--item p16 wmx25 bg-black-075 ba bc-black-3">.wmx25</div>
@@ -382,7 +382,7 @@ description: Stacks provides atomic sizing classes for percentage-based widths &
 <div class="wmn100">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example ps-relative fs-caption ff-mono overflow-x-scroll">
-            <div class="d-flex gs2 fd-column">
+            <div class="d-flex g2 fd-column">
                 <div class="flex--item p16 wmn0 bg-black-075 ba bc-black-3">.wmn0</div>
                 <div class="flex--item p16 wmn1 bg-black-075 ba bc-black-3">.wmn1</div>
                 <div class="flex--item p16 wmn2 bg-black-075 ba bc-black-3">.wmn2</div>
@@ -450,75 +450,75 @@ description: Stacks provides atomic sizing classes for percentage-based widths &
 <div class="h128">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example ps-relative fs-caption ff-mono">
-            <div class="d-flex gs8 fd-column">
+            <div class="d-flex g8 fd-column">
                 <div class="flex--item">
-                    <div class="d-flex gs4 fd-column">
+                    <div class="d-flex g4 fd-column">
                         <div class="flex--item">.h2</div>
                         <div class="flex--item h2 bg-black-075 ba bc-black-3"></div>
                     </div>
                 </div>
                 <div class="flex--item">
-                    <div class="d-flex gs4 fd-column">
+                    <div class="d-flex g4 fd-column">
                         <div class="flex--item">.h4</div>
                         <div class="flex--item h4 bg-black-075 ba bc-black-3"></div>
                     </div>
                 </div>
                 <div class="flex--item">
-                    <div class="d-flex gs4 fd-column">
+                    <div class="d-flex g4 fd-column">
                         <div class="flex--item">.h6</div>
                         <div class="flex--item h6 bg-black-075 ba bc-black-3"></div>
                     </div>
                 </div>
                 <div class="flex--item">
-                    <div class="d-flex gs4 fd-column">
+                    <div class="d-flex g4 fd-column">
                         <div class="flex--item">.h8</div>
                         <div class="flex--item h8 bg-black-075 ba bc-black-3"></div>
                     </div>
                 </div>
                 <div class="flex--item">
-                    <div class="d-flex gs4 fd-column">
+                    <div class="d-flex g4 fd-column">
                         <div class="flex--item">.h12</div>
                         <div class="flex--item h12 bg-black-075 ba bc-black-3"></div>
                     </div>
                 </div>
                 <div class="flex--item">
-                    <div class="d-flex gs4 fd-column">
+                    <div class="d-flex g4 fd-column">
                         <div class="flex--item">.h16</div>
                         <div class="flex--item h16 bg-black-075 ba bc-black-3"></div>
                     </div>
                 </div>
                 <div class="flex--item">
-                    <div class="d-flex gs4 fd-column">
+                    <div class="d-flex g4 fd-column">
                         <div class="flex--item">.h24</div>
                         <div class="flex--item h24 bg-black-075 ba bc-black-3"></div>
                     </div>
                 </div>
                 <div class="flex--item">
-                    <div class="d-flex gs4 fd-column">
+                    <div class="d-flex g4 fd-column">
                         <div class="flex--item">.h32</div>
                         <div class="flex--item h32 bg-black-075 ba bc-black-3"></div>
                     </div>
                 </div>
                 <div class="flex--item">
-                    <div class="d-flex gs4 fd-column">
+                    <div class="d-flex g4 fd-column">
                         <div class="flex--item">.h48</div>
                         <div class="flex--item h48 bg-black-075 ba bc-black-3"></div>
                     </div>
                 </div>
                 <div class="flex--item">
-                    <div class="d-flex gs4 fd-column">
+                    <div class="d-flex g4 fd-column">
                         <div class="flex--item">.h64</div>
                         <div class="flex--item h64 bg-black-075 ba bc-black-3"></div>
                     </div>
                 </div>
                 <div class="flex--item">
-                    <div class="d-flex gs4 fd-column">
+                    <div class="d-flex g4 fd-column">
                         <div class="flex--item">.h96</div>
                         <div class="flex--item h96 bg-black-075 ba bc-black-3"></div>
                     </div>
                 </div>
                 <div class="flex--item">
-                    <div class="d-flex gs4 fd-column">
+                    <div class="d-flex g4 fd-column">
                         <div class="flex--item">.h128</div>
                         <div class="flex--item h128 bg-black-075 ba bc-black-3"></div>
                     </div>

--- a/lib/css/atomic/_stacks-width-height.less
+++ b/lib/css/atomic/_stacks-width-height.less
@@ -20,7 +20,7 @@
 //  ============================================================================
 //  $  WIDTH
 //  ----------------------------------------------------------------------------
-//  $$  PERCENTAGE
+//  $$  PERCENTAGE AND VIEWPORT UNITS
 .w0 { width: 0 !important; }
 .w10 { width: 10% !important; }
 .w20 { width: 20% !important; }
@@ -37,6 +37,8 @@
 .w90 { width: 90% !important; }
 #stacks-internals #responsify('.w100', { width: 100% !important; });
 #stacks-internals #responsify('.w-auto', { width: auto !important; });
+#stacks-internals #responsify('.w-screen', { width: 100vw !important; });
+
 
 //  $$  STATIC
 .ws0,
@@ -89,6 +91,7 @@
 .wmx12 { max-width: @s-full !important; }
 #stacks-internals #responsify('.wmx100', { max-width: 100% !important; });
 #stacks-internals #responsify('.wmx-initial', { max-width: initial !important; });
+#stacks-internals #responsify('.wmx-screen', { max-width: 100vw !important; });
 
 //  ============================================================================
 //  $  MIN-WIDTH
@@ -115,10 +118,11 @@
 //  ============================================================================
 //  $  HEIGHT
 //  ----------------------------------------------------------------------------
-//  $$  PERCENTAGE
+//  $$  PERCENTAGE AND VIEWPORT UNITS
 .h0 { height: 0 !important; }
 #stacks-internals #responsify('.h100', { height: 100% !important; });
 #stacks-internals #responsify('.h-auto', { height: auto !important; });
+#stacks-internals #responsify('.h-screen', { height: 100vh !important; });
 
 //  $$  STATIC
 .hs0,
@@ -168,6 +172,7 @@
 .hmx12 { max-height: @s-full !important; }
 #stacks-internals #responsify('.hmx100', { max-height: 100% !important; });
 #stacks-internals #responsify('.hmx-initial', { max-height: initial !important; });
+#stacks-internals #responsify('.hmx-screen', { max-height: 100vh !important; });
 
 //  ============================================================================
 //  $  MIN-HEIGHT
@@ -187,3 +192,4 @@
 .hmn12 { min-height: @s-full !important; }
 #stacks-internals #responsify('.hmn100', { min-height: 100% !important; });
 #stacks-internals #responsify('.hmn-initial', { min-height: initial !important; });
+#stacks-internals #responsify('.hmx-screen', { min-height: 100vh !important; });


### PR DESCRIPTION
This PR addresses https://github.com/StackExchange/Stacks/issues/832 by adding the following classes:

```
.w-screen { width: 100vw; }
.wmx-screen { max-width: 100vw; }
.h-screen { height: 100vh; }
.hmx-screen { max-height: 100vh; }
.hmn-screen { min-height: 100vh; }
```

This PR renders all of the above as responsive classes, but I think the value of that is debatable.

PS: I also snuck in a little refinement to the docs in the form of gap classes. If nothing else, it better centers text inside the example elements.