### PR TITLE
Replace Less font-family (`@ff-*`), font-size (`@fs-*`), line-height (`@lh-*`) variables with CSS variables

### DIFF
--- a/docs/assets/less/stacks-documentation.less
+++ b/docs/assets/less/stacks-documentation.less
@@ -161,14 +161,14 @@
 .stacks-h4 {
     margin-bottom: 0;
     font-weight: 600;
-    line-height: @lh-sm;
+    line-height: var(--lh-sm);
     color: var(--fc-dark);
     text-rendering: optimizeLegibility;
 }
 
 //  --  Page Title
 .stacks-h1 {
-    font-size: @fs-display1;
+    font-size: var(--fs-display1);
     margin-bottom: 0.5em;
 }
 
@@ -179,21 +179,21 @@
 
 //  --  Section Title
 .stacks-h2 {
-    font-size: @fs-headline1;
+    font-size: var(--fs-headline1);
     padding-top: @su64 + @su24; // Hack for #anchor positioning
     margin-top: -@su64 + -@su24; // Hack for #anchor positioning
 }
 
 //  --  Sub-section Title
 .stacks-h3 {
-    font-size: @fs-subheading;
+    font-size: var(--fs-subheading);
     color: var(--fc-medium);
     padding-top: @su64 + @su24; // Hack for #anchor positioning
     margin-top: -@su64 + -@su24; // Hack for #anchor positioning
 }
 
 .stacks-h4 {
-    font-size: @fs-body3;
+    font-size: var(--fs-body3);
     color: var(--fc-light);
 }
 
@@ -202,8 +202,8 @@
 .stacks-copy {
     margin-top: 0;
     margin-bottom: 1em;
-    font-size: @fs-body3;
-    line-height: @lh-lg;
+    font-size: var(--fs-body3);
+    line-height: var(--lh-lg);
     color: var(--fc-medium);
 
     strong {
@@ -212,7 +212,7 @@
 }
 
 .stacks-copy__lg {
-    font-size: @fs-title;
+    font-size: var(--fs-title);
 }
 
 
@@ -222,10 +222,10 @@
     padding: 3px 5px @su2 @su4;
     border-radius: @br-sm;
     background-color: var(--black-075);
-    font-size: @fs-caption;
+    font-size: var(--fs-caption);
     font-family: var(--ff-mono);
     color: var(--fc-dark);
-    line-height: @lh-xs;
+    line-height: var(--lh-xs);
     vertical-align: middle;
     overflow-wrap: break-word;
     white-space: normal;
@@ -237,8 +237,8 @@
 //  ----------------------------------------------------------------------------
 .stacks-list {
     margin-bottom: 1em;
-    font-size: @fs-body3;
-    line-height: @lh-lg;
+    font-size: var(--fs-body3);
+    line-height: var(--lh-lg);
     color: var(--fc-medium);
 }
 
@@ -277,7 +277,7 @@
     border-bottom-right-radius: @br-md;
     border: 1px solid var(--bc-medium);
     border-top-width: 0;
-    font-size: @fs-body1;
+    font-size: var(--fs-body1);
 
     .dark-mode({
         border-color: var(--bc-lighter);
@@ -323,7 +323,7 @@
     border: 1px solid var(--bc-medium);
     background-color: var(--black-075);
     font-family: var(--ff-mono);
-    font-size: @fs-caption;
+    font-size: var(--fs-caption);
     color: var(--fc-dark);
 }
 
@@ -366,7 +366,7 @@
         width: auto !important;
         height: auto !important;
         padding: 5px 8px;
-        font-size: @fs-caption !important;
+        font-size: var(--fs-caption) !important;
         line-height: 1 !important;
         color: var(--fc-light) !important;
     }

--- a/lib/css/atomic/_stacks-typography.less
+++ b/lib/css/atomic/_stacks-typography.less
@@ -26,21 +26,21 @@ p {
 //  $   TEXT SIZES
 //  ----------------------------------------------------------------------------
 //  Declare font sizes
-.fs-display4 { font-size: @fs-display4 !important; }
-.fs-display3 { font-size: @fs-display3 !important; }
-.fs-display2 { font-size: @fs-display2 !important; }
-.fs-display1 { font-size: @fs-display1 !important; }
-.fs-headline2 { font-size: @fs-headline2 !important; }
-.fs-headline1 { font-size: @fs-headline1 !important; }
-.fs-title { font-size: @fs-title !important; }
-.fs-subheading { font-size: @fs-subheading !important; }
-.fs-body3 { font-size: @fs-body3 !important; }
-.fs-body2 { font-size: @fs-body2 !important; }
-.fs-body1 { font-size: @fs-body1 !important; }
+.fs-display4 { font-size: var(--fs-display4) !important; }
+.fs-display3 { font-size: var(--fs-display3) !important; }
+.fs-display2 { font-size: var(--fs-display2) !important; }
+.fs-display1 { font-size: var(--fs-display1) !important; }
+.fs-headline2 { font-size: var(--fs-headline2) !important; }
+.fs-headline1 { font-size: var(--fs-headline1) !important; }
+.fs-title { font-size: var(--fs-title) !important; }
+.fs-subheading { font-size: var(--fs-subheading) !important; }
+.fs-body3 { font-size: var(--fs-body3) !important; }
+.fs-body2 { font-size: var(--fs-body2) !important; }
+.fs-body1 { font-size: var(--fs-body1) !important; }
 
 .fs-caption,
-.fs-category { font-size: @fs-caption !important; }
-.fs-fine { font-size: @fs-fine !important; }
+.fs-category { font-size: var(--fs-caption) !important; }
+.fs-fine { font-size: var(--fs-fine) !important; }
 
 #stacks-internals #screen-sm({
     .fs-display4 { font-size: 3.8rem !important; }
@@ -77,12 +77,12 @@ p {
 //  ============================================================================
 //  $   LINE HEIGHTS
 //  ----------------------------------------------------------------------------
-.lh-xs { line-height: @lh-xs !important; }
-.lh-sm { line-height: @lh-sm !important; }
-.lh-md { line-height: @lh-md !important; }
-.lh-lg { line-height: @lh-lg !important; }
-.lh-xl { line-height: @lh-xl !important; }
-.lh-xxl { line-height: @lh-xxl !important; }
+.lh-xs { line-height: var(--lh-xs) !important; }
+.lh-sm { line-height: var(--lh-sm) !important; }
+.lh-md { line-height: var(--lh-md) !important; }
+.lh-lg { line-height: var(--lh-lg) !important; }
+.lh-xl { line-height: var(--lh-xl) !important; }
+.lh-xxl { line-height: var(--lh-xxl) !important; }
 .lh-unset { line-height: initial !important; }
 
 //  ============================================================================
@@ -160,20 +160,20 @@ p {
 
 .v-truncate-fade {
     overflow: hidden;
-    -webkit-mask-image: linear-gradient(180deg, #000 @lh-md * 9em, transparent);
-    mask-image: linear-gradient(180deg, #000 @lh-md * 9em, transparent);
-    max-height: @lh-md * 12em;
+    -webkit-mask-image: linear-gradient(180deg, #000 calc(var(--lh-md) * 9em), transparent);
+    mask-image: linear-gradient(180deg, #000 calc(var(--lh-md) * 9em), transparent);
+    max-height: calc(var(--lh-md) * 12em);
 
     &.v-truncate-fade__sm {
-        -webkit-mask-image: linear-gradient(180deg, #000 @lh-md * 3em, transparent);
-        mask-image: linear-gradient(180deg, #000 @lh-md * 3em, transparent);
-        max-height: @lh-md * 6em;
+        -webkit-mask-image: linear-gradient(180deg, #000 calc(var(--lh-md) * 3em), transparent);
+        mask-image: linear-gradient(180deg, #000 calc(var(--lh-md) * 3em), transparent);
+        max-height: calc(var(--lh-md) * 6em);
     }
 
     &.v-truncate-fade__lg {
-        -webkit-mask-image: linear-gradient(180deg, #000 @lh-md * 21em, transparent);
-        mask-image: linear-gradient(180deg, #000 @lh-md * 21em, transparent);
-        max-height: @lh-md * 24em;
+        -webkit-mask-image: linear-gradient(180deg, #000 calc(var(--lh-md) * 21em), transparent);
+        mask-image: linear-gradient(180deg, #000 calc(var(--lh-md) * 21em), transparent);
+        max-height: calc(var(--lh-md) * 24em);
     }
 }
 

--- a/lib/css/base/_stacks-body.less
+++ b/lib/css/base/_stacks-body.less
@@ -20,8 +20,8 @@ html,
 body {
     color: var(--theme-body-font-color);
     font-family: var(--theme-body-font-family);
-    font-size: @fs-base;
-    line-height: @lh-base;
+    font-size: var(--fs-base);
+    line-height: var(--lh-base);
 }
 
 #stacks-internals #screen-sm({

--- a/lib/css/components/_stacks-activity-indicator.less
+++ b/lib/css/components/_stacks-activity-indicator.less
@@ -21,7 +21,7 @@
     background-color: var(--theme-secondary-400);
     box-shadow: 0 0 0 @su4 var(--focus-ring);
     border-radius: 1000px;
-    font-size: @fs-fine;
+    font-size: var(--fs-fine);
     font-weight: 600;
     color: @white;
     text-transform: uppercase;

--- a/lib/css/components/_stacks-badges.less
+++ b/lib/css/components/_stacks-badges.less
@@ -35,7 +35,7 @@
     border-width: 1px;
     border-style: solid;
     border-radius: @br-sm;
-    font-size: @fs-caption;
+    font-size: var(--fs-caption);
     font-weight: normal;
     line-height: 2;
     text-decoration: none;
@@ -66,7 +66,7 @@
     align-self: flex-start;
     padding-right: @su4;
     padding-left: @su4;
-    font-size: @fs-fine;
+    font-size: var(--fs-fine);
     line-height: 1.8;
 }
 
@@ -74,7 +74,7 @@
     align-self: flex-start;
     padding-right: @su2;
     padding-left: @su2;
-    font-size: @fs-fine;
+    font-size: var(--fs-fine);
     line-height: 1.5;
 }
 

--- a/lib/css/components/_stacks-banners.less
+++ b/lib/css/components/_stacks-banners.less
@@ -40,7 +40,7 @@
     border-radius: 0;
     box-shadow: none;
     color: var(--fc-medium);
-    font-size: @fs-body1;
+    font-size: var(--fs-body1);
 
     // If you want to hide and reveal the banner
     &[aria-hidden="true"] {

--- a/lib/css/components/_stacks-blank-states.less
+++ b/lib/css/components/_stacks-blank-states.less
@@ -16,7 +16,7 @@
     margin-right: auto;
 
     p {
-        font-size: @fs-body1;
+        font-size: var(--fs-body1);
         margin-bottom: @su12;
 
         strong {

--- a/lib/css/components/_stacks-breadcrumbs.less
+++ b/lib/css/components/_stacks-breadcrumbs.less
@@ -12,7 +12,7 @@
     flex-wrap: wrap;
     align-items: start;
     color: var(--black-150);
-    font-size: @fs-caption;
+    font-size: var(--fs-caption);
 
     .s-breadcrumbs--item {
         display: flex;

--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -136,8 +136,6 @@
             padding: 0.7em;
             border-radius: calc(var(--br-sm) + 1px);
             font-size: var(--fs-body3);
-            border-radius: calc(var(--br-sm) + 1px);
-            font-size: @fs-body3;
 
             &.s-btn__dropdown {
                 padding-right: 1.8em;

--- a/lib/css/components/_stacks-buttons.less
+++ b/lib/css/components/_stacks-buttons.less
@@ -26,9 +26,9 @@
         background-color: transparent;
         outline: none;
         font-family: inherit;
-        font-size: @fs-body1;
+        font-size: var(--fs-body1);
         font-weight: normal;
-        line-height: @lh-sm;
+        line-height: var(--lh-sm);
         text-align: center;
         text-decoration: none;
         cursor: pointer;
@@ -109,7 +109,7 @@
 
         &.s-btn__xs {
             padding: 0.6em;
-            font-size: @fs-fine;
+            font-size: var(--fs-fine);
 
             &.s-btn__dropdown {
                 padding-right: 1.5em;
@@ -125,7 +125,7 @@
         }
 
         &.s-btn__sm {
-            font-size: @fs-caption;
+            font-size: var(--fs-caption);
 
             &.s-btn__dropdown {
                 padding-right: 2.05em;
@@ -135,7 +135,7 @@
         &.s-btn__md {
             padding: 0.7em;
             border-radius: @br-sm + 1;
-            font-size: @fs-body3;
+            font-size: var(--fs-body3);
 
             &.s-btn__dropdown {
                 padding-right: 1.8em;
@@ -155,8 +155,8 @@
             display: inline-block;
             border-radius: @br-sm;
             padding: @su2 (@su4 - 1px);
-            font-size: @fs-caption;
-            line-height: @lh-xs;
+            font-size: var(--fs-caption);
+            line-height: var(--lh-xs);
             background-color: currentColor;
 
             .highcontrast-mode({ opacity: 0.8; });

--- a/lib/css/components/_stacks-code-blocks.less
+++ b/lib/css/components/_stacks-code-blocks.less
@@ -8,9 +8,9 @@
 //
 
 pre.s-code-block {
-    font-size: @fs-body1;
+    font-size: var(--fs-body1);
     font-family: var(--ff-mono);
-    line-height: @lh-md;
+    line-height: var(--lh-md);
     color: var(--highlight-color);
     background-color: var(--highlight-bg);
     border-radius: @br-md;

--- a/lib/css/components/_stacks-inputs.less
+++ b/lib/css/components/_stacks-inputs.less
@@ -54,7 +54,7 @@
     border-radius: @br-sm;
     background-color: var(--white);
     color: var(--fc-dark);
-    font-size: @fs-body1;
+    font-size: var(--fs-body1);
     font-family: inherit;
 
     //  --  INCREASE FONT SIZE FOR MOBILE SAFARI
@@ -152,7 +152,7 @@ fieldset {
     padding: 0 @su2; // Helps the label visually line up with inputs
     color: var(--fc-dark);
     font-family: inherit;
-    font-size: @fs-body2;
+    font-size: var(--fs-body2);
     font-weight: 600;
 
     &[for] {
@@ -170,7 +170,7 @@ fieldset {
     border-radius: 1000px;
     background-color: var(--black-050);
     color: var(--fc-medium);
-    font-size: @fs-caption;
+    font-size: var(--fs-caption);
     font-weight: 400;
     vertical-align: text-bottom;
 
@@ -205,7 +205,7 @@ fieldset {
 .s-description {
     padding: 0 @su2; // Helps the label visually line up with inputs
     color: var(--fc-medium);
-    font-size: @fs-caption;
+    font-size: var(--fs-caption);
 }
 
 .s-label .s-description,
@@ -229,7 +229,7 @@ fieldset {
     color: var(--fc-medium);
     font-family: inherit;
     white-space: nowrap;
-    line-height: @lh-sm;
+    line-height: var(--lh-sm);
 
     &.s-input-fill__clear {
         border-color: transparent;
@@ -302,10 +302,10 @@ fieldset {
         border-radius: @br-sm;
         background-color: var(--white);
         outline: 0;
-        font-size: @fs-body1;
+        font-size: var(--fs-body1);
         font-family: inherit;
         color: var(--black);
-        line-height: @lh-sm;
+        line-height: var(--lh-sm);
 
         &::-moz-focus-inner {
             outline: none !important;
@@ -654,7 +654,7 @@ fieldset {
 //  ----------------------------------------------------------------------------
 .s-input-message {
     padding: @su2;
-    font-size: @fs-caption;
+    font-size: var(--fs-caption);
 }
 
 //  $$  SIZES
@@ -663,25 +663,25 @@ fieldset {
 .s-textarea__sm,
 .s-label__sm,
 .s-select__sm > select {
-    font-size: @fs-caption;
+    font-size: var(--fs-caption);
 }
 .s-input__md,
 .s-textarea__md,
 .s-label__md,
 .s-select__md > select {
-    font-size: @fs-body3;
+    font-size: var(--fs-body3);
 }
 .s-input__lg,
 .s-textarea__lg,
 .s-label__lg,
 .s-select__lg > select {
-    font-size: @fs-title;
+    font-size: var(--fs-title);
 }
 .s-input__xl,
 .s-textarea__xl,
 .s-label__xl,
 .s-select__xl > select {
-    font-size: @fs-headline1;
+    font-size: var(--fs-headline1);
 }
 
 //  $$  PADDING ADJUSTMENTS WITHIN SIZES

--- a/lib/css/components/_stacks-link-previews.less
+++ b/lib/css/components/_stacks-link-previews.less
@@ -31,7 +31,7 @@
 }
 
 .s-link-preview--title {
-    font-size: @fs-body3;
+    font-size: var(--fs-body3);
     font-weight: bold;
     color: var(--black-900);
 }
@@ -60,7 +60,7 @@ a.s-link-preview--title {
 }
 
 .s-link-preview--details {
-    font-size: @fs-caption;
+    font-size: var(--fs-caption);
     color: var(--black-500);
     margin-top: @su2;
 
@@ -71,7 +71,7 @@ a.s-link-preview--title {
 
 .s-link-preview--body {
     padding: @su12;
-    font-size: @fs-body2;
+    font-size: var(--fs-body2);
 
     *:last-child {
         margin-bottom: 0;
@@ -94,7 +94,7 @@ a.s-link-preview--title {
     border-bottom-right-radius: @br-sm;
     border-top: 1px solid var(--bc-medium);
     padding: @su12;
-    font-size: @fs-caption;
+    font-size: var(--fs-caption);
 
     #stacks-internals #screen-sm({
         flex-direction: column;

--- a/lib/css/components/_stacks-menu.less
+++ b/lib/css/components/_stacks-menu.less
@@ -13,7 +13,7 @@
     .s-menu--title {
         padding: @su8 @su12;
         text-transform: uppercase;
-        font-size: @fs-fine;
+        font-size: var(--fs-fine);
         color: var(--black-600);
     }
 

--- a/lib/css/components/_stacks-modals.less
+++ b/lib/css/components/_stacks-modals.less
@@ -88,9 +88,9 @@
 .s-modal--header {
     margin-bottom: @su16;
     color: var(--fc-dark);
-    font-size: @fs-headline1;
+    font-size: var(--fs-headline1);
     font-weight: normal;
-    line-height: @lh-sm;
+    line-height: var(--lh-sm);
 }
 
 .s-modal--body {

--- a/lib/css/components/_stacks-navigation.less
+++ b/lib/css/components/_stacks-navigation.less
@@ -104,7 +104,7 @@
     }
 
     .s-navigation--title {
-        font-size: @fs-fine;
+        font-size: var(--fs-fine);
         font-weight: bold;
         margin-top: @su16;
         padding: @su6 @su12;
@@ -136,7 +136,7 @@
     &.s-navigation__sm {
         .s-navigation--item {
             padding: @su4 @su12;
-            font-size: @fs-caption;
+            font-size: var(--fs-caption);
 
             &.s-navigation--item__dropdown {
                 padding-right: 2em;

--- a/lib/css/components/_stacks-notices.less
+++ b/lib/css/components/_stacks-notices.less
@@ -19,7 +19,7 @@
     border: 1px solid transparent;
     border-radius: @br-sm;
     color: var(--fc-medium);
-    font-size: @fs-body1;
+    font-size: var(--fs-body1);
 
     .s-toast & {
         max-width: 44rem;

--- a/lib/css/components/_stacks-page-titles.less
+++ b/lib/css/components/_stacks-page-titles.less
@@ -27,9 +27,9 @@
     .s-page-title--header {
         margin: 0;
         margin-bottom: 0;
-        font-size: @fs-headline1;
+        font-size: var(--fs-headline1);
         color: var(--fc-dark);
-        line-height: @lh-sm;
+        line-height: var(--lh-sm);
         font-weight: normal;
     }
 
@@ -37,7 +37,7 @@
         color: var(--fc-light);
         margin-top: @su4;
         margin-bottom: 0;
-        font-size: @fs-body2;
+        font-size: var(--fs-body2);
     }
 
     .s-page-title--actions {

--- a/lib/css/components/_stacks-pagination.less
+++ b/lib/css/components/_stacks-pagination.less
@@ -26,8 +26,8 @@
     background-color: transparent;
     border-radius: @br-sm;
     border: 1px solid var(--bc-medium);
-    font-size: @fs-body1;
-    line-height: @lh-xl;
+    font-size: var(--fs-body1);
+    line-height: var(--lh-xl);
     color: var(--fc-medium);
 
     .highcontrast-mode({ text-decoration: none; });

--- a/lib/css/components/_stacks-popovers.less
+++ b/lib/css/components/_stacks-popovers.less
@@ -26,7 +26,7 @@
     background-color: var(--white);
     box-shadow: var(--bs-md);
     color: var(--fc-dark);
-    font-size: @fs-body1;
+    font-size: var(--fs-body1);
     min-width: 12rem;
     width: 100%;
 

--- a/lib/css/components/_stacks-post-summary.less
+++ b/lib/css/components/_stacks-post-summary.less
@@ -53,7 +53,7 @@
                 height: @su48;
                 flex-direction: column;
                 gap: 0;
-                font-size: @fs-caption;
+                font-size: var(--fs-caption);
 
                 &.s-post-summary--stats-item__emphasized {
                     color: inherit;
@@ -65,7 +65,7 @@
 
                 .s-post-summary--stats-item-number {
                     font-weight: normal;
-                    font-size: @fs-body3;
+                    font-size: var(--fs-body3);
                 }
 
                 &.is-deleted,
@@ -139,7 +139,7 @@
     flex-shrink: 0;
     flex-wrap: wrap;
     align-items: flex-end;
-    font-size: @fs-body1;
+    font-size: var(--fs-body1);
     color: var(--fc-light);
 
     .s-post-summary--stats-item {
@@ -251,11 +251,11 @@
 
     .s-post-summary--content-title {
         display: block;
-        font-size: @fs-body3;
+        font-size: var(--fs-body3);
         margin-top: -0.15rem; // Optical alignment to compensate for title's containing block
         margin-bottom: 0.3846rem;
         padding-right: @su24;
-        line-height: @lh-md;
+        line-height: var(--lh-md);
         font-weight: normal;
         .break-word;
 

--- a/lib/css/components/_stacks-progress-bars.less
+++ b/lib/css/components/_stacks-progress-bars.less
@@ -46,8 +46,8 @@
     height: 100%;
     border-radius: @br-md;
     border: 1px solid transparent;
-    font-size: @fs-caption;
-    line-height: @lh-xs;
+    font-size: var(--fs-caption);
+    line-height: var(--lh-xs);
     color: var(--fc-dark);
     z-index: @zi-base + 2;
 }
@@ -204,7 +204,7 @@
         display: block;
         width: auto;
         height: auto;
-        font-size: @fs-body1;
+        font-size: var(--fs-body1);
         border: 0;
         border-radius: 0;
         padding: @su12 @su6 0 @su6;

--- a/lib/css/components/_stacks-prose.less
+++ b/lib/css/components/_stacks-prose.less
@@ -29,7 +29,7 @@
     }
 
     code {
-        font-size: @fs-body1;
+        font-size: var(--fs-body1);
         font-family: var(--ff-mono);
     }
 
@@ -102,31 +102,31 @@
     }
 
     h1 {
-        font-size: @fs-headline1;
+        font-size: var(--fs-headline1);
         margin-bottom: 0.6em;
     }
 
     h2 {
-        font-size: @fs-title;
+        font-size: var(--fs-title);
         margin-bottom: 0.7em;
     }
 
     h3 {
-        font-size: @fs-subheading;
+        font-size: var(--fs-subheading);
         margin-bottom: 0.74em;
     }
 
     h4 {
-        font-size: @fs-body3;
+        font-size: var(--fs-body3);
         margin-bottom: 1em;
     }
 
     h5 {
-        font-size: @fs-body2;
+        font-size: var(--fs-body2);
     }
 
     h6 {
-        font-size: @fs-body1;
+        font-size: var(--fs-body1);
     }
 
     img,
@@ -381,7 +381,7 @@
             background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='rgb(132, 141, 149)' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M9 17A8 8 0 119 1a8 8 0 010 16zM8 4v6h2V4H8zm0 8v2h2v-2H8z'%3E%3C/path%3E%3C/svg%3E");
             background-repeat: no-repeat;
             background-position: center right;
-            font-size: @fs-body1;
+            font-size: var(--fs-body1);
             color: var(--black-500);
             padding-right: 22px;
             position: absolute;
@@ -404,7 +404,7 @@
         margin: 0 0.1em;
         padding: 0.1em 0.6em;
         font-family: var(--ff-sans);
-        font-size: @fs-fine;
+        font-size: var(--fs-fine);
         line-height: var(--s-prose-line-height);
         color: var(--black-800);
         text-shadow: 0 1px 0 var(--white);
@@ -447,8 +447,8 @@
         width: auto;
         max-height: 600px;
         overflow: auto;
-        font-size: @fs-body1;
-        line-height: @lh-md;
+        font-size: var(--fs-body1);
+        line-height: var(--lh-md);
         background-color: var(--highlight-bg);
         border-radius: @br-md;
 
@@ -463,41 +463,41 @@
     }
 
     &.s-prose__xs {
-        font-size: @fs-caption;
-        line-height: @lh-sm;
+        font-size: var(--fs-caption);
+        line-height: var(--lh-sm);
     }
 
     &.s-prose__sm {
-        font-size: @fs-body1;
-        line-height: @lh-md;
+        font-size: var(--fs-body1);
+        line-height: var(--lh-md);
     }
 
     &.s-prose__md {
-        font-size: @fs-body3;
-        line-height: @lh-xl;
+        font-size: var(--fs-body3);
+        line-height: var(--lh-xl);
     }
 
     &.s-prose__xs,
     &.s-prose__sm,
     &.s-prose__md {
         h1 {
-            font-size: @fs-headline1-relative;
+            font-size: var(--fs-headline1-relative);
         }
 
         h2 {
-            font-size: @fs-title-relative;
+            font-size: var(--fs-title-relative);
         }
 
         h3 {
-            font-size: @fs-subheading-relative;
+            font-size: var(--fs-subheading-relative);
         }
 
         h4 {
-            font-size: @fs-body3-relative;
+            font-size: var(--fs-body3-relative);
         }
 
         h5 {
-            font-size: @fs-body2-relative;
+            font-size: var(--fs-body2-relative);
         }
     }
 }

--- a/lib/css/components/_stacks-tables.less
+++ b/lib/css/components/_stacks-tables.less
@@ -40,7 +40,7 @@
     max-width: 100%;
     border-collapse: collapse;
     border-spacing: 0;
-    font-size: @fs-body1;
+    font-size: var(--fs-body1);
 
     th,
     td {
@@ -71,7 +71,7 @@
         vertical-align: bottom;
         white-space: nowrap;
         background-color: var(--black-025);
-        line-height: @lh-sm;
+        line-height: var(--lh-sm);
     }
 
     //  When in a table body, don't make it bold.
@@ -269,7 +269,7 @@
         th,
         td {
             padding-top: @su12;
-            font-size: @fs-subheading;
+            font-size: var(--fs-subheading);
             font-weight: bold;
         }
     }

--- a/lib/css/components/_stacks-tags.less
+++ b/lib/css/components/_stacks-tags.less
@@ -75,7 +75,7 @@
     border-style: solid;
     border-width: 1px;
     border-radius: @br-sm;
-    font-size: @fs-caption;
+    font-size: var(--fs-caption);
     line-height: 1.846153846;
     text-decoration: none;
     vertical-align: middle;
@@ -91,26 +91,26 @@
 
     //  -- SIZES
     &.s-tag__xs {
-        font-size: @fs-fine;
+        font-size: var(--fs-fine);
         line-height: 1.4;
         padding-left: @su2;
         padding-right: @su2;
     }
     &.s-tag__sm {
-        font-size: @fs-caption;
+        font-size: var(--fs-caption);
         line-height: 1.5;
     }
     &.s-tag__md {
         padding-left: @su6;
         padding-right: @su6;
-        font-size: @fs-body2;
+        font-size: var(--fs-body2);
         line-height: 1.733333333;
     }
     &.s-tag__lg {
         padding-left: @su6;
         padding-right: @su6;
         border-radius: @br-sm + 1;
-        font-size: @fs-subheading;
+        font-size: var(--fs-subheading);
         line-height: 1.684210526;
     }
 }

--- a/lib/css/components/_stacks-toggle-switches.less
+++ b/lib/css/components/_stacks-toggle-switches.less
@@ -97,7 +97,7 @@
             padding: 0.5em 0.7em;
             border-radius: 1000px;
             color: var(--black-500);
-            font-size: @fs-body1;
+            font-size: var(--fs-body1);
             font-weight: 400;
             line-height: 1;
             text-align: center;

--- a/lib/css/components/_stacks-topbar.less
+++ b/lib/css/components/_stacks-topbar.less
@@ -322,7 +322,7 @@
     &:extend(.s-badge);
 
     text-transform: uppercase;
-    font-size: @fs-fine;
+    font-size: var(--fs-fine);
     font-weight: 700;
     margin-left: @su8;
     margin-right: @su8;
@@ -349,7 +349,7 @@
 //  $   SEARCHBAR
 //  ---------------------------------------------------------------------------
 .s-topbar .s-topbar--searchbar {
-    @inputLineHeights: @lh-sm; // Ensure the line heights between the elements match up
+    @inputLineHeights: var(--lh-sm); // Ensure the line heights between the elements match up
     padding: 0 @su8;
     display: flex;
     align-items: center;

--- a/lib/css/components/_stacks-uploader.less
+++ b/lib/css/components/_stacks-uploader.less
@@ -196,7 +196,7 @@
 
     .s-uploader--previews-heading {
         color: var(--black-900);
-        font-size: @fs-body2;
+        font-size: var(--fs-body2);
         font-weight: 600;
         padding-bottom: @su8;
     }

--- a/lib/css/components/_stacks-user-cards.less
+++ b/lib/css/components/_stacks-user-cards.less
@@ -40,7 +40,7 @@
         align-items: start;
 
         .s-user-card--link {
-            font-size: @fs-body2;
+            font-size: var(--fs-body2);
         }
     }
 
@@ -92,7 +92,7 @@
 
     .s-user-card--type {
         grid-column: ~"1 / 3";
-        font-size: @fs-caption;
+        font-size: var(--fs-caption);
         color: var(--theme-primary-400);
 
         a {
@@ -108,7 +108,7 @@
     grid-column: ~"1 / 3";
     grid-row: ~"1 / 2";
     color: var(--black-500);
-    font-size: @fs-caption;
+    font-size: var(--fs-caption);
 }
 
 //  $   USER INFO CONTAINER
@@ -126,7 +126,7 @@
 //  ---------------------------------------------------------------------------
 .s-user-card--link {
     min-width: 0; // Allow things to wrap
-    font-size: @fs-caption;
+    font-size: var(--fs-caption);
     align-items: center;
     flex-wrap: wrap;
     overflow-wrap: break-word;
@@ -142,7 +142,7 @@
     gap: @su6;
 
     li {
-        font-size: @fs-caption;
+        font-size: var(--fs-caption);
     }
 }
 
@@ -155,7 +155,7 @@
 //  ---------------------------------------------------------------------------
 .s-user-card--location,
 .s-user-card--role {
-    font-size: @fs-caption;
+    font-size: var(--fs-caption);
     color: var(--black-500);
 }
 

--- a/lib/css/components/_stacks-widget-static.less
+++ b/lib/css/components/_stacks-widget-static.less
@@ -25,7 +25,7 @@
     border: 1px solid @s-sidebarwidget-outer-border-color;
     border-radius: @br-sm;
     box-shadow: var(--bs-sm);
-    font-size: @fs-body1;
+    font-size: var(--fs-body1);
     background-color: var(--white);
 
     &:not(.s-anchors) a:not(.button):not(.s-btn):not(.post-tag):not(.s-sidebarwidget--action):not(.s-user-card--link) {
@@ -91,7 +91,7 @@
     padding: @s-sidebarwidget-content-inner-spacing @s-sidebarwidget-content-padding;
     background: @s-sidebarwidget-header-background-color;
     color: var(--black-600);
-    font-size: @fs-body2;
+    font-size: var(--fs-body2);
     font-weight: normal;
 
     &:first-child {
@@ -100,11 +100,11 @@
     }
 
     &.s-sidebarwidget__small-bold-text {
-        font-size: @fs-caption;
+        font-size: var(--fs-caption);
         font-weight: bold;
         .-action {
             font-weight: normal;
-            line-height: 1.3 * @fs-caption;  // line-height should be the same as in the outside element, so the header and action baselines line up
+            line-height: calc(1.3 * var(--fs-caption));  // line-height should be the same as in the outside element, so the header and action baselines line up
         }
     }
 
@@ -133,7 +133,7 @@
     float: right;
     margin: 0 0 @su4 @su8;
     color: var(--blue);
-    font-size: @fs-fine;
+    font-size: var(--fs-fine);
     line-height: 1.3 * 15px; // line-height should be the same as in the outside element, so the header and action baselines line up
 }
 

--- a/lib/css/exports/_stacks-constants-type.less
+++ b/lib/css/exports/_stacks-constants-type.less
@@ -74,6 +74,7 @@
     font-weight: 800;
 }
 
+// TODO remove font-family Less variables. Keeping them here for now for comments.
 @ff-sans:
     -apple-system, BlinkMacSystemFont, // San Francisco on macOS and iOS
     "Segoe UI Adjusted", "Segoe UI", // Windows
@@ -87,66 +88,66 @@
     Menlo, Monaco, Consolas, // A few sensible system font choices
     monospace; // The final fallback for rendering in monospace.
 
+html,
 body {
     --ff-sans: @ff-sans;
     --ff-serif: @ff-serif;
     --ff-mono: @ff-mono;
     --theme-body-font-family: var(--ff-sans);
-}
 
 //  ============================================================================
 //  $   FONT SIZES (fs-)
 //      Base font-size is 13px.
 //  ----------------------------------------------------------------------------
-@fs-fine:           11px;
-@fs-caption:        12px;
-@fs-body1:          13px;
+    --fs-fine:           11px;
+    --fs-caption:        12px;
+    --fs-body1:          13px;
 
-//  Relative to the root element
-@fs-body2:               1.153846154rem;
-@fs-body3:               1.307692308rem;
-@fs-subheading:          1.461538462rem;
-@fs-title:               1.615384615rem;
-@fs-headline1:           2.076923077rem;
-@fs-headline2:           2.615384615rem;
-@fs-display1:            3.307692308rem;
-@fs-display2:            4.230769231rem;
-@fs-display3:            5.307692308rem;
-@fs-display4:            7.615384615rem;
+    //  Relative to the root element
+    --fs-body2:               1.153846154rem;
+    --fs-body3:               1.307692308rem;
+    --fs-subheading:          1.461538462rem;
+    --fs-title:               1.615384615rem;
+    --fs-headline1:           2.076923077rem;
+    --fs-headline2:           2.615384615rem;
+    --fs-display1:            3.307692308rem;
+    --fs-display2:            4.230769231rem;
+    --fs-display3:            5.307692308rem;
+    --fs-display4:            7.615384615rem;
 
-//  Relative to the parent
-@fs-body2-relative:      1.153846154em;
-@fs-body3-relative:      1.307692308em;
-@fs-subheading-relative: 1.461538462em;
-@fs-title-relative:      1.615384615em;
-@fs-headline1-relative:  2.076923077em;
-@fs-headline2-relative:  2.615384615em;
-@fs-display1-relative:   3.307692308em;
-@fs-display2-relative:   4.230769231em;
-@fs-display3-relative:   5.307692308em;
-@fs-display4-relative:   7.615384615em;
+    //  Relative to the parent
+    --fs-body2-relative:      1.153846154em;
+    --fs-body3-relative:      1.307692308em;
+    --fs-subheading-relative: 1.461538462em;
+    --fs-title-relative:      1.615384615em;
+    --fs-headline1-relative:  2.076923077em;
+    --fs-headline2-relative:  2.615384615em;
+    --fs-display1-relative:   3.307692308em;
+    --fs-display2-relative:   4.230769231em;
+    --fs-display3-relative:   5.307692308em;
+    --fs-display4-relative:   7.615384615em;
 
-@fs-base: 13px;
-
+    --fs-base: 13px;
 
 //  ============================================================================
 //  $   LINE HEIGHT (lh-)
 //  ----------------------------------------------------------------------------
 // Need to remove the unit off the font-size to make line-height unitless
-// FIXME this shouldn't be public.
-@_stacks-internals-lh-unit:   unit(@fs-base);
+    // FIXME this shouldn't be public. Find a way to use unitless `--fs-base`.
+    --stacks-internals-lh-unit: 13;
 
 // Now the various line-height variables
-@lh-xs:    1;
-@lh-sm:    ((@_stacks-internals-lh-unit + 2) / @_stacks-internals-lh-unit);
-@lh-md:    ((@_stacks-internals-lh-unit + 4) / @_stacks-internals-lh-unit);
-@lh-lg:    ((@_stacks-internals-lh-unit + 8) / @_stacks-internals-lh-unit);
-@lh-xl:    ((@_stacks-internals-lh-unit + 12) / @_stacks-internals-lh-unit);
-@lh-xxl:   2;
+    --lh-xs:    1;
+    --lh-md:    calc((var(--stacks-internals-lh-unit) + 4) / var(--stacks-internals-lh-unit));
+    --lh-sm:    calc((var(--stacks-internals-lh-unit) + 2) / var(--stacks-internals-lh-unit));
+    --lh-lg:    calc((var(--stacks-internals-lh-unit) + 8) / var(--stacks-internals-lh-unit));
+    --lh-xl:    calc((var(--stacks-internals-lh-unit) + 12) / var(--stacks-internals-lh-unit));
+    --lh-xxl:   2;
 
-@lh-base: @lh-md;
+    --lh-base: var(--lh-md);
 
 //      Holdover line-heights from production. These are NOT to be used and
 //      need to be deprecated.
 //  ----------------------------------------------------------------------------
-@lh-6:      ((@_stacks-internals-lh-unit + 6) / @_stacks-internals-lh-unit);
+    --lh-6:      ((var(--stacks-internals-lh-unit) + 6) / var(--stacks-internals-lh-unit));
+}

--- a/lib/css/exports/_stacks-constants-type.less
+++ b/lib/css/exports/_stacks-constants-type.less
@@ -138,8 +138,8 @@ body {
 
 // Now the various line-height variables
     --lh-xs:    1;
-    --lh-md:    calc((var(--stacks-internals-lh-unit) + 4) / var(--stacks-internals-lh-unit));
     --lh-sm:    calc((var(--stacks-internals-lh-unit) + 2) / var(--stacks-internals-lh-unit));
+    --lh-md:    calc((var(--stacks-internals-lh-unit) + 4) / var(--stacks-internals-lh-unit));
     --lh-lg:    calc((var(--stacks-internals-lh-unit) + 8) / var(--stacks-internals-lh-unit));
     --lh-xl:    calc((var(--stacks-internals-lh-unit) + 12) / var(--stacks-internals-lh-unit));
     --lh-xxl:   2;


### PR DESCRIPTION
This PR places these variables within `html, body`. All other variables are in the scope of `body` only, but using that context would break the changes in `_stacks-body.less`. I ran backstop and this change resulted in no visual regressions (3 errors popped up but they were because different randomized avatar images popped up).

IMO we should consider adding CSS variables in the scope of `html` instead of `body` as standard.