### PR TITLE
Migrate  s-topbar--ctas to s-topbar--item__unset

### DIFF
--- a/docs/_data/topbar.json
+++ b/docs/_data/topbar.json
@@ -34,14 +34,14 @@
         "applies": "Child of `.s-topbar`"
     },
     {
-        "class": ".s-topbar--ctas",
-        "description": "Provides layout for various calls to action, e.g. log in or sign up links. This container provides layout only, leaving child elements to their own styling.",
-        "applies": "Child of `.s-topbar`"
+        "class": ".s-topbar--item",
+        "description": "A topbar item element with hover, active and focused styling. Can add `.is-selected`",
+        "applies": "Child of `.s-topbar--content > li`"
     },
     {
-        "class": ".s-topbar--item",
-        "description": "A topbar item element, styles itself based on where it is placed. Can add `.is-selected`",
-        "applies": "Child of `.s-topbar--content > li`,\n`.s-topbar--ctas > li`"
+        "class": ".s-topbar--item__unset",
+        "description": "This class excludes the `.s-topbar--item` from any automatic styling. This is useful for calls to action, e.g. buttons or log in links",
+        "applies": "`.s-topbar--item`"
     },
     {
         "class": ".s-topbar--notice",

--- a/docs/_includes/topbar.html
+++ b/docs/_includes/topbar.html
@@ -141,7 +141,9 @@
             {% else %}
                 <li>
                     <a href="#" class="s-topbar--item s-topbar--item__unset s-btn s-btn__filled ws-nowrap">Log in</a>
-                    <a href="#" class="s-topbar--item s-topbar--item__unset s-btn s-btn__primary ws-nowrap ml4">Sign up</a>
+                </li>
+                <li>
+                    <a href="#" class="s-topbar--item s-topbar--item__unset ml4 s-btn s-btn__primary ws-nowrap">Sign up</a>
                 </li>
             {% endunless %}
         </ol>

--- a/docs/_includes/topbar.html
+++ b/docs/_includes/topbar.html
@@ -67,17 +67,38 @@
             </form>
         {% endunless %}
 
-        {% if showCtas %}
-            <ol class="s-topbar--ctas">
-                <li>
-                    <a href="#" class="s-topbar--item s-btn s-btn__filled ws-nowrap">Log in</a>
-                </li>
-                <li>
-                    <a href="#" class="s-topbar--item s-btn s-btn__primary ws-nowrap">Sign up</a>
-                </li>
-            </ol>
-        {% else %}
-            <ol class="s-topbar--content">
+        <ol class="s-topbar--content">
+            <li>
+                <a href="#" class="s-topbar--item" title="Inbox">
+                    {% icon "Inbox" %}
+                    <span class="s-activity-indicator s-activity-indicator__danger">3</span>
+                </a>
+            </li>
+            <li>
+                <a href="#" class="s-topbar--item" title="Achievements">
+                    {% icon "Achievements" %}
+                    <span class="s-activity-indicator s-activity-indicator__success">+10</span>
+                </a>
+            </li>
+            <li>
+                <a href="#" class="s-topbar--item" title="Review queues">
+                    {% icon "ReviewQueue" %}
+                    <div class="s-activity-indicator s-activity-indicator__danger">
+                        <div class="v-visible-sr">New activity</div>
+                    </div>
+                </a>
+            </li>
+            <li>
+                <a href="#" class="s-topbar--item" title="Help center">
+                    {% icon "Help" %}
+                </a>
+            </li>
+            <li>
+                <a href="#" class="s-topbar--item" title="Site switcher">
+                    {% icon "StackExchange" %}
+                </a>
+            </li>
+            {% unless showCtas %}
                 {% unless hideSearch %}
                     <li>
                         <button
@@ -117,37 +138,12 @@
                         </a>
                     </li>
                 {% endunless %}
+            {% else %}
                 <li>
-                    <a href="#" class="s-topbar--item" title="Inbox">
-                        {% icon "Inbox" %}
-                        <span class="s-activity-indicator s-activity-indicator__danger">3</span>
-                    </a>
+                    <a href="#" class="s-topbar--item s-topbar--item__unset s-btn s-btn__filled ws-nowrap">Log in</a>
+                    <a href="#" class="s-topbar--item s-topbar--item__unset s-btn s-btn__primary ws-nowrap ml4">Sign up</a>
                 </li>
-                <li>
-                    <a href="#" class="s-topbar--item" title="Achievements">
-                        {% icon "Achievements" %}
-                        <span class="s-activity-indicator s-activity-indicator__success">+10</span>
-                    </a>
-                </li>
-                <li>
-                    <a href="#" class="s-topbar--item" title="Review queues">
-                        {% icon "ReviewQueue" %}
-                        <div class="s-activity-indicator s-activity-indicator__danger">
-                            <div class="v-visible-sr">New activity</div>
-                        </div>
-                    </a>
-                </li>
-                <li>
-                    <a href="#" class="s-topbar--item" title="Help center">
-                        {% icon "Help" %}
-                    </a>
-                </li>
-                <li>
-                    <a href="#" class="s-topbar--item" title="Site switcher">
-                        {% icon "StackExchange" %}
-                    </a>
-                </li>
-            </ol>
-        {% endif %}
+            {% endunless %}
+        </ol>
     </div>
 </header>

--- a/docs/product/components/topbar.html
+++ b/docs/product/components/topbar.html
@@ -138,6 +138,8 @@ description: The topbar component is a navigation bar that is placed at the top 
     <ol class="s-topbar--content">
         <li>
             <a href="…" class="s-topbar--item s-topbar--item__unset s-btn s-btn__filled">Log in</a>
+        </li>
+        <li>
             <a href="…" class="s-topbar--item s-topbar--item__unset ml4 s-btn s-btn__primary">Sign up</a>
         </li>
     </ol>

--- a/docs/product/components/topbar.html
+++ b/docs/product/components/topbar.html
@@ -135,12 +135,10 @@ description: The topbar component is a navigation bar that is placed at the top 
         <li><a href="…" class="s-navigation--item">For Teams</a></li>
     </ol>
 
-    <ol class="s-topbar--ctas">
+    <ol class="s-topbar--content">
         <li>
-            <a href="…" class="s-topbar--item s-btn s-btn__filled">Log in</a>
-        </li>
-        <li>
-            <a href="…" class="s-topbar--item s-btn s-btn__primary">Sign up</a>
+            <a href="…" class="s-topbar--item s-topbar--item__unset s-btn s-btn__filled">Log in</a>
+            <a href="…" class="s-topbar--item s-topbar--item__unset ml4 s-btn s-btn__primary">Sign up</a>
         </li>
     </ol>
 </header>

--- a/lib/css/components/_stacks-topbar.less
+++ b/lib/css/components/_stacks-topbar.less
@@ -243,8 +243,7 @@
 //  ===========================================================================
 //  $   CONTENT & CTAS
 //  ---------------------------------------------------------------------------
-.s-topbar .s-topbar--content,
-.s-topbar .s-topbar--ctas {
+.s-topbar .s-topbar--content {
     display: flex;
     height: 100%;
     .list-reset;
@@ -252,14 +251,12 @@
     & > li {
         display: inline-flex;
     }
-}
 
-.s-topbar .s-topbar--content {
     overflow-x: auto; // Allow this content to scroll if it gets too long
     @scrollbar-styles(); // Style the scrollbars
     margin-left: auto; // Push this section as far to the right as possible
 
-    .s-topbar--item {
+    .s-topbar--item:not(.s-topbar--item__unset) {
         color: var(--theme-topbar-item-color);
         display: inline-flex;
         align-items: center;
@@ -294,21 +291,9 @@
             transition: top @te-smooth 0.15s;
         }
     }
-}
 
-// CTAs: Sign in, Sign up, etc. on the far right
-.s-topbar .s-topbar--ctas {
-    padding-left: @su4;
-    padding-right: @su8;
-    overflow-x: auto; // Allow this content to scroll if it gets too long
-    @scrollbar-styles(); // Style the scrollbars
-    margin-left: auto; // Push this section as far to the right as possible
-
-    li + li {
-        margin-left: @su4;
-    }
-
-    .s-topbar--item {
+    // provide only layout styling for unset items
+    .s-topbar--item__unset {
         align-self: center;
         padding-top: @su8;
         padding-bottom: @su8;


### PR DESCRIPTION
Scrolling is a bit funny when both a `--content` and a `--ctas` exist together. The solution is to combine the two and just not apply `--content` styling to the ctas. This approach gives us more flexibility in what a user can add to a topbar's content.

Addresses [this concern on MSE](https://meta.stackexchange.com/a/377605/395497).