### PR TITLE
Restore 0 margin and padding

### DIFF
--- a/lib/css/atomic/spacing.less
+++ b/lib/css/atomic/spacing.less
@@ -100,7 +100,7 @@ body {
     responsive,
     '.mtn',
     { .template(@value) { margin-top: calc(var(~"--su@{value}") * -1) !important; } },
-    0 1 2 4 6 8 12 16 24 32 48 64 96 128
+    1 2 4 6 8 12 16 24 32 48 64 96 128
 );
 
 // $$ Right margin

--- a/lib/css/atomic/spacing.less
+++ b/lib/css/atomic/spacing.less
@@ -75,6 +75,8 @@ body {
     1 2 4 6 8 12 16 24 32 48 64 96 128
 );
 
+#stacks-internals #responsify('.m0', { margin: 0 !important; });
+
 // $$ Margin negative
 #stacks-internals #build-classes(
     responsive,
@@ -91,12 +93,14 @@ body {
     1 2 4 6 8 12 16 24 32 48 64 96 128
 );
 
+#stacks-internals #responsify('.mt0', { margin-top: 0 !important; });
+
 // $$ Top margin negative
 #stacks-internals #build-classes(
     responsive,
     '.mtn',
     { .template(@value) { margin-top: calc(var(~"--su@{value}") * -1) !important; } },
-    1 2 4 6 8 12 16 24 32 48 64 96 128
+    0 1 2 4 6 8 12 16 24 32 48 64 96 128
 );
 
 // $$ Right margin
@@ -106,6 +110,8 @@ body {
     { .template(@value) { margin-right: var(~"--su@{value}") !important; } },
     1 2 4 6 8 12 16 24 32 48 64 96 128
 );
+
+#stacks-internals #responsify('.mr0', { margin-right: 0 !important; });
 
 // $$ Right margin negative
 #stacks-internals #build-classes(
@@ -123,6 +129,8 @@ body {
     1 2 4 6 8 12 16 24 32 48 64 96 128
 );
 
+#stacks-internals #responsify('.mb0', { margin-bottom: 0 !important; });
+
 // $$ Bottom margin negative
 #stacks-internals #build-classes(
     responsive,
@@ -138,6 +146,8 @@ body {
     { .template(@value) { margin-left: var(~"--su@{value}") !important; } },
     1 2 4 6 8 12 16 24 32 48 64 96 128
 );
+
+#stacks-internals #responsify('.ml0', { margin-left: 0 !important; });
 
 // $$ Left margin negative
 #stacks-internals #build-classes(
@@ -176,12 +186,16 @@ body {
     1 2 4 6 8 12 16 24 32 48 64 96 128
 );
 
+#stacks-internals #responsify('.p0', { padding: 0 !important; });
+
 //  $$  Top Padding
 #stacks-internals #build-classes(
     responsive,
     '.pt', { .template(@value) { padding-top: var(~"--su@{value}") !important; } },
     1 2 4 6 8 12 16 24 32 48 64 96 128
 );
+
+#stacks-internals #responsify('.pt', { padding-top: 0 !important; });
 
 //  $$  Right Padding
 #stacks-internals #build-classes(
@@ -197,12 +211,16 @@ body {
     1 2 4 6 8 12 16 24 32 48 64 96 128
 );
 
+#stacks-internals #responsify('.pr', { padding-right: 0 !important; });
+
 //  $$  Left Padding
 #stacks-internals #build-classes(
     responsive,
     '.pl', { .template(@value) { padding-left: var(~"--su@{value}") !important; } },
     1 2 4 6 8 12 16 24 32 48 64 96 128
 );
+
+#stacks-internals #responsify('.pl', { padding-left: 0 !important; });
 
 //  $$  X-Axis Padding
 #stacks-internals #build-classes(

--- a/lib/css/atomic/spacing.less
+++ b/lib/css/atomic/spacing.less
@@ -195,7 +195,7 @@ body {
     1 2 4 6 8 12 16 24 32 48 64 96 128
 );
 
-#stacks-internals #responsify('.pt', { padding-top: 0 !important; });
+#stacks-internals #responsify('.pt0', { padding-top: 0 !important; });
 
 //  $$  Right Padding
 #stacks-internals #build-classes(
@@ -211,7 +211,7 @@ body {
     1 2 4 6 8 12 16 24 32 48 64 96 128
 );
 
-#stacks-internals #responsify('.pr', { padding-right: 0 !important; });
+#stacks-internals #responsify('.pr0', { padding-right: 0 !important; });
 
 //  $$  Left Padding
 #stacks-internals #build-classes(
@@ -220,7 +220,7 @@ body {
     1 2 4 6 8 12 16 24 32 48 64 96 128
 );
 
-#stacks-internals #responsify('.pl', { padding-left: 0 !important; });
+#stacks-internals #responsify('.pl0', { padding-left: 0 !important; });
 
 //  $$  X-Axis Padding
 #stacks-internals #build-classes(


### PR DESCRIPTION
This PR restores `mt0`, etc. by calling it separately outside of our CSS variables. It also responsifies each.