### PR TITLE
add accessibility attributes to s-popover

### DIFF
--- a/lib/ts/controllers/s-popover.ts
+++ b/lib/ts/controllers/s-popover.ts
@@ -302,8 +302,6 @@ export class PopoverController extends BasePopoverController {
     public override connect(): void {
         super.connect();
 
-        //Make sure the popover is screen reader friendly
-        this.referenceElement.setAttribute("role", "button");
         this.toggleAccessibilityAttributes();
     }
 

--- a/lib/ts/controllers/s-popover.ts
+++ b/lib/ts/controllers/s-popover.ts
@@ -278,19 +278,33 @@ export class PopoverController extends BasePopoverController {
     private boundHideOnEscapePress!: any;
 
     /**
-     * Toggles optional classes in addition to BasePopoverController.shown
+     * Toggles optional classes and accessibility attributes in addition to BasePopoverController.shown
      */
-    protected shown(dispatcher: Element|null = null) {
+    protected override shown(dispatcher: Element|null = null) {
         this.toggleOptionalClasses(true);
+        this.toggleAccessibilityAttributes(true);
         super.shown(dispatcher);
     }
 
     /**
-     * Toggles optional classes in addition to BasePopoverController.hidden
+     * Toggles optional classes and accessibility attributes in addition to BasePopoverController.hidden
      */
-    protected hidden(dispatcher: Element|null = null) {
+    protected override hidden(dispatcher: Element|null = null) {
         this.toggleOptionalClasses(false);
+        this.toggleAccessibilityAttributes(false);
         super.hidden(dispatcher);
+    }
+
+
+    /**
+     * Initializes accessibility attributes in addition to BasePopoverController.connect
+     */
+    public override connect(): void {
+        super.connect();
+
+        //Make sure the popover is screen reader friendly
+        this.referenceElement.setAttribute("role", "button");
+        this.toggleAccessibilityAttributes();
     }
 
     /**
@@ -307,7 +321,7 @@ export class PopoverController extends BasePopoverController {
     /**
      * Unbinds global events to the document for hiding popovers on user interaction
      */
-    protected  unbindDocumentEvents() {
+    protected unbindDocumentEvents() {
         document.removeEventListener("mousedown", this.boundHideOnOutsideClick);
         document.removeEventListener("keyup", this.boundHideOnEscapePress);
     }
@@ -356,6 +370,14 @@ export class PopoverController extends BasePopoverController {
         this.data.get("toggle-class")!.split(/\s+/).forEach(function (cls: string) {
             cl.toggle(cls, show);
         });
+    }
+
+    /**
+     * Toggles accessibility attributes based on whether the popover is shown or not
+     * @param {boolean=} show - A boolean indicating whether this is being triggered by a show or hide.
+     */
+    private toggleAccessibilityAttributes(show?: boolean) {
+        this.referenceElement.ariaExpanded = show?.toString() || this.referenceElement.ariaExpanded || 'false';
     }
 }
 


### PR DESCRIPTION
# Summary

In order for popovers to be accessible to screen readers and other assistive technologies there are a few requirements that need to be met as laid out here: https://techservicesillinois.github.io/accessibility/examples/popover.html

> A popover must indicate if it is expanded (visible) or collapsed (hidden) and the trigger for the popover must be associated with the popover region to be displayed.
> 
> * button (role) – set on the popover trigger.
> * aria-expanded (state) – Set to true if the popover is visible; false if the popover is hidden.
> * aria-controls (property) (optional) – Set to the HTML id of the region toggled by popover trigger.

I think it makes the most sense to take care of this in the Stacks component level so all popovers are automatically accessible.

# Implementation

It looks like we're already handling the optional `aria-controls` attribute 🎉 . So this PR adds the `role` attributes automatically to all elements that have a popover, as well as add the `aria-expanded` state as appropriate to the elements.

Based on this post the `role` attribute is supported on most, if not all, html elements so hopefully setting the `role` automatically is not an issue: https://stackoverflow.com/a/18664038/1458738

