### PR TITLE
fix: maintain post summary menu button opacity

### DIFF
--- a/lib/css/components/post-summary.less
+++ b/lib/css/components/post-summary.less
@@ -393,7 +393,7 @@
 
 .s-post-summary__ignored,
 .s-post-summary__deleted {
-    .s-post-summary--content {
+    .s-post-summary--content > *:not(.s-post-summary--content-menu-button) {
         opacity: 0.6;
     }
 


### PR DESCRIPTION
Fixes #964

See meta post: [The [un-]bookmark and "Unfollow" tooltips for deleted posts are barely visible](https://meta.stackexchange.com/questions/379082/the-un-bookmark-and-unfollow-tooltips-for-deleted-posts-are-barely-visible)