### PR TITLE
feat: add post summary micro variant

### DIFF
--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -607,9 +607,6 @@ description: The post summary component summarizes various content and associate
                         <a href="#">Clicking through a viewpager2?</a>
                     </h3>
                 </div>
-                <a href="#" class="s-btn s-btn__muted s-post-summary--content-menu-button">
-                    {% icon "EllipsisVertical" %}
-                </a>
             </div>
             <div class="s-post-summary s-post-summary__micro">
                 <div class="s-post-summary--stats">

--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -584,73 +584,81 @@ description: The post summary component summarizes various content and associate
                 <time class="s-user-card--time">…</time>
             </div>
         </div>
+        <a href="#" class="s-btn s-btn__muted s-post-summary--content-menu-button">
+            {% icon "EllipsisVertical" %}
+        </a>
     </div>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example p0">
-            <div class="py16">
-                <div class="s-card bs-sm mx-auto my16 p0 wmx3">
-                    <div class="s-post-summary s-post-summary__micro">
-                        <div class="s-post-summary--stats">
-                            <div class="s-post-summary--stats-item">
-                                <span class="s-post-summary--stats-item-number">
-                                    0
-                                </span>
-                                <span class="s-post-summary--stats-item-unit">
-                                    answers
-                                </span>
-                            </div>
-                        </div>
-                        <div class="s-post-summary--content">
-                            <h3 class="s-post-summary--content-title">
-                                <a href="#">Clicking through a viewpager2?</a>
-                            </h3>
+            <div class="s-post-summary s-post-summary__micro">
+                <div class="s-post-summary--stats">
+                    <div class="s-post-summary--stats-item">
+                        <span class="s-post-summary--stats-item-number">
+                            0
+                        </span>
+                        <span class="s-post-summary--stats-item-unit">
+                            answers
+                        </span>
+                    </div>
+                </div>
+                <div class="s-post-summary--content">
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">Clicking through a viewpager2?</a>
+                    </h3>
+                </div>
+                <a href="#" class="s-btn s-btn__muted s-post-summary--content-menu-button">
+                    {% icon "EllipsisVertical" %}
+                </a>
+            </div>
+            <div class="s-post-summary s-post-summary__micro">
+                <div class="s-post-summary--stats">
+                    <div class="s-post-summary--stats-item has-answers">
+                        <span class="s-post-summary--stats-item-number">
+                            1
+                        </span>
+                        <span class="s-post-summary--stats-item-unit">
+                            answer
+                        </span>
+                    </div>
+                </div>
+                <div class="s-post-summary--content">
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">What permissions does github_token require for releases from a github action</a>
+                    </h3>
+                    <div class="s-post-summary--meta">
+                        <div class="s-user-card s-user-card__minimal">
+                            <time class="s-user-card--time">Apr 1</time>
                         </div>
                     </div>
-                    <div class="s-post-summary s-post-summary__micro">
-                        <div class="s-post-summary--stats">
-                            <div class="s-post-summary--stats-item has-answers">
-                                <span class="s-post-summary--stats-item-number">
-                                    1
-                                </span>
-                                <span class="s-post-summary--stats-item-unit">
-                                    answer
-                                </span>
-                            </div>
-                        </div>
-                        <div class="s-post-summary--content">
-                            <h3 class="s-post-summary--content-title">
-                                <a href="#">What permissions does github_token require for releases from a github action</a>
-                            </h3>
-                            <div class="s-post-summary--meta">
-                                <div class="s-user-card s-user-card__minimal">
-                                    <time class="s-user-card--time">Apr 1, 2022</time>
-                                </div>
-                            </div>
+                    <a href="#" class="s-btn s-btn__muted s-post-summary--content-menu-button">
+                        {% icon "EllipsisVertical" %}
+                    </a>
+                </div>
+            </div>
+            <div class="s-post-summary s-post-summary__micro">
+                <div class="s-post-summary--stats">
+                    <div class="s-post-summary--stats-item has-answers has-accepted-answer">
+                        <span class="s-post-summary--stats-item-number">
+                            32
+                        </span>
+                        <span class="s-post-summary--stats-item-unit">
+                            answer
+                        </span>
+                    </div>
+                </div>
+                <div class="s-post-summary--content">
+                    <h3 class="s-post-summary--content-title">
+                        <a href="#">Parentheses is Invalid Bash</a>
+                    </h3>
+                    <div class="s-post-summary--meta">
+                        <div class="s-user-card s-user-card__minimal">
+                            <time class="s-user-card--time">Mar 25, 2022</time>
                         </div>
                     </div>
-                    <div class="s-post-summary s-post-summary__micro">
-                        <div class="s-post-summary--stats">
-                            <div class="s-post-summary--stats-item has-answers has-accepted-answer">
-                                <span class="s-post-summary--stats-item-number">
-                                    32
-                                </span>
-                                <span class="s-post-summary--stats-item-unit">
-                                    answer
-                                </span>
-                            </div>
-                        </div>
-                        <div class="s-post-summary--content">
-                            <h3 class="s-post-summary--content-title">
-                                <a href="#">Parentheses is Invalid Bash</a>
-                            </h3>
-                            <div class="s-post-summary--meta">
-                                <div class="s-user-card s-user-card__minimal">
-                                    <time class="s-user-card--time">Mar 25, 2022</time>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <a href="#" class="s-btn s-btn__muted s-post-summary--content-menu-button">
+                        {% icon "EllipsisVertical" %}
+                    </a>
                 </div>
             </div>
         </div>

--- a/docs/product/components/post-summary.html
+++ b/docs/product/components/post-summary.html
@@ -557,6 +557,105 @@ description: The post summary component summarizes various content and associate
         </div>
     </div>
 
+    
+    {% header "h3", "Micro" %}
+    <!-- TODO: Update copy for Micro -->
+    <p class="stacks-copy">There are compact views where it’s appropriate to reduce the amount of information within the post summary. The micro view forces the smallest breakpoint layout in any context, stacking the meta data on top and putting everything into a single column.</p>
+    <div class="stacks-preview">
+{% highlight html %}
+<div class="s-post-summary s-post-summary__micro">
+    <div class="s-post-summary--stats">
+        <div class="s-post-summary--stats-item">
+            @Svg.CheckmarkSm
+            <span class="s-post-summary--stats-item-number">
+                …
+            </span>
+            <span class="s-post-summary--stats-item-unit">
+                answers
+            </span>
+        </div>
+    </div>
+    <div class="s-post-summary--content">
+        <h3 class="s-post-summary--content-title">
+            <a href="…">…</a>
+        </h3>
+        <div class="s-post-summary--meta">
+            <div class="s-user-card s-user-card__micro">
+                <time class="s-user-card--time">…</time>
+            </div>
+        </div>
+    </div>
+</div>
+{% endhighlight %}
+        <div class="stacks-preview--example p0">
+            <div class="py16">
+                <div class="s-card bs-sm mx-auto my16 p0 wmx3">
+                    <div class="s-post-summary s-post-summary__micro">
+                        <div class="s-post-summary--stats">
+                            <div class="s-post-summary--stats-item">
+                                <span class="s-post-summary--stats-item-number">
+                                    0
+                                </span>
+                                <span class="s-post-summary--stats-item-unit">
+                                    answers
+                                </span>
+                            </div>
+                        </div>
+                        <div class="s-post-summary--content">
+                            <h3 class="s-post-summary--content-title">
+                                <a href="#">Clicking through a viewpager2?</a>
+                            </h3>
+                        </div>
+                    </div>
+                    <div class="s-post-summary s-post-summary__micro">
+                        <div class="s-post-summary--stats">
+                            <div class="s-post-summary--stats-item has-answers">
+                                <span class="s-post-summary--stats-item-number">
+                                    1
+                                </span>
+                                <span class="s-post-summary--stats-item-unit">
+                                    answer
+                                </span>
+                            </div>
+                        </div>
+                        <div class="s-post-summary--content">
+                            <h3 class="s-post-summary--content-title">
+                                <a href="#">What permissions does github_token require for releases from a github action</a>
+                            </h3>
+                            <div class="s-post-summary--meta">
+                                <div class="s-user-card s-user-card__minimal">
+                                    <time class="s-user-card--time">Apr 1, 2022</time>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="s-post-summary s-post-summary__micro">
+                        <div class="s-post-summary--stats">
+                            <div class="s-post-summary--stats-item has-answers has-accepted-answer">
+                                <span class="s-post-summary--stats-item-number">
+                                    32
+                                </span>
+                                <span class="s-post-summary--stats-item-unit">
+                                    answer
+                                </span>
+                            </div>
+                        </div>
+                        <div class="s-post-summary--content">
+                            <h3 class="s-post-summary--content-title">
+                                <a href="#">Parentheses is Invalid Bash</a>
+                            </h3>
+                            <div class="s-post-summary--meta">
+                                <div class="s-user-card s-user-card__minimal">
+                                    <time class="s-user-card--time">Mar 25, 2022</time>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     {% header "h3", "Legacy" %}
     <p class="stacks-copy">If you only need to display the original three stats and don’t need to interleave different content types, a legacy layout may be appropriate. This view is considered deprecated and will not receive updates. Care will be needed to move bounties to within the title block.</p>
     <div class="stacks-preview">

--- a/lib/css/components/post-summary.less
+++ b/lib/css/components/post-summary.less
@@ -18,7 +18,9 @@
     }
 
     #stacks-internals #screen-md({
-        flex-direction: column;
+        &:not(.s-post-summary__micro) {
+            flex-direction: column;
+        }
     });
 
     &.s-post-summary__minimal {
@@ -32,6 +34,48 @@
 
         .s-post-summary--content {
             width: 100%;
+        }
+    }
+
+    &.s-post-summary__micro {
+        align-items: center;
+        border-bottom: none;
+        gap: var(--su12);
+        padding: var(--su12);
+
+        .s-post-summary--stats {
+            align-items: center;
+            flex-direction: row;
+            font-size: var(--fs-caption);
+            margin: 0;
+            width: auto;
+
+            .s-post-summary--stats-item {
+                border-radius: var(--br-sm);
+                padding: calc(var(--su2) + var(--su1)) var(--su4);
+                width: calc(var(--su32) + var(--su6));
+
+                &:not(.has-answers) {
+                    border: 1px solid var(--black-150);
+                }
+            }
+        }
+        .s-post-summary--stats-item-unit {
+            .v-visible-sr;
+        }
+        .s-post-summary--content {
+            display: flex;
+            flex-direction: row;
+        }
+        .s-post-summary--content-title{
+            flex-grow: 1;
+            font-size: var(--fs-body1);
+            margin-bottom: 0;
+        }
+        .s-post-summary--meta {
+            .s-user-card {
+                flex-wrap: nowrap;
+            }
         }
     }
 

--- a/lib/css/components/post-summary.less
+++ b/lib/css/components/post-summary.less
@@ -41,7 +41,7 @@
         align-items: center;
         border-bottom: none;
         gap: var(--su12);
-        padding: var(--su4) var(--su12);
+        padding: var(--su8) var(--su12);
 
         .s-post-summary--stats {
             align-items: center;
@@ -79,8 +79,9 @@
             }
         }
         .s-post-summary--content-menu-button {
-            margin-right: calc(var(--su8) * -1);
+            margin: calc(var(--su6) * -1);
             inset: initial;
+            padding: var(--su6) !important;
             position: relative !important;
         }
         .s-post-summary--meta {

--- a/lib/css/components/post-summary.less
+++ b/lib/css/components/post-summary.less
@@ -41,7 +41,7 @@
         align-items: center;
         border-bottom: none;
         gap: var(--su12);
-        padding: var(--su12);
+        padding: var(--su4) var(--su12);
 
         .s-post-summary--stats {
             align-items: center;
@@ -64,13 +64,24 @@
             .v-visible-sr;
         }
         .s-post-summary--content {
+            align-items: center;
             display: flex;
             flex-direction: row;
+            gap: var(--su12);
         }
         .s-post-summary--content-title{
             flex-grow: 1;
             font-size: var(--fs-body1);
             margin-bottom: 0;
+
+            a {
+                .v-truncate2;
+            }
+        }
+        .s-post-summary--content-menu-button {
+            margin-right: calc(var(--su8) * -1);
+            inset: initial;
+            position: relative !important;
         }
         .s-post-summary--meta {
             .s-user-card {


### PR DESCRIPTION
resolves #966

See https://deploy-preview-967--stacks.netlify.app/product/components/post-summary/#micro

## Questions

- **Should we truncate titles? If so, how many lines?** (This _could_ be handled in core as needed. Curious if we should prescribe truncation though. There's implications when it comes to vertically aligning elements within the post summary.)
- **What's the recommended title font size?** (Profile currently uses `body2`, sidebar currently uses `body1`)
- **Should items include borders?** (I'm assuming they can be added as needed by consumers but I'm not sure if we want to unify this.)
- **Should we include support for timestamps? Or any other optional data, for that matter?** (Profile currently includes timestamp)

## TODOs

- [ ] Update documentation

## Screenshot

### Second draft

Below are screenshots with a couple variations (unanswered/short title/no date/no menu, longer title/short date/longest title/long date). There's more that _could_ exist in these post summaries.

![image](https://user-images.githubusercontent.com/647177/171288941-4a15fab6-6642-42ee-a1cd-d2f1f6adb06e.png)

![image](https://user-images.githubusercontent.com/647177/171288883-2c8d2b85-45a1-4d45-bd1c-c30279b3cfad.png)

<details>
<summary>First draft</summary>

![image](https://user-images.githubusercontent.com/647177/171277191-f33ca971-954f-484c-97d7-d88d9ebe2558.png)

</details>

