### PR TITLE
fix: revert non-js banner changes from #707

### DIFF
--- a/docs/product/components/banners.html
+++ b/docs/product/components/banners.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Banners
+figma: https://www.figma.com/file/9MG6BQ5X0FlHV0rQ3c9ugA/Banners
 description: Banners are a type of <a href="/product/components/notices">notice</a>, delivering both system and engagement messaging. These are highly intrusive messaging methods and so should be used appropriately.
 ---
 <!-- Additional javascript -->
@@ -18,17 +19,17 @@ description: Banners are a type of <a href="/product/components/notices">notice<
 }
 </style>
 <aside class="s-banner js-notice-banner" role="alert" aria-hidden="true">
-    <div class="grid grid__center jc-space-between s-banner--container" role="alertdialog" aria-describedby="notice-message">
-        <div class="grid gs8 gsx mx0" aria-label="notice message">
-            <div class="grid--cell">
+    <div class="d-flex flex__center jc-space-between s-banner--container" role="alertdialog" aria-describedby="notice-message">
+        <div class="d-flex g8" aria-label="notice message">
+            <div class="flex--item">
                 {% icon "Lock" %}
             </div>
-            <div class="grid ai-center">
+            <div class="d-flex ai-center">
                 <p class="m0"><strong>Stacks is currently frozen in read-only mode.</strong> Contact the team to restore access.</p>
             </div>
         </div>
-        <div class="grid--cell ml-auto myn8" aria-label="dismiss notice">
-            <a class="p8 s-btn grid grid__center fc-dark js-notice-close" role="status" aria-hidden="true">
+        <div class="flex--item ml-auto myn8" aria-label="dismiss notice">
+            <a class="p8 s-btn d-flex flex__center fc-dark js-notice-close" role="status" aria-hidden="true">
                 {% icon "ClearSm", "m0" %}
             </a>
         </div>
@@ -78,11 +79,11 @@ description: Banners are a type of <a href="/product/components/notices">notice<
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="p16 bar-sm bg-black-050 ba bc-black-3">
-                <div class="grid gs24 ai-center fw-wrap">
-                    <div class="grid--cell">
-                        <div class="grid gs8 gsx ai-center">
-                            <label class="grid--cell s-label fs-body1" for="sys-banner-style">Style</label>
-                            <div class="grid--cell s-select">
+                <div class="d-flex g24 ai-center fw-wrap">
+                    <div class="flex--item">
+                        <div class="d-flex g8 ai-center">
+                            <label class="flex--item s-label fs-body1" for="sys-banner-style">Style</label>
+                            <div class="flex--item s-select">
                                 <select id="sys-banner-style" class="js-sys-banner-style-menu">
                                     <option name="sys-banner-style" id="sys-banner-style-info" data-class="s-banner__info" selected>Info</option>
                                     <option name="sys-banner-style" id="sys-banner-style-success" data-class="s-banner__success">Success</option>
@@ -92,20 +93,20 @@ description: Banners are a type of <a href="/product/components/notices">notice<
                             </div>
                         </div>
                     </div>
-                    <div class="grid--cell">
-                        <div class="grid gs8 gsx ai-center">
-                            <input type="checkbox" id="sys-banner-type" class="grid--cell s-checkbox js-sys-banner-type">
-                            <label class="grid--cell s-label fs-body1" for="sys-banner-type">Important?</label>
+                    <div class="flex--item">
+                        <div class="d-flex g8 ai-center">
+                            <input type="checkbox" id="sys-banner-type" class="flex--item s-checkbox js-sys-banner-type">
+                            <label class="flex--item s-label fs-body1" for="sys-banner-type">Important?</label>
                         </div>
                     </div>
-                    <div class="grid--cell">
-                        <div class="grid gs8 gsx ai-center">
-                            <input type="checkbox" id="sys-banner-position" class="grid--cell s-checkbox js-sys-banner-position">
-                            <label class="grid--cell s-label fs-body1" for="sys-banner-position">Pinned?</label>
+                    <div class="flex--item">
+                        <div class="d-flex g8 ai-center">
+                            <input type="checkbox" id="sys-banner-position" class="flex--item s-checkbox js-sys-banner-position">
+                            <label class="flex--item s-label fs-body1" for="sys-banner-position">Pinned?</label>
                         </div>
                     </div>
-                    <button class="grid--cell s-btn s-btn__filled js-sys-banner-show">Show example</button>
-                    <button class="grid--cell s-btn s-btn__danger js-sys-banner-remove d-none">Remove example</button>
+                    <button class="flex--item s-btn s-btn__filled js-sys-banner-show">Show example</button>
+                    <button class="flex--item s-btn s-btn__danger js-sys-banner-remove d-none">Remove example</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR reverts some (probably unintentional) changes made in #707 from the banners docs page.

- add back the figma link
- revert class name changes to `grid` back to `flex`

---

From Stacks feedback received Mon Jun 13, 2022 9:26 AM:

> **New submission in stacks's feedback-banners**
> The example is broken: the items in the banner are in a column instead of a row. Also the style changers (with the "Important?" and "Pinned?" checkboxes) are in a column too. (Chrome 102.0.5005.63, on Windows 10 Pro 19044.1741).

### Before

<img width="824" alt="image" src="https://user-images.githubusercontent.com/647177/173376820-2f8c17f0-3583-4e56-9c67-994af9fac0be.png">

### After

<img width="824" alt="image" src="https://user-images.githubusercontent.com/647177/173376888-1f505cb8-736b-4713-9bbe-38f4e97d0910.png">
