### PR TITLE
fix(a11y): improve input icon contrast overall

### DIFF
--- a/docs/product/components/inputs.html
+++ b/docs/product/components/inputs.html
@@ -26,7 +26,7 @@ description: Input elements are used to gather information from users.
     <label class="flex--item s-label" for="example-item2">Display name</label>
     <div class="d-flex ps-relative">
         <input class="s-input" id="example-item2" type="text" placeholder="Enter your input here" disabled />
-        @Svg.Lock.With("s-input-icon fc-black-300")
+        @Svg.Lock.With("s-input-icon fc-black-400")
     </div>
 </div>
 {% endhighlight %}
@@ -50,7 +50,7 @@ description: Input elements are used to gather information from users.
                         <label class="flex--item s-label" for="example-item2">Display name</label>
                         <div class="d-flex ps-relative">
                             <input class="s-input" id="example-item2" type="text" placeholder="Enter your input here" disabled />
-                            {% icon "Lock", "s-input-icon fc-black-300" %}
+                            {% icon "Lock", "s-input-icon fc-black-400" %}
                         </div>
                     </div>
                 </div>

--- a/lib/css/components/inputs.less
+++ b/lib/css/components/inputs.less
@@ -641,11 +641,7 @@ fieldset {
     &.s-input-icon__creditcard {
         right: auto;
         left: 0.7em;
-        color: var(--black-200);
-
-        .highcontrast-mode({
-            color: var(--black-400);
-        });
+        color: var(--black-400);
     }
 }
 

--- a/lib/css/components/inputs.less
+++ b/lib/css/components/inputs.less
@@ -616,11 +616,7 @@ fieldset {
     }
 
     .s-input-icon {
-        color: var(--black-200);
-
-        .highcontrast-mode({
-            color: var(--black-400);
-        });
+        color: var(--black-400);
     }
 
     .s-label {

--- a/lib/css/components/topbar.less
+++ b/lib/css/components/topbar.less
@@ -153,7 +153,7 @@
     // Search input
     --theme-topbar-search-color: @black-700;
     --theme-topbar-search-background: @white;
-    --theme-topbar-search-placeholder: @black-200;
+    --theme-topbar-search-placeholder: @black-400;
     --theme-topbar-search-border: @black-200;
     --theme-topbar-search-border-focus: @blue-300;
     --theme-topbar-search-shadow-focus: 0 0 0 var(--su-static4) var(--focus-ring);

--- a/lib/css/exports/constants-colors.less
+++ b/lib/css/exports/constants-colors.less
@@ -247,7 +247,7 @@
     // Topbar Search input
     --theme-topbar-search-color: var(--black-700);
     --theme-topbar-search-background: var(--white);
-    --theme-topbar-search-placeholder: var(--black-200);
+    --theme-topbar-search-placeholder: var(--black-400);
     --theme-topbar-search-border: var(--black-200);
     --theme-topbar-search-border-focus: var(--blue-300);
     --theme-topbar-search-shadow-focus: 0 0 0 var(--su-static4) var(--focus-ring);


### PR DESCRIPTION
fixes #997 by setting `.s-input-icon` color to `black-400`