### PR TITLE
fix(a11y): fix topbar forced dark mode navigation item focus style

### DIFF
--- a/lib/css/components/topbar.less
+++ b/lib/css/components/topbar.less
@@ -130,6 +130,9 @@
     }
 
     .s-navigation {
+        .s-navigation--item:focus-visible {
+            box-shadow: var(--theme-topbar-search-shadow-focus);
+        }
         .s-navigation--item:not(.is-selected) {
             color: var(--theme-topbar-item-color);
         }
@@ -238,9 +241,6 @@
     });
 
     --scrollbar: hsla(0, 0%, 100%, 0.2);
-
-    // Sets "Dark mode" color for --focus-ring-muted
-    --focus-ring-muted: hsla(@black-h, @black-s, 100%, 10%);
 }
 
 //  ===========================================================================

--- a/lib/css/components/topbar.less
+++ b/lib/css/components/topbar.less
@@ -238,6 +238,9 @@
     });
 
     --scrollbar: hsla(0, 0%, 100%, 0.2);
+
+    // Sets "Dark mode" color for --focus-ring-muted
+    --focus-ring-muted: hsla(@black-h, @black-s, 100%, 10%);
 }
 
 //  ===========================================================================


### PR DESCRIPTION
fixes #995

![image](https://user-images.githubusercontent.com/647177/176753621-987b6110-626f-4197-b8db-c6601cbf6235.png)

See it in action here: https://deploy-preview-1000--stacks.netlify.app/product/components/topbar/#theming