### PR TITLE
docs(a11y): add accessibility scan button

### DIFF
--- a/docs/_includes/layouts/page.html
+++ b/docs/_includes/layouts/page.html
@@ -100,14 +100,19 @@
             </div>
         </aside>
     </div>
-    <button class="s-btn s-btn__filled z-nav-fixed ps-fixed b12 r12 js-a11y-btn" role="button"
-        aria-controls="a11y-popover"
-        data-controller="s-popover"
-        data-action="s-popover#toggle"
-        data-s-popover-placement="top-end"
-        data-s-popover-toggle-class="is-selected">
-        Accessibility scan
-    </button>
+    <div class="s-btn-group ps-fixed b12 r12">
+        <button class="s-btn s-btn__filled z-nav-fixed js-a11y-scan-btn" role="button">
+            Accessibility scan
+        </button>
+        <button class="d-none s-btn s-btn__filled s-btn__danger s-btn__dropdown z-nav-fixed js-a11y-issues-btn" role="button"
+            aria-controls="a11y-popover"
+            data-controller="s-popover"
+            data-action="s-popover#toggle"
+            data-s-popover-placement="top-end"
+            data-s-popover-toggle-class="is-selected">
+            No issues detected
+        </button>
+    </div>
     <div class="s-popover" id="a11y-popover">
         <div class="s-popover--arrow"></div>
         <div class="js-a11y-violation-info">

--- a/docs/_includes/layouts/page.html
+++ b/docs/_includes/layouts/page.html
@@ -100,6 +100,21 @@
             </div>
         </aside>
     </div>
+    <button class="s-btn s-btn__filled z-nav-fixed ps-fixed b12 r12 js-a11y-btn" role="button"
+        aria-controls="a11y-popover"
+        data-controller="s-popover"
+        data-action="s-popover#toggle"
+        data-s-popover-placement="top-end"
+        data-s-popover-toggle-class="is-selected">
+        Accessibility scan
+    </button>
+    <div class="s-popover" id="a11y-popover">
+        <div class="s-popover--arrow"></div>
+        <div class="js-a11y-violation-info">
+            Hover over <span class="ba baw2 bas-dashed bc-error">violating elements</span> see details here.
+        </div>
+        <div class="ff-mono mt12 fs-caption">Open your browser console for even more details</div>
+    </div>
     {% include 'scripts.html' %}
 </body>
 </html>

--- a/docs/assets/js/global.a11y-checker.ts
+++ b/docs/assets/js/global.a11y-checker.ts
@@ -1,0 +1,95 @@
+import * as axe from "axe-core";
+import { AxeResults, ImpactValue } from "axe-core";
+
+// to increase or decrease the scope of issues we're reporting, change this
+const impactLevelsToInclude: ImpactValue[] = ["serious", "critical"];
+
+const a11yButton = document.querySelector(".js-a11y-btn");
+const a11yViolationInfo = document.querySelector(".js-a11y-violation-info");
+
+function renderAccessibilityButton() {
+    a11yButton?.addEventListener("click", scan);
+}
+
+function scan() {
+    setLoadingState();
+    setTimeout(doRun, 10); // shove axe scan into the background to keep our UI responsive
+
+    function doRun() {
+        axe.run()
+            .then(reportResults)
+            .catch(error => console.error("error running accessibility scan", error));
+    }
+}
+
+function setLoadingState() {
+    a11yButton?.classList.add("is-loading");
+    a11yButton?.textContent = "Scanning…";
+}
+
+function reportResults(results: AxeResults) {
+    let filteredViolations = results
+        .violations
+        .filter(v => impactLevelsToInclude.includes(v.impact));
+
+    updateAccessibilityButton(filteredViolations)
+
+    if (filteredViolations.length > 0) {
+        console.warn("Accessibility issues found!");
+        console.table(filteredViolations);
+    }
+
+    for (let violation of filteredViolations) {
+        for (let affectedNode of violation.nodes) {
+            affectedNode.target.forEach(targets => {
+                document.querySelectorAll(targets).forEach(target => {
+                    target.classList.add("ba", "baw2", "bas-dashed", "bc-error");
+                    // @ts-ignore
+                    target.addEventListener("mouseenter", (e) => showViolationDetails(e, violation, affectedNode));
+                });
+            })
+        }
+    }
+}
+
+function updateAccessibilityButton(violations: axe.Result[]) {
+    a11yButton?.classList.remove("is-loading");
+
+    if (violations.length > 0 && a11yButton) {
+        a11yButton.classList.add("s-btn__danger", "s-btn--badge", "s-btn__dropdown");
+        a11yButton.textContent = "Accessibility issues ";
+        a11yButton.append(`<span class="s-btn--badge"><span class="s-btn--number">${violations.length}</span></span>`)
+
+        // a11yButton.off("click"); // prevent triggering another accessibility scan when we want to toggle the violation popover instead
+    }
+}
+
+function showViolationDetails(event: Event, violation: axe.Result, affectedNode: axe.NodeResult) {
+    console.group("Accessibility issue");
+    console.warn("Violation: ", violation);
+    console.warn("Affected Node: ", affectedNode);
+    console.groupEnd();
+
+    const reportHtml = `
+<div class="mb4"><strong>Rule ID: </strong> <span>${escapeHtml(violation.id)}</span></div>
+<div class="mb4"><strong>Help: </strong> <span><a href="${escapeHtml(violation.helpUrl)}">${escapeHtml(violation.help)}</a></span></div>
+<div class="mb4"><strong>Impact: </strong> <span>${escapeHtml(affectedNode.impact)}</span></div>
+<pre class="mb4 s-code-block fs-fine ws-pre-wrap">${escapeHtml(affectedNode.failureSummary)}</pre>
+`
+    a11yViolationInfo?.innerHTML = reportHtml;
+}
+
+// https://stackoverflow.com/a/6234804/1370722
+function escapeHtml(unsafe) {
+    return unsafe
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
+
+// @ts-ignore
+$(document).ready(function() {
+    renderAccessibilityButton();
+});

--- a/docs/assets/js/global.a11y-checker.ts
+++ b/docs/assets/js/global.a11y-checker.ts
@@ -6,17 +6,17 @@ import { AxeResults, ImpactValue } from "axe-core";
 // to increase or decrease the scope of issues we're reporting, change this
 const impactLevelsToInclude: ImpactValue[] = ["serious", "critical"];
 
-const a11yScanButton = document.querySelector(".js-a11y-scan-btn");
-const a11yIssuesButton = document.querySelector(".js-a11y-issues-btn");
+const a11yScanBtn = document.querySelector(".js-a11y-scan-btn");
+const a11yIssuesBtn = document.querySelector(".js-a11y-issues-btn");
 const a11yViolationInfo = document.querySelector(".js-a11y-violation-info");
 
 function renderAccessibilityButton() {
-    a11yScanButton?.addEventListener("click", scan);
+    a11yScanBtn?.addEventListener("click", scan);
 }
 
 function scan() {
-    if (a11yScanButton) {
-        setLoadingState(a11yScanButton);
+    if (a11yScanBtn) {
+        setLoadingState(a11yScanBtn);
     }
     setTimeout(doRun, 10); // shove axe scan into the background to keep our UI responsive
 
@@ -29,9 +29,9 @@ function scan() {
     }
 }
 
-function setLoadingState(a11yScanButton: Element) {
-    a11yScanButton.classList.add("is-loading");
-    a11yScanButton.textContent = "Scanning…";
+function setLoadingState(a11yScanBtn: Element) {
+    a11yScanBtn.classList.add("is-loading");
+    a11yScanBtn.textContent = "Scanning…";
 }
 
 function reportResults(results: AxeResults) {
@@ -70,13 +70,13 @@ function reportResults(results: AxeResults) {
 }
 
 function updateAccessibilityButton(violations: axe.Result[]) {
-    a11yScanButton?.classList.remove("is-loading");
+    a11yScanBtn?.classList.remove("is-loading");
 
-    if (a11yIssuesButton && a11yScanButton) {
+    if (a11yIssuesBtn && a11yScanBtn) {
         if (violations.length === 0) {
-            a11yIssuesButton.classList.remove("s-btn__danger");
+            a11yIssuesBtn.classList.remove("s-btn__danger");
         } else {
-            a11yIssuesButton.classList.add("s-btn__danger");
+            a11yIssuesBtn.classList.add("s-btn__danger");
         }
         const issuesEl = `
 <span>
@@ -86,10 +86,10 @@ function updateAccessibilityButton(violations: axe.Result[]) {
 </span>
 </span>
 `;
-        a11yIssuesButton.classList.remove("d-none")
-        a11yScanButton.textContent = "Rescan";
-        a11yIssuesButton.innerHTML = issuesEl;
-        // a11yScanButton.removeEventListener("click", scan); // prevent triggering another accessibility scan when we want to toggle the violation popover instead
+        a11yIssuesBtn.classList.remove("d-none")
+        a11yScanBtn.textContent = "Rescan";
+        a11yIssuesBtn.innerHTML = issuesEl;
+        // a11yScanBtn.removeEventListener("click", scan); // prevent triggering another accessibility scan when we want to toggle the violation popover instead
     }
 }
 
@@ -127,8 +127,7 @@ function escapeHtml(unsafe: any) {
     );
 }
 
-renderAccessibilityButton();
-
 // @ts-ignore
 $(document).ready(function () {
+    a11yScanBtn?.addEventListener("click", scan);
 });

--- a/docs/assets/js/global.a11y-checker.ts
+++ b/docs/assets/js/global.a11y-checker.ts
@@ -63,10 +63,20 @@ function updateAccessibilityButton(violations: axe.Result[]) {
     a11yButton?.classList.remove("is-loading");
 
     if (violations.length > 0 && a11yButton) {
-        a11yButton.classList.add("s-btn__danger", "s-btn--badge", "s-btn__dropdown");
-        a11yButton.textContent = "Accessibility issues ";
-        a11yButton.append(`<span class="s-btn--badge"><span class="s-btn--number">${violations.length}</span></span>`)
-
+        a11yButton.classList.add(
+            "s-btn__danger",
+            "s-btn--badge",
+            "s-btn__dropdown"
+        );
+        const issuesEl = `
+<span>
+<span>Accessibility issues</span>
+<span class="s-btn--badge">
+<span class="s-btn--number">${violations.length}</span>
+</span>
+</span>
+`;
+        a11yButton.innerHTML = issuesEl;
         a11yButton.removeEventListener("click", scan); // prevent triggering another accessibility scan when we want to toggle the violation popover instead
     }
 }

--- a/docs/assets/js/global.a11y-checker.ts
+++ b/docs/assets/js/global.a11y-checker.ts
@@ -57,7 +57,7 @@ function reportResults(results: AxeResults) {
                             );
                             // @ts-ignore
                             target.addEventListener("mouseenter", (e) =>
-                                showViolationDetails(e, violation, affectedNode)
+                                showViolationDetails(violation, affectedNode)
                             );
                         });
                     });
@@ -91,7 +91,6 @@ function updateAccessibilityButton(violations: axe.Result[]) {
 }
 
 function showViolationDetails(
-    event: Event,
     violation: axe.Result,
     affectedNode: axe.NodeResult
 ) {

--- a/docs/assets/js/global.a11y-checker.ts
+++ b/docs/assets/js/global.a11y-checker.ts
@@ -9,6 +9,8 @@ const impactLevelsToInclude: ImpactValue[] = ["serious", "critical"];
 const a11yScanBtn = document.querySelector(".js-a11y-scan-btn");
 const a11yIssuesBtn = document.querySelector(".js-a11y-issues-btn");
 const a11yViolationInfo = document.querySelector(".js-a11y-violation-info");
+const errorClasses: string[] = ["ba", "baw2", "bas-dashed", "bc-error", "axe-error"];
+const btnLoadingClasses: string[] = ["is-loading", "s-btn__muted"];
 
 function renderAccessibilityButton() {
     a11yScanBtn?.addEventListener("click", scan);
@@ -18,6 +20,10 @@ function scan() {
     if (a11yScanBtn) {
         setLoadingState(a11yScanBtn);
     }
+    document.querySelectorAll(".axe-error").forEach(el => {
+        el.classList.remove(...errorClasses);
+    });
+
     setTimeout(doRun, 10); // shove axe scan into the background to keep our UI responsive
 
     function doRun() {
@@ -30,7 +36,8 @@ function scan() {
 }
 
 function setLoadingState(a11yScanBtn: Element) {
-    a11yScanBtn.classList.add("is-loading");
+    a11yScanBtn.classList.add(...btnLoadingClasses);
+    a11yScanBtn.setAttribute("disabled", "true");
     a11yScanBtn.textContent = "Scanning…";
 }
 
@@ -45,19 +52,12 @@ function reportResults(results: AxeResults) {
         if (filteredViolations.length > 0) {
             console.warn("Accessibility issues found!");
             console.table(filteredViolations);
-
             for (const violation of filteredViolations) {
                 for (const affectedNode of violation.nodes) {
                     affectedNode.target.forEach((targets) => {
                         document.querySelectorAll(targets).forEach((target) => {
-                            target.classList.add(
-                                "ba",
-                                "baw2",
-                                "bas-dashed",
-                                "bc-error"
-                            );
-                            // @ts-ignore
-                            target.addEventListener("mouseenter", (e) =>
+                            target.classList.add(...errorClasses);
+                            target.addEventListener("mouseenter", () =>
                                 showViolationDetails(violation, affectedNode)
                             );
                         });
@@ -70,9 +70,10 @@ function reportResults(results: AxeResults) {
 }
 
 function updateAccessibilityButton(violations: axe.Result[]) {
-    a11yScanBtn?.classList.remove("is-loading");
-
     if (a11yIssuesBtn && a11yScanBtn) {
+        a11yScanBtn.classList.remove(...btnLoadingClasses);
+        a11yScanBtn.removeAttribute("disabled");
+
         if (violations.length === 0) {
             a11yIssuesBtn.classList.remove("s-btn__danger");
         } else {
@@ -89,7 +90,6 @@ function updateAccessibilityButton(violations: axe.Result[]) {
         a11yIssuesBtn.classList.remove("d-none")
         a11yScanBtn.textContent = "Rescan";
         a11yIssuesBtn.innerHTML = issuesEl;
-        // a11yScanBtn.removeEventListener("click", scan); // prevent triggering another accessibility scan when we want to toggle the violation popover instead
     }
 }
 

--- a/docs/assets/js/global.a11y-checker.ts
+++ b/docs/assets/js/global.a11y-checker.ts
@@ -6,16 +6,17 @@ import { AxeResults, ImpactValue } from "axe-core";
 // to increase or decrease the scope of issues we're reporting, change this
 const impactLevelsToInclude: ImpactValue[] = ["serious", "critical"];
 
-const a11yButton = document.querySelector(".js-a11y-btn");
+const a11yScanButton = document.querySelector(".js-a11y-scan-btn");
+const a11yIssuesButton = document.querySelector(".js-a11y-issues-btn");
 const a11yViolationInfo = document.querySelector(".js-a11y-violation-info");
 
 function renderAccessibilityButton() {
-    a11yButton?.addEventListener("click", scan);
+    a11yScanButton?.addEventListener("click", scan);
 }
 
 function scan() {
-    if (a11yButton) {
-        setLoadingState(a11yButton);
+    if (a11yScanButton) {
+        setLoadingState(a11yScanButton);
     }
     setTimeout(doRun, 10); // shove axe scan into the background to keep our UI responsive
 
@@ -28,9 +29,9 @@ function scan() {
     }
 }
 
-function setLoadingState(a11yButton: Element) {
-    a11yButton.classList.add("is-loading");
-    a11yButton.textContent = "Scanning…";
+function setLoadingState(a11yScanButton: Element) {
+    a11yScanButton.classList.add("is-loading");
+    a11yScanButton.textContent = "Scanning…";
 }
 
 function reportResults(results: AxeResults) {
@@ -69,14 +70,14 @@ function reportResults(results: AxeResults) {
 }
 
 function updateAccessibilityButton(violations: axe.Result[]) {
-    a11yButton?.classList.remove("is-loading");
+    a11yScanButton?.classList.remove("is-loading");
 
-    if (violations.length > 0 && a11yButton) {
-        a11yButton.classList.add(
-            "s-btn__danger",
-            "s-btn--badge",
-            "s-btn__dropdown"
-        );
+    if (a11yIssuesButton && a11yScanButton) {
+        if (violations.length === 0) {
+            a11yIssuesButton.classList.remove("s-btn__danger");
+        } else {
+            a11yIssuesButton.classList.add("s-btn__danger");
+        }
         const issuesEl = `
 <span>
 <span>Accessibility issues</span>
@@ -85,8 +86,10 @@ function updateAccessibilityButton(violations: axe.Result[]) {
 </span>
 </span>
 `;
-        a11yButton.innerHTML = issuesEl;
-        a11yButton.removeEventListener("click", scan); // prevent triggering another accessibility scan when we want to toggle the violation popover instead
+        a11yIssuesButton.classList.remove("d-none")
+        a11yScanButton.textContent = "Rescan";
+        a11yIssuesButton.innerHTML = issuesEl;
+        // a11yScanButton.removeEventListener("click", scan); // prevent triggering another accessibility scan when we want to toggle the violation popover instead
     }
 }
 
@@ -124,7 +127,8 @@ function escapeHtml(unsafe: any) {
     );
 }
 
+renderAccessibilityButton();
+
 // @ts-ignore
 $(document).ready(function () {
-    renderAccessibilityButton();
 });

--- a/docs/assets/js/global.a11y-checker.ts
+++ b/docs/assets/js/global.a11y-checker.ts
@@ -22,7 +22,9 @@ function scan() {
     function doRun() {
         axe.run()
             .then(reportResults)
-            .catch(error => console.error("error running accessibility scan", error));
+            .catch((error) =>
+                console.error("error running accessibility scan", error)
+            );
     }
 }
 
@@ -32,26 +34,33 @@ function setLoadingState(a11yButton: Element) {
 }
 
 function reportResults(results: AxeResults) {
-    const { violations } =  results;
+    const { violations } = results;
     let filteredViolations;
 
     if (violations) {
-        filteredViolations  = violations.filter(v => {
+        filteredViolations = violations.filter((v) => {
             return v.impact && impactLevelsToInclude.includes(v.impact);
         });
         if (filteredViolations.length > 0) {
             console.warn("Accessibility issues found!");
             console.table(filteredViolations);
 
-            for (let violation of filteredViolations) {
-                for (let affectedNode of violation.nodes) {
-                    affectedNode.target.forEach(targets => {
-                        document.querySelectorAll(targets).forEach(target => {
-                            target.classList.add("ba", "baw2", "bas-dashed", "bc-error");
+            for (const violation of filteredViolations) {
+                for (const affectedNode of violation.nodes) {
+                    affectedNode.target.forEach((targets) => {
+                        document.querySelectorAll(targets).forEach((target) => {
+                            target.classList.add(
+                                "ba",
+                                "baw2",
+                                "bas-dashed",
+                                "bc-error"
+                            );
                             // @ts-ignore
-                            target.addEventListener("mouseenter", (e) => showViolationDetails(e, violation, affectedNode));
+                            target.addEventListener("mouseenter", (e) =>
+                                showViolationDetails(e, violation, affectedNode)
+                            );
                         });
-                    })
+                    });
                 }
             }
         }
@@ -81,7 +90,11 @@ function updateAccessibilityButton(violations: axe.Result[]) {
     }
 }
 
-function showViolationDetails(event: Event, violation: axe.Result, affectedNode: axe.NodeResult) {
+function showViolationDetails(
+    event: Event,
+    violation: axe.Result,
+    affectedNode: axe.NodeResult
+) {
     console.group("Accessibility issue");
     console.warn("Violation: ", violation);
     console.warn("Affected Node: ", affectedNode);
@@ -92,7 +105,7 @@ function showViolationDetails(event: Event, violation: axe.Result, affectedNode:
 <div class="mb4"><strong>Help: </strong> <span><a href="${escapeHtml(violation.helpUrl)}">${escapeHtml(violation.help)}</a></span></div>
 <div class="mb4"><strong>Impact: </strong> <span>${escapeHtml(affectedNode.impact)}</span></div>
 <pre class="mb4 s-code-block fs-fine ws-pre-wrap">${escapeHtml(affectedNode.failureSummary)}</pre>
-`
+`;
     if (a11yViolationInfo) {
         a11yViolationInfo.innerHTML = reportHtml;
     }
@@ -101,15 +114,18 @@ function showViolationDetails(event: Event, violation: axe.Result, affectedNode:
 // https://stackoverflow.com/a/6234804/1370722
 // TODO: add type
 function escapeHtml(unsafe: any) {
-    return unsafe && unsafe
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#039;");
+    return (
+        unsafe &&
+        unsafe
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#039;")
+    );
 }
 
 // @ts-ignore
-$(document).ready(function() {
+$(document).ready(function () {
     renderAccessibilityButton();
 });

--- a/docs/assets/js/index.ts
+++ b/docs/assets/js/index.ts
@@ -13,3 +13,4 @@ import "./global.navigation";
 import "./global.hamburger";
 import "./global.theming";
 import "./global.feedback";
+import "./global.a11y-checker";

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@stackoverflow/stacks-icons": "^2.27.0",
         "@typescript-eslint/eslint-plugin": "^5.29.0",
         "@typescript-eslint/parser": "^5.29.0",
+        "axe-core": "^4.4.2",
         "backstopjs": "^6.1.0",
         "concurrently": "^7.2.2",
         "css-loader": "^6.7.1",
@@ -1550,6 +1551,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
+    },
+    "node_modules/axe-core": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
+      "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/axios": {
       "version": "0.21.4",
@@ -11319,6 +11329,12 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "dev": true
+    },
+    "axe-core": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
+      "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
       "dev": true
     },
     "axios": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@stackoverflow/stacks-icons": "^2.27.0",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",
+    "axe-core": "^4.4.2",
     "backstopjs": "^6.1.0",
     "concurrently": "^7.2.2",
     "css-loader": "^6.7.1",


### PR DESCRIPTION
This PR adds an "accessibility scan" button to the Stacks docs. We might want to instead just opt for an extension like the [axe DevTools extension](https://www.deque.com/axe/devtools/).

Btw, this is real rough with just a quick-once over to kinda have this as a proof of concept.