### PR TITLE
feat(components): add indeterminate checkbox state

### DIFF
--- a/docs/product/components/checkbox.html
+++ b/docs/product/components/checkbox.html
@@ -341,9 +341,6 @@ description: A checkable input that visually shows if an option is true or false
                     </div>
                 </div>
             </fieldset>
-            <script>
-                document.getElementById("indeterminate-checkbox-1").indeterminate = true;
-            </script>
         </div>
     </div>
 </section>
@@ -469,3 +466,7 @@ description: A checkable input that visually shows if an option is true or false
         </div>
     </div>
 </section>
+
+<script>
+    document.getElementById("indeterminate-checkbox-1").indeterminate = true;
+</script>

--- a/docs/product/components/checkbox.html
+++ b/docs/product/components/checkbox.html
@@ -308,6 +308,44 @@ description: A checkable input that visually shows if an option is true or false
             </fieldset>
         </div>
     </div>
+
+    {% header "h3", "Indeterminate state" %}
+    <p class="stacks-copy">Uses <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes"><code>.indeterminate</code></a> checkbox state</p>
+    <div class="stacks-preview">
+{% highlight html %}
+<fieldset class="d-flex gs8 gsy fd-column">
+    <div class="flex--item">
+        <div class="d-flex gs8 gsx">
+            <div class="flex--item">
+                <input class="s-checkbox" type="checkbox" name="" id="indeterminate-checkbox-1" />
+            </div>
+            <label class="flex--item s-label fw-normal" for="indeterminate-checkbox-1">
+                Select all
+            </label>
+        </div>
+    </div>
+</fieldset>
+
+<script>
+    document.getElementById("indeterminate-checkbox-1").indeterminate = true;
+</script>
+{% endhighlight %}
+        <div class="stacks-preview--example">
+            <fieldset class="d-flex gs8 gsy fd-column">
+                <div class="flex--item">
+                    <div class="d-flex gs8 gsx">
+                        <div class="flex--item">
+                            <input class="s-checkbox" type="checkbox" name="" id="indeterminate-checkbox-1" />
+                        </div>
+                        <label class="flex--item s-label fw-normal" for="indeterminate-checkbox-1">Select all</label>
+                    </div>
+                </div>
+            </fieldset>
+            <script>
+                document.getElementById("indeterminate-checkbox-1").indeterminate = true;
+            </script>
+        </div>
+    </div>
 </section>
 
 <section class="stacks-section">

--- a/docs/product/components/checkbox.html
+++ b/docs/product/components/checkbox.html
@@ -310,7 +310,11 @@ description: A checkable input that visually shows if an option is true or false
     </div>
 
     {% header "h3", "Indeterminate state" %}
-    <p class="stacks-copy">Uses <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes"><code>.indeterminate</code></a> checkbox state</p>
+    <p class="stacks-copy">Checkboxes can be styled by using the <code>:indeterminate</code> pseudo class.</p>
+    {% tip, "", "mb32" %}
+        <strong>Note:</strong> The <code>:indeterminate</code> pseudo class can only be set via JavaScript. Use the <code>HTMLInputElement</code> object's <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes"><code>indeterminate</code></a> property to set the state.
+    {% endtip %}
+
     <div class="stacks-preview">
 {% highlight html %}
 <fieldset class="d-flex gs8 gsy fd-column">

--- a/lib/css/components/inputs.less
+++ b/lib/css/components/inputs.less
@@ -377,10 +377,9 @@ fieldset {
         background-repeat: no-repeat;
         background-size: contain;
 
-        &:checked {
+        &:checked, &:indeterminate {
             border-color: var(--theme-secondary-400) !important;
             background-color: var(--theme-secondary-400);
-            background-image: url("data:image/svg+xml,%3Csvg width='11' height='11' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M10 3.41L8.59 2 4 6.59 2.41 5 1 6.41l3 3z' fill='%23fff'/%3E%3C/svg%3E");
 
             .highcontrast-dark-mode({
                 border-color: var(--blue-700) !important;
@@ -390,6 +389,13 @@ fieldset {
             &:focus {
                 border-color: var(--theme-secondary-400);
             }
+        }
+
+        &:checked {
+            background-image: url("data:image/svg+xml,%3Csvg width='11' height='11' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M10 3.41L8.59 2 4 6.59 2.41 5 1 6.41l3 3z' fill='%23fff'/%3E%3C/svg%3E");
+        }
+        &:indeterminate {
+            background-image: url("data:image/svg+xml,%3Csvg width='11' height='11' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2 4.5 h7 v2 h-7 z' fill='%23fff'/%3E%3C/svg%3E");
         }
 
         &:focus {


### PR DESCRIPTION
Allows for [.indeterminate](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes) checkbox property to be set to true by using [`:indeterminate`](https://developer.mozilla.org/en-US/docs/Web/CSS/:indeterminate) selector

* Here's the [current indeterminate handling (doesn't exist)](https://codepen.io/KyleMit/pen/YzaGdWr)
* Here's an [example of the fix inlined into a pen](https://codepen.io/KyleMit/pen/XWEjoMX)
* Here's some [decoded svgs that I used to get the background image right](https://codepen.io/KyleMit/pen/yLKaGzL)
  * I started with using `<rect>` svg element, but that didn't inline nicely for some reason, so stuck to path, which is what we're using now

Also added new section to the docs:

![image](https://user-images.githubusercontent.com/4307307/178773587-34e09f98-9e16-493f-86ff-6e304429c3c5.png)
