### PR TITLE
Fix typescript errors when using Stacks package

### DIFF
--- a/lib/ts/controllers/s-table.ts
+++ b/lib/ts/controllers/s-table.ts
@@ -142,7 +142,7 @@ function getCellSlot(cell: HTMLTableCellElement): number {
     if (!(cell.parentElement && cell.parentElement.parentElement instanceof HTMLTableSectionElement)) {
         throw "invalid table"
     }
-    const result = buildIndexOrGetCellSlot(cell.parentElement.parentElement, cell);
+    const result = buildIndexOrGetCellSlot(cell.parentElement.parentElement as any as HTMLTableSectionElement, cell);
     if (typeof result !== "number") {
         throw "shouldn't happen"
     }

--- a/lib/ts/controllers/s-tooltip.ts
+++ b/lib/ts/controllers/s-tooltip.ts
@@ -101,7 +101,7 @@ export class TooltipController extends BasePopoverController {
 
         var popover = document.getElementById(popoverId);
         if (!popover) {
-            popover = document.createElement("div");
+            popover = document.createElement("div") as any as HTMLElement;
             popover.id = popoverId;
             popover.className = "s-popover s-popover__tooltip pe-none";
             popover.setAttribute("aria-hidden", "true");


### PR DESCRIPTION
# Summary

We are using the Stacks package in our solution in Visual Studio but there are these typescript compilation related errors that show up within the IDE:
![image](https://user-images.githubusercontent.com/4502154/178774292-728616b8-1346-4012-9211-095cb4619ee7.png)

I'm not sure if my proposed changes are the best way to address this but having those errors in my Visual Studio can be quite annoying and I haven't been able to figure out a way to hide/ignore them. This PR is my naïve attempt at trying to get rid of those errors.

If I make the proposed changes on my machine the errors go away: 
![image](https://user-images.githubusercontent.com/4502154/178774650-b267441b-17cd-45ed-a6a2-c45eedf3217b.png)
But this doesn't solve it for others and the issue would most likely reoccur if we were to update the package and the files are overwritten.