### PR TITLE
refactor(a11y): contrast improvements

### DIFF
--- a/docs/assets/js/entry.banners.js
+++ b/docs/assets/js/entry.banners.js
@@ -21,7 +21,6 @@ $(document).ready(function() {
         topnav.css("top","");
         sysCloseBtn.removeClass("d-none");
         sysBanner.show().attr("aria-hidden","false").removeClass(typeClasses).addClass(sysStyle);
-        sysCloseIcon.removeClass("fc-white").addClass("fc-dark");
 
         if (sysPos.is(":checked")) {
             topnav.removeClass("t0").css("top", sysBannerHeight + "px");
@@ -30,13 +29,6 @@ $(document).ready(function() {
 
         if (sysType.is(":checked")) {
             sysBanner.addClass("s-banner__important");
-
-            if (sysStyle == "s-banner__warning" || sysStyle == "s-banner__success") {
-                sysCloseIcon.removeClass("fc-white").addClass("fc-dark");
-            }
-            else {
-                sysCloseIcon.removeClass("fc-dark").addClass("fc-white");
-            }
         }
     });
 

--- a/docs/product/components/banners.html
+++ b/docs/product/components/banners.html
@@ -29,7 +29,7 @@ description: Banners are a type of <a href="/product/components/notices">notice<
             </div>
         </div>
         <div class="flex--item ml-auto myn8" aria-label="dismiss notice">
-            <a class="p8 s-btn d-flex flex__center fc-dark js-notice-close" role="status" aria-hidden="true">
+            <a class="p8 s-btn d-flex flex__center fc-inherit js-notice-close" role="status" aria-hidden="true">
                 {% icon "ClearSm", "m0" %}
             </a>
         </div>

--- a/lib/css/components/banners.less
+++ b/lib/css/components/banners.less
@@ -63,12 +63,6 @@
         -webkit-transform: translate3d(0, 0, 0);
         transform: translate3d(0, 0, 0);
     }
-
-    //  If it's a really important banner
-    &.s-banner__important {
-        border-color: transparent;
-        color: var(--white);
-    }
 }
 
 //  --  When we want to keep hero content capped

--- a/lib/css/components/breadcrumbs.less
+++ b/lib/css/components/breadcrumbs.less
@@ -11,7 +11,7 @@
     display: flex;
     flex-wrap: wrap;
     align-items: start;
-    color: var(--black-150);
+    color: var(--black-300);
     font-size: var(--fs-caption);
 
     .s-breadcrumbs--item {
@@ -26,8 +26,6 @@
         margin-right: var(--su4);
         margin-left: var(--su4);
 
-        .highcontrast-mode({ color: var(--black-350); });
-
         #stacks-internals #screen-sm({
             margin-right: var(--su2);
             margin-left: var(--su2);
@@ -35,10 +33,10 @@
     }
 
     .s-breadcrumbs--link {
-        color: var(--black-350);
+        color: var(--black-500);
 
         &:hover {
-            color: var(--black-600);
+            color: var(--black-700);
         }
     }
 }

--- a/lib/css/components/inputs.less
+++ b/lib/css/components/inputs.less
@@ -180,16 +180,16 @@ fieldset {
 
     &.s-label--status__required {
         background-color: var(--red-100);
-        color: var(--red-600);
+        color: var(--red-700);
 
-        .dark-mode({
-            color: var(--red-800);
-        });
+        .dark-mode({ color: var(--red-900); });
     }
 
     &.s-label--status__new {
         background-color: var(--green-100);
         color: var(--green-700);
+
+        .dark-mode({ color: var(--green-800); });
     }
 
     &.s-label--status__beta {

--- a/lib/css/components/notices.less
+++ b/lib/css/components/notices.less
@@ -192,7 +192,8 @@
 
 //  $$  IMPORTANT
 //  ----------------------------------------------------------------------------
-.s-notice__important {
+.s-notice__important,
+.s-banner__important {
     border-color: transparent;
     background-color: var(--black-700);
     color: var(--white);

--- a/lib/css/components/notices.less
+++ b/lib/css/components/notices.less
@@ -49,6 +49,9 @@
     &.s-notice__important,
     &.s-banner__important {
         background-color: var(--theme-secondary-400);
+
+        .dark-mode({ background-color: var(--theme-secondary-500); });
+        .highcontrast-mode({ border-color: transparent; });
     }
 
     // Improve the presentation of buttons
@@ -75,7 +78,6 @@
     border-color: var(--green-200);
     background-color: var(--green-050);
 
-    // Bump up the border contrast in high contrast mode
     .highcontrast-mode({
         background-color: var(--green-200);
         border-color: var(--green-400);
@@ -86,11 +88,14 @@
         background-color: var(--green-400);
         color: var(--black-900);
 
-        // Bump up the text in high contrast
-        .highcontrast-mode({
+        .dark-mode({
             background-color: var(--green-500);
             color: var(--white);
+        });
+        .highcontrast-mode({
+            background-color: var(--green-500);
             border-color: transparent;
+            color: var(--white);
         });
     }
 
@@ -114,7 +119,6 @@
     border-color: var(--yellow-300);
     background-color: var(--yellow-050);
 
-    // Bump up the border contrast in high contrast mode
     .highcontrast-mode({
         background-color: var(--yellow-200);
         border-color: var(--yellow-700);
@@ -125,11 +129,14 @@
         background-color: var(--yellow-400);
         color: var(--black-900);
 
-        // Bump up the text in high contrast
-        .highcontrast-mode({
+        .dark-mode({
             background-color: var(--yellow-500);
             color: var(--white);
+        });
+        .highcontrast-mode({
+            background-color: var(--yellow-500);
             border-color: transparent;
+            color: var(--white);
         });
     }
 
@@ -157,20 +164,17 @@
     border-color: var(--red-200);
     background-color: var(--red-050);
 
-    // Bump up the border contrast in high contrast mode
-    .highcontrast-mode({
-        background-color: var(--red-200);
-        border-color: var(--red-500);
-
-        &.s-notice__important,
-        &.s-banner__important {
-            background-color: var(--red-500);
-        }
-    });
-
     &.s-notice__important,
     &.s-banner__important {
-        background-color: var(--red-400);
+        background-color: var(--red-500);
+
+        .dark-mode({
+            background-color: var(--red-600);
+        });
+        .highcontrast-mode({
+            border-color: transparent;
+            color: var(--white);
+        });
     }
 
     // Improve the presentation of buttons


### PR DESCRIPTION
### The following component now pass WCAG AA for color contrast in both light and dark modes:

- banner
- breadcrumbs
- label (specifically `.s-label--status`)
- notice

### Before and after screenshots

#### Banner

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/647177/179012916-9dbb32d6-e998-4bc5-bcd5-23748aaffa52.png)
![image](https://user-images.githubusercontent.com/647177/179017495-09fd863f-45b3-42e0-8ba5-0e6079590b38.png)
![image](https://user-images.githubusercontent.com/647177/179017622-34503613-7b1a-498d-a11d-0698f0ca6542.png)
![image](https://user-images.githubusercontent.com/647177/179017843-37a53417-8ea9-4de3-ac43-3c8d618b51f1.png)

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/647177/179012829-a2d02064-b85e-44bf-9a05-4409577c9e23.png)
![image](https://user-images.githubusercontent.com/647177/179018027-856bf34b-5b16-4287-bd78-df0a748393c5.png)
![image](https://user-images.githubusercontent.com/647177/179018147-8694d9e1-13f5-460f-8312-f3f49c3b0b1f.png)
![image](https://user-images.githubusercontent.com/647177/179018821-73d9212f-6fdc-473a-8aa3-7b85eb83db22.png)

</details>

#### Breadcrumbs

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/647177/179019145-d77a1f2b-150c-4ace-8dbb-3b0c4840ea47.png)
![image](https://user-images.githubusercontent.com/647177/179019236-e4d7c87e-1c64-450a-b6e2-fe1f14a4fcfa.png)

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/647177/179019354-ead8bbee-fc70-4a78-a7fd-1c11ce25271d.png)
![image](https://user-images.githubusercontent.com/647177/179019444-baccdf6c-7a33-4854-91d9-5d9f374b7e99.png)


</details>

#### Label

<details>
<summary>Before</summary>


</details>

<details>
<summary>After</summary>


</details>

#### Notice

<details>
<summary>Before</summary>


</details>

<details>
<summary>After</summary>


</details>