### PR TITLE
fix(button): contrast, focus state fixes

### DIFF
--- a/lib/css/components/buttons.less
+++ b/lib/css/components/buttons.less
@@ -197,7 +197,11 @@
         border-color: var(--theme-button-filled-border-color);
         box-shadow: inset 0 1px 0 0 hsla(0, 0, 100%, 0.7);
 
-        .dark-mode({ box-shadow: none; });
+        .dark-mode({
+            &:not(:focus) {
+                box-shadow: none;
+            }
+        });
 
         &:hover,
         &:focus,
@@ -278,7 +282,11 @@
             border-color: transparent;
             box-shadow: inset 0 1px 0 0 hsla(0, 0%, 100%, 0.4);
 
-            .dark-mode({ box-shadow: none; });
+            .dark-mode({
+                &:not(:focus) {
+                    box-shadow: none;
+                }
+            });
 
             .highcontrast-mode({
                 background-color: var(--black-400);
@@ -380,7 +388,11 @@
             border-color: transparent;
             box-shadow: inset 0 1px 0 0 hsla(0, 0%, 100%, 0.4);
 
-            .dark-mode({ box-shadow: none; });
+            .dark-mode({
+                &:not(:focus) {
+                    box-shadow: none;
+                }
+            });
 
             .highcontrast-mode({
                 color: var(--white);
@@ -440,7 +452,9 @@
         box-shadow: inset 0 1px 0 0 hsla(0, 0%, 100%, 0.4);
 
         .dark-mode({
-            box-shadow: none;
+            &:not(:focus) {
+                box-shadow: none;
+            }
 
             &:not(.is-selected) {
                 background-color: var(--theme-secondary-300);

--- a/lib/css/components/buttons.less
+++ b/lib/css/components/buttons.less
@@ -443,6 +443,7 @@
             box-shadow: none;
 
             &:not(.is-selected) {
+                background-color: var(--theme-secondary-300);
                 color: var(--black);
             }
         });

--- a/lib/css/components/buttons.less
+++ b/lib/css/components/buttons.less
@@ -464,6 +464,7 @@
         .highcontrast-mode({
             &:not(.is-selected) {
                 border-color: transparent;
+                background-color: var(--theme-secondary-400);
                 color: var(--white);
             }
         });


### PR DESCRIPTION
This PR fixes two accessibility issues with `.s-btn` in dark mode:

<details>
<summary>Increases color contrast for primary button</summary>

### Before
Contrast: 3.39:1
<img width="726" alt="image" src="https://user-images.githubusercontent.com/647177/180047674-6699b6bc-5427-4efe-a2ae-47fe93fec1af.png">

### After
Contrast: 6.15:1
<img width="730" alt="image" src="https://user-images.githubusercontent.com/647177/180047483-0be99746-af79-4c43-abf0-cab60b786240.png">

</details>

- Adds focus outline (as box-shadow) to any buttons missing it