### PR TITLE
modify ignored post summary selectors to be more specific

### DIFF
--- a/lib/css/components/post-summary.less
+++ b/lib/css/components/post-summary.less
@@ -403,10 +403,9 @@
 
 .s-post-summary__ignored,
 .s-post-summary__deleted {
-    .s-post-summary--content > *:not(.s-post-summary--content-menu-button) {
+    .s-post-summary--content > *:not(.s-post-summary--content-menu-button):not(.s-post-summary--meta) {
         opacity: 0.6;
     }
-
     // TODO DEPRECATED remove `:not(.is-deleted)`
     .s-post-summary--stats-item:not(.s-badge):not(.is-deleted) {
         opacity: 0.6;
@@ -430,7 +429,13 @@
         color: var(--black-500);
     }
 
-    .s-post-summary--meta {
+    .s-post-summary--meta > *:not(.s-post-summary--meta-tags) {
+        opacity: 0.6;
+        filter: grayscale(100%);
+    }
+
+    .s-post-summary--meta-tags > a {
+        opacity: 0.6;
         filter: grayscale(100%);
     }
 }


### PR DESCRIPTION
# Summary

This is to address a visual glitch due to some changes I'm making within the StackOverflow project.

Right now the opacity and grey filters are applied to all children of ignored post summaries. Which means if I add a popover within the post summary via javascript it too gets its opacity and filter modified. It also throws off the coordinates of the absolute positioning:
<img src="https://user-images.githubusercontent.com/4502154/180078143-2062f716-3b09-438d-b6a4-0b61369ad53e.png" width=100 />

My PR that isn't working correctly right now: https://github.com/StackEng/StackOverflow/pull/12396
Codepen of suggested fix: https://codepen.io/mukunku/pen/RwMVorL

# Testing

I compared the Stacks product pages for the post summary component before and after my change and it looks like it is working okay:
<img src="https://user-images.githubusercontent.com/4502154/180078244-3a75024b-1965-4598-a0ac-55845f5c0f34.png" width=100 />

After this change my popovers are rendering correctly:
<img src="https://user-images.githubusercontent.com/4502154/180078408-e122f29f-f524-46b6-a2fc-04342dcaa52a.png" width=100 />