### PR TITLE
refactor(color): adjust high contrast colors

### DIFF
--- a/lib/css/exports/constants-colors.less
+++ b/lib/css/exports/constants-colors.less
@@ -709,10 +709,10 @@
     --black-900: hsl(@black-h, @black-s, 0%);
 
     // Orange
-    --orange-050: hsl(@orange-h, 100%, 97.5%);
-    --orange-100: hsl(@orange-h, 100%, 94%);
-    --orange-200: hsl(@orange-h, 100%, 88%);
-    --orange-300: hsl(@orange-h, 100%, 82%);
+    --orange-050: hsl(@orange-h, 100%, 93%);
+    --orange-100: hsl(@orange-h, 100%, 90%);
+    --orange-200: hsl(@orange-h, 100%, 86%);
+    --orange-300: hsl(@orange-h, 100%, 81%);
     --orange-400: hsl(@orange-h, 100%, 34%);
     --orange-500: hsl(@orange-h, 100%, 29%);
     --orange-600: hsl(@orange-h, 100%, 24%);
@@ -721,10 +721,10 @@
     --orange-900: hsl(@orange-h, 100%, 8%);
 
     // Blue
-    --blue-050: hsl(@blue-h, 100%, 97.5%);
-    --blue-100: hsl(@blue-h, 100%, 95%);
-    --blue-200: hsl(@blue-h, 100%, 90%);
-    --blue-300: hsl(@blue-h, 100%, 85%);
+    --blue-050: hsl(@blue-h, 100%, 94%);
+    --blue-100: hsl(@blue-h, 100%, 92%);
+    --blue-200: hsl(@blue-h, 100%, 89%);
+    --blue-300: hsl(@blue-h, 100%, 86%);
     --blue-400: hsl(@blue-h, 100%, 25%);
     --blue-500: hsl(@blue-h, 100%, 20%);
     --blue-600: hsl(@blue-h, 100%, 15%);
@@ -733,10 +733,10 @@
     --blue-900: hsl(@blue-h, 100%, 5%);
 
     // Powder
-    --powder-050: hsl(@powder-h, 100%, 97.5%);
-    --powder-100: hsl(@powder-h, 85%, 96%);
-    --powder-200: hsl(@powder-h, 75%, 92%);
-    --powder-300: hsl(@powder-h, 70%, 88%);
+    --powder-050: hsl(@powder-h, 100%, 95%);
+    --powder-100: hsl(@powder-h, 85%, 93%);
+    --powder-200: hsl(@powder-h, 75%, 89%);
+    --powder-300: hsl(@powder-h, 70%, 86%);
     --powder-400: hsl(@powder-h, 55%, 28%);
     --powder-500: hsl(@powder-h, 60%, 24%);
     --powder-600: hsl(@powder-h, 70%, 20%);
@@ -745,11 +745,11 @@
     --powder-900: hsl(@powder-h, 75%, 8%);
 
     // Green
-    --green-025: hsl(@green-h, 100%, 97%);
-    --green-050: hsl(@green-h, 100%, 96%);
-    --green-100: hsl(@green-h, 100%, 94%);
-    --green-200: hsl(@green-h, 100%, 88%);
-    --green-300: hsl(@green-h, 100%, 82%);
+    --green-025: hsl(@green-h, 100%, 94%);
+    --green-050: hsl(@green-h, 100%, 91%);
+    --green-100: hsl(@green-h, 100%, 87%);
+    --green-200: hsl(@green-h, 100%, 83%);
+    --green-300: hsl(@green-h, 100%, 78%);
     --green-400: hsl(@green-h, 100%, 18%);
     --green-500: hsl(@green-h, 100%, 15%);
     --green-600: hsl(@green-h, 100%, 12%);
@@ -758,10 +758,10 @@
     --green-900: hsl(@green-h, 100%, 3%);
 
     // Yellow
-    --yellow-050: hsl(@yellow-h, 100%, 95%);
-    --yellow-100: hsl(@yellow-h, 100%, 92%);
-    --yellow-200: hsl(@yellow-h, 95%, 85%);
-    --yellow-300: hsl(@yellow-h, 95%, 78%);
+    --yellow-050: hsl(@yellow-h, 100%, 92%);
+    --yellow-100: hsl(@yellow-h, 100%, 88%);
+    --yellow-200: hsl(@yellow-h, 95%, 83%);
+    --yellow-300: hsl(@yellow-h, 95%, 75%);
     --yellow-400: hsl(@yellow-h, 100%, 28%);
     --yellow-500: hsl(@yellow-h, 100%, 26%);
     --yellow-600: hsl(@yellow-h, 100%, 23%);
@@ -770,10 +770,10 @@
     --yellow-900: hsl(@yellow-h, 100%, 7%);
 
     // Red
-    --red-050: hsl(@red-h, 100%, 97.5%);
-    --red-100: hsl(@red-h, 100%, 95%);
-    --red-200: hsl(@red-h, 100%, 90%);
-    --red-300: hsl(@red-h, 100%, 85%);
+    --red-050: hsl(@red-h, 100%, 94%);
+    --red-100: hsl(@red-h, 100%, 92%);
+    --red-200: hsl(@red-h, 100%, 89%);
+    --red-300: hsl(@red-h, 100%, 86%);
     --red-400: hsl(@red-h, 100%, 35%);
     --red-500: hsl(@red-h, 100%, 29%);
     --red-600: hsl(@red-h, 100%, 23%);
@@ -865,10 +865,10 @@
     --black-900: hsl(@black-h, @black-s, 100%);
 
     // Orange
-    --orange-050: hsl(@orange-h, 100%, 4%);
-    --orange-100: hsl(@orange-h, 100%, 8%);
-    --orange-200: hsl(@orange-h, 100%, 16%);
-    --orange-300: hsl(@orange-h, 100%, 24%);
+    --orange-050: hsl(@orange-h, 100%, 7%);
+    --orange-100: hsl(@orange-h, 100%, 9%);
+    --orange-200: hsl(@orange-h, 100%, 15%);
+    --orange-300: hsl(@orange-h, 100%, 22%);
     --orange-400: hsl(@orange-h, 100%, 64%);
     --orange-500: hsl(@orange-h, 100%, 71%);
     --orange-600: hsl(@orange-h, 100%, 77%);
@@ -877,10 +877,10 @@
     --orange-900: hsl(@orange-h, 100%, 91%);
 
     // Blue
-    --blue-050: hsl(@blue-h, 100%, 4%);
+    --blue-050: hsl(@blue-h, 100%, 7%);
     --blue-100: hsl(@blue-h, 100%, 11%);
-    --blue-200: hsl(@blue-h, 100%, 18%);
-    --blue-300: hsl(@blue-h, 100%, 25%);
+    --blue-200: hsl(@blue-h, 100%, 17%);
+    --blue-300: hsl(@blue-h, 100%, 24%);
     --blue-400: hsl(@blue-h, 100%, 75%);
     --blue-500: hsl(@blue-h, 100%, 80%);
     --blue-600: hsl(@blue-h, 100%, 85%);
@@ -889,10 +889,10 @@
     --blue-900: hsl(@blue-h, 100%, 95%);
 
     // Powder
-    --powder-050: hsl(@powder-h, 100%, 6%);
-    --powder-100: hsl(@powder-h, 90%, 8%);
+    --powder-050: hsl(@powder-h, 100%, 7%);
+    --powder-100: hsl(@powder-h, 95%, 10%);
     --powder-200: hsl(@powder-h, 80%, 14%);
-    --powder-300: hsl(@powder-h, 60%, 20%);
+    --powder-300: hsl(@powder-h, 76%, 19%);
     --powder-400: hsl(@powder-h, 55%, 72%);
     --powder-500: hsl(@powder-h, 60%, 76%);
     --powder-600: hsl(@powder-h, 70%, 80%);
@@ -901,11 +901,11 @@
     --powder-900: hsl(@powder-h, 75%, 92%);
 
     // Green
-    --green-025: hsl(@green-h, 100%, 3%);
-    --green-050: hsl(@green-h, 100%, 4%);
-    --green-100: hsl(@green-h, 100%, 6%);
-    --green-200: hsl(@green-h, 100%, 12%);
-    --green-300: hsl(@green-h, 100%, 18%);
+    --green-025: hsl(@green-h, 100%, 5%);
+    --green-050: hsl(@green-h, 100%, 6%);
+    --green-100: hsl(@green-h, 100%, 7%);
+    --green-200: hsl(@green-h, 100%, 11%);
+    --green-300: hsl(@green-h, 100%, 15%);
     --green-400: hsl(@green-h, 100%, 65%);
     --green-500: hsl(@green-h, 100%, 71%);
     --green-600: hsl(@green-h, 100%, 77%);
@@ -914,10 +914,10 @@
     --green-900: hsl(@green-h, 100%, 94%);
 
     // Yellow
-    --yellow-050: hsl(@yellow-h, 100%, 4%);
-    --yellow-100: hsl(@yellow-h, 100%, 8%);
-    --yellow-200: hsl(@yellow-h, 95%, 16%);
-    --yellow-300: hsl(@yellow-h, 95%, 24%);
+    --yellow-050: hsl(@yellow-h, 100%, 6%);
+    --yellow-100: hsl(@yellow-h, 100%, 9%);
+    --yellow-200: hsl(@yellow-h, 100%, 14%);
+    --yellow-300: hsl(@yellow-h, 100%, 20%);
     --yellow-400: hsl(@yellow-h, 100%, 55%);
     --yellow-500: hsl(@yellow-h, 100%, 63%);
     --yellow-600: hsl(@yellow-h, 100%, 71%);
@@ -926,10 +926,10 @@
     --yellow-900: hsl(@yellow-h, 100%, 95%);
 
     // Red
-    --red-050: hsl(@red-h, 100%, 4%);
-    --red-100: hsl(@red-h, 100%, 8%);
-    --red-200: hsl(@red-h, 100%, 16%);
-    --red-300: hsl(@red-h, 100%, 24%);
+    --red-050: hsl(@red-h, 100%, 9%);
+    --red-100: hsl(@red-h, 100%, 12%);
+    --red-200: hsl(@red-h, 100%, 17%);
+    --red-300: hsl(@red-h, 100%, 22%);
     --red-400: hsl(@red-h, 100%, 70%);
     --red-500: hsl(@red-h, 100%, 75%);
     --red-600: hsl(@red-h, 100%, 80%);


### PR DESCRIPTION
@allejo mentioned that `red-050` is indistinct from black in dark mode (and from white in light mode). This PR adjust lower color stops to provide adequate contrast on similar monochromatic colors.

<details>
<summary>Before</summary>
<img width="632" alt="image" src="https://user-images.githubusercontent.com/647177/181044771-1b16cb6c-8ce6-40b3-b99e-8669e65d07fc.png">
</details>

<details>
<summary>After</summary>
<img width="633" alt="image" src="https://user-images.githubusercontent.com/647177/181044923-1436b02c-ede5-4dd4-94b6-8a35fe71b518.png">
</details>