### PR TITLE
Pull in classes from Stacks-Editor

### DIFF
--- a/docs/_data/spinner.json
+++ b/docs/_data/spinner.json
@@ -27,8 +27,8 @@
     },
     {
       "class": ".is-loading",
-      "applies": "Any element",
-      "description": "Prepends a spinner pseudo-element to the element"
+      "applies": "Any text-based elements",
+      "description": "Prepends a spinner pseudo-element to the element. Prefer using the spinner component when possible."
     }
   ]
 }

--- a/docs/_data/spinner.json
+++ b/docs/_data/spinner.json
@@ -24,6 +24,11 @@
       "class": ".s-spinner__lg",
       "applies": ".s-spinner",
       "description": "A large style for the largest layouts"
+    },
+    {
+      "class": ".is-loading",
+      "applies": "Any element",
+      "description": "Prepends a spinner pseudo-element to the element"
     }
   ]
 }

--- a/docs/product/components/inputs.html
+++ b/docs/product/components/inputs.html
@@ -29,6 +29,14 @@ description: Input elements are used to gather information from users.
         @Svg.Lock.With("s-input-icon fc-black-400")
     </div>
 </div>
+
+<div class="d-flex gs4 gsy fd-column ps-relative is-readonly">
+    <label class="flex--item s-label" for="example-item3">Legal Name</label>
+    <div class="d-flex ps-relative">
+        <input class="s-input" id="example-item3" type="text" placeholder="Enter your input here" readonly />
+        @Svg.Lock.With("s-input-icon fc-black-400")
+    </div>
+</div>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="d-flex gs16 gsy fd-column">
@@ -51,6 +59,15 @@ description: Input elements are used to gather information from users.
                         <div class="d-flex ps-relative">
                             <input class="s-input" id="example-item2" type="text" placeholder="Enter your input here" disabled />
                             {% icon "Lock", "s-input-icon fc-black-400" %}
+                        </div>
+                    </div>
+                </div>
+                <div class="flex--item">
+                    <div class="d-flex gs4 gsy fd-column ps-relative is-readonly">
+                        <label class="flex--item s-label" for="example-item3">Legal name</label>
+                        <div class="d-flex ps-relative">
+                            <input class="s-input" id="example-item3" type="text" placeholder="Enter your input here" readonly value="Prefilled readonly input" />
+                            {% icon "Lock", "s-input-icon" %}
                         </div>
                     </div>
                 </div>

--- a/docs/product/components/spinner.html
+++ b/docs/product/components/spinner.html
@@ -47,6 +47,9 @@ description: A loading spinner is used for indicating a loading state of a page 
 <div class="s-spinner s-spinner__lg fc-theme-primary">
     <div class="v-visible-sr">Loading…</div>
 </div>
+<div class="is-loading">
+    Loading…
+</div>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="d-flex gs16 fw-wrap">
@@ -73,6 +76,11 @@ description: A loading spinner is used for indicating a loading state of a page 
                 <div class="flex--item">
                     <div class="s-spinner s-spinner__lg fc-theme-primary">
                         <div class="v-visible-sr">Loading…</div>
+                    </div>
+                </div>
+                <div class="flex--item">
+                    <div class="is-loading">
+                        Loading…
                     </div>
                 </div>
             </div>

--- a/docs/product/components/spinner.html
+++ b/docs/product/components/spinner.html
@@ -17,7 +17,7 @@ description: A loading spinner is used for indicating a loading state of a page 
             <tbody class="fs-caption">
                 {% for item in spinner.spinner %}
                     <tr>
-                        <td><code class="stacks-code">{{ item.class }}</code></td>
+                        <td><code class="stacks-code ws-nowrap">{{ item.class }}</code></td>
                         <td>{% if item.applies == "N/A" %}<em class="fc-black-350">{{ item.applies }}</em>{% else %}<code class="stacks-code">{{ item.applies }}</code>{% endif %}</td>
                         <td>{{ item.description }}</td>
                     </tr>

--- a/lib/css/components/buttons.less
+++ b/lib/css/components/buttons.less
@@ -640,50 +640,12 @@
     }
 
     //  $$  Loading Icon
-    //      Adds a loading icon into the button
+    //      see spinner.less for full implementation
     //  ----------------------------------------------------------------------------
-    .s-btn {
-        &.is-loading {
-            padding-left: 2.2em;
-
-            &:before {
-                content: "";
-                position: absolute;
-                opacity: 0.3;
-                left: 0.6em;
-                top: calc(50% - 0.6em);
-                width: 1.23076923em;
-                height: 1.23076923em;
-                border-width: 2px;
-                border-style: solid;
-                border-color: currentColor;
-                border-radius: var(--br-circle);
-            }
-
-            &:after {
-                content: "";
-                position: absolute;
-                left: 0.6em;
-                top: calc(50% - 0.6em);
-                width: 1.23076923em;
-                height: 1.23076923em;
-                border-width: 2px;
-                border-style: solid;
-                border-color: transparent;
-                border-left-color: currentColor;
-                border-radius: var(--br-circle);
-                animation: s-spinner-rotate 0.9s infinite cubic-bezier(0.5, 0.1, 0.5, 0.9);
-                // see spinner.less for an explanation of the following two
-                filter: invert(0); // (*)
-                transform-origin: 50% 50% 1px; // (*)
-            }
-
-            .svg-icon:first-child {
-                margin-left: -23px;
-                // If the first thing in the button is an icon, let's hide it on loading
-                // We only want to modify the visibility, since we still want it to have shape and keep the same layout.
-                opacity: 0;
-            }
-        }
+    .s-btn.is-loading  .svg-icon:first-child {
+        margin-left: -23px;
+        // If the first thing in the button is an icon, let's hide it on loading
+        // We only want to modify the visibility, since we still want it to have shape and keep the same layout.
+        opacity: 0;
     }
 }

--- a/lib/css/components/inputs.less
+++ b/lib/css/components/inputs.less
@@ -469,6 +469,9 @@ fieldset {
     }
 
     //  Readonly
+    //  Note: The readonly attribute is not supported on select elements
+    //  See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly
+    //  and https://github.com/StackExchange/Stacks/pull/1040#discussion_r931144086
     &[readonly],
     .is-readonly & {
         border-color: var(--bc-light);

--- a/lib/css/components/inputs.less
+++ b/lib/css/components/inputs.less
@@ -462,21 +462,23 @@ fieldset {
 .s-input,
 .s-textarea,
 .s-select > select {
-    //  Disabled, Read-only
-    &[disabled],
-    &[read-only] {
-        cursor: not-allowed;
-        opacity: 0.5;
-
-        .highcontrast-mode({
-            opacity: 0.5;
-        });
-    }
-
     //  Disabled
     &[disabled] {
         cursor: not-allowed;
         opacity: 0.5;
+    }
+
+    //  Readonly
+    &[readonly],
+    .is-readonly & {
+        border-color: var(--bc-light);
+        background-color: var(--black-050);
+        color: var(--black-200);
+        cursor: not-allowed;
+
+        .highcontrast-mode({
+            color: var(--fc-light);
+        });
     }
 }
 
@@ -485,6 +487,7 @@ fieldset {
 //      Classes are applied at the wrapping container level.
 //  ----------------------------------------------------------------------------
 .is-disabled,
+.is-readonly,
 .has-success,
 .has-error,
 .has-warning {
@@ -623,6 +626,22 @@ fieldset {
 
     .s-input-icon {
         color: var(--black-400);
+    }
+
+    .s-label {
+        cursor: not-allowed;
+    }
+}
+
+//  $$  READONLY
+//  ----------------------------------------------------------------------------
+.is-readonly {
+    .s-input-icon {
+        color: var(--black-200);
+
+        .highcontrast-mode({
+            color: var(--fc-light);
+        });
     }
 
     .s-label {

--- a/lib/css/components/spinner.less
+++ b/lib/css/components/spinner.less
@@ -96,6 +96,44 @@
     }
 }
 
+.is-loading {
+    position: relative;
+    padding-left: 2.2em;
+
+    &:before {
+        content: "";
+        position: absolute;
+        opacity: 0.3;
+        left: 0.6em;
+        top: calc(50% - 0.6em);
+        width: 1.23076923em;
+        height: 1.23076923em;
+        border-width: 2px;
+        border-style: solid;
+        border-color: currentColor;
+        border-radius: var(--br-circle);
+    }
+
+    &:after {
+        content: "";
+        position: absolute;
+        left: 0.6em;
+        top: calc(50% - 0.6em);
+        width: 1.23076923em;
+        height: 1.23076923em;
+        border-width: 2px;
+        border-style: solid;
+        border-color: transparent;
+        border-left-color: currentColor;
+        border-radius: var(--br-circle);
+        animation: s-spinner-rotate 0.9s infinite
+            cubic-bezier(0.5, 0.1, 0.5, 0.9);
+        // see _stacks-spinner.less for an explanation of the following two
+        filter: invert(0); // (*)
+        transform-origin: 50% 50% 1px; // (*)
+    }
+}
+
 // Keyframes
 @keyframes s-spinner-rotate {
     from {


### PR DESCRIPTION
This PR adds in a new `is-readonly` input class and abstracts out the button `is-loading` class to be used anywhere. I've added examples / docs for both items, as well as tested in both dark and highcontrast modes.

Ideally, this would be multiple PRs since they're individual features, but we can merge w/o squashing if you'd like each commit to appear in the changelog.