### PR TITLE
refactor(color): adjust dark themed low stops

### DIFF
--- a/lib/css/exports/constants-colors.less
+++ b/lib/css/exports/constants-colors.less
@@ -636,37 +636,25 @@
     // Reassemble as a single hsl value
     --theme-secondary-color: .assemble-color(theme-secondary-color)[];
 
-    // Primary Theming
-    --theme-primary-025: .native-darken-desaturate(theme-primary-color, 17, 82)[];
-    --theme-primary-050: .native-darken-desaturate(theme-primary-color, 15, 47)[];
-    --theme-primary-075: .native-darken-desaturate(theme-primary-color, 13, 39)[];
-    --theme-primary-100: .native-darken-desaturate(theme-primary-color, 11, 32)[];
-    --theme-primary-150: .native-darken-desaturate(theme-primary-color, 9, 23)[];
-    --theme-primary-200: .native-darken-desaturate(theme-primary-color, 7, 15)[];
-    --theme-primary-300: .native-darken-desaturate(theme-primary-color, 5, 7)[];
-    --theme-primary-350: var(--theme-primary-color);
-    --theme-primary-400: .native-tint(theme-primary-color, 21)[];
-    --theme-primary-500: .native-tint(theme-primary-color, 36)[];
-    --theme-primary-600: .native-tint(theme-primary-color, 51)[];
-    --theme-primary-700: .native-tint(theme-primary-color, 66)[];
-    --theme-primary-800: .native-tint(theme-primary-color, 81)[];
-    --theme-primary-900: .native-tint(theme-primary-color, 96)[];
+    .dark-themed-colors-generator(@variant) {
+        --theme-@{variant}-025: .native-darken-desaturate(~"theme-@{variant}-color", 45, 60)[];
+        --theme-@{variant}-050: .native-darken-desaturate(~"theme-@{variant}-color", 18, 45)[];
+        --theme-@{variant}-075: .native-darken-desaturate(~"theme-@{variant}-color", 16, 35)[];
+        --theme-@{variant}-100: .native-darken-desaturate(~"theme-@{variant}-color", 14, 28)[];
+        --theme-@{variant}-150: .native-darken-desaturate(~"theme-@{variant}-color", 12, 22)[];
+        --theme-@{variant}-200: .native-darken-desaturate(~"theme-@{variant}-color", 8, 15)[];
+        --theme-@{variant}-300: .native-darken-desaturate(~"theme-@{variant}-color", 6, 5)[];
+        --theme-@{variant}-350: var(~"--theme-@{variant}-color");
+        --theme-@{variant}-400: .native-tint(~"theme-@{variant}-color", 21)[];
+        --theme-@{variant}-500: .native-tint(~"theme-@{variant}-color", 36)[];
+        --theme-@{variant}-600: .native-tint(~"theme-@{variant}-color", 51)[];
+        --theme-@{variant}-700: .native-tint(~"theme-@{variant}-color", 66)[];
+        --theme-@{variant}-800: .native-tint(~"theme-@{variant}-color", 81)[];
+        --theme-@{variant}-900: .native-tint(~"theme-@{variant}-color", 96)[];
+    }
 
-    // Secondary Theming
-    --theme-secondary-025: .native-darken-desaturate(theme-secondary-color, 17, 82)[];
-    --theme-secondary-050: .native-darken-desaturate(theme-secondary-color, 15, 47)[];
-    --theme-secondary-075: .native-darken-desaturate(theme-secondary-color, 13, 39)[];
-    --theme-secondary-100: .native-darken-desaturate(theme-secondary-color, 11, 32)[];
-    --theme-secondary-150: .native-darken-desaturate(theme-secondary-color, 9, 23)[];
-    --theme-secondary-200: .native-darken-desaturate(theme-secondary-color, 7, 15)[];
-    --theme-secondary-300: .native-darken-desaturate(theme-secondary-color, 5, 7)[];
-    --theme-secondary-350: var(--theme-secondary-color);
-    --theme-secondary-400: .native-tint(theme-secondary-color, 21)[];
-    --theme-secondary-500: .native-tint(theme-secondary-color, 36)[];
-    --theme-secondary-600: .native-tint(theme-secondary-color, 51)[];
-    --theme-secondary-700: .native-tint(theme-secondary-color, 66)[];
-    --theme-secondary-800: .native-tint(theme-secondary-color, 81)[];
-    --theme-secondary-900: .native-tint(theme-secondary-color, 96)[];
+    .dark-themed-colors-generator(primary);
+    .dark-themed-colors-generator(secondary);
 
     // Fades
     --focus-ring: .native-fade(theme-secondary-color, 25)[];

--- a/lib/css/exports/mixins.less
+++ b/lib/css/exports/mixins.less
@@ -154,8 +154,8 @@
     @darkenAmountPercentage: .load-color-variables(@darken-amount)[@amountPercentage];
     @desaturateAmountPercentage: .load-color-variables(@desaturate-amount)[@amountPercentage];
     @result: hsl(var(~"--@{color-prefix}-h"),
-                 clamp(10%, calc(var(~"--@{color-prefix}-s") - @desaturateAmountPercentage), 90%),
-                 clamp(20%, calc(var(~"--@{color-prefix}-l") - @darkenAmountPercentage), 100%));
+                 clamp(10%, calc(var(~"--@{color-prefix}-s") - @desaturateAmountPercentage), 100%),
+                 clamp(15%, calc(var(~"--@{color-prefix}-l") - @darkenAmountPercentage), 100%));
 }
 
 // Decrease the lightness of a color in the HSL color space by an absolute amount.


### PR DESCRIPTION
// TODO fill this out

### Minor color change

This PR will result in some elements using lower color stops having minor color changes in dark mode. Most notable is `.s-btn.

#### `.s-btn`

<details>
<summary>before</summary>

![image](https://user-images.githubusercontent.com/647177/181088353-4173f6f8-8b35-4152-b47e-26ba2965b6c0.png)

</details>

<details>
<summary>after</summary>

![image](https://user-images.githubusercontent.com/647177/181088388-be9ad416-6b81-469e-b174-edf05950d178.png)

</details>