### PR TITLE
Add controller for easily attaching keyboard shortcuts to buttons and fields

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -47,7 +47,6 @@
                     data-controller="s-keyboard-shortcut"
                     data-s-keyboard-shortcut-ctrl-value="true"
                     data-s-keyboard-shortcut-key-value="/"
-                    data-s-keyboard-shortcut-action-value="focus"
                 />
                 {% icon "Search", "s-input-icon s-input-icon__search" %}
             </div>

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -37,7 +37,18 @@
 
         <div class="s-topbar--searchbar w100 wmx3 sm:wmx-initial js-search">
             <div class="s-topbar--searchbar--input-group">
-                <input id="searchbox" type="text" placeholder="Search Stacks…" value="" autocomplete="off" class="s-input s-input__search" />
+                <input
+                    id="searchbox"
+                    type="text"
+                    placeholder="Search Stacks…"
+                    value=""
+                    autocomplete="off"
+                    class="s-input s-input__search"
+                    data-controller="s-keyboard-shortcut"
+                    data-s-keyboard-shortcut-ctrl-value="true"
+                    data-s-keyboard-shortcut-key-value="/"
+                    data-s-keyboard-shortcut-action-value="focus"
+                />
                 {% icon "Search", "s-input-icon s-input-icon__search" %}
             </div>
         </div>

--- a/lib/ts/controllers/index.ts
+++ b/lib/ts/controllers/index.ts
@@ -1,5 +1,6 @@
 // export all controllers *with helpers* so they can be bulk re-exported by the package entry point
 export { ExpandableController } from './s-expandable-control';
+export { KeyboardShortcutController } from './s-keyboard-shortcut';
 export { hideModal, ModalController, showModal } from './s-modal';
 export { TabListController } from './s-navigation-tablist';
 export { attachPopover, detachPopover, hidePopover, BasePopoverController, PopoverController, showPopover } from './s-popover';

--- a/lib/ts/controllers/s-keyboard-shortcut.ts
+++ b/lib/ts/controllers/s-keyboard-shortcut.ts
@@ -1,0 +1,117 @@
+import { StacksController } from "../stacks";
+import { shallowEquals } from "../shared/utilities";
+
+interface Shortcut {
+    ctrl?: boolean;
+    shift?: boolean;
+    alt?: boolean;
+    meta?: boolean;
+    key: string;
+}
+
+type ClickableElement = HTMLAnchorElement | HTMLButtonElement | HTMLDetailsElement;
+const clickableElements = ['a', 'button', 'details'];
+
+type FocusableElement = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+const focusableElements = ['input', 'select', 'textarea'];
+
+export class KeyboardShortcutController extends StacksController {
+    declare ctrlValue: boolean;
+    declare shiftValue: boolean;
+    declare altValue: boolean;
+    declare metaValue: boolean;
+    declare keyValue: string;
+
+    static values = {
+        ctrl: Boolean,
+        meta: Boolean,
+        shift: Boolean,
+        alt: Boolean,
+        key: String,
+    };
+
+    private cachedShortcut: null | Shortcut = null;
+
+    get shortcut(): Shortcut {
+        if (this.cachedShortcut) {
+            return this.cachedShortcut;
+        }
+
+        return this.cachedShortcut = {
+            key: this.keyValue.toUpperCase(),
+            ...(this.ctrlValue ? { ctrl: true } : {}),
+            ...(this.metaValue ? { meta: true } : {}),
+            ...(this.shiftValue ? { shift: true } : {}),
+            ...(this.altValue ? { alt: true } : {}),
+        };
+    }
+
+    connect() {
+        window.addEventListener('keydown', this.handleKeyPress);
+    }
+
+    disconnect() {
+        window.removeEventListener('keydown', this.handleKeyPress);
+    }
+
+    //
+    // Rebuild our shortcut cache if our shortcut definition changes
+    //
+
+    ctrlValueChanged() {
+        this.cachedShortcut = null;
+    }
+
+    shiftValueChanged() {
+        this.cachedShortcut = null;
+    }
+
+    altValueChanged() {
+        this.cachedShortcut = null;
+    }
+
+    metaValueChanged() {
+        this.cachedShortcut = null;
+    }
+
+    keyValueChanged() {
+        this.cachedShortcut = null;
+    }
+
+    private handleKeyPress = (event: KeyboardEvent) => {
+        // If we're inside a text field, ignore any custom keyboard shortcuts
+        if (this.isInputInFocus()) {
+            return;
+        }
+
+        const keyPress = {
+            key: event.key.toUpperCase(),
+            ...(event.ctrlKey ? { ctrl: true } : {}),
+            ...(event.metaKey ? { meta: true } : {}),
+            ...(event.shiftKey ? { shift: true } : {}),
+            ...(event.altKey ? { alt: true } : {}),
+        };
+
+        if (shallowEquals(this.shortcut, keyPress)) {
+            event.preventDefault();
+
+            const tag = this.element.tagName.toLowerCase();
+
+            if (clickableElements.indexOf(tag) >= 0) {
+                (this.element as ClickableElement).click();
+            } else if (focusableElements.indexOf(tag) >= 0) {
+                (this.element as FocusableElement).focus();
+            }
+        }
+    };
+
+    private isInputInFocus = (): boolean => {
+        const nodeName = document.activeElement?.nodeName.toLowerCase();
+
+        if (!nodeName) {
+            return false;
+        }
+
+        return ['input', 'textarea', 'select'].includes(nodeName);
+    }
+}

--- a/lib/ts/index.ts
+++ b/lib/ts/index.ts
@@ -1,9 +1,19 @@
 import '../css/stacks.less';
-import { ExpandableController, ModalController, PopoverController, TableController, TabListController, TooltipController, UploaderController } from './controllers';
+import {
+    ExpandableController,
+    KeyboardShortcutController,
+    ModalController,
+    PopoverController,
+    TableController,
+    TabListController,
+    TooltipController,
+    UploaderController
+} from './controllers';
 import { application, StacksApplication } from './stacks';
 
 // register all built-in controllers
 application.register("s-expandable-control", ExpandableController);
+application.register("s-keyboard-shortcut", KeyboardShortcutController);
 application.register("s-modal", ModalController);
 application.register("s-navigation-tablist", TabListController);
 application.register("s-popover", PopoverController);

--- a/lib/ts/shared/utilities.ts
+++ b/lib/ts/shared/utilities.ts
@@ -1,0 +1,8 @@
+type Indexable = Record<string | number | symbol, any>;
+
+export function shallowEquals(obj1: Indexable, obj2: Indexable) {
+    return (
+        Object.keys(obj1).length === Object.keys(obj2).length &&
+        Object.keys(obj1).every(key => obj1[key] === obj2[key])
+    );
+}


### PR DESCRIPTION
I've had this locally in a stash for a while so figured I'd finally push it up. Here's a new controller for quickly attaching keyboard shortcuts to form fields and clickable elements. I haven't written documentation for this controller yet, figured I'd wait on that depending on whether or not this was accepted.

I added a sample use in the Stacks docs to bring focus to the search bar on <kbd>CTRL</kbd> + <kbd>/</kbd>.