### PR TITLE
docs(a11y): add accessibility guidelines page

### DIFF
--- a/docs/_data/site-navigation.json
+++ b/docs/_data/site-navigation.json
@@ -16,16 +16,20 @@
               "url": "/product/guidelines/building/"
             },
             {
+              "title": "Releasing Stacks",
+              "url": "/product/guidelines/releasing/"
+            },
+            {
+              "title": "Accessibility",
+              "url": "/product/guidelines/accessibility/"
+            },
+            {
               "title": "Conditional classes",
               "url": "/product/guidelines/conditional-classes/"
             },
             {
               "title": "JavaScript",
               "url": "/product/guidelines/javascript/"
-            },
-            {
-              "title": "Releasing Stacks",
-              "url": "/product/guidelines/releasing/"
             },
             {
               "title": "Theming",

--- a/docs/product/guidelines/accessibility.html
+++ b/docs/product/guidelines/accessibility.html
@@ -1,0 +1,38 @@
+---
+layout: page
+title: Accessibility
+description: A non-comprehensive guide to accessibility best practices when using Stacks.
+---
+
+<section class="stacks-section">
+    {% header "h2", "Overview" %}
+    <!-- TODO: Mention dry stuff - trying to meet WCAG 2.1 -->
+    <!-- TODO: State Stacks' goals/aspirations wrt a11y broadly. Think inclusive design principles https://inclusivedesignprinciples.org/ -->
+    <!-- TODO: Mention constant "work in progress" nature, "no such thing as 100% accessible" -->
+</section>
+
+<section class="stacks-section">
+    {% header "h2", "Accessibility testing" %}
+    <!-- TODO: Comment on how we test for accessibility. Mention mabl, dev tools, extensions, assistive technologies. -->
+</section>
+
+<section class="stacks-section">
+    {% header "h2", "Structural markup" %}
+    <!-- TODO: Comment on the benefits of using semantically correct structural markup -->
+</section>
+
+<section class="stacks-section">
+    {% header "h2", "Using WAI-ARIA" %}
+    <!-- TODO: Document best practices for using WAI-ARIA, mention visually hidden content (link to https://stackoverflow.design/product/base/visibility/#classes). Consider recommending an approach for aria-label vs visually hidden content. -->
+</section>
+
+<section class="stacks-section">
+    {% header "h2", "Color contrast" %}
+    <!-- TODO: Mention (and link to) high contrast and dark modes. Mention the benefits wrt accessibility. -->
+    <!-- TODO: Touch on limitations of WCAG 2.1 in this context. Maybe give a nod to WCAG 3.0 standards. -->
+</section>
+
+<section class="stacks-section">
+    {% header "h2", "Additonal resources" %}
+    <!-- TODO: Link to informative resources. Bootstrap had a pretty good list https://getbootstrap.com/docs/5.2/getting-started/accessibility/#additional-resources -->
+</section>

--- a/docs/product/guidelines/accessibility.html
+++ b/docs/product/guidelines/accessibility.html
@@ -5,34 +5,84 @@ description: A non-comprehensive guide to accessibility best practices when usin
 ---
 
 <section class="stacks-section">
-    {% header "h2", "Overview" %}
-    <!-- TODO: Mention dry stuff - trying to meet WCAG 2.1 -->
-    <!-- TODO: State Stacks' goals/aspirations wrt a11y broadly. Think inclusive design principles https://inclusivedesignprinciples.org/ -->
-    <!-- TODO: Mention constant "work in progress" nature, "no such thing as 100% accessible" -->
+    {% header "h2", "Goals" %}
+    <!-- TODO: WCAG 2.1 -->
+    <!-- TODO: Consider a special mention for POUR https://uiowa.instructure.com/courses/40/pages/accessibility-principles-pour -->
+    <!-- TODO: Inclusive design principles https://inclusivedesignprinciples.org/ -->
+    <!-- TOOD: Describe how a11y helps everyone -->
+        <!-- "We’re Just Temporarily Abled" https://uxmag.com/articles/were-just-temporarily-abled -->
 </section>
 
 <section class="stacks-section">
     {% header "h2", "Accessibility testing" %}
-    <!-- TODO: Comment on how we test for accessibility. Mention mabl, dev tools, extensions, assistive technologies. -->
+    <!-- TODO: Comment on how we test for accessibility. -->
+    <!-- TODO: Mention and link to publicly accessible tools: dev tools, extensions -->
+    <!-- TODO: Mention internal tools and resources: mabl, deque -->
+    <!-- TODO: Outline common assistive technologies and resources to use it to test against -->
 </section>
 
 <section class="stacks-section">
-    {% header "h2", "Structural markup" %}
-    <!-- TODO: Comment on the benefits of using semantically precise structural markup -->
+    {% header "h2", "Input methods" %}
+    {% header "h3", "Keyboard navigation" %}
+    <!-- TODO: Outline considerations related to keyboard navigation -->
+    {% header "h3", "Touch navigation" %}
+    <!-- TODO: Outline considerations related to touch navigations -->
+        <!-- Mention fine motor impairments -->
+    {% header "h3", "Assitive technologies" %}
+    <!-- TODO: Mention specific assistive tech and how to build with it in mind -->
+        <!-- Screen readers -->
+        <!-- Voice-based navigation -->
+</section>
+
+<!-- TODO: This section is getting bloated. Consider splitting it up -->
+<section class="stacks-section">
+    {% header "h2", "Markup" %}
+    {% header "h3", "Structural markup" %}
+        <!-- Use the correct HTML element to define the structure of the document -->
+        <!-- Mention assistive tech wrt navigating the page -->
+    {% header "h3", "Semantic markup" %}
+        <!-- Use the correct HTML element to match the intended role of an element -->
+    {% header "h3", "Using WAI-ARIA" %}
+    <!-- TODO: Document best practices for using WAI-ARIA -->
+        <!-- Spcial callouts for label/labelledby, describedby, expanded, hidden, live -->
+        <!-- Mention the role attribute and when to use it -->
+    <!-- TODO: Mention visually hidden content (link to https://stackoverflow.design/product/base/visibility/#classes). -->
+    {% header "h3", "Images and alt text" %}
+    <!-- TODO: Explain alt text best practices. -->
 </section>
 
 <section class="stacks-section">
-    {% header "h2", "Using WAI-ARIA" %}
-    <!-- TODO: Document best practices for using WAI-ARIA, mention visually hidden content (link to https://stackoverflow.design/product/base/visibility/#classes). Consider recommending an approach for aria-label vs visually hidden content. -->
+    {% header "h2", "Language" %}
+    <!-- TODO: Outline best practices wrt writing copy with accessibility in mind -->
+        <!-- Specific consideration for cognitive disabilities -->
+        <!-- Suggest avoiding input method-specific words like "hover" or "click" -->
+        <!-- Outline qualities of a good label -->
+        <!-- Mention link text being comprehendable out of context See: https://webaim.org/techniques/hypertext/ -->
 </section>
 
 <section class="stacks-section">
-    {% header "h2", "Color contrast" %}
-    <!-- TODO: Mention (and link to) high contrast and dark modes. Mention the benefits wrt accessibility. -->
+    <!-- "Visual accessibility" probably isn't the best heading for this section. Maybe "Color" and something else? "Legibility"? IDK -->
+    {% header "h2", "Visual accessibility" %}
+    {% header "h3", "High contrast and dark modes" %}
+    <!-- TODO: Mention the benefits wrt accessibility. -->
+    {% header "h4", "Contrast limitation of WCAG 2.1" %}
     <!-- TODO: Touch on limitations of WCAG 2.1 in this context. Maybe give a nod to WCAG 3.0 standards. -->
+    {% header "h3", "Don't rely on color alone" %}
+    <!-- TODO: Mention how a design shouldn't rely exclusively on color -->
+    {% header "h3", "Readability" %}
+    <!-- TODO: Mention font-size, line-height, line-length, text justification, and native browser/OS controls to adapt content -->
+    {% header "h3", "Motion" %}
+    <!-- TODO: Mention how Stacks support prefers-reduced-motion -->
 </section>
 
 <section class="stacks-section">
     {% header "h2", "Additonal resources" %}
     <!-- TODO: Link to informative resources. Bootstrap had a pretty good list https://getbootstrap.com/docs/5.2/getting-started/accessibility/#additional-resources -->
+    <!-- W3C Intro to a11y https://www.w3.org/WAI/fundamentals/accessibility-intro/ -->
+</section>
+
+<section class="stacks-section">
+    {% header "h2", "Contributing" %}
+    <!-- TODO: a11y is a work in progress -->
+    <!-- TODO: Call to file GH issues of a11y issues -->
 </section>

--- a/docs/product/guidelines/accessibility.html
+++ b/docs/product/guidelines/accessibility.html
@@ -18,7 +18,7 @@ description: A non-comprehensive guide to accessibility best practices when usin
 
 <section class="stacks-section">
     {% header "h2", "Structural markup" %}
-    <!-- TODO: Comment on the benefits of using semantically correct structural markup -->
+    <!-- TODO: Comment on the benefits of using semantically precise structural markup -->
 </section>
 
 <section class="stacks-section">


### PR DESCRIPTION
I think our documentation could benefit from a standalone accessibility-focused page. Consider this a big ol' work in progress atm.

### TODO
- [ ] Complete "Overview" section
- [ ] Complete "Accessibility testing" section
- [ ] Complete "Structural markup" section
- [ ] Complete "Using WAI-ARIA" section
    - [ ] Change this heading to be more friendly to those not familiar with the world of a11y
- [ ] Complete "Color contrast" section
- [ ] Complete "Additonal resources" section
- [ ] Consider cross-linking opportunities
- [ ] Consider level of detail per section necessary

cc @CGuindon @shainanigans