### PR TITLE
fix(labels): increase contrast

### DIFF
--- a/lib/css/components/labels.less
+++ b/lib/css/components/labels.less
@@ -63,9 +63,10 @@
 
     &.s-label--status__required {
         --_bg: var(--red-100);
-        --_fc: var(--red-600);
+        --_fc: var(--red-700);
 
         .dark-mode({
+            --_bg: var(--red-050);
             --_fc: var(--red-800);
         });
     }
@@ -73,6 +74,11 @@
     &.s-label--status__new {
         --_bg: var(--green-100);
         --_fc: var(--green-700);
+
+        .dark-mode({
+            --_bg: var(--green-050);
+            --_fc: var(--green-800);
+        });
     }
 
     &.s-label--status__beta {


### PR DESCRIPTION
> At least one label on Stacks does not pass AA color contrast. Investigate which labels do not pass and fix the color on said labels.

This PR increases the contrast on the `required` variant in light mode, and the `required` and `success` variants in dark mode.

Labels deploy preview: https://deploy-preview-1065--stacks.netlify.app/product/components/labels/#status

<details>
<summary>Light mode (required) screenshots</summary>

#### Before

![image](https://user-images.githubusercontent.com/647177/184723652-2e8c8c57-1ce6-493e-bd1b-f3704aaf5259.png)

#### After

![image](https://user-images.githubusercontent.com/647177/184723770-3fb0b612-806f-4f8e-924c-526e9e34f309.png)

</details>

<details>
<summary>Dark mode (required, success) screenshots</summary>

#### Before

![image](https://user-images.githubusercontent.com/647177/184723882-d430d47a-ecca-4588-be6c-a6cacdf784a0.png)

#### After

![image](https://user-images.githubusercontent.com/647177/184723908-5501cc7a-76d5-4d05-ad20-f2569a87efa1.png)

</details>

