### PR TITLE
Revert "build(deps-dev): bump @stackoverflow/stacks-icons from 3.0.2 to 3.0.4 (#1072)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@11ty/eleventy": "^1.0.2",
         "@highlightjs/cdn-assets": "^11.6.0",
         "@stackoverflow/stacks-editor": "^0.7.0",
-        "@stackoverflow/stacks-icons": "^3.0.4",
+        "@stackoverflow/stacks-icons": "^3.0.2",
         "@typescript-eslint/eslint-plugin": "^5.33.1",
         "@typescript-eslint/parser": "^5.33.0",
         "backstopjs": "^6.1.1",
@@ -663,9 +663,9 @@
       }
     },
     "node_modules/@stackoverflow/stacks-icons": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-3.0.4.tgz",
-      "integrity": "sha512-96/XYk34tue58Ty7JnOvDAQbdiiNqnFVy/Etus5MfXshUYlLIHf0eupbRVf+FwLEuij7PuPbavUBRvlvTMhHsw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-3.0.2.tgz",
+      "integrity": "sha512-MQgbMNa8kvS1J/jn5vIFBvkJ4s+8PhjpGtek4eq8qYbLapXGaCPKl84lh5yWZ59PbnI25V1voNB8c5X5UeMAPA==",
       "dev": true
     },
     "node_modules/@stimulus/core": {
@@ -10845,9 +10845,9 @@
       }
     },
     "@stackoverflow/stacks-icons": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-3.0.4.tgz",
-      "integrity": "sha512-96/XYk34tue58Ty7JnOvDAQbdiiNqnFVy/Etus5MfXshUYlLIHf0eupbRVf+FwLEuij7PuPbavUBRvlvTMhHsw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-3.0.2.tgz",
+      "integrity": "sha512-MQgbMNa8kvS1J/jn5vIFBvkJ4s+8PhjpGtek4eq8qYbLapXGaCPKl84lh5yWZ59PbnI25V1voNB8c5X5UeMAPA==",
       "dev": true
     },
     "@stimulus/core": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@11ty/eleventy": "^1.0.2",
     "@highlightjs/cdn-assets": "^11.6.0",
     "@stackoverflow/stacks-editor": "^0.7.0",
-    "@stackoverflow/stacks-icons": "^3.0.4",
+    "@stackoverflow/stacks-icons": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "^5.33.1",
     "@typescript-eslint/parser": "^5.33.0",
     "backstopjs": "^6.1.1",


### PR DESCRIPTION
I was a little hasty to merge #1072.

We can't use [ES Modules in 11ty](https://github.com/11ty/eleventy/issues/836) and the UMD of the latest [Stacks-Icons](https://github.com/StackExchange/Stacks-Icons) [references the `window` object](https://github.com/StackExchange/Stacks-Icons/blob/20129794925219d7edef2fbb28468dc1023d0d40/src/js/browser.ts#L10-L12), which breaks 11ty.

```
…
[w:eleventy] [11ty] Eleventy CLI Fatal Error: (more in DEBUG output)
[w:eleventy] [11ty] 1. Error in your Eleventy config file '/Users/dan/Code/Stacks/docs/.eleventy.js'. (via EleventyConfigError)
[w:eleventy] [11ty] 2. window is not defined (via ReferenceError)
[w:eleventy] [11ty] 
[w:eleventy] [11ty] Original error stack trace: ReferenceError: window is not defined
[w:eleventy] [11ty]     at /Users/dan/Code/Stacks/node_modules/@stackoverflow/stacks-icons/build/index.umd.js:1127:5
[w:eleventy] [11ty]     at /Users/dan/Code/Stacks/node_modules/@stackoverflow/stacks-icons/build/index.umd.js:2:68
…
```

Reverting this update for now until this issue is resolved.