### PR TITLE
build(deps-dev): bump @stackoverflow/stacks-icons from 3.0.2 to 3.0.4 (again)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@11ty/eleventy": "^1.0.2",
         "@highlightjs/cdn-assets": "^11.6.0",
         "@stackoverflow/stacks-editor": "^0.7.0",
-        "@stackoverflow/stacks-icons": "^3.0.2",
+        "@stackoverflow/stacks-icons": "^3.0.4",
         "@typescript-eslint/eslint-plugin": "^5.33.1",
         "@typescript-eslint/parser": "^5.33.0",
         "backstopjs": "^6.1.1",
@@ -663,9 +663,9 @@
       }
     },
     "node_modules/@stackoverflow/stacks-icons": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-3.0.2.tgz",
-      "integrity": "sha512-MQgbMNa8kvS1J/jn5vIFBvkJ4s+8PhjpGtek4eq8qYbLapXGaCPKl84lh5yWZ59PbnI25V1voNB8c5X5UeMAPA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-3.0.4.tgz",
+      "integrity": "sha512-96/XYk34tue58Ty7JnOvDAQbdiiNqnFVy/Etus5MfXshUYlLIHf0eupbRVf+FwLEuij7PuPbavUBRvlvTMhHsw==",
       "dev": true
     },
     "node_modules/@stimulus/core": {
@@ -10845,9 +10845,9 @@
       }
     },
     "@stackoverflow/stacks-icons": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-3.0.2.tgz",
-      "integrity": "sha512-MQgbMNa8kvS1J/jn5vIFBvkJ4s+8PhjpGtek4eq8qYbLapXGaCPKl84lh5yWZ59PbnI25V1voNB8c5X5UeMAPA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-3.0.4.tgz",
+      "integrity": "sha512-96/XYk34tue58Ty7JnOvDAQbdiiNqnFVy/Etus5MfXshUYlLIHf0eupbRVf+FwLEuij7PuPbavUBRvlvTMhHsw==",
       "dev": true
     },
     "@stimulus/core": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@11ty/eleventy": "^1.0.2",
     "@highlightjs/cdn-assets": "^11.6.0",
     "@stackoverflow/stacks-editor": "^0.7.0",
-    "@stackoverflow/stacks-icons": "^3.0.2",
+    "@stackoverflow/stacks-icons": "^3.0.4",
     "@typescript-eslint/eslint-plugin": "^5.33.1",
     "@typescript-eslint/parser": "^5.33.0",
     "backstopjs": "^6.1.1",


### PR DESCRIPTION
> **Note**
> Original PR bumping @stackoverflow/stacks-icons (#1072) reverted in #1075 

Bumps [@stackoverflow/stacks-icons](https://github.com/StackExchange/Stacks-Icons) from 3.0.2 to 3.0.4.
- [Release notes](https://github.com/StackExchange/Stacks-Icons/releases)
- [Commits](https://github.com/StackExchange/Stacks-Icons/compare/v3.0.2...v3.0.4)

---
updated-dependencies:
- dependency-name: "@stackoverflow/stacks-icons"
  dependency-type: direct:development
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>