### PR TITLE
fix(tooltip): resolve accessibility issues

### DIFF
--- a/lib/ts/controllers/s-tooltip.ts
+++ b/lib/ts/controllers/s-tooltip.ts
@@ -68,7 +68,7 @@ export class TooltipController extends BasePopoverController {
     /**
      * Cancels the scheduled tooltip popover display and hides it if already displayed
      */
-    hide(dispatcher: Event | Element | null = null) {
+    scheduleHide(dispatcher: Event | Element | null = null) {
         window.clearTimeout(this.activeTimeout);
         this.activeTimeout = window.setTimeout(() => super.hide(dispatcher), 100);
     }
@@ -174,13 +174,13 @@ export class TooltipController extends BasePopoverController {
      */
     private hideIfWithin(event: Event) {
         if ((<Element>event.target!).contains(this.referenceElement)) {
-            this.hide();
+            this.scheduleHide();
         }
     }
 
     private hideOnEscapeKeyEvent(event: KeyboardEvent) {
         if (event.key === "Escape") {
-            this.hide();
+            this.scheduleHide();
         }
     }
     /**
@@ -188,7 +188,7 @@ export class TooltipController extends BasePopoverController {
      */
      private bindKeyboardEvents() {
         this.boundScheduleShow = this.boundScheduleShow || this.scheduleShow.bind(this);
-        this.boundHide = this.boundHide || this.hide.bind(this);
+        this.boundHide = this.boundHide || this.scheduleHide.bind(this);
         this.boundHideOnEscapeKeyEvent = this.boundHideOnEscapeKeyEvent || this.hideOnEscapeKeyEvent.bind(this);
 
         this.referenceElement.addEventListener("focus", this.boundScheduleShow);
@@ -210,7 +210,7 @@ export class TooltipController extends BasePopoverController {
      */
     private bindMouseEvents() {
         this.boundScheduleShow = this.boundScheduleShow || this.scheduleShow.bind(this);
-        this.boundHide = this.boundHide || this.hide.bind(this);
+        this.boundHide = this.boundHide || this.scheduleHide.bind(this);
         this.boundClearActiveTimeout = this.boundClearActiveTimeout || this.clearActiveTimeout.bind(this);
 
         this.referenceElement.addEventListener("mouseover", this.boundScheduleShow);

--- a/lib/ts/controllers/s-tooltip.ts
+++ b/lib/ts/controllers/s-tooltip.ts
@@ -105,7 +105,6 @@ export class TooltipController extends BasePopoverController {
             popover = document.createElement("div");
             popover.id = popoverId;
             popover.className = "s-popover s-popover__tooltip pe-none";
-            popover.setAttribute("aria-hidden", "true");
             popover.setAttribute("role", "tooltip");
 
             const parentNode = this.element.parentNode;

--- a/lib/ts/controllers/s-tooltip.ts
+++ b/lib/ts/controllers/s-tooltip.ts
@@ -13,6 +13,7 @@ export class TooltipController extends BasePopoverController {
     private boundScheduleShow!: () => void;
     private boundHide!: () => void;
     private boundHideIfWithin!: () => void;
+    private boundHideOnEscapeKeyEvent!: () => void;
     private activeTimeout!: number;
 
     /**
@@ -27,12 +28,14 @@ export class TooltipController extends BasePopoverController {
         if (window.matchMedia("(hover: hover)").matches) {
             this.bindMouseEvents();
         }
+        this.bindKeyboardEvents();
     }
 
     /**
      * Unbinds mouse events in addition to BasePopoverController.disconnect
      */
     disconnect() {
+        this.unbindKeyboardEvents();
         this.unbindMouseEvents();
         super.disconnect();
     }
@@ -169,6 +172,34 @@ export class TooltipController extends BasePopoverController {
         }
     }
 
+    private hideOnEscapeKeyEvent(event: KeyboardEvent) {
+        console.log("weeeee")
+        if (event.key === "Escape") {
+            this.hide();
+        }
+    }
+    /**
+     * Binds mouse events to show/hide on reference element hover
+     */
+     private bindKeyboardEvents() {
+        this.boundScheduleShow = this.boundScheduleShow || this.scheduleShow.bind(this);
+        this.boundHide = this.boundHide || this.hide.bind(this);
+        this.boundHideOnEscapeKeyEvent = this.boundHideOnEscapeKeyEvent || this.hideOnEscapeKeyEvent.bind(this);
+
+        this.referenceElement.addEventListener("focus", this.boundScheduleShow);
+        this.referenceElement.addEventListener("blur", this.boundHide);
+        document.addEventListener("keyup", this.boundHideOnEscapeKeyEvent);
+    }
+    /**
+     * Unbinds all mouse events
+     */
+     private unbindKeyboardEvents() {
+        this.referenceElement.removeEventListener("focus", this.boundScheduleShow);
+        this.referenceElement.removeEventListener("blur", this.boundHide);
+        document.removeEventListener("keyup", this.boundHideOnEscapeKeyEvent);
+    }
+
+
     /**
      * Binds mouse events to show/hide on reference element hover
      */
@@ -178,8 +209,6 @@ export class TooltipController extends BasePopoverController {
 
         this.referenceElement.addEventListener("mouseover", this.boundScheduleShow);
         this.referenceElement.addEventListener("mouseout", this.boundHide);
-        this.referenceElement.addEventListener("focus", this.boundScheduleShow);
-        this.referenceElement.addEventListener("blur", this.boundHide);
     }
 
     /**

--- a/lib/ts/controllers/s-tooltip.ts
+++ b/lib/ts/controllers/s-tooltip.ts
@@ -173,7 +173,6 @@ export class TooltipController extends BasePopoverController {
     }
 
     private hideOnEscapeKeyEvent(event: KeyboardEvent) {
-        console.log("weeeee")
         if (event.key === "Escape") {
             this.hide();
         }


### PR DESCRIPTION
This PR resolves issues mentioned in https://github.com/StackEng/StackOverflow/pull/12658#discussion_r953802943, those issues being:

- [x] Have the <kbd>Escape</kbd> key dismiss the tooltip
- [x] Persist the tooltip when hovered
- [x] Remove `aria-hidden=true` attribute added via JS

There was mention of adding `aria-describedby` to elements with tooltips, but [we already recommend that in Stacks documentation](https://stackoverflow.design/product/components/popovers/#rich-tooltips). Dynamically generated tooltips get an `id` and set the value of the `aria-describedby` attribute on the reference element to that `id`, so I think we should be all set there. I wasn't sure if setting `aria-describedby` on tooltip generation was ok, but I saw this on [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role#description):

> Elements with the tooltip role should be referenced through the use of [aria-describedby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) **before or when the tooltip is displayed**.