### PR TITLE
fix(topbar): add required `nav` element around navigational `<ol>`s

### DIFF
--- a/docs/_data/topbar.json
+++ b/docs/_data/topbar.json
@@ -46,7 +46,7 @@
     {
         "class": ".s-topbar--navigation",
         "description": "Apply to `nav` to ensure proper layout",
-        "applies": "Child of `.s-topbar`"
+        "applies": "Parent of `.s-topbar--container`"
     },
     {
         "class": ".s-topbar--notice",

--- a/docs/_data/topbar.json
+++ b/docs/_data/topbar.json
@@ -44,6 +44,11 @@
         "applies": "`.s-topbar--item`"
     },
     {
+        "class": ".s-topbar--navigation",
+        "description": "Apply to `nav` to ensure proper layout",
+        "applies": "Child of `.s-topbar`"
+    },
+    {
         "class": ".s-topbar--notice",
         "description": "A badge-styled notice that stands out. Add `.is-unread` to make it stand out more",
         "applies": "Child of `.s-topbar`"

--- a/docs/_includes/topbar.html
+++ b/docs/_includes/topbar.html
@@ -16,31 +16,33 @@
         {% endif %}
 
         {% unless hideNavigation %}
-            <ol class="s-navigation fw-nowrap sm:d-none">
-                {% if showFullNavigation %}
-                    <li>
-                        <a href="#" class="s-navigation--item">
-                            About
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#" class="s-navigation--item is-selected">
-                            Products
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#" class="s-navigation--item">
-                            For Teams
-                        </a>
-                    </li>
-                {% else %}
-                    <li>
-                        <a href="#" class="s-navigation--item">
-                            Products
-                        </a>
-                    </li>
-                {% endif %}
-            </ol>
+            <nav class="s-topbar--navigation" aria-label="Demo primary navigation" role="presentation">
+                <ol class="s-navigation fw-nowrap sm:d-none">
+                    {% if showFullNavigation %}
+                        <li>
+                            <a href="#" class="s-navigation--item">
+                                About
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#" class="s-navigation--item is-selected">
+                                Products
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#" class="s-navigation--item">
+                                For Teams
+                            </a>
+                        </li>
+                    {% else %}
+                        <li>
+                            <a href="#" class="s-navigation--item">
+                                Products
+                            </a>
+                        </li>
+                    {% endif %}
+                </ol>
+            </nav>
         {% endunless %}
 
         {% unless hideSearch %}
@@ -67,85 +69,87 @@
             </form>
         {% endunless %}
 
-        <ol class="s-topbar--content">
-            <li>
-                <a href="#" class="s-topbar--item" aria-label="Inbox">
-                    {% icon "Inbox" %}
-                    <span class="s-activity-indicator s-activity-indicator__danger">3</span>
-                </a>
-            </li>
-            <li>
-                <a href="#" class="s-topbar--item" aria-label="Achievements">
-                    {% icon "Achievements" %}
-                    <span class="s-activity-indicator s-activity-indicator__success">+10</span>
-                </a>
-            </li>
-            <li>
-                <a href="#" class="s-topbar--item" aria-label="Review queues">
-                    {% icon "ReviewQueue" %}
-                    <div class="s-activity-indicator s-activity-indicator__danger">
-                        <div class="v-visible-sr">New activity</div>
-                    </div>
-                </a>
-            </li>
-            <li>
-                <a href="#" class="s-topbar--item" aria-label="Help center">
-                    {% icon "Help" %}
-                </a>
-            </li>
-            <li>
-                <a href="#" class="s-topbar--item" aria-label="Site switcher">
-                    {% icon "StackExchange" %}
-                </a>
-            </li>
-            {% unless showCtas %}
-                {% unless hideSearch %}
-                    <li>
-                        <button
-                            class="s-topbar--item s-btn s-btn__unset c-pointer d-none sm:d-inline-flex js-search-button"
-                            type="button">
-                                {% icon "Search" %}
-                        </button>
-                    </li>
-                {% endunless %}
-                {% if isMod %}
-                    <li>
-                        <a href="#" class="s-topbar--item" title="Moderator inbox">
-                            {% icon "Moderator" %}
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#" class="s-topbar--item" title="8 posts flagged for moderator attention">
-                            <span class="s-badge s-badge__bounty">8</span>
-                        </a>
-                    </li>
-                {% endif %}
-                {% unless hideUserCard %}
-                    <li>
-                        <a href="#" class="s-topbar--item s-user-card s-user-card__small">
-                            <span class="s-avatar s-avatar__24 s-user-card--avatar">
-                                <img class="s-avatar--image" alt="demo avatar" src="{{ "/assets/img/anonymous-user.svg" | url }}" />
-                                <span class="v-visible-sr">John Doe</span>
-                            </span>
-                            <div class="s-user-card--info">
-                                <ul class="s-user-card--awards">
-                                    <li class="s-user-card--rep">3,145</li>
-                                    <li class="s-award-bling s-award-bling__gold">3</li>
-                                    <li class="s-award-bling s-award-bling__silver">9</li>
-                                    <li class="s-award-bling s-award-bling__bronze">20</li>
-                                </ul>
-                            </div>
-                        </a>
-                    </li>
-                {% endunless %}
-            {% else %}
+        <nav class="s-topbar--navigation" aria-label="Demo secondary navigation" role="presentation">
+            <ol class="s-topbar--content">
                 <li>
-                    <a href="#" class="s-topbar--item s-topbar--item__unset s-btn s-btn__filled ws-nowrap">Log in</a>
+                    <a href="#" class="s-topbar--item" aria-label="Inbox">
+                        {% icon "Inbox" %}
+                        <span class="s-activity-indicator s-activity-indicator__danger">3</span>
+                    </a>
                 </li>
                 <li>
-                    <a href="#" class="s-topbar--item s-topbar--item__unset ml4 s-btn s-btn__primary ws-nowrap">Sign up</a>
+                    <a href="#" class="s-topbar--item" aria-label="Achievements">
+                        {% icon "Achievements" %}
+                        <span class="s-activity-indicator s-activity-indicator__success">+10</span>
+                    </a>
                 </li>
-            {% endunless %}
-        </ol>
+                <li>
+                    <a href="#" class="s-topbar--item" aria-label="Review queues">
+                        {% icon "ReviewQueue" %}
+                        <div class="s-activity-indicator s-activity-indicator__danger">
+                            <div class="v-visible-sr">New activity</div>
+                        </div>
+                    </a>
+                </li>
+                <li>
+                    <a href="#" class="s-topbar--item" aria-label="Help center">
+                        {% icon "Help" %}
+                    </a>
+                </li>
+                <li>
+                    <a href="#" class="s-topbar--item" aria-label="Site switcher">
+                        {% icon "StackExchange" %}
+                    </a>
+                </li>
+                {% unless showCtas %}
+                    {% unless hideSearch %}
+                        <li>
+                            <button
+                                class="s-topbar--item s-btn s-btn__unset c-pointer d-none sm:d-inline-flex js-search-button"
+                                type="button">
+                                    {% icon "Search" %}
+                            </button>
+                        </li>
+                    {% endunless %}
+                    {% if isMod %}
+                        <li>
+                            <a href="#" class="s-topbar--item" title="Moderator inbox">
+                                {% icon "Moderator" %}
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#" class="s-topbar--item" title="8 posts flagged for moderator attention">
+                                <span class="s-badge s-badge__bounty">8</span>
+                            </a>
+                        </li>
+                    {% endif %}
+                    {% unless hideUserCard %}
+                        <li>
+                            <a href="#" class="s-topbar--item s-user-card s-user-card__small">
+                                <span class="s-avatar s-avatar__24 s-user-card--avatar">
+                                    <img class="s-avatar--image" alt="demo avatar" src="{{ "/assets/img/anonymous-user.svg" | url }}" />
+                                    <span class="v-visible-sr">John Doe</span>
+                                </span>
+                                <div class="s-user-card--info">
+                                    <ul class="s-user-card--awards">
+                                        <li class="s-user-card--rep">3,145</li>
+                                        <li class="s-award-bling s-award-bling__gold">3</li>
+                                        <li class="s-award-bling s-award-bling__silver">9</li>
+                                        <li class="s-award-bling s-award-bling__bronze">20</li>
+                                    </ul>
+                                </div>
+                            </a>
+                        </li>
+                    {% endunless %}
+                {% else %}
+                    <li>
+                        <a href="#" class="s-topbar--item s-topbar--item__unset s-btn s-btn__filled ws-nowrap">Log in</a>
+                    </li>
+                    <li>
+                        <a href="#" class="s-topbar--item s-topbar--item__unset ml4 s-btn s-btn__primary ws-nowrap">Sign up</a>
+                    </li>
+                {% endunless %}
+            </ol>
+        </nav>
     </div>
 </header>

--- a/docs/_includes/topbar.html
+++ b/docs/_includes/topbar.html
@@ -16,7 +16,7 @@
         {% endif %}
 
         {% unless hideNavigation %}
-            <nav class="s-topbar--navigation" aria-label="Demo primary navigation" role="presentation">
+            <nav aria-label="Demo primary navigation" role="presentation">
                 <ol class="s-navigation fw-nowrap sm:d-none">
                     {% if showFullNavigation %}
                         <li>

--- a/docs/product/components/topbar.html
+++ b/docs/product/components/topbar.html
@@ -132,7 +132,7 @@ description: The topbar component is a navigation bar that is placed at the top 
         New
     </a>
 
-    <nav class="s-topbar--navigation" aria-label="More from Stack Overflow">
+    <nav aria-label="More from Stack Overflow">
         <ol class="s-navigation">
             <li><a href="…" class="s-navigation--item">About</a></li>
             <li><a href="…" class="s-navigation--item is-selected">Products</a></li>

--- a/docs/product/components/topbar.html
+++ b/docs/product/components/topbar.html
@@ -37,18 +37,19 @@ description: The topbar component is a navigation bar that is placed at the top 
     <div class="s-topbar--container">
         <a href="…" class="s-topbar--menu-btn"><span></span></a>
         <a href="…" class="s-topbar--logo">@Svg.LogoGlyph.with("native")</a>
-
-        <ol class="s-topbar--content">
-            <li>
-                <a href="…" class="s-topbar--item s-user-card s-user-card__small">…</a>
-            </li>
-            <li>
-                <a href="…" class="s-topbar--item" aria-label="Inbox">
-                    @Svg.Inbox <span class="s-activity-indicator">…</span>
-                </a>
-            </li>
-            <li><a href="…" class="s-topbar--item">…</a></li>
-        </ol>
+        <nav class="s-topbar--navigation" aria-label="notifications, help, and network">
+            <ol class="s-topbar--content">
+                <li>
+                    <a href="…" class="s-topbar--item s-user-card s-user-card__small">…</a>
+                </li>
+                <li>
+                    <a href="…" class="s-topbar--item" aria-label="Inbox">
+                        @Svg.Inbox <span class="s-activity-indicator">…</span>
+                    </a>
+                </li>
+                <li><a href="…" class="s-topbar--item">…</a></li>
+            </ol>
+        </nav>
     </div>
 </header>
 {% endhighlight %}
@@ -100,7 +101,9 @@ description: The topbar component is a navigation bar that is placed at the top 
         </div>
     </form>
 
-    <ol class="s-topbar--content">…</ol>
+    <nav class="s-topbar--navigation" aria-label="primary navigation">
+        <ol class="s-topbar--content">…</ol>
+    </nav>
 </header>
 {% endhighlight %}
         <div class="stacks-preview--example">
@@ -129,20 +132,24 @@ description: The topbar component is a navigation bar that is placed at the top 
         New
     </a>
 
-    <ol class="s-navigation">
-        <li><a href="…" class="s-navigation--item">About</a></li>
-        <li><a href="…" class="s-navigation--item is-selected">Products</a></li>
-        <li><a href="…" class="s-navigation--item">For Teams</a></li>
-    </ol>
+    <nav class="s-topbar--navigation" aria-label="More from Stack Overflow">
+        <ol class="s-navigation">
+            <li><a href="…" class="s-navigation--item">About</a></li>
+            <li><a href="…" class="s-navigation--item is-selected">Products</a></li>
+            <li><a href="…" class="s-navigation--item">For Teams</a></li>
+        </ol>
+    </nav>
 
-    <ol class="s-topbar--content">
-        <li>
-            <a href="…" class="s-topbar--item s-topbar--item__unset s-btn s-btn__filled">Log in</a>
-        </li>
-        <li>
-            <a href="…" class="s-topbar--item s-topbar--item__unset ml4 s-btn s-btn__primary">Sign up</a>
-        </li>
-    </ol>
+    <nav class="s-topbar--navigation" aria-label="Log in or sign up">
+        <ol class="s-topbar--content">
+            <li>
+                <a href="…" class="s-topbar--item s-topbar--item__unset s-btn s-btn__filled">Log in</a>
+            </li>
+            <li>
+                <a href="…" class="s-topbar--item s-topbar--item__unset ml4 s-btn s-btn__primary">Sign up</a>
+            </li>
+        </ol>
+    </nav>
 </header>
 {% endhighlight %}
         <div class="stacks-preview--example">

--- a/lib/css/components/topbar.less
+++ b/lib/css/components/topbar.less
@@ -246,6 +246,15 @@
 //  ===========================================================================
 //  $   CONTENT & CTAS
 //  ---------------------------------------------------------------------------
+.s-topbar--navigation {
+    display: flex;
+    height: 100%;
+
+    overflow-x: auto; // Allow this content to scroll if it gets too long
+    @scrollbar-styles(); // Style the scrollbars
+    margin-left: auto; // Push this section as far to the right as possible
+}
+
 .s-topbar .s-topbar--content {
     display: flex;
     height: 100%;
@@ -255,6 +264,7 @@
         display: inline-flex;
     }
 
+    // TODO remove once all topbars include necessary nav.s-topbar--navigation wrapper elements
     overflow-x: auto; // Allow this content to scroll if it gets too long
     @scrollbar-styles(); // Style the scrollbars
     margin-left: auto; // Push this section as far to the right as possible


### PR DESCRIPTION
Navigational elements _must_ be wrapped in `nav` elements (or include `aria` roles to indicate they're navigational).

This PR wraps topbar nav element groups (`<ol>`) in `<nav>`s, adds `.s-topbar--navigation` for styling, and updates the docs/examples as necessary.