### PR TITLE
fix(table): ensure disabled rows meet contrast minimums

### DIFF
--- a/lib/css/components/tables.less
+++ b/lib/css/components/tables.less
@@ -307,11 +307,24 @@
     //  $$  Disabled rows
     //  ------------------------------------------------------------------------
     tr.is-disabled {
-        background-color: var(--black-025);
+        position: relative;
+
+        &:after {
+            content: '';
+            inset: 0;
+            position: absolute;
+            z-index: -1;
+        }
 
         th:not(.is-enabled),
         td:not(.is-enabled) {
-            opacity: calc(var(--_o-disabled) * 0.6); // 0.5 * 0.6 = 0.3
+            color: var(--fc-light);
+            text-decoration: line-through;
+        }
+    }
+    &:not(.s-table__stripes) {
+        tr.is-disabled:after {
+            background-color: var(--black-025);
         }
     }
 }


### PR DESCRIPTION
> Inactive rows do not pass. Should they? Let’s discuss and potentially solve.

`.s-table` rows that have `.is-disabled` need to meet WCAG contrast minimums*. 

The closest exception would be [**incidental** UI elements](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum#dfn-user-interface-component):

> Text or images of text that are part of an inactive [user interface component](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum#dfn-user-interface-component), that are [pure decoration](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum#dfn-pure-decoration), that are not visible to anyone, or that are part of a picture that contains significant other visual content, have no contrast requirement.

<details>
<summary>Screenshot (before)</summary>

![20220829-172945](https://user-images.githubusercontent.com/647177/187304667-45b3ba50-13b6-4d39-bb36-e399c2a34f1b.png)

</details>

<details>
<summary>Screenshot (after)</summary>

![20220829-172630](https://user-images.githubusercontent.com/647177/187304715-6d74ce26-743b-4997-9d56-9a866ee99c6d.png)

</details>

### TODO
- [ ] Include dark mode background color
- [ ] Add a `aria` attribute to examples to indicate state

> **Note**
> *I'm still finding supporting evidence that disabled table rows aren't exempt
