### PR TITLE
docs: button group docs mention the wrong aria attribute in one place

### DIFF
--- a/docs/product/components/button-groups.html
+++ b/docs/product/components/button-groups.html
@@ -31,7 +31,7 @@ description: Button groups are a collection of buttons. This component is used i
 
 {% header "h2", "Accessibility" %}
 <p class="stacks-copy">
-    When used as navigation or a filter, button groups should include the <code class="stacks-code">aria-label</code> attribute with the <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current#values"></a>appropriate value</a>.
+    When used as navigation or a filter, button groups should include the <code class="stacks-code">aria-current</code> attribute with the <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current#values"></a>appropriate value</a>.
 </p>
 
 <section class="stacks-section">


### PR DESCRIPTION
The rest of this section correctly says `aria-current` already.