### PR TITLE
fix(toggle): ensure "off" toggle switch label meets contrast minimums

### DIFF
--- a/lib/css/components/toggle-switches.less
+++ b/lib/css/components/toggle-switches.less
@@ -117,7 +117,8 @@
                     color: var(--white);
 
                     .dark-mode({
-                        background-color: var(--black-400);
+                        background-color: var(--black-350);
+                        // color: var(--black);
                     });
                 }
 

--- a/lib/css/components/toggle-switches.less
+++ b/lib/css/components/toggle-switches.less
@@ -113,7 +113,7 @@
         input[type="radio"]:checked {
             + label {
                 &.s-toggle-switch--label-off {
-                    background-color: var(--black-300);
+                    background-color: var(--black-500);
                     color: @white;
 
                     .highcontrast-mode({

--- a/lib/css/components/toggle-switches.less
+++ b/lib/css/components/toggle-switches.less
@@ -114,10 +114,10 @@
             + label {
                 &.s-toggle-switch--label-off {
                     background-color: var(--black-500);
-                    color: @white;
+                    color: var(--white);
 
-                    .highcontrast-mode({
-                        color: var(--white);
+                    .dark-mode({
+                        background-color: var(--black-400);
                     });
                 }
 


### PR DESCRIPTION
This PR changes the colors on `.s-toggle-switch--label-off` to meet WCAG contrast minimums. See the change in the [deploy preview](https://deploy-preview-1099--stacks.netlify.app/product/components/toggle-switch/#3-or-more-options).

## Before

![image](https://user-images.githubusercontent.com/647177/189367060-a0a8e1e9-0ac0-4531-9579-f4bd7e6215df.png)
![image](https://user-images.githubusercontent.com/647177/189366122-fa8b563a-f32a-4d65-99ff-bf97474e34c4.png)
![image](https://user-images.githubusercontent.com/647177/189367137-45b29a11-1e2b-482d-a1d0-f8846d6d2a9d.png)
![image](https://user-images.githubusercontent.com/647177/189366184-61a82a06-3809-4c46-99bb-fc33c86ac428.png)


## After

![image](https://user-images.githubusercontent.com/647177/189367226-debbb0c2-3f7b-47fe-8969-4ad1e0b613d2.png)
![image](https://user-images.githubusercontent.com/647177/189366256-bab5602a-124d-4637-91f3-f47db6e8a629.png)
![image](https://user-images.githubusercontent.com/647177/189368388-a586f23b-2959-419d-a1d4-dc0cc48d8060.png)
![image](https://user-images.githubusercontent.com/647177/189368342-5e784356-0877-435c-96ef-706081455d88.png)
