### PR TITLE
fix(input): increase placeholder text contrasts

### DIFF
--- a/lib/css/components/inputs.less
+++ b/lib/css/components/inputs.less
@@ -73,21 +73,13 @@
 
     //  --  PLACEHOLDER
     //  ------------------------------------------------------------------------
+    &::placeholder,
     &::-webkit-input-placeholder {
-        color: var(--black-200);
-
-        .highcontrast-mode({
-            color: var(--black-400);
-        });
+        color: var(--black-500);
     }
 
     &::placeholder {
-        color: var(--black-200);
         opacity: 1;
-
-        .highcontrast-mode({
-            color: var(--black-400);
-        });
     }
 
     // --  STYLE SCROLLBARS


### PR DESCRIPTION
From WCAG SC 1.4.3:

> The minimum contrast success criterion (1.4.3) applies to text in the page, including placeholder text and text that is shown when a pointer is hovering over an object or when an object has keyboard focus. If any of these are used in a page, the text needs to provide sufficient contrast.

## Before

![image](https://user-images.githubusercontent.com/647177/189371061-eccb3056-7ecf-42a6-9750-47c23b2757eb.png)

## After

![image](https://user-images.githubusercontent.com/647177/189371151-40fde0d6-4406-468a-b011-b526b4590c94.png)
