### PR TITLE
Darkened user card time for highlighted

### DIFF
--- a/lib/css/components/user-cards.less
+++ b/lib/css/components/user-cards.less
@@ -29,6 +29,10 @@
         background-color: var(--theme-secondary-050);
         border-radius: var(--br-md);
 
+        .s-user-card--time {
+            color: var(--black-600);
+        }
+
         .s-user-card--type {
             color: var(--black-700);
         }


### PR DESCRIPTION
For `s-user-card__highlighted`, the `s-user-card--time` text colour was darkened from `--black-500` to `--black-600`.

Before:
![image](https://user-images.githubusercontent.com/100864517/190468138-e6aadc6b-0073-4956-94ff-a99cf4a8e8b1.png)


After:
![image](https://user-images.githubusercontent.com/100864517/190467995-2153124a-37af-499d-a4f7-c9e212975b1e.png)
