### PR TITLE
refactor(award-bling): turn into standalone component

### DIFF
--- a/docs/_data/award-bling.json
+++ b/docs/_data/award-bling.json
@@ -1,0 +1,20 @@
+{
+  "title": "Award bling",
+  "types": [
+    {
+      "repType": "gold",
+      "label": "4",
+      "description": "A \"gold\" award."
+    },
+    {
+      "repType": "silver",
+      "label": "15",
+      "description": "A \"silver\" award."
+    },
+    {
+      "repType": "bronze",
+      "label": "23",
+      "description": "A \"bronze\" award."
+    }
+  ]
+}

--- a/docs/_data/site-navigation.json
+++ b/docs/_data/site-navigation.json
@@ -171,6 +171,10 @@
               "url": "/product/components/avatars/"
             },
             {
+              "title": "Award bling",
+              "url": "/product/components/award-bling/"
+            },
+            {
               "title": "Badges",
               "url": "/product/components/badges/"
             },

--- a/docs/product/components/award-bling.html
+++ b/docs/product/components/award-bling.html
@@ -1,0 +1,49 @@
+---
+layout: page
+title: Award bling
+figma: https://www.figma.com/file/i2HeoRFKn6MXAWn2UuTDHc/Badges
+description: Award bling is used to indicate award type in badges, topbar, and user cards.
+---
+<section class="stacks-section">
+    {% header "h2", "Types" %}
+    <p class="stacks-copy">Use award bling to indicate the type of award.</p>
+    <div class="stacks-preview">
+{% highlight html %}
+<span class="s-award-bling s-award-bling__gold">…</span>
+<span class="s-award-bling s-award-bling__silver">…</span>
+<span class="s-award-bling s-award-bling__bronze">…</span>
+{% endhighlight %}
+        <div class="stacks-preview--example">
+            <div class="overflow-x-auto" tabindex="0">
+                <table class="wmn5 s-table s-table__bx-simple">
+                    <thead>
+                        <tr>
+                            <th scope="col">Example</th>
+                            <th scope="col" class="s-table--cell5">Class</th>
+                            <th scope="col">Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for bling in award-bling.types %}
+                            <tr>
+                                <td class="va-middle pr8">
+                                    <span class="s-award-bling s-award-bling__{{ bling.repType }}">
+                                        {{ bling.label }}
+                                        <span class="v-visible-sr">{{ bling.repType }} awards</span>
+                                    </span>
+                                </td>
+                                <td class="va-middle">
+                                    <div class="d-flex g4 fw-wrap">
+                                        <code class="stacks-code">.s-award-bling</code>
+                                        <code class="stacks-code">.s-award-bling__{{ bling.repType }}</code>
+                                    </div>
+                                </td>
+                                <td class="va-middle">{{ bling.description }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</section>

--- a/lib/css/components/award-bling.less
+++ b/lib/css/components/award-bling.less
@@ -1,0 +1,28 @@
+.s-award-bling {
+    --_ab-bg: unset;
+
+    &&__gold {
+        --_ab-bg: var(--gold);
+    }
+
+    &__silver {
+        --_ab-bg: var(--silver);
+    }
+
+    &__bronze {
+        --_ab-bg: var(--bronze);
+    }
+
+    &:before {
+        background-color: var(--_ab-bg);
+        border-radius: 100%;
+        content: "";
+        margin-right: var(--su4);
+        height: var(--su8);
+        width: var(--su8);
+    }
+
+    align-items: center;
+    color: inherit;
+    display: flex;
+}

--- a/lib/css/components/badges.less
+++ b/lib/css/components/badges.less
@@ -220,37 +220,3 @@
         border-color: transparent;
     }
 }
-
-//  $$  Award Count
-//  ---------------------------------------------------------------------------
-.s-award-bling {
-    display: flex;
-    align-items: center;
-    color: inherit;
-
-    &:before {
-        content: "";
-        margin-right: 4px;
-        width: 8px;
-        height: 8px;
-        border-radius: 100%;
-    }
-
-    &.s-award-bling__gold {
-        &:before {
-            background-color: var(--gold);
-        }
-    }
-
-    &.s-award-bling__silver {
-        &:before {
-            background-color: var(--silver);
-        }
-    }
-
-    &.s-award-bling__bronze {
-        &:before {
-            background-color: var(--bronze);
-        }
-    }
-}

--- a/lib/css/stacks-static.less
+++ b/lib/css/stacks-static.less
@@ -18,6 +18,7 @@
 
 //  --  COMPONENTS
 @import "components/activity-indicator.less";
+@import "components/award-bling.less";
 @import "components/avatars.less";
 @import "components/badges.less";
 @import "components/empty-states.less";


### PR DESCRIPTION
`.s-award-badge` was already standalone, but the code CSS was created from `badges.less` and there was no documentation. This PR adds _light_ award badge documentation, moves `.s-award-badge` to `award-badge.less`, and refactors it to use prefixed* pseudo-private custom properties. This PR should change nothing on the consumer's end.

*I've prefixed the pseudo-private custom properties with `ab` to keep it from colliding with other pseudo-private custom properties when rendered within other components. Gotta watch that "pseudo" part.