### PR TITLE
feature(btn): extend disabled styling to include `aria-disabled` attribute

### DIFF
--- a/docs/product/components/buttons.html
+++ b/docs/product/components/buttons.html
@@ -456,8 +456,32 @@ description: Buttons are user interface elements which allows users to take acti
 </section>
 
 <section class="stacks-section">
-    {% header "h2", "Additional classes" %}
+    {% header "h2", "Additional styles" %}
     <p class="stacks-copy">Stacks provides additional classes for cases that are a bit more rare.
+
+    {% header "h3", "Disabled" %}
+    <div class="overflow-x-auto mb32" tabindex="0">
+        <table class="wmn4 s-table s-table__bx-simple">
+            <thead>
+                <tr>
+                    <th scope="col">Type</th>
+                    <th scope="col">Class</th>
+                    <th scope="col" class="s-table-cell5">Definition</th>
+                    <th scope="col">Example</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <th scope="row" class="va-middle">Disabled</th>
+                    <td class="va-middle">
+                        <code class="stacks-code">[aria-disabled="true"]</code>
+                    </td>
+                    <td class="va-middle">Adds disabled styling to any element with <code class="stacks-code">.s-btn</code> applied.</td>
+                    <td class="va-middle"><a class="s-btn s-btn__filled" href="#" aria-disabled="true">Ask question</button></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 
     {% header "h3", "Resets" %}
     <div class="overflow-x-auto mb32" tabindex="0">

--- a/lib/css/components/buttons.less
+++ b/lib/css/components/buttons.less
@@ -74,7 +74,7 @@
         }
 
         &[disabled],
-        &.is-disabled {
+        &[aria-disabled="true"] {
             opacity: var(--_o-disabled-static);
             pointer-events: none;
             box-shadow: none !important;
@@ -602,7 +602,7 @@
         &:active,
         &:focus,
         &[disabled]
-        &.is-disabled {
+        &[aria-disabled="true"] {
             background: none;
             box-shadow: none;
         }

--- a/lib/css/components/buttons.less
+++ b/lib/css/components/buttons.less
@@ -73,7 +73,8 @@
             box-shadow: 0 0 0 var(--su-static4) var(--focus-ring);
         }
 
-        &[disabled] {
+        &[disabled],
+        &.is-disabled {
             opacity: var(--_o-disabled-static);
             pointer-events: none;
             box-shadow: none !important;
@@ -600,7 +601,8 @@
         &:hover,
         &:active,
         &:focus,
-        &[disabled] {
+        &[disabled]
+        &.is-disabled {
             background: none;
             box-shadow: none;
         }


### PR DESCRIPTION
This PR adds disabled styling to `.s-btn` elements with `[aria-disabled="true"]` (and a little docs update to mention it).

cc @allejo