### PR TITLE
docs(icon): update data-icon usage instructions

### DIFF
--- a/docs/product/resources/icons.html
+++ b/docs/product/resources/icons.html
@@ -36,12 +36,12 @@ description: Stacks provides a complete icon set, managed separately in the <a h
     </div>
 
     {% header "h3", "Prototypes" %}
-    <p class="stacks-copy">Our icon set also includes a JavaScript library for use in protoypes outside our production environment. This JavaScript is loaded in our Stacks playground in <a href="https://codepen.io/pen?template=wvmRgdp">Codepen</a>. If you’re building a prototype in your own environment, you’ll need to include Stacks as a dependency as well as the <a href="https://github.com/StackExchange/Stacks-Icons#using-the-front-end-helper-for-prototyping">icons library</a>.</p>
+    <p class="stacks-copy">Our icon set also includes a JavaScript library for use in prototypes outside our production environment. This JavaScript is loaded in our Stacks playground in <a href="https://codepen.io/pen?template=wvmRgdp">Codepen</a>. When using <code>data-icon</code> attributes, you need to prefix the icon names with <code>Icon</code> (e.g. <code>IconLogo</code>). If you’re building a prototype in your own environment, you’ll need to include Stacks as a dependency as well as the <a href="https://github.com/StackExchange/Stacks-Icons#using-the-front-end-helper-for-prototyping">icons library</a>.</p>
     <div class="stacks-preview">
 {% highlight html %}
-<svg data-icon="Logo"></svg>
-<svg data-icon="Logo" class="native"></svg>
-<svg data-icon="Logo" class="fc-black-350 float-right js-dropdown-target"></svg>
+<svg data-icon="IconLogo"></svg>
+<svg data-icon="IconLogo" class="native"></svg>
+<svg data-icon="IconLogo" class="fc-black-350 float-right js-dropdown-target"></svg>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="d-flex gs24 fw-wrap ff-mono">


### PR DESCRIPTION
Originally discussed when we updated codepen links to use the new template in this commit: https://github.com/StackExchange/Stacks/commit/e3b1d4512c3d25447afb01075da0e296fafd3d10

Icon data attributes now need to be prefixed with "Icon":

```diff
- <svg data-icon="Logo"></svg>
+ <svg data-icon="IconLogo"></svg>
```

Updates this section of documetation - https://deploy-preview-1116--stacks.netlify.app/product/resources/icons/#prototypes

![image](https://user-images.githubusercontent.com/4307307/191306290-057c2029-b965-4e62-8377-f2871640cca1.png)
