### PR TITLE
Bug fix - Inconsistent table border width size on zoom and extra spaces between table cells

### DIFF
--- a/lib/css/components/tables.less
+++ b/lib/css/components/tables.less
@@ -41,13 +41,11 @@
     border-collapse: collapse;
     border-spacing: 0;
     font-size: var(--fs-body1);
-
+    border: 0.01px solid var(--bc-medium); // A quick and dirty workaround with 0.01px, because the Browser will fallback to at least 1px
     th,
     td {
         padding: var(--su8);
-        border-top: 1px solid var(--bc-medium);
-        border-left: 1px solid var(--bc-medium);
-        border-right: 1px solid var(--bc-medium);
+        border-left: 0.01px solid var(--bc-medium);
         vertical-align: middle;
         color: var(--fc-medium);
         text-align: left;
@@ -66,6 +64,11 @@
         color: var(--fc-dark);
     }
 
+    tr {
+        border-bottom: 0.01px solid var(--bc-medium);
+        position: initial;
+    }
+
     //  Custom styles when in a table head
     thead th {
         vertical-align: bottom;
@@ -77,17 +80,6 @@
     //  When in a table body, don't make it bold.
     tbody th {
         font-weight: normal;
-    }
-
-    //  If it's the last row, add a bottom border
-    tr:last-of-type td,
-    tr:last-of-type th {
-        border-bottom: 1px solid var(--bc-medium);
-    }
-
-    //  If two table bodies are next to each other, visually separate them
-    tbody + tbody {
-        border-top: var(--su-static2) solid var(--bc-medium);
     }
 }
 
@@ -196,13 +188,12 @@
     //  ------------------------------------------------------------------------
     //  --  No Borders
     &.s-table__b0 {
-        th,
+        border: 0;
+        tr,
         td,
-        tr:last-of-type th,
-        tr:last-of-type td {
-            border-color: transparent;
+        th {
+            border: none
         }
-
         //  Clear Header Styles
         thead th {
             background-color: transparent;
@@ -214,52 +205,39 @@
         //  This makes the border transparent, so we need to use whitespace
         //  to achieve the same effect a 2px gray border achieves.
         tbody + tbody {
-            border-color: transparent;
-            border-width: var(--su-static12);
+            // border-color: transparent;
+            // border-width: var(--su-static12);
         }
     }
 
     //  --  Horizontal Only with Table Outline
     &.s-table__bx {
-        tr {
-            > *:not(:first-child) {
-                border-left-color: transparent;
-            }
-            > *:not(:last-child) {
-                border-right-color: transparent;
-            }
+        th,
+        td {
+            border-left: none
         }
     }
 
     //  --  Horizontal Only without Table Outline
     &.s-table__bx-simple {
+        border: 0;
+        tr {
+            &:last-of-type {
+                border-bottom: 0;
+            }
+        }
         th,
         td {
-            border-left-color: transparent;
-            border-right-color: transparent;
+            border: none;
         }
         thead th {
-            border-top-color: transparent;
-            border-bottom-color: var(--bc-darker);
+            border-bottom: 0.01px solid var(--bc-darker);
+            // box-shadow: 0 1px 0 0 var(--bc-darker);
             //  Clear Header Styles
             background-color: transparent;
             text-transform: initial;
             font-size: inherit;
             letter-spacing: initial;
-        }
-        tbody tr {
-            &:first-of-type th,
-            &:first-of-type td {
-                border-top-color: transparent;
-            }
-            &:last-of-type th,
-            &:last-of-type td {
-                border-bottom-color: transparent;
-            }
-        }
-        tfoot th,
-        tfoot td {
-            border-bottom-color: transparent;
         }
     }
 
@@ -294,7 +272,6 @@
     //  $$  Progress Bar
     //  ------------------------------------------------------------------------
     td.s-table--progress {
-        border-right: none;
         text-align: right;
     }
 
@@ -302,19 +279,43 @@
         border-left: none;
         padding-left: 0;
         width: 120px;
+        box-shadow: none;
     }
 
     //  $$  Disabled rows
     //  ------------------------------------------------------------------------
     tr.is-disabled {
-        background-color: var(--black-025);
+        th,
+        td {
+            background-color: var(--black-025);
+            
+        }
 
         th:not(.is-enabled),
         td:not(.is-enabled) {
-            opacity: calc(var(--_o-disabled) * 0.6); // 0.5 * 0.6 = 0.3
+            color: var(--black-150);
         }
     }
 }
+
+@media (min-resolution: 120dpi) {
+    table, th, td {
+      border-width: 0.75px;
+    }
+  }
+  
+  @media (min-resolution: 144dpi) {
+    table, th, td {
+      border-width: 0.666px;
+    }
+  }
+  
+  @media (min-resolution: 192dpi) {
+    table, th, td {
+      border-width: 0.5px;
+    }
+  }
+
 
 //  ============================================================================
 //  $  TABLE CELL SIZES

--- a/lib/css/components/tables.less
+++ b/lib/css/components/tables.less
@@ -20,6 +20,7 @@
 //    - Totals row
 //    - Sortable tables
 //  • TABLE CELL SIZES
+//  • TABLE BORDER WITH SIZES ON ZOOM
 //
 
 //  ============================================================================
@@ -41,7 +42,7 @@
     border-collapse: collapse;
     border-spacing: 0;
     font-size: var(--fs-body1);
-    border: 0.01px solid var(--bc-medium); // A quick and dirty workaround with 0.01px, because the Browser will fallback to at least 1px
+    border: 0.01px solid var(--bc-medium); // Using 0.01 is workaround for border-with calculation, because the Browser will fallback to at least 1px
     th,
     td {
         padding: var(--su8);
@@ -298,25 +299,6 @@
     }
 }
 
-@media (min-resolution: 120dpi) {
-    table, th, td {
-      border-width: 0.75px;
-    }
-  }
-  
-  @media (min-resolution: 144dpi) {
-    table, th, td {
-      border-width: 0.666px;
-    }
-  }
-  
-  @media (min-resolution: 192dpi) {
-    table, th, td {
-      border-width: 0.5px;
-    }
-  }
-
-
 //  ============================================================================
 //  $  TABLE CELL SIZES
 //  ============================================================================
@@ -336,3 +318,24 @@
 .s-table--cell10 { width: @table-columns * 10; }
 .s-table--cell11 { width: @table-columns * 11; }
 .s-table--cell12 { width: @table-columns * 12; }
+
+//  ============================================================================
+//  $  TABLE BORDER WITH SIZES ON ZOOM
+//  ============================================================================
+@media (min-resolution: 120dpi) {
+    table, th, td {
+      border-width: 0.75px;
+    }
+  }
+  
+  @media (min-resolution: 144dpi) {
+    table, th, td {
+      border-width: 0.666px;
+    }
+  }
+  
+  @media (min-resolution: 192dpi) {
+    table, th, td {
+      border-width: 0.5px;
+    }
+  }

--- a/lib/css/components/tables.less
+++ b/lib/css/components/tables.less
@@ -202,13 +202,6 @@
             font-size: inherit;
             letter-spacing: initial;
         }
-
-        //  This makes the border transparent, so we need to use whitespace
-        //  to achieve the same effect a 2px gray border achieves.
-        tbody + tbody {
-            // border-color: transparent;
-            // border-width: var(--su-static12);
-        }
     }
 
     //  --  Horizontal Only with Table Outline
@@ -233,7 +226,6 @@
         }
         thead th {
             border-bottom: 0.01px solid var(--bc-darker);
-            // box-shadow: 0 1px 0 0 var(--bc-darker);
             //  Clear Header Styles
             background-color: transparent;
             text-transform: initial;


### PR DESCRIPTION
## Problems:
- When zooming in/out, browser draw borders based on calculation (`1px` * [zoom]). So for example `1px * 150% = 1.5px` and sometimes there is `1px` border with and sometime `2px`.
- Table is poorly designed using transparent backgrounds, which cause display problems.
## Solution:
- Redesigned table (removed current pattern for displaying borders) and adding new solution
- Added 0.01px workaround, where browsers will fallback to at least `1px`
- Changed the border-width to the appropriate decimal per scaling level at the end of the file
- Removed opacity for disable table row, because it affects background color and also text => added text color and background color from Stacks color palette

## Results:
### Zoom 100%
All tables looks similar - There are only small things caused by the fact that I remove the transparent border.
### Zoom 150%
_Not sure why upload images here does not work, so please open each section in new window for compare_.
#### Default table
[Before](https://user-images.githubusercontent.com/28909808/193539348-840950a9-0059-4f4b-b7c4-568e96499d0a.png)
[After](https://user-images.githubusercontent.com/28909808/193539402-13bdda2f-0159-44e9-9105-82ba1c527ab9.png)

#### Table with horizontal lines (`s-table__bx`)
[Before](https://user-images.githubusercontent.com/28909808/193539460-e74ef76f-8e5a-4968-af0e-897623dba13c.png)
[After](https://user-images.githubusercontent.com/28909808/193539533-ff8655e3-2201-45fb-8c48-73c654a9b16b.png)

#### Simple border (`s-table__bx-simple`)
[Before](https://user-images.githubusercontent.com/28909808/193539579-fd242c1a-22bf-462e-872a-0b45aaf66e4a.png)
[After](https://user-images.githubusercontent.com/28909808/193539623-14015048-f1c4-42f8-a0cf-000c9e263303.png)

#### No borders (`s-table__b0`)
[Before](https://user-images.githubusercontent.com/28909808/193539691-80f1912c-87a7-4e4e-af6d-18026fd615d6.png)
[After](https://user-images.githubusercontent.com/28909808/193539732-52913de7-b820-4bc3-8b14-d9c3ca5a94a7.png)
#### Zebra striping (`s-table__stripes`)
[Before](https://user-images.githubusercontent.com/28909808/193539835-f9a7995f-d499-4f63-b163-3e9b406091ba.png)
[After](https://user-images.githubusercontent.com/28909808/193539879-6c2e6527-a049-4176-9b98-2bf732a66dfa.png)

#### Spacing - small (`s-table__sm`)
[Before](https://user-images.githubusercontent.com/28909808/193539999-fb3addb7-ed71-4f46-88ae-0c963460af52.png)
[After](https://user-images.githubusercontent.com/28909808/193540066-14279da4-5ec9-4576-8b50-7b15eb918d78.png)

#### Spacing - Large (`s-table__lg`)
[Before](https://user-images.githubusercontent.com/28909808/193540118-671500e8-34da-4df4-9cf1-08040c626530.png)
[After](https://user-images.githubusercontent.com/28909808/193540220-fa383c94-0480-42a6-94c9-801ff31ec286.png)

#### Sortable tables (`s-table__sortable`)
[Before](https://user-images.githubusercontent.com/28909808/193540338-53772072-2518-482c-a008-ee7201e0bc6b.png)
[After](https://user-images.githubusercontent.com/28909808/193540438-a0e422fb-dbe4-4265-b984-2b7ebf6b5352.png)

#### Bar graphs (`s-table--progress-bar`)
[Before](https://user-images.githubusercontent.com/28909808/193540520-1b48a8b7-eab6-406b-80a9-a134a4ca5f29.png)
[After](https://user-images.githubusercontent.com/28909808/193540642-9442c8b9-8ecb-4a31-b736-daf0e64e6c38.png)

#### Bulk actions (`s-table--bulk`)
[Before](https://user-images.githubusercontent.com/28909808/193540804-7c56fb5b-4d85-4874-a7df-4930251f12ad.png)
[After](https://user-images.githubusercontent.com/28909808/193540855-ec740fc1-c61f-43d6-8cea-0e1b0c1a7063.png)

#### Total rows (`s-table--totals`)
[Before](https://user-images.githubusercontent.com/28909808/193541007-424575a3-62dc-43a1-8c59-2dec6398c6fa.png)
[After](https://user-images.githubusercontent.com/28909808/193541090-4cda90d4-e5ab-480d-a0c5-d0299c45db1d.png)

#### Inactive rows (`<tr class="is-disabled">`)
[Before](https://user-images.githubusercontent.com/28909808/193541293-922f2697-cf0c-4af7-b6e4-27632a8076d2.png)
[After](https://user-images.githubusercontent.com/28909808/193541352-a0687a1d-33c9-4051-a07a-904587f8a61b.png)

## Results
- All tables now looks consistent with 1px border across browsers, table variants and zoom levels
- There is no spacing between cells

## Tested
- Tested on Chrome 106.0.5249.91, Safari 15.6.1, Firefox 105.0.1, Edge  105.0.1343.53

## Note
I **created all variations of Table component in Figma**, if designers would like to use it in their component library.

What do you think?

Hope it helps!















