### PR TITLE
Increased specificity to get a higher priority for rewriting styles from primary.css

### DIFF
--- a/lib/css/components/post-summary.less
+++ b/lib/css/components/post-summary.less
@@ -318,7 +318,7 @@
     }
 }
 
-.s-post-summary__deleted {
+.s-post-summary.s-post-summary__deleted { // Increased specificity to 0,2,0 (this is needed to get a higher priority for rewriting primary.css)
     background-color: var(--red-025);
 
     .s-badge__filled {


### PR DESCRIPTION
Hi!

I took care about this bug #957 

Variants does not work without `s-post-summary` selector, so it is possible to increase the specificity of the selector with certainty and achieve that it will have a higher priority and override `s-post-summary__watched` if both selectors are there. We can remove this selector override when it's not in `primary.css` file.

Tested in Stacks and https://stackoverflow.com/

![Shot from Stackoverflow.com](https://user-images.githubusercontent.com/28909808/193994623-07872918-f81e-4734-bb00-d3002c35aa59.png)

I have one question about that. What is `primary.css` used for or why are the same elements there?

Hope this helps!