### PR TITLE
 refactor(popovers): use pseudo-private custom properties

### DIFF
--- a/lib/css/components/popovers.less
+++ b/lib/css/components/popovers.less
@@ -1,197 +1,148 @@
-//
-//  STACK OVERFLOW
-//  POPOVERS
-//
-//  This CSS comes from Stacks, our CSS & Pattern library for rapidly building
-//  Stack Overflow. For documentation of all these classes and how to contribute,
-//  visit https://stackoverflow.design/
-//
-//  TABLE OF CONTENTS
-//  • VARIABLES
-//  • BASE STYLE
-//  • ARROWS
-//  • LOCATIONS
-//
-//  ============================================================================
-//  $   BASE STYLES
-//  ----------------------------------------------------------------------------
 .s-popover {
-    display: none;
-    position: absolute;
-    max-width: 24rem;
-    padding: var(--su12);
-    z-index: var(--zi-popovers);
+    --_po-bg: var(--white);
+    --_po-bc: var(--bc-medium);
+    --_po-bs: var(--bs-md);
+    --_po-d: none;
+    --_po-wmn: 12rem;
+    --_po-w: 100%;
+    // arrow
+    --_po-arrow-fc: var(--white);
+    --_po-arrow-b: unset;
+    --_po-arrow-l: unset;
+    --_po-arrow-r: unset;
+    --_po-arrow-t: unset;
+    --_po-arrow-ps: calc(var(--su6) * -1); // ps suffix used for placement, not positioning value
+    --_po-arrow-after-b: unset;
+    --_po-arrow-after-l: unset;
+    --_po-arrow-after-r: unset;
+    --_po-arrow-after-t: unset;
+    --_po-arrow-after-bs: unset;
+  
+    // CONTEXTUAL STYLES
+    .dark-mode({
+        --_po-bg: var(--black-075);
+        --_po-bc: var(--bc-light);
+        --_po-bs: var(--bs-lg);
+        --_po-arrow-fc: var(--black-075);
+    });
+  
+    // MODIFIERS
+    &.is-visible {
+        --_po-d: block;
+    }
+    &&__tooltip {
+        --_po-wmn: unset;
+        --_po-w: auto;
+    }
+  
+    // CHILD ELEMENTS
+    // Arrow
+    &[data-popper-placement^="top"] > &--arrow,
+    & &--arrow__bc,
+    & &--arrow__bl,
+    & &--arrow__br {
+        --_po-arrow-b: var(--_po-arrow-ps);
+        --_po-arrow-after-b: var(--su-static1);
+        --_po-arrow-after-bs: 2px 2px 5px 0 hsla(0, 0%, 0%, 0.07), 2px 2px 2px -1px hsla(0, 0%, 0%, 0.1);
+        .highcontrast-mode({ --_po-arrow-after-bs: 1px 1px 0 0 var(--bc-medium); });
+    }
+    &[data-popper-placement^="bottom"] > &--arrow,
+    & &--arrow__tc,
+    & &--arrow__tl,
+    & &--arrow__tr {
+        --_po-arrow-t: var(--_po-arrow-ps);
+        --_po-arrow-after-t: var(--su-static1);
+        --_po-arrow-after-bs: -1px -1px 1px 0 hsla(0, 0%, 0%, 0.12);
+        .highcontrast-mode({ --_po-arrow-after-bs: -1px -1px 0 0 var(--bc-medium); });
+    }
+    &[data-popper-placement^="left"] > &--arrow,
+    & &--arrow__rc,
+    & &--arrow__rt,
+    & &--arrow__rb {
+        --_po-arrow-r: var(--_po-arrow-ps);
+        --_po-arrow-after-r: var(--su-static1);
+        --_po-arrow-after-bs: 2px -2px 5px 0 hsla(0, 0%, 0%, 0.07), 2px -2px 2px -1px hsla(0, 0%, 0%, 0.1);
+        .highcontrast-mode({ --_po-arrow-after-bs: 1px -1px 0 0 var(--bc-medium); });
+    }
+    &[data-popper-placement^="right"] > &--arrow,
+    & &--arrow__lc,
+    & &--arrow__lt,
+    & &--arrow__lb {
+        --_po-arrow-l: var(--_po-arrow-ps);
+        --_po-arrow-after-l: var(--su-static1);
+        --_po-arrow-after-bs: -2px 2px 5px 0 hsla(0, 0%, 0%, 0.07), -2px 2px 2px -1px hsla(0, 0%, 0%, 0.1);
+        .highcontrast-mode({ --_po-arrow-after-bs: -1px 1px 0 0 var(--bc-medium); });
+    }
+    & &--arrow__tc,
+    & &--arrow__bc {
+        --_po-arrow-l: calc(50% - var(--su6));
+    }
+    & &--arrow__lc,
+    & &--arrow__rc {
+        --_po-arrow-t: calc(50% - var(--su6));
+    }
+    & &--arrow__tr,
+    .s-popover--arrow__br {
+        --_po-arrow-r: var(--su12);
+    }
+    & &--arrow__rb,
+    & &--arrow__lb {
+        --_po-arrow-b: var(--su12);
+    }
+    & &--arrow {
+        &,
+        &:before,
+        &:after {
+            display: block;
+            height: var(--su12);
+            position: absolute;
+            width: var(--su12);
+            z-index: -1;
+        }
+        &:before, // This renders our border
+        &:after {
+            content: '';
+            transform: rotate(45deg);
+        }
+        &:after { // This renders our foreground color
+            bottom: var(--_po-arrow-after-b);
+            box-shadow: var(--_po-arrow-after-bs);
+            left: var(--_po-arrow-after-l);
+            right: var(--_po-arrow-after-r);
+            top: var(--_po-arrow-after-t);
+
+            background: currentColor;
+            border-radius: calc(var(--su-static1) * 1.5);
+        }
+
+        bottom: var(--_po-arrow-b);
+        color: var(--_po-arrow-fc);
+        left: var(--_po-arrow-l);
+        right: var(--_po-arrow-r);
+        top: var(--_po-arrow-t);
+    }
+    // Close btn
+    & &--close {
+        float: right; // Use floats for title wrapping
+        top: calc(var(--su8) * -1); // Compensate for s-popover's padding
+        right: calc(var(--su8) * -1); // Compensate for s-popover's padding
+        padding: var(--su8) !important;
+    }
+  
+    background-color: var(--_po-bg);
+    border: 1px solid var(--_po-bc);
+    box-shadow: var(--_po-bs);
+    display: var(--_po-d);
+    min-width: var(--_po-wmn);
+    width: var(--_po-w);
+  
     border-radius: var(--br-md);
-    border: 1px solid var(--bc-medium);
-    background-color: var(--white);
-    box-shadow: var(--bs-md);
     color: var(--fc-dark);
     font-size: var(--fs-body1);
-    min-width: 12rem;
-    width: 100%;
-
-    // Guard against popovers being in a container with white-space: nowrap
-    // Without this, the content pops *out* of the popover.
-    white-space: normal; 
-
-    .dark-mode({
-        background-color: var(--black-075);
-        border-color: var(--bc-light);
-        box-shadow: var(--bs-lg);
-    });
-
-    &.s-popover__tooltip {
-        width: auto;
-        min-width: unset;
-    }
-
-    &.is-visible {
-        display: block;
-    }
-
-    &[data-popper-placement^="top"] > .s-popover--arrow,
-    .s-popover--arrow__bc,
-    .s-popover--arrow__bl,
-    .s-popover--arrow__br {
-        bottom: calc(var(--su6) * -1);
-
-        &:after {
-            bottom: 1px;
-            box-shadow: 2px 2px 5px 0 hsla(0, 0, 0, 0.07), 2px 2px 2px -1px hsla(0, 0, 0, 0.1);
-
-            .highcontrast-mode({
-                box-shadow: 1px 1px 0 0 var(--bc-medium);
-            });
-        }
-    }
-
-    &[data-popper-placement^="bottom"] > .s-popover--arrow,
-    .s-popover--arrow__tc,
-    .s-popover--arrow__tl,
-    .s-popover--arrow__tr {
-        top: calc(var(--su6) * -1);
-
-        &:after {
-            top: 1px;
-            box-shadow: -1px -1px 1px 0 hsla(0, 0, 0, 0.12);
-
-            .highcontrast-mode({
-                box-shadow: -1px -1px 0 0 var(--bc-medium);
-            });
-        }
-    }
-
-    &[data-popper-placement^="left"] > .s-popover--arrow,
-    .s-popover--arrow__rc,
-    .s-popover--arrow__rt,
-    .s-popover--arrow__rb {
-        right: calc(var(--su6) * -1);
-
-        &:after {
-            right: 1px;
-            box-shadow: 2px -2px 5px 0 hsla(0, 0, 0, 0.07), 2px -2px 2px -1px hsla(0, 0, 0, 0.1);
-
-            .highcontrast-mode({
-                box-shadow: 1px -1px 0 0 var(--bc-medium);
-            });
-        }
-    }
-
-    &[data-popper-placement^="right"] > .s-popover--arrow,
-    .s-popover--arrow__lc,
-    .s-popover--arrow__lt,
-    .s-popover--arrow__lb {
-        left: calc(var(--su6) * -1);
-
-        &:after {
-            left: 1px;
-            box-shadow: -2px 2px 5px 0 hsla(0, 0, 0, 0.07), -2px 2px 2px -1px hsla(0, 0, 0, 0.1);
-
-            .highcontrast-mode({
-                box-shadow: -1px 1px 0 0 var(--bc-medium);
-            });
-        }
-    }
-
-    .s-popover--arrow__tc,
-    .s-popover--arrow__bc {
-        left: calc(50% - var(--su6));
-    }
-
-    .s-popover--arrow__lc,
-    .s-popover--arrow__rc {
-        top: calc(50% - var(--su6));
-    }
-
-    .s-popover--arrow__tr,
-    .s-popover--arrow__br {
-        right: var(--su12);
-    }
-
-    .s-popover--arrow__rb,
-    .s-popover--arrow__lb {
-        bottom: var(--su12);
-    }
-}
-
-//  ============================================================================
-//  $   CLOSE BUTTON
-//  ----------------------------------------------------------------------------
-
-.s-popover--close {
-    float: right; // Use floats for title wrapping
-    top: calc(var(--su8) * -1); // Compensate for s-popover's padding
-    right: calc(var(--su8) * -1); // Compensate for s-popover's padding
-    padding: var(--su8) !important;
-}
-
-//  ============================================================================
-//  $   ARROWS
-//  ----------------------------------------------------------------------------
-//
-//  TABLE OF CONTENTS
-//  • BASE STYLE
-//  • LOCATIONS
-//      • TOP
-//      • BOTTOM
-//      • TOP & BOTTOM DIRECTIONS (Left, Center, Right)
-//      • LEFT
-//      • RIGHT
-//      • LEFT & RIGHT DIRECTIONS (Top, Center, Bottom)
-//
-//  ============================================================================
-//  $   BASE STYLE
-//      Sets the base arrow style for tooltips, popovers, and dropdowns.
-//  ----------------------------------------------------------------------------
-
-.s-popover--arrow,
-.s-popover--arrow:before,
-.s-popover--arrow:after {
+    max-width: 24rem;
+    padding: var(--su12);
     position: absolute;
-    display: block;
-    width: var(--su12);
-    height: var(--su12);
-    z-index: -1;
-}
-
-.s-popover--arrow {
-    color: var(--white);
-
-    .dark-mode({
-        color: var(--black-075);
-    });
-}
-
-.s-popover--arrow:before {
-    // This renders our border
-    content: '';
-    transform: rotate(45deg);
-}
-
-.s-popover--arrow:after {
-    // This renders our foreground color
-    content: '';
-    transform: rotate(45deg);
-    border-radius: 1.5px;
-    background: currentColor;
-}
+    white-space: normal; // Guard against popovers being in a container with white-space: nowrap. Without this, the content pops *out* of the popover.
+    z-index: var(--zi-popovers);
+  }
+  


### PR DESCRIPTION
This PR refactors `.s-popover` component styling to use pseudo-private custom properties.

> **Note**
> This PR should result in no visual changes for the `.s-popover` component.