### PR TITLE
Improve a11y support for table sorting

### DIFF
--- a/docs/_data/tables.json
+++ b/docs/_data/tables.json
@@ -62,7 +62,7 @@
     },
     {
       "attribute": "data-action=\"click->s-table#sort\"",
-      "applies": "th",
+      "applies": "button",
       "description": "Causes a click on the header cell to sort by this column"
     },
     {

--- a/docs/product/components/tables.html
+++ b/docs/product/components/tables.html
@@ -756,7 +756,7 @@ description: Tables are used to list all information from a data set. The base s
                 {% for item in tables.data-attributes %}
                     <tr>
                         <th scope="row"><code class="stacks-code">{{ item.attribute }}</code></th>
-                        <td><code class="stacks-code">{{ item.applies }}</td>
+                        <td><code class="stacks-code">{{ item.applies }}</code></td>
                         <td class="p8">{{ item.description }}</td>
                     </tr>
                 {% endfor %}

--- a/docs/product/components/tables.html
+++ b/docs/product/components/tables.html
@@ -771,19 +771,25 @@ description: Tables are used to list all information from a data set. The base s
     <table class="s-table s-table__sortable" data-controller="s-table">
         <thead>
             <tr>
-                <th data-s-table-target="column" data-action="click->s-table#sort">
-                    Season
-                    @Svg.ArrowUpSm.With("js-sorting-indicator js-sorting-indicator-asc d-none")
-                    @Svg.ArrowDownSm.With("js-sorting-indicator js-sorting-indicator-desc d-none")
-                    @Svg.ArrowUpDownSm.With("js-sorting-indicator js-sorting-indicator-none")
+                <th data-s-table-target="column">
+                    <button data-action="click->s-table#sort">
+                        Season
+                        @Svg.ArrowUpSm.With("js-sorting-indicator js-sorting-indicator-asc d-none")
+                        @Svg.ArrowDownSm.With("js-sorting-indicator js-sorting-indicator-desc d-none")
+                        @Svg.ArrowUpDownSm.With("js-sorting-indicator js-sorting-indicator-none")
+                    </button>
                 </th>
-                <th data-s-table-target="column" data-action="click->s-table#sort">
-                    Starts in month
-                    …
+                <th data-s-table-target="column">
+                    <button data-action="click->s-table#sort">
+                        Starts in month
+                        …
+                    </button>
                 </th>
-                <th data-s-table-target="column" data-action="click->s-table#sort">
-                    Typical temperature in °C
-                    …
+                <th data-s-table-target="column">
+                    <button data-action="click->s-table#sort">
+                        Typical temperature in °C
+                        …
+                    </button>
                 </th>
             </tr>
         </thead>
@@ -805,23 +811,29 @@ description: Tables are used to list all information from a data set. The base s
                 <table class="s-table s-table__sortable" data-controller="s-table">
                     <thead>
                         <tr>
-                            <th data-s-table-target="column" data-action="click->s-table#sort">
-                                Season
-                                {% icon "ArrowUpSm", "js-sorting-indicator js-sorting-indicator-asc d-none" %}
-                                {% icon "ArrowDownSm", "js-sorting-indicator js-sorting-indicator-desc d-none" %}
-                                {% icon "ArrowUpDownSm", "js-sorting-indicator js-sorting-indicator-none" %}
+                            <th data-s-table-target="column">
+                                <button data-action="click->s-table#sort">
+                                    Season
+                                    {% icon "ArrowUpSm", "js-sorting-indicator js-sorting-indicator-asc d-none" %}
+                                    {% icon "ArrowDownSm", "js-sorting-indicator js-sorting-indicator-desc d-none" %}
+                                    {% icon "ArrowUpDownSm", "js-sorting-indicator js-sorting-indicator-none" %}
+                                </button>
                             </th>
-                            <th data-s-table-target="column" data-action="click->s-table#sort">
-                                Starts in month
-                                {% icon "ArrowUpSm", "js-sorting-indicator js-sorting-indicator-asc d-none" %}
-                                {% icon "ArrowDownSm", "js-sorting-indicator js-sorting-indicator-desc d-none" %}
-                                {% icon "ArrowUpDownSm", "js-sorting-indicator js-sorting-indicator-none" %}
+                            <th data-s-table-target="column">
+                                <button data-action="click->s-table#sort">
+                                    Starts in month
+                                    {% icon "ArrowUpSm", "js-sorting-indicator js-sorting-indicator-asc d-none" %}
+                                    {% icon "ArrowDownSm", "js-sorting-indicator js-sorting-indicator-desc d-none" %}
+                                    {% icon "ArrowUpDownSm", "js-sorting-indicator js-sorting-indicator-none" %}
+                                </button>
                             </th>
-                            <th data-s-table-target="column" data-action="click->s-table#sort">
-                                Typical temperature in °C
-                                {% icon "ArrowUpSm", "js-sorting-indicator js-sorting-indicator-asc d-none" %}
-                                {% icon "ArrowDownSm", "js-sorting-indicator js-sorting-indicator-desc d-none" %}
-                                {% icon "ArrowUpDownSm", "js-sorting-indicator js-sorting-indicator-none" %}
+                            <th data-s-table-target="column">
+                                <button data-action="click->s-table#sort">
+                                    Typical temperature in °C
+                                    {% icon "ArrowUpSm", "js-sorting-indicator js-sorting-indicator-asc d-none" %}
+                                    {% icon "ArrowDownSm", "js-sorting-indicator js-sorting-indicator-desc d-none" %}
+                                    {% icon "ArrowUpDownSm", "js-sorting-indicator js-sorting-indicator-none" %}
+                                </button>
                             </th>
                         </tr>
                     </thead>

--- a/lib/css/components/tables.less
+++ b/lib/css/components/tables.less
@@ -66,21 +66,6 @@
         color: var(--fc-dark);
     }
 
-    th.s-table--sortable-column {
-        padding: 0;
-
-        button.s-table--clickable-header {
-            appearance: none;
-            background-color: transparent;
-            border: 0;
-            color: currentColor;
-            cursor: pointer;
-            padding: var(--su8);
-            text-align: left;
-            width: 100%;
-        }
-    }
-
     //  Custom styles when in a table head
     thead th {
         vertical-align: bottom;
@@ -295,9 +280,23 @@
         color: var(--fc-light);
         cursor: pointer;
 
+        &[data-s-table-target="column"] {
+            padding: 0;
+        }
+
         //  If an anchor is used, it should appear like a normal header
-        a {
+        a,
+        button {
             color: inherit;
+        }
+
+        button {
+            appearance: none;
+            background-color: transparent;
+            border: 0;
+            padding: var(--su8);
+            text-align: left;
+            width: 100%;
         }
 
         //  Selected state

--- a/lib/css/components/tables.less
+++ b/lib/css/components/tables.less
@@ -66,6 +66,21 @@
         color: var(--fc-dark);
     }
 
+    th.s-table--sortable-column {
+        padding: 0;
+
+        button.s-table--clickable-header {
+            appearance: none;
+            background-color: transparent;
+            border: 0;
+            color: currentColor;
+            cursor: pointer;
+            padding: var(--su8);
+            text-align: left;
+            width: 100%;
+        }
+    }
+
     //  Custom styles when in a table head
     thead th {
         vertical-align: bottom;

--- a/lib/css/components/tables.less
+++ b/lib/css/components/tables.less
@@ -280,11 +280,12 @@
         color: var(--fc-light);
         cursor: pointer;
 
+        // If this column is sortable, then the padding will come from the button
         &[data-s-table-target="column"] {
             padding: 0;
         }
 
-        //  If an anchor is used, it should appear like a normal header
+        // If an anchor is used, it should appear like a normal header
         a,
         button {
             color: inherit;

--- a/lib/ts/controllers/s-table.ts
+++ b/lib/ts/controllers/s-table.ts
@@ -24,7 +24,7 @@ export class TableController extends Stacks.StacksController {
         this.columnTargets.forEach(this.ensureHeadersAreClickable);
     }
 
-    sort(evt: Event) {
+    sort(evt: PointerEvent) {
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const controller = this;
         const sortTriggerEl = evt.currentTarget;
@@ -144,10 +144,15 @@ export class TableController extends Stacks.StacksController {
 
             header.classList.toggle('is-sorted', isCurrent && direction !== SortOrder.None);
             header.classList.toggle(sortedHeaderBackground, isCurrent);
-            header.setAttribute('aria-sort', direction);
             header.querySelectorAll('.js-sorting-indicator').forEach((icon) => {
                 icon.classList.toggle('d-none', !icon.classList.contains('js-sorting-indicator-' + classSuffix));
             });
+
+            if (isCurrent) {
+                header.setAttribute('aria-sort', direction);
+            } else {
+                header.removeAttribute('aria-sort');
+            }
         });
     }
 

--- a/lib/ts/controllers/s-table.ts
+++ b/lib/ts/controllers/s-table.ts
@@ -11,9 +11,6 @@ enum SortOrder {
     None = 'none',
 }
 
-const sortedHeaderBackground = 'bg-powder-200';
-const sortedColumnBackground = 'bg-powder-100';
-
 export class TableController extends Stacks.StacksController {
     readonly columnTarget!: HTMLTableCellElement;
     readonly columnTargets!: HTMLTableCellElement[];
@@ -115,12 +112,6 @@ export class TableController extends Stacks.StacksController {
             const row = rows[rowIndex];
             row.parentElement!.removeChild(row);
 
-            for (let i = 0; i < row.cells.length; i++) {
-                const cell = row.cells.item(i);
-
-                cell?.classList.toggle(sortedColumnBackground, i === colno);
-            }
-
             if (firstBottomRow) {
                 tbody.insertBefore(row, firstBottomRow);
             } else {
@@ -143,7 +134,6 @@ export class TableController extends Stacks.StacksController {
                 : SortOrder.None;
 
             header.classList.toggle('is-sorted', isCurrent && direction !== SortOrder.None);
-            header.classList.toggle(sortedHeaderBackground, isCurrent);
             header.querySelectorAll('.js-sorting-indicator').forEach((icon) => {
                 icon.classList.toggle('d-none', !icon.classList.contains('js-sorting-indicator-' + classSuffix));
             });


### PR DESCRIPTION
The current method of triggering a sort in tables is not accessible. This is due to the fact that you are attaching an event listener to the `click` event on an element that naturally is not clickable; therefore, keyboard only users are not capable of interacting with the headers since focus is never moved onto them.

My proposed syntax moves the contents of a table header cell into a button, which is where the `data-action` attribute will now live.

```html
<th data-s-table-target="column">
    <button data-action="click->s-table#sort">
        Season
        @Svg.ArrowUpSm.With("js-sorting-indicator js-sorting-indicator-asc d-none")
        @Svg.ArrowDownSm.With("js-sorting-indicator js-sorting-indicator-desc d-none")
        @Svg.ArrowUpDownSm.With("js-sorting-indicator js-sorting-indicator-none")
    </button>
</th>
```

## CSS Changes

I have added some rules described as follows:

- `.s-table__sortable thead th[data-s-table-target="column"]` :: if a `th` has this attribute attached to it, then it should be assumed that it's a sortable column and the padding will come from the `<button>` instead of it so that there's no weird gap between the button and the header cell that's not clickable
- `.s-table__sortable thead th button` :: there are certain rules that need to happen here so I've stuffed them here to avoid repetition in our markup
  - This can cause problems if there's a button with a popup attached to it. Is this likely to happen?

## Backward Compatibility

I have introduced a `ensureHeadersAreClickable` method that transforms the old table syntax to the next syntax so that any Stacks table gets these a11y fixes for free! I currently have a warning in there telling devs in a non-prod environment to update their markup.

## What do these changes NOT do?

This PR does **not** change/improve any screen reader announcements in terms of announcing new sorting or changing of table captions. For the moment, we'll continue to rely on an SR's support of `aria-sort`.

## Resources

- [W3 ARIA APG sortable table](https://www.w3.org/WAI/ARIA/apg/example-index/table/sortable-table)
- [Deque sortable table](https://dequeuniversity.com/library/aria/table-sortable)