### PR TITLE
refactor(spinner): use pseudo-private custom properties

### DIFF
--- a/lib/css/components/spinner.less
+++ b/lib/css/components/spinner.less
@@ -1,36 +1,39 @@
-//
-//  STACK OVERFLOW
-//  SPINNER
-//
-//  This CSS comes from Stacks, our CSS & Pattern library for rapidly building
-//  Stack Overflow. For documentation of all these classes and how to contribute,
-//  visit https://stackoverflow.design/
-//
-//  TABLE OF CONTENTS
-//  • BASE STYLE
-//
-//  ============================================================================
-//  $   SPINNER BASE STYLE
-//  ----------------------------------------------------------------------------
-
 .s-spinner {
-    position: relative;
-    width: var(--su-static24);
-    height: var(--su-static24);
-    text-align: left; // When within a parent that has text-align: center, the spinner's entire container spins, not just the spinner. Let's force text-align left so things spin internally.
+    --_sp-size: var(--su-static24);
+    --_sp-before-baw: calc(var(--su-static1) * 3); // 3px
 
+    // MODIFIERS
+    &&__xs {
+        --_sp-size: var(--su-static12);
+        --_sp-before-baw: var(--su-static1);
+    }
+    &&__sm {
+        --_sp-size: var(--su-static16);
+        --_sp-before-baw: var(--su-static2);
+    }
+    &&__md {
+        --_sp-size: var(--su-static32);
+        --_sp-before-baw: var(--su-static4);
+    }
+    &&__lg {
+        --_sp-size: var(--su-static48);
+        --_sp-before-baw: var(--su-static6);
+    }
+
+    // CHILD ELEMENTS
     &:before,
     &:after {
+        border: var(--_sp-before-baw) solid currentColor;
+
+        border-radius: var(--br-circle);
         content: '';
+        height: 100%;
         position: absolute;
         width: 100%;
-        height: 100%;
-        border: 3px solid currentColor;
-        border-radius: var(--br-circle);
     }
     &:before {
         opacity: 0.25;
-        transform: rotate(90deg); // (*)
+        transform: rotate(90deg); // [1]
     }
     &:after {
         border-top-color: transparent;
@@ -39,99 +42,43 @@
         animation: s-spinner-rotate 0.9s infinite cubic-bezier(0.5, 0.1, 0.5, 0.9);
     }
 
-    &.s-spinner__xs {
-        width: var(--su-static12);
-        height: var(--su-static12);
-        &:before,
-        &:after {
-            border-width: 1px;
-        }
-    }
+    height: var(--_sp-size);
+    width: var(--_sp-size);
 
-    &.s-spinner__sm {
-        width: var(--su-static16);
-        height: var(--su-static16);
-        &:before,
-        &:after {
-            border-width: var(--su-static2);
-        }
-    }
-
-    &.s-spinner__md {
-        width: var(--su-static32);
-        height: var(--su-static32);
-        &:before,
-        &:after {
-            border-width: var(--su-static4);
-        }
-    }
-
-    &.s-spinner__lg {
-        width: var(--su-static48);
-        height: var(--su-static48);
-        &:before,
-        &:after {
-            border-width: var(--su-static6);
-        }
-    }
-
-    // Cross-browser fixes. These are all practically no-ops, so we could just specify them
-    // without browser hacks, but that would be punishing non-broken browsers with extra
-    // unnecessary compositing work.
-    &,
-    &:before,
-    &:after {
-        // Safari: At least at 1dpp resolution, Safari crops the transformed elements
-        // too aggressively, leading to a very visible flat edge part of the circle.
-        // This invisible box shadow increases the area that the effects work on and thus
-        // makes the circle round again.
-        //
-        // Targeting only Safari:
-        // https://browserstrangeness.bitbucket.io/css_hacks.html#safari
-        @media not all and (min-resolution: 0.001dpcm) {
-            @supports (-webkit-appearance:none) and (stroke-color:transparent) {
-                box-shadow: 0 0 0 2px transparent;
-            }
-        }
-    }
+    position: relative;
+    text-align: left; // [2]
 }
 
 .is-loading {
-    position: relative;
-    padding-left: 2.2em;
+    --_li-offset: 0.6em;
+    --_il-size: 1.23076923em;
 
-    &:before {
-        content: "";
-        position: absolute;
-        opacity: 0.3;
-        left: 0.6em;
-        top: calc(50% - 0.6em);
-        width: 1.23076923em;
-        height: 1.23076923em;
-        border-width: 2px;
-        border-style: solid;
-        border-color: currentColor;
-        border-radius: var(--br-circle);
-    }
-
+    &:before,
     &:after {
-        content: "";
-        position: absolute;
-        left: 0.6em;
-        top: calc(50% - 0.6em);
-        width: 1.23076923em;
-        height: 1.23076923em;
-        border-width: 2px;
+        border-radius: var(--br-circle);
         border-style: solid;
+        border-width: var(--su-static2);
+        content: "";
+        height: var(--_il-size);
+        left: var(--_li-offset);
+        position: absolute;
+        top: calc(50% - var(--_li-offset));
+        width: var(--_il-size);
+    }
+    &:before {
+        border-color: currentColor;
+        opacity: 0.3;
+    }
+    &:after {
+        animation: s-spinner-rotate 0.9s infinite cubic-bezier(0.5, 0.1, 0.5, 0.9);
         border-color: transparent;
         border-left-color: currentColor;
-        border-radius: var(--br-circle);
-        animation: s-spinner-rotate 0.9s infinite
-            cubic-bezier(0.5, 0.1, 0.5, 0.9);
-        // see _stacks-spinner.less for an explanation of the following two
-        filter: invert(0); // (*)
-        transform-origin: 50% 50% 1px; // (*)
+        filter: invert(0); // [1]
+        transform-origin: 50% 50% 1px; // [1]
     }
+
+    position: relative;
+    padding-left: 2.2em;
 }
 
 // Keyframes
@@ -143,3 +90,6 @@
         transform: rotate(360deg);
     }
 }
+
+// [1] no-op to reduce wobble in Edge. More info: https://github.com/StackExchange/Stacks/blob/d2af26aca06c47e3f1f7a638e49b221a9e28e450/lib/css/components/_stacks-spinner.less#L16-L26
+// [2] When within a parent that has text-align: center, the spinner's entire container spins, not just the spinner. Let's force text-align left so things spin internally.

--- a/lib/css/components/spinner.less
+++ b/lib/css/components/spinner.less
@@ -1,29 +1,29 @@
 .s-spinner {
     --_sp-size: var(--su-static24);
-    --_sp-before-baw: calc(var(--su-static1) * 3); // 3px
+    --_sp-baw: calc(var(--su-static1) * 3); // 3px
 
     // MODIFIERS
     &&__xs {
         --_sp-size: var(--su-static12);
-        --_sp-before-baw: var(--su-static1);
+        --_sp-baw: var(--su-static1);
     }
     &&__sm {
         --_sp-size: var(--su-static16);
-        --_sp-before-baw: var(--su-static2);
+        --_sp-baw: var(--su-static2);
     }
     &&__md {
         --_sp-size: var(--su-static32);
-        --_sp-before-baw: var(--su-static4);
+        --_sp-baw: var(--su-static4);
     }
     &&__lg {
         --_sp-size: var(--su-static48);
-        --_sp-before-baw: var(--su-static6);
+        --_sp-baw: var(--su-static6);
     }
 
     // CHILD ELEMENTS
     &:before,
     &:after {
-        border: var(--_sp-before-baw) solid currentColor;
+        border: var(--_sp-baw) solid currentColor;
 
         border-radius: var(--br-circle);
         content: '';
@@ -77,8 +77,8 @@
         transform-origin: 50% 50% 1px; // [1]
     }
 
-    position: relative;
     padding-left: 2.2em;
+    position: relative;
 }
 
 // Keyframes

--- a/lib/css/components/spinner.less
+++ b/lib/css/components/spinner.less
@@ -1,23 +1,23 @@
 .s-spinner {
-    --_sp-size: var(--su-static24);
     --_sp-baw: calc(var(--su-static1) * 3); // 3px
+    --_sp-size: var(--su-static24);
 
     // MODIFIERS
     &&__xs {
-        --_sp-size: var(--su-static12);
         --_sp-baw: var(--su-static1);
+        --_sp-size: var(--su-static12);
     }
     &&__sm {
-        --_sp-size: var(--su-static16);
         --_sp-baw: var(--su-static2);
+        --_sp-size: var(--su-static16);
     }
     &&__md {
-        --_sp-size: var(--su-static32);
         --_sp-baw: var(--su-static4);
+        --_sp-size: var(--su-static32);
     }
     &&__lg {
-        --_sp-size: var(--su-static48);
         --_sp-baw: var(--su-static6);
+        --_sp-size: var(--su-static48);
     }
 
     // CHILD ELEMENTS


### PR DESCRIPTION
This PR refactors `.s-spinner` component and `.is-loading`state class styling to use pseudo-private custom properties and removes a > 4 year old Safari fix that seems no longer relevant.

> **Note**
> This PR should result in no visual changes for the `.s-spinner` component or the `.is-loading` state class.