### PR TITLE
fix(gap): swap gap axis names

### DIFF
--- a/docs/_data/gap.json
+++ b/docs/_data/gap.json
@@ -75,124 +75,124 @@
   ],
   "row": [
     {
-      "class": "gx0",
+      "class": "gy0",
       "define": "Add no space between rows",
       "responsive": true
     },
     {
-      "class": "gx1",
+      "class": "gy1",
       "define": "Space out rows by 1px",
       "responsive": true
     },
     {
-      "class": "gx2",
+      "class": "gy2",
       "define": "Space out rows by 2px",
       "responsive": true
     },
     {
-      "class": "gx4",
+      "class": "gy4",
       "define": "Space out rows by 4px",
       "responsive": true
     },
     {
-      "class": "gx6",
+      "class": "gy6",
       "define": "Space out rows by 6px",
       "responsive": true
     },
     {
-      "class": "gx8",
+      "class": "gy8",
       "define": "Space out rows by 8px",
       "responsive": true
     },
     {
-      "class": "gx12",
+      "class": "gy12",
       "define": "Space out rows by 12px",
       "responsive": true
     },
     {
-      "class": "gx16",
+      "class": "gy16",
       "define": "Space out rows by 16px",
       "responsive": true
     },
     {
-      "class": "gx24",
+      "class": "gy24",
       "define": "Space out rows by 24px",
       "responsive": true
     },
     {
-      "class": "gx32",
+      "class": "gy32",
       "define": "Space out rows by 32px",
       "responsive": true
     },
     {
-      "class": "gx48",
+      "class": "gy48",
       "define": "Space out rows by 48px",
       "responsive": true
     },
     {
-      "class": "gx64",
+      "class": "gy64",
       "define": "Space out rows by 64px",
       "responsive": true
     }
   ],
   "column": [
     {
-      "class": "gy0",
+      "class": "gx0",
       "define": "Add no space between columns",
       "responsive": true
     },
     {
-      "class": "gy1",
+      "class": "gx1",
       "define": "Space out columns by 1px",
       "responsive": true
     },
     {
-      "class": "gy2",
+      "class": "gx2",
       "define": "Space out columns by 2px",
       "responsive": true
     },
     {
-      "class": "gy4",
+      "class": "gx4",
       "define": "Space out columns by 4px",
       "responsive": true
     },
     {
-      "class": "gy6",
+      "class": "gx6",
       "define": "Space out columns by 6px",
       "responsive": true
     },
     {
-      "class": "gy8",
+      "class": "gx8",
       "define": "Space out columns by 8px",
       "responsive": true
     },
     {
-      "class": "gy12",
+      "class": "gx12",
       "define": "Space out columns by 12px",
       "responsive": true
     },
     {
-      "class": "gy16",
+      "class": "gx16",
       "define": "Space out columns by 16px",
       "responsive": true
     },
     {
-      "class": "gy24",
+      "class": "gx24",
       "define": "Space out columns by 24px",
       "responsive": true
     },
     {
-      "class": "gy32",
+      "class": "gx32",
       "define": "Space out columns by 32px",
       "responsive": true
     },
     {
-      "class": "gy48",
+      "class": "gx48",
       "define": "Space out columns by 48px",
       "responsive": true
     },
     {
-      "class": "gy64",
+      "class": "gx64",
       "define": "Space out columns by 64px",
       "responsive": true
     }

--- a/docs/product/base/gap.html
+++ b/docs/product/base/gap.html
@@ -64,73 +64,10 @@ description: Atomic CSS gap classes allow you to set spacing on the direct child
     </div>
 </section>
 
-
-<section class="stacks-section">
-    <!-- TODO: write description -->
-    {% header "h2", "Row gap" %}
-    <p class="stacks-copy">Spacing can be set on just the x-axis with <code class="stacks-code">.gx</code> classes. They can be used independently or in combination with other atomic gap classes.</p>
-    <div class="overflow-x-auto mb48" tabindex="0">
-        <table class="wmn4 s-table s-table__bx-simple">
-            <thead>
-                <tr>
-                    <th class="s-table--cell3" scope="col">Class</th>
-                    <th scope="col">Definition</th>
-                    <th class="s-table--cell2 ta-center" scope="col"><a class="s-link s-link__inherit" href="{{ "/product/guidelines/conditional-classes#responsive" | url }}">Responsive?</a></th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for item in gap.row %}
-                    <tr class="fs-caption">
-                        <th scope="row"><code class="stacks-code">.{{ item.class }}</code></th>
-                        <td>{{ item.define }}</td>
-                        <td class="ta-center">
-                            {% if item.responsive %}
-                                {% icon "Checkmark", "fc-green-500" %}
-                            {% endif %}
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
-
-    {% header "h3", "Row examples" %}
-    <div class="stacks-preview">
-{% highlight html %}
-<div class="d-grid gx0">…</div>
-<div class="d-grid gx1">…</div>
-<div class="d-grid gx2">…</div>
-<div class="d-grid gx4">…</div>
-<div class="d-grid gx8">…</div>
-<div class="d-grid gx12">…</div>
-<div class="d-grid gx16">…</div>
-<div class="d-grid gx24">…</div>
-<div class="d-grid gx32">…</div>
-<div class="d-grid gx48">…</div>
-<div class="d-grid gx64">…</div>
-{% endhighlight %}
-        <div class="stacks-preview--example ff-mono">
-            {% for item in gap.row %}
-                <div class="mb16 d-grid {{ item.class }} grid__3 bg-black-075 ba bc-black-3 p16">
-                    <div class="grid--item bg-black-100 p8 h32 ba bc-black-4">
-                        .{{ item.class }}
-                    </div>
-                    <div class="grid--item bg-black-100 p8 h32 ba bc-black-4"></div>
-                    <div class="grid--item bg-black-100 p8 h32 ba bc-black-4"></div>
-                    <div class="grid--item bg-black-100 p8 h32 ba bc-black-4"></div>
-                    <div class="grid--item bg-black-100 p8 h32 ba bc-black-4"></div>
-                    <div class="grid--item bg-black-100 p8 h32 ba bc-black-4"></div>
-                </div>
-            {% endfor %}
-        </div>
-    </div>
-</section>
-
-
 <section class="stacks-section">
     <!-- TODO: write description -->
     {% header "h2", "Column gap" %}
-    <p class="stacks-copy">Spacing can be set on just the y-axis with <code class="stacks-code">.gy</code> classes. They can be used independently or in combination with other atomic gap classes.</p>
+    <p class="stacks-copy">Spacing can be set on just the x-axis with <code class="stacks-code">.gx</code> classes. They can be used independently or in combination with other atomic gap classes.</p>
     <div class="overflow-x-auto mb48" tabindex="0">
         <table class="wmn4 s-table s-table__bx-simple">
             <thead>
@@ -159,6 +96,67 @@ description: Atomic CSS gap classes allow you to set spacing on the direct child
     {% header "h3", "Column examples" %}
     <div class="stacks-preview">
 {% highlight html %}
+<div class="d-grid gx0">…</div>
+<div class="d-grid gx1">…</div>
+<div class="d-grid gx2">…</div>
+<div class="d-grid gx4">…</div>
+<div class="d-grid gx8">…</div>
+<div class="d-grid gx12">…</div>
+<div class="d-grid gx16">…</div>
+<div class="d-grid gx24">…</div>
+<div class="d-grid gx32">…</div>
+<div class="d-grid gx48">…</div>
+<div class="d-grid gx64">…</div>
+{% endhighlight %}
+        <div class="stacks-preview--example ff-mono">
+            {% for item in gap.column %}
+                <div class="mb16 d-grid {{ item.class }} grid__3 bg-black-075 ba bc-black-3 p16">
+                    <div class="grid--item bg-black-100 p8 h32 ba bc-black-4">
+                        .{{ item.class }}
+                    </div>
+                    <div class="grid--item bg-black-100 p8 h32 ba bc-black-4"></div>
+                    <div class="grid--item bg-black-100 p8 h32 ba bc-black-4"></div>
+                    <div class="grid--item bg-black-100 p8 h32 ba bc-black-4"></div>
+                    <div class="grid--item bg-black-100 p8 h32 ba bc-black-4"></div>
+                    <div class="grid--item bg-black-100 p8 h32 ba bc-black-4"></div>
+                </div>
+            {% endfor %}
+        </div>
+    </div>
+</section>
+
+<section class="stacks-section">
+    <!-- TODO: write description -->
+    {% header "h2", "Row gap" %}
+    <p class="stacks-copy">Spacing can be set on just the y-axis with <code class="stacks-code">.gy</code> classes. They can be used independently or in combination with other atomic gap classes.</p>
+    <div class="overflow-x-auto mb48" tabindex="0">
+        <table class="wmn4 s-table s-table__bx-simple">
+            <thead>
+                <tr>
+                    <th class="s-table--cell3" scope="col">Class</th>
+                    <th scope="col">Definition</th>
+                    <th class="s-table--cell2 ta-center" scope="col"><a class="s-link s-link__inherit" href="{{ "/product/guidelines/conditional-classes#responsive" | url }}">Responsive?</a></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for item in gap.row %}
+                    <tr class="fs-caption">
+                        <th scope="row"><code class="stacks-code">.{{ item.class }}</code></th>
+                        <td>{{ item.define }}</td>
+                        <td class="ta-center">
+                            {% if item.responsive %}
+                                {% icon "Checkmark", "fc-green-500" %}
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    {% header "h3", "Row examples" %}
+    <div class="stacks-preview">
+{% highlight html %}
 <div class="d-grid gy0">…</div>
 <div class="d-grid gy1">…</div>
 <div class="d-grid gy2">…</div>
@@ -172,7 +170,7 @@ description: Atomic CSS gap classes allow you to set spacing on the direct child
 <div class="d-grid gy64">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example ff-mono">
-            {% for item in gap.column %}
+            {% for item in gap.row %}
                 <div class="mb16 d-grid {{ item.class }} grid__3 bg-black-075 ba bc-black-3 p16">
                     <div class="grid--item bg-black-100 p8 h32 ba bc-black-4">
                         .{{ item.class }}

--- a/lib/css/atomic/gap.less
+++ b/lib/css/atomic/gap.less
@@ -1,28 +1,15 @@
-#stacks-internals #responsify('.g0', { --_gap-x: 0; --_gap-y: 0; });
-#stacks-internals #responsify('.g1', { --_gap-x: var(--su1); --_gap-y: var(--su1); });
-#stacks-internals #responsify('.g2', { --_gap-x: var(--su2); --_gap-y: var(--su2); });
-#stacks-internals #responsify('.g4', { --_gap-x: var(--su4); --_gap-y: var(--su4); });
-#stacks-internals #responsify('.g6', { --_gap-x: var(--su6); --_gap-y: var(--su6); });
-#stacks-internals #responsify('.g8', { --_gap-x: var(--su8); --_gap-y: var(--su8); });
-#stacks-internals #responsify('.g12', { --_gap-x: var(--su12); --_gap-y: var(--su12); });
-#stacks-internals #responsify('.g16', { --_gap-x: var(--su16); --_gap-y: var(--su16); });
-#stacks-internals #responsify('.g24', { --_gap-x: var(--su24); --_gap-y: var(--su24); });
-#stacks-internals #responsify('.g32', { --_gap-x: var(--su32); --_gap-y: var(--su32); });
-#stacks-internals #responsify('.g48', { --_gap-x: var(--su48); --_gap-y: var(--su48); });
-#stacks-internals #responsify('.g64', { --_gap-x: var(--su64); --_gap-y: var(--su64); });
-
-#stacks-internals #responsify('.gx0', { --_gap-x: 0; });
-#stacks-internals #responsify('.gx1', { --_gap-x: var(--su1); });
-#stacks-internals #responsify('.gx2', { --_gap-x: var(--su2); });
-#stacks-internals #responsify('.gx4', { --_gap-x: var(--su4); });
-#stacks-internals #responsify('.gx6', { --_gap-x: var(--su6); });
-#stacks-internals #responsify('.gx8', { --_gap-x: var(--su8); });
-#stacks-internals #responsify('.gx12', { --_gap-x: var(--su12); });
-#stacks-internals #responsify('.gx16', { --_gap-x: var(--su16); });
-#stacks-internals #responsify('.gx24', { --_gap-x: var(--su24); });
-#stacks-internals #responsify('.gx32', { --_gap-x: var(--su32); });
-#stacks-internals #responsify('.gx48', { --_gap-x: var(--su48); });
-#stacks-internals #responsify('.gx64', { --_gap-x: var(--su64); });
+#stacks-internals #responsify('.g0', { --_gap-y: 0; --_gap-x: 0; });
+#stacks-internals #responsify('.g1', { --_gap-y: var(--su1); --_gap-x: var(--su1); });
+#stacks-internals #responsify('.g2', { --_gap-y: var(--su2); --_gap-x: var(--su2); });
+#stacks-internals #responsify('.g4', { --_gap-y: var(--su4); --_gap-x: var(--su4); });
+#stacks-internals #responsify('.g6', { --_gap-y: var(--su6); --_gap-x: var(--su6); });
+#stacks-internals #responsify('.g8', { --_gap-y: var(--su8); --_gap-x: var(--su8); });
+#stacks-internals #responsify('.g12', { --_gap-y: var(--su12); --_gap-x: var(--su12); });
+#stacks-internals #responsify('.g16', { --_gap-y: var(--su16); --_gap-x: var(--su16); });
+#stacks-internals #responsify('.g24', { --_gap-y: var(--su24); --_gap-x: var(--su24); });
+#stacks-internals #responsify('.g32', { --_gap-y: var(--su32); --_gap-x: var(--su32); });
+#stacks-internals #responsify('.g48', { --_gap-y: var(--su48); --_gap-x: var(--su48); });
+#stacks-internals #responsify('.g64', { --_gap-y: var(--su64); --_gap-x: var(--su64); });
 
 #stacks-internals #responsify('.gy0', { --_gap-y: 0; });
 #stacks-internals #responsify('.gy1', { --_gap-y: var(--su1); });
@@ -37,8 +24,21 @@
 #stacks-internals #responsify('.gy48', { --_gap-y: var(--su48); });
 #stacks-internals #responsify('.gy64', { --_gap-y: var(--su64); });
 
-.gx0, .gx1, .gx2, .gx4, .gx6, .gx8, .gx12, .gx16, .gx24, .gx32, .gx48, .gx64,
+#stacks-internals #responsify('.gx0', { --_gap-x: 0; });
+#stacks-internals #responsify('.gx1', { --_gap-x: var(--su1); });
+#stacks-internals #responsify('.gx2', { --_gap-x: var(--su2); });
+#stacks-internals #responsify('.gx4', { --_gap-x: var(--su4); });
+#stacks-internals #responsify('.gx6', { --_gap-x: var(--su6); });
+#stacks-internals #responsify('.gx8', { --_gap-x: var(--su8); });
+#stacks-internals #responsify('.gx12', { --_gap-x: var(--su12); });
+#stacks-internals #responsify('.gx16', { --_gap-x: var(--su16); });
+#stacks-internals #responsify('.gx24', { --_gap-x: var(--su24); });
+#stacks-internals #responsify('.gx32', { --_gap-x: var(--su32); });
+#stacks-internals #responsify('.gx48', { --_gap-x: var(--su48); });
+#stacks-internals #responsify('.gx64', { --_gap-x: var(--su64); });
+
 .gy0, .gy1, .gy2, .gy4, .gy6, .gy8, .gy12, .gy16, .gy24, .gy32, .gy48, .gy64,
+.gx0, .gx1, .gx2, .gx4, .gx6, .gx8, .gx12, .gx16, .gx24, .gx32, .gx48, .gx64,
 .g0, .g1, .g2, .g4, .g6, .g8, .g12, .g16, .g24, .g32, .g48, .g64 {
-  gap: var(--_gap-x, 0) var(--_gap-y, 0);
+  gap: var(--_gap-y, 0) var(--_gap-x, 0);
 }

--- a/lib/css/atomic/gap.less
+++ b/lib/css/atomic/gap.less
@@ -11,19 +11,6 @@
 #stacks-internals #responsify('.g48', { --_gap-y: var(--su48); --_gap-x: var(--su48); });
 #stacks-internals #responsify('.g64', { --_gap-y: var(--su64); --_gap-x: var(--su64); });
 
-#stacks-internals #responsify('.gy0', { --_gap-y: 0; });
-#stacks-internals #responsify('.gy1', { --_gap-y: var(--su1); });
-#stacks-internals #responsify('.gy2', { --_gap-y: var(--su2); });
-#stacks-internals #responsify('.gy4', { --_gap-y: var(--su4); });
-#stacks-internals #responsify('.gy6', { --_gap-y: var(--su6); });
-#stacks-internals #responsify('.gy8', { --_gap-y: var(--su8); });
-#stacks-internals #responsify('.gy12', { --_gap-y: var(--su12); });
-#stacks-internals #responsify('.gy16', { --_gap-y: var(--su16); });
-#stacks-internals #responsify('.gy24', { --_gap-y: var(--su24); });
-#stacks-internals #responsify('.gy32', { --_gap-y: var(--su32); });
-#stacks-internals #responsify('.gy48', { --_gap-y: var(--su48); });
-#stacks-internals #responsify('.gy64', { --_gap-y: var(--su64); });
-
 #stacks-internals #responsify('.gx0', { --_gap-x: 0; });
 #stacks-internals #responsify('.gx1', { --_gap-x: var(--su1); });
 #stacks-internals #responsify('.gx2', { --_gap-x: var(--su2); });
@@ -37,8 +24,21 @@
 #stacks-internals #responsify('.gx48', { --_gap-x: var(--su48); });
 #stacks-internals #responsify('.gx64', { --_gap-x: var(--su64); });
 
-.gy0, .gy1, .gy2, .gy4, .gy6, .gy8, .gy12, .gy16, .gy24, .gy32, .gy48, .gy64,
+#stacks-internals #responsify('.gy0', { --_gap-y: 0; });
+#stacks-internals #responsify('.gy1', { --_gap-y: var(--su1); });
+#stacks-internals #responsify('.gy2', { --_gap-y: var(--su2); });
+#stacks-internals #responsify('.gy4', { --_gap-y: var(--su4); });
+#stacks-internals #responsify('.gy6', { --_gap-y: var(--su6); });
+#stacks-internals #responsify('.gy8', { --_gap-y: var(--su8); });
+#stacks-internals #responsify('.gy12', { --_gap-y: var(--su12); });
+#stacks-internals #responsify('.gy16', { --_gap-y: var(--su16); });
+#stacks-internals #responsify('.gy24', { --_gap-y: var(--su24); });
+#stacks-internals #responsify('.gy32', { --_gap-y: var(--su32); });
+#stacks-internals #responsify('.gy48', { --_gap-y: var(--su48); });
+#stacks-internals #responsify('.gy64', { --_gap-y: var(--su64); });
+
 .gx0, .gx1, .gx2, .gx4, .gx6, .gx8, .gx12, .gx16, .gx24, .gx32, .gx48, .gx64,
+.gy0, .gy1, .gy2, .gy4, .gy6, .gy8, .gy12, .gy16, .gy24, .gy32, .gy48, .gy64,
 .g0, .g1, .g2, .g4, .g6, .g8, .g12, .g16, .g24, .g32, .g48, .g64 {
   gap: var(--_gap-y, 0) var(--_gap-x, 0);
 }


### PR DESCRIPTION
This PR addresses a mistake introduced in https://github.com/StackExchange/Stacks/pull/1143. This shouldn't impact any existing production code. 

This was a really silly mistake on my part. I assumed (for who knows what reason) that gap values were `gap: x-axis y-axis`. While reviewing https://github.com/StackExchange/Stacks/pull/1157, I realized that I implemented gap axis values backwards. [MDN says](https://developer.mozilla.org/en-US/docs/Web/CSS/gap#formal_syntax) `gap = 
  <'row-gap'> <'column-gap'>`. Really embarrassing!

In any case, this PR will fix the issue before it gets to prod and any meaningful adoption of `.gx`/`.gy` classes occurs.