### PR TITLE
docs(adr): add a template for adrs

### DIFF
--- a/adrs/0000-template.md
+++ b/adrs/0000-template.md
@@ -1,0 +1,16 @@
+# [ADR Title]
+
+**Date:** [YYYY-MM-DD]
+
+**Status:** [ 🚧 Proposed | ✅ Accepted | 🚫 Rejected ]
+
+**Related PR:** [#xxxx (when applicable)]
+
+### Issue
+[describe in few sentences the problem we need to solve]
+
+### Decision
+[describe in few sentences the proposed solution to the issue]
+
+##### Disclaimer
+This is just a template: while we expect the above items to appear in every ADRs, feel free to add any additional points as you see fit based on your ADR context (e.g. Consequences, etc...).

--- a/adrs/0000-template.md
+++ b/adrs/0000-template.md
@@ -2,8 +2,6 @@
 
 **Date:** [YYYY-MM-DD]
 
-**Status:** [ 🚧 Proposed | ✅ Accepted | 🚫 Rejected ]
-
 **Related PR:** [#xxxx (when applicable)]
 
 ### Issue

--- a/adrs/0000-template.md
+++ b/adrs/0000-template.md
@@ -12,5 +12,5 @@
 ### Decision
 [describe in few sentences the proposed solution to the issue]
 
-##### Disclaimer
-This is just a template: while we expect the above items to appear in every ADRs, feel free to add any additional points as you see fit based on your ADR context (e.g. Consequences, etc...).
+### Additional info
+[anything else you'd like to add; remove this section if it is empty]

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -1,0 +1,21 @@
+# Architecture Decision Records (ADRs)
+An architecture decision record (ADR) is a document that captures an important architecture decision made along with its context and consequences. We strive to keep these records small and lean.
+
+### Goal
+We want to record important design decisions to help current and future contributors of the library to understand the reasons for doing things a certain way.
+
+
+### Lightweight Process
+
+- Create a new branch on this repository and copy `adrs/0000-template.md` to a new file with the next free number.
+- Modify the template to add details about your proposal and add any supporting picture under the `adrs/images` folder.
+- Make a Pull Request (PR) for your branch.
+- Once consensus is reached and approvals given using the Github review system, the PR can be merged.
+
+In case the team has already agreed on a decision and no further async discussion is necessary just go ahead an record it directly without opening any PR.
+
+
+### Disclaimer
+
+As of today, the primary audience for these ADRs artefacts is the Stacks Core Team. If circumnstances will change and we feel a broader audience should get involved in the decision making process we could look into evolving our process in something a bit more formal like the internal [Stack Overflow RFC process](https://github.com/StackEng/StackOverflow/blob/master/docs/rfcs/0001-lightweight-rfc-process.md).
+

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -4,7 +4,6 @@ An architecture decision record (ADR) is a document that captures an important a
 ### Goal
 We want to record important design decisions to help current and future contributors of the library to understand the reasons for doing things a certain way.
 
-
 ### Lightweight Process
 
 - Create a new branch on this repository and copy `adrs/0000-template.md` to a new file with the next free number.
@@ -13,7 +12,6 @@ We want to record important design decisions to help current and future contribu
 - Once consensus is reached and approvals given using the Github review system, the PR can be merged.
 
 In case the team has already agreed on a decision and no further async discussion is necessary just go ahead an record it directly without opening any PR.
-
 
 ### Disclaimer
 

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -7,7 +7,7 @@ We want to record important design decisions to help current and future contribu
 ### Lightweight Process
 
 - Create a new branch on this repository and copy `adrs/0000-template.md` to a new file with the next free number.
-- Modify the template to add details about your proposal and add any supporting picture under the `adrs/images` folder.
+- Modify the template to add details about your proposal and add any supporting diagram preferably in [ASCII](https://textik.com/).
 - Make a Pull Request (PR) for your branch.
 - Once consensus is reached and approvals given using the Github review system, the PR can be merged.
 

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -17,5 +17,5 @@ In case the team has already agreed on a decision and no further async discussio
 
 ### Disclaimer
 
-As of today, the primary audience for these ADRs artefacts is the Stacks Core Team. If circumnstances will change and we feel a broader audience should get involved in the decision making process we could look into evolving our process in something a bit more formal like the internal [Stack Overflow RFC process](https://github.com/StackEng/StackOverflow/blob/master/docs/rfcs/0001-lightweight-rfc-process.md).
+As of today, the primary audience for these ADRs artifacts is the Stacks Core Team. If circumstances will change and we feel a broader audience should get involved in the decision making process we could look into evolving our process in something a bit more formal like the internal [Stack Overflow RFC process](https://github.com/StackEng/StackOverflow/blob/master/docs/rfcs/0001-lightweight-rfc-process.md).
 

--- a/adrs/README.md
+++ b/adrs/README.md
@@ -15,5 +15,5 @@ In case the team has already agreed on a decision and no further async discussio
 
 ### Disclaimer
 
-As of today, the primary audience for these ADRs artifacts is the Stacks Core Team. If circumstances will change and we feel a broader audience should get involved in the decision making process we could look into evolving our process in something a bit more formal like the internal [Stack Overflow RFC process](https://github.com/StackEng/StackOverflow/blob/master/docs/rfcs/0001-lightweight-rfc-process.md).
+As of today, the primary audience for these ADRs artifacts is the core Stacks Team. If circumstances change and we feel a broader audience should get involved in the decision making process we could look into evolving our process in something a bit more formal like the internal Stack Overflow RFC process.
 


### PR DESCRIPTION
We have been talking in several occasions within our Stacks Core Team about documenting our architecture decisions in a format that is easily consumable by all contributors.

This is my attempt to get us kick started with that.
I would like to keep the process as lean as possible in the beginning and explore more complex avenues (e.g. RFCs) only when we feel the need for it.
 
 In my "backlog" I have already 2 items which will eventually benefit from written ADRs:
- Deprecation Strategy
- Testing Strategy

I know that Dan have something about:
- Pseudo Private Custom Properties

 Looking forward to get your feedback. 🙂