### PR TITLE
fix(badges): render all modifiers with adjoined base class

### DIFF
--- a/lib/css/components/badges.less
+++ b/lib/css/components/badges.less
@@ -13,17 +13,17 @@
     // CONTEXTUAL STYLES
     .highcontrast-mode({
         // Badge counts
-        &__gold,
-        &__silver,
-        &__bronze,
+        &&__gold,
+        &&__silver,
+        &&__bronze,
         // Number counts
-        &__rep,
-        &__rep-down,
-        &__votes,
+        &&__rep,
+        &&__rep-down,
+        &&__votes,
         // Users
-        &__admin,
-        &__moderator,
-        &__staff {
+        &&__admin,
+        &&__moderator,
+        &&__staff {
             --_ba-bc: currentColor;
         }
     });


### PR DESCRIPTION
This PR ensures all modifier styles on the badge component are output with the base component class prepended.

### Before

```css
…
body.theme-highcontrast .s-badge__gold,
body.theme-highcontrast .s-badge__silver,
body.theme-highcontrast .s-badge__bronze,
body.theme-highcontrast .s-badge__rep,
body.theme-highcontrast .s-badge__rep-down,
body.theme-highcontrast .s-badge__votes,
body.theme-highcontrast .s-badge__admin,
body.theme-highcontrast .s-badge__moderator,
body.theme-highcontrast .s-badge__staff {
  --_ba-bc: currentColor;
}
…
```

### After

```css
…
body.theme-highcontrast .s-badgebody.theme-highcontrast .s-badge__gold,
body.theme-highcontrast .s-badgebody.theme-highcontrast .s-badge__silver,
body.theme-highcontrast .s-badgebody.theme-highcontrast .s-badge__bronze,
body.theme-highcontrast .s-badgebody.theme-highcontrast .s-badge__rep,
body.theme-highcontrast .s-badgebody.theme-highcontrast .s-badge__rep-down,
body.theme-highcontrast .s-badgebody.theme-highcontrast .s-badge__votes,
body.theme-highcontrast .s-badgebody.theme-highcontrast .s-badge__admin,
body.theme-highcontrast .s-badgebody.theme-highcontrast .s-badge__moderator,
body.theme-highcontrast .s-badgebody.theme-highcontrast .s-badge__staff {
  --_ba-bc: currentColor;
}
…
```