### PR TITLE
Add distinct code of conduct file and Netlify badge

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+This project observes the [Stack Exchange Code of Conduct](https://meta.stackexchange.com/conduct). Relevant parts of the Code of Conduct have been copied below. In the event that the content here doesn't match or contradicts the aforementioned Code of Conduct, then the Stack Exchange Code of Conduct takes precedent. Please file an issue against this repo to bring any issues to our attention.
+
+## Our Expectations
+
+- Be clear and constructive when giving feedback, and be open when receiving it.
+- Be inclusive and respectful.
+
+## Unacceptable Behavior
+
+- No subtle put-downs or unfriendly language.
+- No name-calling or personal attacks.
+- No bigotry.
+- No harassment.
+
+## Reporting
+
+- Contact us. https://meta.stackexchange.com/contact

--- a/docs/_includes/layouts/page.html
+++ b/docs/_includes/layouts/page.html
@@ -88,6 +88,9 @@
                         </div>
                     </form>
                 </div>
+                <div class="ta-right">
+                    <a href="https://www.netlify.com"><img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Deploys by Netlify" /></a>
+                </div>
             </div>
         </main>
     </div>


### PR DESCRIPTION
Having a distinct Code of Conduct file is a qualifier for Netlify's [open source plan](https://www.netlify.com/legal/open-source-policy/). Also adds Netlify's badge to the bottom of each page.

See StackExchange/Stacks-Editor#232 for more context.