### PR TITLE
docs(banner): improve example interaction

### DIFF
--- a/docs/assets/js/entry.banners.js
+++ b/docs/assets/js/entry.banners.js
@@ -4,43 +4,57 @@ $(document).ready(function() {
     var sysBanner = $(".js-notice-banner");
     var sysBannerHeight = sysBanner.outerHeight();
     var sysBannerBtn = $(".js-sys-banner-show");
-    var sysCloseBtn = $(".js-sys-banner-remove, .js-notice-close");
+    var sysRemoveBtn = $(".js-sys-banner-remove, .js-notice-close");
     var sysStyleMenu = $(".js-sys-banner-style-menu");
     var sysType = $(".js-sys-banner-type");
     var sysPos = $(".js-sys-banner-position");
     var typeClasses = ("s-banner__info s-banner__success s-banner__warning s-banner__danger s-banner__dark s-banner__important is-pinned");
 
-    sysBannerBtn.on("click", function(e) {
+    function setShowHideBtns(show) {
+        if (show) {
+            sysBannerBtn.addClass("d-none");
+            sysRemoveBtn.removeClass("d-none");
+        } else {
+            sysBannerBtn.removeClass("d-none");
+            sysRemoveBtn.addClass("d-none");
+        }
+    }
+    function setStyle(e) {
         var sysStyle = sysStyleMenu.find(":selected").data("class");
-
         e.preventDefault();
         e.stopPropagation();
 
-        $(this).text("Update example");
-        topnav.css("top","");
-        sysCloseBtn.removeClass("d-none");
         sysBanner.show().attr("aria-hidden","false").removeClass(typeClasses).addClass(sysStyle);
+        setShowHideBtns(true);
 
+        // Pin banner
         if (sysPos.is(":checked")) {
             topnav.removeClass("t0").css("top", sysBannerHeight + "px");
             sysBanner.addClass("is-pinned");
+        } else {
+            topnav.addClass("t0").css("top", "");
+            sysBanner.removeClass("is-pinned");
         }
-
+        // Add `important` modifier
         if (sysType.is(":checked")) {
             sysBanner.addClass("s-banner__important");
-
+        } else {
+            sysBanner.removeClass("s-banner__important");
         }
-    });
+    }
 
-    sysCloseBtn.on("click", function(e) {
+    function reset(e) {
         e.preventDefault();
         e.stopPropagation();
 
         topnav.addClass("t0");
         sysBanner.hide().attr("aria-hidden","true").removeClass(typeClasses);
+        setShowHideBtns(false);
+    }
 
-        sysBannerBtn.text("Show example");
-        sysCloseBtn.addClass("d-none");
-    });
-
+    sysBannerBtn.on("click", setStyle);
+    sysStyleMenu.on("change", setStyle);
+    sysPos.on("change", setStyle);
+    sysType.on("change", setStyle);
+    sysRemoveBtn.on("click", reset);
 });


### PR DESCRIPTION
I got tired of clicking that "Update example" button every time I changed the example settings, so I made it so that any change to the settings just goes ahead and updates the example.

Here's an example of the example update example:

![20221110-041059](https://user-images.githubusercontent.com/647177/201207155-d193ad9d-74bf-488e-bb26-fe2ffc9bd793.gif)
