### PR TITLE
fix(badge): ensure answered style overrides votes style

### DIFF
--- a/lib/css/components/badges.less
+++ b/lib/css/components/badges.less
@@ -19,7 +19,7 @@
         // Number counts
         &&__rep,
         &&__rep-down,
-        &&__votes,
+        &&__votes:not(&__answered),
         // Users
         &&__admin,
         &&__moderator,
@@ -76,7 +76,7 @@
     }
     &&__rep,
     &&__rep-down,
-    &&__votes {
+    &&__votes:not(&__answered) {
         --_ba-bg: var(--white);
     }
     &&__answered {
@@ -96,7 +96,7 @@
         --_ba-bc: var(--red-400);
         --_ba-fc: var(--red-500);
     }
-    &&__votes {
+    &&__votes:not(&__answered) {
         --_ba-bc: var(--black-150);
         --_ba-fc: var(--black-700);
     }


### PR DESCRIPTION
After v.1.5.0 was shipped in Core, I noticed a bug on the profile post summaries vote badge.

![image](https://user-images.githubusercontent.com/647177/204891315-dfc6e634-1a75-4e19-a8ac-446b761988fc.png)

This PR resolves this bug by ensuring the answered styling is used when both the answered and votes modifier classes are applied to `.s-badge`.