### PR TITLE
fix(linters): address all existing violations in the codebase

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
 *.md
 .vscode/
 dist/
+# TODO: prettier is breaking less files while formatting
+*.less

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
     "singleQuote": false,
     "quoteProps": "consistent",
     "trailingComma": "es5",
-    "printWidth": 80
+    "printWidth": 80,
+    "endOfLine": "auto"
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Stacks documentation can be found at https://stackoverflow.design/
 
 - [Using Stacks](#using-stacks)
 - [Building Stacks](#building-stacks)
+- [Linting Stacks](#linting-stacks)
+- [Testing Stacks](#testing-stacks)
 - [Bugs and feature requests](#bugs-and-feature-requests)
 - [Contributing](#contributing)
 - [License](#license)
@@ -31,6 +33,26 @@ Using Stacks is outlined in our [usage guidelines](https://stackoverflow.design/
 To contribute to Stacks documentation or its CSS library, you’ll need to build Stacks locally. View our [building guidelines](https://stackoverflow.design/product/guidelines/building).
 
 Having trouble getting these steps to work? Open [an issue](https://github.com/StackExchange/Stacks/issues/new) with a `setup` label.
+
+## Linting Stacks
+
+Run all lint suites by running:
+```sh
+npm run lint
+```
+
+Lint the styles (stylelint) by running:
+```sh
+npm run lint:css
+```
+Lint the typescript source code (eslint) via running:
+```sh
+npm run lint:ts
+```
+Lint the source code format (prettier) via running:
+```sh
+npm run lint:format
+```
 
 ## Testing Stacks
 Stacks has implemented visual regression testing with [Backstop](https://github.com/garris/BackstopJS). To test if your new feature introduces visual regressions, run `npm run test` in a new Terminal window while Stacks is running. After the tests have run, a new browser window with any regressions will show. If the regressions are desired, you can run `npm run approve` to establish the new baseline.

--- a/lib/css/atomic/gap.less
+++ b/lib/css/atomic/gap.less
@@ -40,5 +40,5 @@
 .gx0, .gx1, .gx2, .gx4, .gx6, .gx8, .gx12, .gx16, .gx24, .gx32, .gx48, .gx64,
 .gy0, .gy1, .gy2, .gy4, .gy6, .gy8, .gy12, .gy16, .gy24, .gy32, .gy48, .gy64,
 .g0, .g1, .g2, .g4, .g6, .g8, .g12, .g16, .g24, .g32, .g48, .g64 {
-  gap: var(--_gap-y, 0) var(--_gap-x, 0);
+    gap: var(--_gap-y, 0) var(--_gap-x, 0);
 }

--- a/lib/css/components/cards.less
+++ b/lib/css/components/cards.less
@@ -11,7 +11,7 @@
         --_ca-bc: var(--bc-light);
 
         //  Dim only the first child card content
-         > * {
+        > * {
             opacity: 0.65;
         }
     }

--- a/lib/css/components/expandable.less
+++ b/lib/css/components/expandable.less
@@ -111,4 +111,4 @@
     -webkit-clip-path: var(--_ex-clip-path);
     clip-path: var(--_ex-clip-path);
     transition: clip-path 0s var(--_ex-transition-duration), -webkit-clip-path 0s var(--_ex-transition-duration);
-  }
+}

--- a/lib/css/components/inputs.less
+++ b/lib/css/components/inputs.less
@@ -609,34 +609,18 @@ fieldset {
     font-size: var(--fs-caption);
 }
 
-//  $$  SIZES
+//  $$  PADDING ADJUSTMENTS AND SIZES
 //  ----------------------------------------------------------------------------
 .s-input__sm,
 .s-textarea__sm,
 .s-select__sm > select {
     font-size: var(--fs-caption);
 }
+
 .s-input__md,
 .s-textarea__md,
 .s-select__md > select {
     font-size: var(--fs-body3);
-}
-.s-input__lg,
-.s-textarea__lg,
-.s-select__lg > select {
-    font-size: var(--fs-title);
-}
-.s-input__xl,
-.s-textarea__xl,
-.s-select__xl > select {
-    font-size: var(--fs-headline1);
-}
-
-//  $$  PADDING ADJUSTMENTS WITHIN SIZES
-//  ----------------------------------------------------------------------------
-.s-input__md,
-.s-textarea__md,
-.s-select__md > select {
     padding-top: 0.5em;
     padding-bottom: 0.5em;
     border-radius: calc(var(--br-sm) + 1px);
@@ -650,6 +634,7 @@ fieldset {
 .s-input__lg,
 .s-textarea__lg,
 .s-select__lg > select {
+    font-size: var(--fs-title);
     padding: 0.45em 0.6em;
     border-radius: calc(var(--br-sm) + 1px);
 }
@@ -657,6 +642,7 @@ fieldset {
 .s-input__xl,
 .s-textarea__xl,
 .s-select__xl > select {
+    font-size: var(--fs-headline1);
     padding: 0.4em 0.5em;
     border-radius: var(--br-md);
 }

--- a/lib/css/components/pagination.less
+++ b/lib/css/components/pagination.less
@@ -1,5 +1,5 @@
 .s-pagination {
-   & &--item {
+    & &--item {
         --_pa-item-bg: transparent;
         --_pa-item-bc: var(--bc-medium);
         --_pa-item-fc: var(--fc-medium);

--- a/lib/css/components/popovers.less
+++ b/lib/css/components/popovers.less
@@ -17,7 +17,7 @@
     --_po-arrow-after-r: unset;
     --_po-arrow-after-t: unset;
     --_po-arrow-after-bs: unset;
-  
+
     // CONTEXTUAL STYLES
     .dark-mode({
         --_po-bg: var(--black-075);
@@ -25,7 +25,7 @@
         --_po-bs: var(--bs-lg);
         --_po-arrow-fc: var(--black-075);
     });
-  
+
     // MODIFIERS
     &.is-visible {
         --_po-d: block;
@@ -34,7 +34,7 @@
         --_po-wmn: unset;
         --_po-w: auto;
     }
-  
+
     // CHILD ELEMENTS
     // Arrow
     &[data-popper-placement^="top"] > &--arrow,
@@ -128,14 +128,14 @@
         right: calc(var(--su8) * -1); // Compensate for s-popover's padding
         padding: var(--su8) !important;
     }
-  
+
     background-color: var(--_po-bg);
     border: 1px solid var(--_po-bc);
     box-shadow: var(--_po-bs);
     display: var(--_po-d);
     min-width: var(--_po-wmn);
     width: var(--_po-w);
-  
+
     border-radius: var(--br-md);
     color: var(--fc-dark);
     font-size: var(--fs-body1);
@@ -144,5 +144,4 @@
     position: absolute;
     white-space: normal; // Guard against popovers being in a container with white-space: nowrap. Without this, the content pops *out* of the popover.
     z-index: var(--zi-popovers);
-  }
-  
+}

--- a/lib/ts/controllers/index.ts
+++ b/lib/ts/controllers/index.ts
@@ -1,8 +1,15 @@
 // export all controllers *with helpers* so they can be bulk re-exported by the package entry point
-export { ExpandableController } from './s-expandable-control';
-export { hideModal, ModalController, showModal } from './s-modal';
-export { TabListController } from './s-navigation-tablist';
-export { attachPopover, detachPopover, hidePopover, BasePopoverController, PopoverController, showPopover } from './s-popover';
-export { TableController } from './s-table';
-export { setTooltipHtml, setTooltipText, TooltipController } from './s-tooltip';
-export { UploaderController } from './s-uploader';
+export { ExpandableController } from "./s-expandable-control";
+export { hideModal, ModalController, showModal } from "./s-modal";
+export { TabListController } from "./s-navigation-tablist";
+export {
+    attachPopover,
+    detachPopover,
+    hidePopover,
+    BasePopoverController,
+    PopoverController,
+    showPopover,
+} from "./s-popover";
+export { TableController } from "./s-table";
+export { setTooltipHtml, setTooltipText, TooltipController } from "./s-tooltip";
+export { UploaderController } from "./s-uploader";

--- a/lib/ts/controllers/s-expandable-control.ts
+++ b/lib/ts/controllers/s-expandable-control.ts
@@ -1,4 +1,4 @@
-import * as Stacks from '../stacks';
+import * as Stacks from "../stacks";
 
 // Radio buttons only trigger a change event when they're *checked*, but not when
 // they're *unchecked*. Therefore, if we have an active `s-expandable-control` in
@@ -12,10 +12,15 @@ const RADIO_OFF_EVENT = "s-expandable-control:radio-off";
 
 function globalChangeListener(e: UIEvent) {
     const target = e.target;
-    if (!(target instanceof HTMLInputElement) || target.nodeName !== "INPUT" || target.type !== "radio") {
+    if (
+        !(target instanceof HTMLInputElement) ||
+        target.nodeName !== "INPUT" ||
+        target.type !== "radio"
+    ) {
         return;
     }
-    document.querySelectorAll('input[type="radio"][name="' + target.name + '"]')
+    document
+        .querySelectorAll('input[type="radio"][name="' + target.name + '"]')
         .forEach(function (other) {
             if (other === e.target) {
                 return;
@@ -37,12 +42,18 @@ function globalChangeListenerRequired(required: boolean) {
     if (required) {
         refCount++;
         if (refCount === 1) {
-            document.body.addEventListener("change", globalChangeListener as EventListener);
+            document.body.addEventListener(
+                "change",
+                globalChangeListener as EventListener
+            );
         }
     } else {
         refCount--;
         if (refCount === 0) {
-            document.body.removeEventListener("change", globalChangeListener as EventListener);
+            document.body.removeEventListener(
+                "change",
+                globalChangeListener as EventListener
+            );
         }
     }
 }
@@ -55,7 +66,12 @@ export class ExpandableController extends Stacks.StacksController {
     private lastKeydownClickTimestamp = 0;
 
     initialize() {
-        if (this.element.nodeName === "INPUT" && ["radio", "checkbox"].indexOf((<HTMLInputElement>this.element).type) >= 0) {
+        if (
+            this.element.nodeName === "INPUT" &&
+            ["radio", "checkbox"].indexOf(
+                (<HTMLInputElement>this.element).type
+            ) >= 0
+        ) {
             this.isCollapsed = this._isCollapsedForCheckable.bind(this);
             this.events = ["change", RADIO_OFF_EVENT];
             this.isCheckable = true;
@@ -65,40 +81,41 @@ export class ExpandableController extends Stacks.StacksController {
             this.events = ["click", "keydown"];
         }
         this.listener = this.listener.bind(this);
-    };
-
+    }
 
     // for non-checkable elements, the initial source of truth is the collapsed/expanded
     // state of the controlled element (unless the element doesn't exist)
     _isCollapsedForClickable() {
         const cc = this.controlledExpandables;
         // the element is considered collapsed if *any* target element is collapsed
-        return cc.length > 0 ? !cc.every(element => element.classList.contains("is-expanded")) : this.element.getAttribute("aria-expanded") === "false";
-    };
+        return cc.length > 0
+            ? !cc.every((element) => element.classList.contains("is-expanded"))
+            : this.element.getAttribute("aria-expanded") === "false";
+    }
 
     // for checkable elements, the initial source of truth is the checked state
     _isCollapsedForCheckable() {
         return !(<HTMLInputElement>this.element).checked;
-    };
-
+    }
 
     get controlledExpandables() {
         const attr = this.element.getAttribute("aria-controls");
         if (!attr) {
             throw `[aria-controls="targetId1 ... targetIdN"] attribute required`;
         }
-        const result = attr.split(/\s+/g)
-            .map(s => document.getElementById(s))
+        const result = attr
+            .split(/\s+/g)
+            .map((s) => document.getElementById(s))
             .filter((e): e is HTMLElement => !!e);
         if (!result.length) {
-            throw "couldn't find controls"
+            throw "couldn't find controls";
         }
         return result;
-    };
+    }
 
     _dispatchShowHideEvent(isShow: boolean) {
         this.triggerEvent(isShow ? "show" : "hide");
-    };
+    }
 
     _toggleClass(doAdd: boolean) {
         if (!this.data.has("toggle-class")) {
@@ -107,22 +124,30 @@ export class ExpandableController extends Stacks.StacksController {
         const cl = this.element.classList;
         const toggleClass = this.data.get("toggle-class");
         if (!toggleClass) {
-            throw "couldn't find toggle class"
+            throw "couldn't find toggle class";
         }
         toggleClass.split(/\s+/).forEach(function (cls) {
             cl.toggle(cls, !!doAdd);
         });
-    };
+    }
 
     listener(e: Event) {
         let newCollapsed;
         if (this.isCheckable) {
             newCollapsed = !(<HTMLInputElement>this.element).checked;
         } else {
-            if (e.type == "keydown" && (e instanceof KeyboardEvent && e.keyCode != 13 && e.keyCode != 32)) {
+            if (
+                e.type == "keydown" &&
+                e instanceof KeyboardEvent &&
+                e.keyCode != 13 &&
+                e.keyCode != 32
+            ) {
                 return;
             }
-            if (e.target !== e.currentTarget && ["A", "BUTTON"].indexOf((<HTMLElement>e.target).nodeName) >= 0) {
+            if (
+                e.target !== e.currentTarget &&
+                ["A", "BUTTON"].indexOf((<HTMLElement>e.target).nodeName) >= 0
+            ) {
                 return;
             }
 
@@ -133,24 +158,31 @@ export class ExpandableController extends Stacks.StacksController {
             // doesn't guarantee it.
             if (e.type == "keydown") {
                 this.lastKeydownClickTimestamp = Date.now();
-            } else if (e.type == "click" && Date.now() - this.lastKeydownClickTimestamp < 300) {
+            } else if (
+                e.type == "click" &&
+                Date.now() - this.lastKeydownClickTimestamp < 300
+            ) {
                 return;
             }
-            newCollapsed = this.element.getAttribute("aria-expanded") === "true";
+            newCollapsed =
+                this.element.getAttribute("aria-expanded") === "true";
             if (e.type === "click") {
                 (<HTMLInputElement>this.element).blur();
             }
         }
-        this.element.setAttribute("aria-expanded", newCollapsed ? "false" : "true");
+        this.element.setAttribute(
+            "aria-expanded",
+            newCollapsed ? "false" : "true"
+        );
         for (const controlledElement of this.controlledExpandables) {
             controlledElement.classList.toggle("is-expanded", !newCollapsed);
         }
         this._dispatchShowHideEvent(!newCollapsed);
         this._toggleClass(!newCollapsed);
-    };
+    }
 
     connect() {
-        this.events.forEach(e => {
+        this.events.forEach((e) => {
             this.element.addEventListener(e, this.listener.bind(this));
         }, this);
 
@@ -163,31 +195,44 @@ export class ExpandableController extends Stacks.StacksController {
         // Note: aria-expanded is currently an invalid attribute on radio elements
         // Support for aria-expanded is being debated by the W3C https://github.com/w3c/aria/issues/1404 as recently as June 2022
         if (!this.isRadio) {
-            this.element.setAttribute("aria-expanded", this.isCollapsed() ? "false" : "true");
+            this.element.setAttribute(
+                "aria-expanded",
+                this.isCollapsed() ? "false" : "true"
+            );
         }
         if (this.isCheckable) {
             const cc = this.controlledExpandables;
             if (cc.length) {
                 const expected = !this.isCollapsed();
                 // if any element does not match the expected state, set them all to the expected state
-                if (cc.some(element => element.classList.contains("is-expanded") !== expected)) {
-                    for (const controlledElement of this.controlledExpandables) {
-                        controlledElement.classList.toggle("is-expanded", expected);
+                if (
+                    cc.some(
+                        (element) =>
+                            element.classList.contains("is-expanded") !==
+                            expected
+                    )
+                ) {
+                    for (const controlledElement of this
+                        .controlledExpandables) {
+                        controlledElement.classList.toggle(
+                            "is-expanded",
+                            expected
+                        );
                     }
                     this._dispatchShowHideEvent(expected);
                     this._toggleClass(expected);
                 }
             }
         }
-    };
+    }
 
     disconnect() {
-        this.events.forEach(e => {
+        this.events.forEach((e) => {
             this.element.removeEventListener(e, this.listener.bind(this));
         }, this);
 
         if (this.isRadio) {
             globalChangeListenerRequired(false);
         }
-    };
+    }
 }

--- a/lib/ts/controllers/s-modal.ts
+++ b/lib/ts/controllers/s-modal.ts
@@ -220,7 +220,7 @@ export class ModalController extends Stacks.StacksController {
                 } else if (!e.shiftKey && e.target === lastTabbable) {
                     e.preventDefault();
                     firstTabbable.focus();
-                } 
+                }
             }
         }
     }
@@ -255,7 +255,7 @@ export class ModalController extends Stacks.StacksController {
         const target = <Node>e.target;
         // check if the document was clicked inside either the toggle element or the modal itself
         // note: .contains also returns true if the node itself matches the target element
-        if (!this.modalTarget.querySelector(".s-modal--dialog")!.contains(target) && document.body.contains(target)) {
+        if (!this.modalTarget.querySelector(".s-modal--dialog")?.contains(target) && document.body.contains(target)) {
             this._toggle(false, e);
         }
     }

--- a/lib/ts/controllers/s-modal.ts
+++ b/lib/ts/controllers/s-modal.ts
@@ -13,7 +13,7 @@ export class ModalController extends Stacks.StacksController {
 
     private _boundTabTrap!: (event: KeyboardEvent) => void;
 
-    connect () {
+    connect() {
         this.validate();
     }
 
@@ -22,26 +22,26 @@ export class ModalController extends Stacks.StacksController {
      */
     disconnect() {
         this.unbindDocumentEvents();
-    };
+    }
 
     /**
      * Toggles the visibility of the modal
      */
-    toggle (dispatcher: Event|Element|null = null) {
+    toggle(dispatcher: Event | Element | null = null) {
         this._toggle(undefined, dispatcher);
     }
 
     /**
      * Shows the modal
      */
-    show (dispatcher: Event|Element|null = null) {
+    show(dispatcher: Event | Element | null = null) {
         this._toggle(true, dispatcher);
     }
 
     /**
      * Hides the modal
      */
-    hide (dispatcher: Event|Element|null = null) {
+    hide(dispatcher: Event | Element | null = null) {
         this._toggle(false, dispatcher);
     }
 
@@ -52,10 +52,15 @@ export class ModalController extends Stacks.StacksController {
         // check for returnElement support
         const returnElementSelector = this.data.get("return-element");
         if (returnElementSelector) {
-            this.returnElement = <HTMLElement>document.querySelector(returnElementSelector);
+            this.returnElement = <HTMLElement>(
+                document.querySelector(returnElementSelector)
+            );
 
             if (!this.returnElement) {
-                throw "Unable to find element by return-element selector: " + returnElementSelector;
+                throw (
+                    "Unable to find element by return-element selector: " +
+                    returnElementSelector
+                );
             }
         }
     }
@@ -64,9 +69,13 @@ export class ModalController extends Stacks.StacksController {
      * Toggles the visibility of the modal element
      * @param show Optional parameter that force shows/hides the element or toggles it if left undefined
      */
-    private _toggle (show?: boolean | undefined, dispatcher: Event|Element|null = null) {
+    private _toggle(
+        show?: boolean | undefined,
+        dispatcher: Event | Element | null = null
+    ) {
         let toShow = show;
-        const isVisible = this.modalTarget.getAttribute("aria-hidden") === "false";
+        const isVisible =
+            this.modalTarget.getAttribute("aria-hidden") === "false";
 
         // if we're letting the class toggle, we need to figure out if the popover is visible manually
         if (typeof toShow === "undefined") {
@@ -81,10 +90,14 @@ export class ModalController extends Stacks.StacksController {
         const dispatchingElement = this.getDispatcher(dispatcher);
 
         // show/hide events trigger before toggling the class
-        const triggeredEvent = this.triggerEvent(toShow ? "show" : "hide", {
-            returnElement: this.returnElement,
-            dispatcher: this.getDispatcher(dispatchingElement)
-        }, this.modalTarget);
+        const triggeredEvent = this.triggerEvent(
+            toShow ? "show" : "hide",
+            {
+                returnElement: this.returnElement,
+                dispatcher: this.getDispatcher(dispatchingElement),
+            },
+            this.modalTarget
+        );
 
         // if this pre-show/hide event was prevented, don't attempt to continue changing the modal state
         if (triggeredEvent.defaultPrevented) {
@@ -97,29 +110,41 @@ export class ModalController extends Stacks.StacksController {
         if (toShow) {
             this.bindDocumentEvents();
             this.focusInsideModal();
-        }
-        else {
+        } else {
             this.unbindDocumentEvents();
             this.focusReturnElement();
             this.removeModalOnHide();
         }
 
         // check for transitionend support
-        const supportsTransitionEnd = (this.modalTarget).ontransitionend !== undefined;
+        const supportsTransitionEnd =
+            this.modalTarget.ontransitionend !== undefined;
 
         // shown/hidden events trigger after toggling the class
         if (supportsTransitionEnd) {
             // wait until after the modal finishes transitioning to fire the event
-            this.modalTarget.addEventListener("transitionend", () => {
-                //TODO this is firing waaay to soon?
-                this.triggerEvent(toShow ? "shown" : "hidden", {
-                    dispatcher: dispatchingElement
-                }, this.modalTarget);
-            }, { once: true });
+            this.modalTarget.addEventListener(
+                "transitionend",
+                () => {
+                    //TODO this is firing waaay to soon?
+                    this.triggerEvent(
+                        toShow ? "shown" : "hidden",
+                        {
+                            dispatcher: dispatchingElement,
+                        },
+                        this.modalTarget
+                    );
+                },
+                { once: true }
+            );
         } else {
-            this.triggerEvent(toShow ? "shown" : "hidden", {
-                dispatcher: dispatchingElement
-            }, this.modalTarget);
+            this.triggerEvent(
+                toShow ? "shown" : "hidden",
+                {
+                    dispatcher: dispatchingElement,
+                },
+                this.modalTarget
+            );
         }
     }
 
@@ -131,12 +156,19 @@ export class ModalController extends Stacks.StacksController {
             return;
         }
 
-        this.modalTarget.addEventListener("s-modal:hidden", () => {
-            // double check the element still exists when the event is called
-            if (this.returnElement && document.body.contains(this.returnElement)) {
-                this.returnElement.focus();
-            }
-        }, {once: true });
+        this.modalTarget.addEventListener(
+            "s-modal:hidden",
+            () => {
+                // double check the element still exists when the event is called
+                if (
+                    this.returnElement &&
+                    document.body.contains(this.returnElement)
+                ) {
+                    this.returnElement.focus();
+                }
+            },
+            { once: true }
+        );
     }
 
     /**
@@ -147,17 +179,26 @@ export class ModalController extends Stacks.StacksController {
             return;
         }
 
-        this.modalTarget.addEventListener("s-modal:hidden", () => {
-            this.element.remove();
-        }, {once: true });
+        this.modalTarget.addEventListener(
+            "s-modal:hidden",
+            () => {
+                this.element.remove();
+            },
+            { once: true }
+        );
     }
 
     /**
      * Gets all elements within the modal that could receive keyboard focus.
      */
     private getAllTabbables() {
-        return Array.from(this.modalTarget.querySelectorAll<HTMLElement>("[href], input, select, textarea, button, [tabindex]"))
-            .filter((el: Element) => el.matches(":not([disabled]):not([tabindex='-1'])"));
+        return Array.from(
+            this.modalTarget.querySelectorAll<HTMLElement>(
+                "[href], input, select, textarea, button, [tabindex]"
+            )
+        ).filter((el: Element) =>
+            el.matches(":not([disabled]):not([tabindex='-1'])")
+        );
     }
 
     /**
@@ -165,7 +206,7 @@ export class ModalController extends Stacks.StacksController {
      */
     private firstVisible(elements: HTMLElement[]) {
         // https://stackoverflow.com/a/21696585
-        return elements.find(el => el.offsetParent !== null);
+        return elements.find((el) => el.offsetParent !== null);
     }
 
     /**
@@ -181,17 +222,22 @@ export class ModalController extends Stacks.StacksController {
      * Otherwise, the first visible focusable element will receive focus.
      */
     private focusInsideModal() {
-        this.modalTarget.addEventListener("s-modal:shown", () => {
-            const initialFocus = this.firstVisible(this.initialFocusTargets) ?? this.firstVisible(this.getAllTabbables());
-            initialFocus?.focus();
-        }, {once: true });
+        this.modalTarget.addEventListener(
+            "s-modal:shown",
+            () => {
+                const initialFocus =
+                    this.firstVisible(this.initialFocusTargets) ??
+                    this.firstVisible(this.getAllTabbables());
+                initialFocus?.focus();
+            },
+            { once: true }
+        );
     }
 
     /**
      * Returns keyboard focus to the modal if it has left or is about to leave.
      */
     private keepFocusWithinModal(e: KeyboardEvent) {
-
         // If somehow the user has tabbed out of the modal or if focus started outside the modal, push them to the first item.
         if (!this.modalTarget.contains(<Element>e.target)) {
             const focusTarget = this.firstVisible(this.getAllTabbables());
@@ -228,11 +274,14 @@ export class ModalController extends Stacks.StacksController {
     /**
      * Binds global events to the document for hiding popovers on user interaction
      */
-    private bindDocumentEvents () {
+    private bindDocumentEvents() {
         // in order for removeEventListener to remove the right event, this bound function needs a constant reference
-        this._boundClickFn = this._boundClickFn || this.hideOnOutsideClick.bind(this);
-        this._boundKeypressFn = this._boundKeypressFn || this.hideOnEscapePress.bind(this);
-        this._boundTabTrap = this._boundTabTrap || this.keepFocusWithinModal.bind(this);
+        this._boundClickFn =
+            this._boundClickFn || this.hideOnOutsideClick.bind(this);
+        this._boundKeypressFn =
+            this._boundKeypressFn || this.hideOnEscapePress.bind(this);
+        this._boundTabTrap =
+            this._boundTabTrap || this.keepFocusWithinModal.bind(this);
 
         document.addEventListener("mousedown", this._boundClickFn);
         document.addEventListener("keyup", this._boundKeypressFn);
@@ -242,7 +291,7 @@ export class ModalController extends Stacks.StacksController {
     /**
      * Unbinds global events to the document for hiding popovers on user interaction
      */
-    private unbindDocumentEvents () {
+    private unbindDocumentEvents() {
         document.removeEventListener("mousedown", this._boundClickFn);
         document.removeEventListener("keyup", this._boundKeypressFn);
         document.removeEventListener("keydown", this._boundTabTrap);
@@ -251,11 +300,16 @@ export class ModalController extends Stacks.StacksController {
     /**
      * Forces the popover to hide if a user clicks outside of it or its reference element
      */
-    private hideOnOutsideClick (e: Event) {
+    private hideOnOutsideClick(e: Event) {
         const target = <Node>e.target;
         // check if the document was clicked inside either the toggle element or the modal itself
         // note: .contains also returns true if the node itself matches the target element
-        if (!this.modalTarget.querySelector(".s-modal--dialog")?.contains(target) && document.body.contains(target)) {
+        if (
+            !this.modalTarget
+                .querySelector(".s-modal--dialog")
+                ?.contains(target) &&
+            document.body.contains(target)
+        ) {
             this._toggle(false, e);
         }
     }
@@ -263,9 +317,12 @@ export class ModalController extends Stacks.StacksController {
     /**
      * Forces the popover to hide if the user presses escape while it, one of its childen, or the reference element are focused
      */
-    private hideOnEscapePress (e: KeyboardEvent) {
+    private hideOnEscapePress(e: KeyboardEvent) {
         // if the ESC key (27) wasn't pressed or if no popovers are showing, return
-        if (e.which !== 27 || this.modalTarget.getAttribute("aria-hidden") === "true") {
+        if (
+            e.which !== 27 ||
+            this.modalTarget.getAttribute("aria-hidden") === "true"
+        ) {
             return;
         }
 
@@ -276,14 +333,12 @@ export class ModalController extends Stacks.StacksController {
      * Determines the correct dispatching element from a potential input
      * @param dispatcher The event or element to get the dispatcher from
      */
-    private getDispatcher(dispatcher: Event|Element|null = null) : Element {
+    private getDispatcher(dispatcher: Event | Element | null = null): Element {
         if (dispatcher instanceof Event) {
             return <Element>dispatcher.target;
-        }
-        else if (dispatcher instanceof Element) {
+        } else if (dispatcher instanceof Element) {
             return dispatcher;
-        }
-        else {
+        } else {
             return this.element;
         }
     }
@@ -311,7 +366,10 @@ export function hideModal(element: HTMLElement) {
  * @param show whether to force show/hide the modal; toggles the modal if left undefined
  */
 function toggleModal(element: HTMLElement, show?: boolean | undefined) {
-    const controller = Stacks.application.getControllerForElementAndIdentifier(element, "s-modal") as ModalController;
+    const controller = Stacks.application.getControllerForElementAndIdentifier(
+        element,
+        "s-modal"
+    ) as ModalController;
 
     if (!controller) {
         throw "Unable to get s-modal controller from element";

--- a/lib/ts/controllers/s-navigation-tablist.ts
+++ b/lib/ts/controllers/s-navigation-tablist.ts
@@ -1,7 +1,6 @@
 import * as Stacks from "../stacks";
 
 export class TabListController extends Stacks.StacksController {
-
     private boundSelectTab!: (event: MouseEvent) => void;
     private boundHandleKeydown!: (event: KeyboardEvent) => void;
 
@@ -59,8 +58,12 @@ export class TabListController extends Stacks.StacksController {
         }
 
         // Use circular navigation when users go past the first or last tab.
-        if (tabIndex < 0) { tabIndex = tabs.length - 1; }
-        if (tabIndex >= tabs.length) { tabIndex = 0; }
+        if (tabIndex < 0) {
+            tabIndex = tabs.length - 1;
+        }
+        if (tabIndex >= tabs.length) {
+            tabIndex = 0;
+        }
 
         tabElement = tabs[tabIndex];
         this.switchToTab(tabElement);
@@ -74,23 +77,30 @@ export class TabListController extends Stacks.StacksController {
      * the s-navigation-tablist:select event is prevented.
      */
     private switchToTab(newTab: HTMLElement) {
-
         const oldTab = this.selectedTab;
-        if (oldTab === newTab) { return; }
+        if (oldTab === newTab) {
+            return;
+        }
 
-        if (this.triggerEvent("select", { oldTab, newTab }).defaultPrevented) { return; }
+        if (this.triggerEvent("select", { oldTab, newTab }).defaultPrevented) {
+            return;
+        }
 
         this.selectedTab = newTab;
         this.triggerEvent("selected", { oldTab, newTab });
     }
-    
+
     /**
      * Returns the currently selected tab or null if no tabs are selected.
      */
-    public get selectedTab() : HTMLElement | null {
-        return this.tabTargets.find(e => e.getAttribute("aria-selected") === "true") || null;
+    public get selectedTab(): HTMLElement | null {
+        return (
+            this.tabTargets.find(
+                (e) => e.getAttribute("aria-selected") === "true"
+            ) || null
+        );
     }
-    
+
     /**
      * Switches the tablist to the provided tab, updating the tabs and panels
      * to reflect the change.
@@ -99,19 +109,19 @@ export class TabListController extends Stacks.StacksController {
      */
     public set selectedTab(selectedTab: HTMLElement | null) {
         for (const tab of this.tabTargets) {
-            const panelId = tab.getAttribute('aria-controls');
+            const panelId = tab.getAttribute("aria-controls");
             const panel = panelId ? document.getElementById(panelId) : null;
 
             if (tab === selectedTab) {
-                tab.classList.add('is-selected');
-                tab.setAttribute('aria-selected', 'true');
-                tab.removeAttribute('tabindex');
-                panel?.classList.remove('d-none');
+                tab.classList.add("is-selected");
+                tab.setAttribute("aria-selected", "true");
+                tab.removeAttribute("tabindex");
+                panel?.classList.remove("d-none");
             } else {
-                tab.classList.remove('is-selected');
-                tab.setAttribute('aria-selected', 'false');
-                tab.setAttribute('tabindex', '-1');
-                panel?.classList.add('d-none');
+                tab.classList.remove("is-selected");
+                tab.setAttribute("aria-selected", "false");
+                tab.setAttribute("tabindex", "-1");
+                panel?.classList.add("d-none");
             }
         }
     }

--- a/lib/ts/controllers/s-popover.ts
+++ b/lib/ts/controllers/s-popover.ts
@@ -1,8 +1,12 @@
-import { createPopper, Placement } from '@popperjs/core';
-import type * as Popper from '@popperjs/core';
+import { createPopper, Placement } from "@popperjs/core";
+import type * as Popper from "@popperjs/core";
 import * as Stacks from "../stacks";
 
-type OutsideClickBehavior = "always" | "never" | "if-in-viewport" | "after-dismissal";
+type OutsideClickBehavior =
+    | "always"
+    | "never"
+    | "if-in-viewport"
+    | "after-dismissal";
 
 export abstract class BasePopoverController extends Stacks.StacksController {
     private popper!: Popper.Instance;
@@ -31,7 +35,9 @@ export abstract class BasePopoverController extends Stacks.StacksController {
      */
     get isVisible() {
         const popoverElement = this.popoverElement;
-        return popoverElement ? popoverElement.classList.contains("is-visible") : false;
+        return popoverElement
+            ? popoverElement.classList.contains("is-visible")
+            : false;
     }
 
     /**
@@ -39,28 +45,43 @@ export abstract class BasePopoverController extends Stacks.StacksController {
      */
     get isInViewport() {
         const element = this.popoverElement;
-        if (!this.isVisible || !element) { return false; }
+        if (!this.isVisible || !element) {
+            return false;
+        }
 
         // From https://stackoverflow.com/a/5354536.  Theoretically, this could be calculated using Popper's detectOverflow function,
         // but it's unclear how to access that with our current configuration.
 
         const rect = element.getBoundingClientRect();
-        const viewHeight = Math.max(document.documentElement.clientHeight, window.innerHeight);
-        const viewWidth = Math.max(document.documentElement.clientWidth, window.innerWidth);
+        const viewHeight = Math.max(
+            document.documentElement.clientHeight,
+            window.innerHeight
+        );
+        const viewWidth = Math.max(
+            document.documentElement.clientWidth,
+            window.innerWidth
+        );
 
-        return rect.bottom > 0 && rect.top < viewHeight && rect.right > 0 && rect.left < viewWidth;
+        return (
+            rect.bottom > 0 &&
+            rect.top < viewHeight &&
+            rect.right > 0 &&
+            rect.left < viewWidth
+        );
     }
 
     protected get shouldHideOnOutsideClick() {
-        const hideBehavior = <OutsideClickBehavior>this.data.get("hide-on-outside-click");
+        const hideBehavior = <OutsideClickBehavior>(
+            this.data.get("hide-on-outside-click")
+        );
         switch (hideBehavior) {
             case "after-dismissal":
             case "never":
                 return false;
             case "if-in-viewport":
-                    return this.isInViewport;
+                return this.isInViewport;
             default:
-                    return true;
+                return true;
         }
     }
 
@@ -97,21 +118,27 @@ export abstract class BasePopoverController extends Stacks.StacksController {
     /**
      * Toggles the visibility of the popover
      */
-    toggle(dispatcher: Event|Element|null = null) {
+    toggle(dispatcher: Event | Element | null = null) {
         this.isVisible ? this.hide(dispatcher) : this.show(dispatcher);
     }
 
     /**
      * Shows the popover if not already visible
      */
-    show(dispatcher: Event|Element|null = null) {
-        if (this.isVisible) { return; }
+    show(dispatcher: Event | Element | null = null) {
+        if (this.isVisible) {
+            return;
+        }
 
         const dispatcherElement = this.getDispatcher(dispatcher);
 
-        if (this.triggerEvent("show", {
-            dispatcher: dispatcherElement
-        }).defaultPrevented) { return; }
+        if (
+            this.triggerEvent("show", {
+                dispatcher: dispatcherElement,
+            }).defaultPrevented
+        ) {
+            return;
+        }
 
         if (!this.popper) {
             this.initializePopper();
@@ -128,14 +155,20 @@ export abstract class BasePopoverController extends Stacks.StacksController {
     /**
      * Hides the popover if not already hidden
      */
-    hide(dispatcher: Event|Element|null = null) {
-        if (!this.isVisible) { return; }
+    hide(dispatcher: Event | Element | null = null) {
+        if (!this.isVisible) {
+            return;
+        }
 
         const dispatcherElement = this.getDispatcher(dispatcher);
 
-        if (this.triggerEvent("hide", {
-            dispatcher: dispatcherElement
-        }).defaultPrevented) { return; }
+        if (
+            this.triggerEvent("hide", {
+                dispatcher: dispatcherElement,
+            }).defaultPrevented
+        ) {
+            return;
+        }
 
         this.popoverElement.classList.remove("is-visible");
 
@@ -148,7 +181,10 @@ export abstract class BasePopoverController extends Stacks.StacksController {
         }
 
         // on first interaction, hide-on-outside-click with value "after-dismissal" reverts to the default behavior
-        if (<OutsideClickBehavior>this.data.get("hide-on-outside-click") === "after-dismissal") {
+        if (
+            <OutsideClickBehavior>this.data.get("hide-on-outside-click") ===
+            "after-dismissal"
+        ) {
             this.data.delete("hide-on-outside-click");
         }
 
@@ -158,20 +194,20 @@ export abstract class BasePopoverController extends Stacks.StacksController {
     /**
      * Binds document events for this popover and fires the shown event
      */
-    protected shown(dispatcher: Element|null = null) {
+    protected shown(dispatcher: Element | null = null) {
         this.bindDocumentEvents();
         this.triggerEvent("shown", {
-            dispatcher: dispatcher
+            dispatcher: dispatcher,
         });
     }
 
     /**
      * Unbinds document events for this popover and fires the hidden event
      */
-    protected hidden(dispatcher: Element|null = null) {
+    protected hidden(dispatcher: Element | null = null) {
         this.unbindDocumentEvents();
         this.triggerEvent("hidden", {
-            dispatcher: dispatcher
+            dispatcher: dispatcher,
         });
     }
 
@@ -187,21 +223,21 @@ export abstract class BasePopoverController extends Stacks.StacksController {
      */
     private initializePopper() {
         this.popper = createPopper(this.referenceElement, this.popoverElement, {
-            placement: this.data.get("placement") as Placement || "bottom",
+            placement: (this.data.get("placement") as Placement) || "bottom",
             modifiers: [
                 {
                     name: "offset",
                     options: {
                         offset: [0, 10], // The entire popover should be 10px away from the element
-                    }
+                    },
                 },
                 {
                     name: "arrow",
                     options: {
-                        element: ".s-popover--arrow"
+                        element: ".s-popover--arrow",
                     },
                 },
-            ]
+            ],
         });
     }
 
@@ -215,14 +251,21 @@ export abstract class BasePopoverController extends Stacks.StacksController {
 
         // if there is an alternative reference selector and that element exists, use it (and throw if it isn't found)
         if (referenceSelector) {
-            this.referenceElement = <HTMLElement>this.element.querySelector(referenceSelector);
+            this.referenceElement = <HTMLElement>(
+                this.element.querySelector(referenceSelector)
+            );
 
             if (!this.referenceElement) {
-                throw "Unable to find element by reference selector: " + referenceSelector;
+                throw (
+                    "Unable to find element by reference selector: " +
+                    referenceSelector
+                );
             }
         }
 
-        const popoverId = this.referenceElement.getAttribute(this.popoverSelectorAttribute);
+        const popoverId = this.referenceElement.getAttribute(
+            this.popoverSelectorAttribute
+        );
 
         let popoverElement: HTMLElement | null = null;
 
@@ -230,7 +273,7 @@ export abstract class BasePopoverController extends Stacks.StacksController {
         if (popoverId) {
             popoverElement = document.getElementById(popoverId);
 
-            if (!popoverElement){
+            if (!popoverElement) {
                 throw `[${this.popoverSelectorAttribute}="{POPOVER_ID}"] required`;
             }
         }
@@ -250,14 +293,14 @@ export abstract class BasePopoverController extends Stacks.StacksController {
      * Determines the correct dispatching element from a potential input
      * @param dispatcher The event or element to get the dispatcher from
      */
-    protected getDispatcher(dispatcher: Event|Element|null = null) : Element {
+    protected getDispatcher(
+        dispatcher: Event | Element | null = null
+    ): Element {
         if (dispatcher instanceof Event) {
             return <Element>dispatcher.target;
-        }
-        else if (dispatcher instanceof Element) {
+        } else if (dispatcher instanceof Element) {
             return dispatcher;
-        }
-        else {
+        } else {
             return this.element;
         }
     }
@@ -278,12 +321,12 @@ export class PopoverController extends BasePopoverController {
     protected popoverSelectorAttribute = "aria-controls";
 
     private boundHideOnOutsideClick!: (event: MouseEvent) => void;
-    private boundHideOnEscapePress!:  (event: KeyboardEvent) => void;
+    private boundHideOnEscapePress!: (event: KeyboardEvent) => void;
 
     /**
      * Toggles optional classes and accessibility attributes in addition to BasePopoverController.shown
      */
-    protected override shown(dispatcher: Element|null = null) {
+    protected override shown(dispatcher: Element | null = null) {
         this.toggleOptionalClasses(true);
         this.toggleAccessibilityAttributes(true);
         super.shown(dispatcher);
@@ -292,12 +335,11 @@ export class PopoverController extends BasePopoverController {
     /**
      * Toggles optional classes and accessibility attributes in addition to BasePopoverController.hidden
      */
-    protected override hidden(dispatcher: Element|null = null) {
+    protected override hidden(dispatcher: Element | null = null) {
         this.toggleOptionalClasses(false);
         this.toggleAccessibilityAttributes(false);
         super.hidden(dispatcher);
     }
-
 
     /**
      * Initializes accessibility attributes in addition to BasePopoverController.connect
@@ -312,8 +354,10 @@ export class PopoverController extends BasePopoverController {
      * Binds global events to the document for hiding popovers on user interaction
      */
     protected bindDocumentEvents() {
-        this.boundHideOnOutsideClick = this.boundHideOnOutsideClick || this.hideOnOutsideClick.bind(this);
-        this.boundHideOnEscapePress = this.boundHideOnEscapePress || this.hideOnEscapePress.bind(this);
+        this.boundHideOnOutsideClick =
+            this.boundHideOnOutsideClick || this.hideOnOutsideClick.bind(this);
+        this.boundHideOnEscapePress =
+            this.boundHideOnEscapePress || this.hideOnEscapePress.bind(this);
 
         document.addEventListener("mousedown", this.boundHideOnOutsideClick);
         document.addEventListener("keyup", this.boundHideOnEscapePress);
@@ -335,10 +379,15 @@ export class PopoverController extends BasePopoverController {
         const target = <Node>e.target;
         // check if the document was clicked inside either the reference element or the popover itself
         // note: .contains also returns true if the node itself matches the target element
-        if (this.shouldHideOnOutsideClick && !this.referenceElement.contains(target) && !this.popoverElement.contains(target) && document.body.contains(target)) {
+        if (
+            this.shouldHideOnOutsideClick &&
+            !this.referenceElement.contains(target) &&
+            !this.popoverElement.contains(target) &&
+            document.body.contains(target)
+        ) {
             this.hide(e);
         }
-    };
+    }
 
     /**
      * Forces the popover to hide if the user presses escape while it, one of its childen, or the reference element are focused
@@ -357,7 +406,7 @@ export class PopoverController extends BasePopoverController {
         }
 
         this.hide(e);
-    };
+    }
 
     /**
      * Toggles all classes on the originating element based on the `class-toggle` data
@@ -380,7 +429,8 @@ export class PopoverController extends BasePopoverController {
      * @param {boolean=} show - A boolean indicating whether this is being triggered by a show or hide.
      */
     private toggleAccessibilityAttributes(show?: boolean) {
-        const expandedValue = show?.toString() || this.referenceElement.ariaExpanded || "false";
+        const expandedValue =
+            show?.toString() || this.referenceElement.ariaExpanded || "false";
         this.referenceElement.ariaExpanded = expandedValue;
         this.referenceElement.setAttribute("aria-expanded", expandedValue);
     }
@@ -447,21 +497,26 @@ export interface PopoverOptions {
  *                If the popover does not have a parent element, it will be inserted as a immediately after the reference element.
  * @param options an optional collection of options to use when configuring the popover.
  */
-export function attachPopover(element: Element, popover: Element | string, options?: PopoverOptions)
-    {
+export function attachPopover(
+    element: Element,
+    popover: Element | string,
+    options?: PopoverOptions
+) {
     const { referenceElement, popover: existingPopover } = getPopover(element);
 
     if (existingPopover) {
-        throw `element already has popover with id="${existingPopover.id}"`
+        throw `element already has popover with id="${existingPopover.id}"`;
     }
 
     if (!referenceElement) {
-        throw `element has invalid data-s-popover-reference-selector attribute`
+        throw `element has invalid data-s-popover-reference-selector attribute`;
     }
 
-    if (typeof popover === 'string') {
+    if (typeof popover === "string") {
         // eslint-disable-next-line no-unsanitized/method
-        const elements = document.createRange().createContextualFragment(popover).children;
+        const elements = document
+            .createRange()
+            .createContextualFragment(popover).children;
         if (elements.length !== 1) {
             throw "popover should contain a single element";
         }
@@ -471,7 +526,7 @@ export function attachPopover(element: Element, popover: Element | string, optio
     const existingId = referenceElement.getAttribute("aria-controls");
     let popoverId = popover.id;
 
-    if (!popover.classList.contains('s-popover')) {
+    if (!popover.classList.contains("s-popover")) {
         throw `popover should have the "s-popover" class but had class="${popover.className}"`;
     }
 
@@ -480,7 +535,8 @@ export function attachPopover(element: Element, popover: Element | string, optio
     }
 
     if (!popoverId) {
-        popoverId = "--stacks-s-popover-" + Math.random().toString(36).substring(2, 10);
+        popoverId =
+            "--stacks-s-popover-" + Math.random().toString(36).substring(2, 10);
         popover.id = popoverId;
     }
 
@@ -496,7 +552,10 @@ export function attachPopover(element: Element, popover: Element | string, optio
 
     if (options) {
         if (options.toggleOnClick) {
-            referenceElement.setAttribute("data-action", "click->s-popover#toggle");
+            referenceElement.setAttribute(
+                "data-action",
+                "click->s-popover#toggle"
+            );
         }
         if (options.placement) {
             element.setAttribute("data-s-popover-placement", options.placement);
@@ -513,7 +572,8 @@ export function attachPopover(element: Element, popover: Element | string, optio
  * @returns The popover that was attached to the element.
  */
 export function detachPopover(element: Element) {
-    const { isPopover, controller, referenceElement, popover } = getPopover(element);
+    const { isPopover, controller, referenceElement, popover } =
+        getPopover(element);
 
     // Hide the popover so its events fire.
     controller?.hide();
@@ -534,13 +594,13 @@ export function detachPopover(element: Element) {
 
 interface GetPopoverResult {
     /** indicates whether or not the element has s-popover in its `data-controller` class */
-    isPopover: boolean,
+    isPopover: boolean;
     /** element's existing `PopoverController` or null it it has not been configured yet */
-    controller: PopoverController | null,
+    controller: PopoverController | null;
     /** popover's reference element as would live in `referenceSelector` or null if invalid */
-    referenceElement: Element | null,
+    referenceElement: Element | null;
     /** popover currently associated with the controller, or null if one does not exist in the DOM */
-    popover: HTMLElement | null
+    popover: HTMLElement | null;
 }
 
 /**
@@ -549,11 +609,21 @@ interface GetPopoverResult {
  * @param element An element that may have `data-controller="s-popover"`.
  */
 function getPopover(element: Element): GetPopoverResult {
-    const isPopover = element.getAttribute("data-controller")?.includes("s-popover") || false;
-    const controller = Stacks.application.getControllerForElementAndIdentifier(element, "s-popover") as PopoverController;
-    const referenceSelector = element.getAttribute("data-s-popover-reference-selector");
-    const referenceElement = referenceSelector ? element.querySelector(referenceSelector) : element;
-    const popoverId = referenceElement ? referenceElement.getAttribute("aria-controls") : null;
+    const isPopover =
+        element.getAttribute("data-controller")?.includes("s-popover") || false;
+    const controller = Stacks.application.getControllerForElementAndIdentifier(
+        element,
+        "s-popover"
+    ) as PopoverController;
+    const referenceSelector = element.getAttribute(
+        "data-s-popover-reference-selector"
+    );
+    const referenceElement = referenceSelector
+        ? element.querySelector(referenceSelector)
+        : element;
+    const popoverId = referenceElement
+        ? referenceElement.getAttribute("aria-controls")
+        : null;
     const popover = popoverId ? document.getElementById(popoverId) : null;
     return { isPopover, controller, referenceElement, popover };
 }
@@ -564,12 +634,18 @@ function getPopover(element: Element): GetPopoverResult {
  * @param controllerName The name of the controller to add/remove
  * @param include Whether to add the controllerName value
  */
-function toggleController(el: Element, controllerName: string, include: boolean) {
-    const controllers = new Set(el.getAttribute('data-controller')?.split(/\s+/));
+function toggleController(
+    el: Element,
+    controllerName: string,
+    include: boolean
+) {
+    const controllers = new Set(
+        el.getAttribute("data-controller")?.split(/\s+/)
+    );
     if (include) {
         controllers.add(controllerName);
     } else {
         controllers.delete(controllerName);
     }
-    el.setAttribute('data-controller', Array.from(controllers).join(' '))
+    el.setAttribute("data-controller", Array.from(controllers).join(" "));
 }

--- a/lib/ts/controllers/s-table.ts
+++ b/lib/ts/controllers/s-table.ts
@@ -198,7 +198,7 @@ function buildIndexOrGetCellSlot(
     findCell?: HTMLTableCellElement
 ) {
     const index = [];
-    let curRow = section.children[0];
+    let curRow: Element | null = section.children[0];
 
     // the elements of these two arrays are synchronized; the first array contains table cell elements,
     // the second one contains a number that indicates for how many more rows this elements will
@@ -253,7 +253,7 @@ function buildIndexOrGetCellSlot(
             }
             curSlot++;
         }
-        if (curRow?.nextElementSibling) {
+        if (curRow) {
             curRow = curRow.nextElementSibling;
         }
     }

--- a/lib/ts/controllers/s-table.ts
+++ b/lib/ts/controllers/s-table.ts
@@ -7,19 +7,29 @@ export class TableController extends Stacks.StacksController {
 
     setCurrentSort(headElem: Element, direction: "asc" | "desc" | "none") {
         if (["asc", "desc", "none"].indexOf(direction) < 0) {
-            throw "direction must be one of asc, desc, or none"
+            throw "direction must be one of asc, desc, or none";
         }
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const controller = this;
         this.columnTargets.forEach(function (target) {
             const isCurrrent = target === headElem;
 
-            target.classList.toggle("is-sorted", isCurrrent && direction !== "none");
+            target.classList.toggle(
+                "is-sorted",
+                isCurrrent && direction !== "none"
+            );
 
-            target.querySelectorAll(".js-sorting-indicator").forEach(function (icon) {
-                const visible = isCurrrent ? direction : "none";
-                icon.classList.toggle("d-none", !icon.classList.contains("js-sorting-indicator-" + visible));
-            });
+            target
+                .querySelectorAll(".js-sorting-indicator")
+                .forEach(function (icon) {
+                    const visible = isCurrrent ? direction : "none";
+                    icon.classList.toggle(
+                        "d-none",
+                        !icon.classList.contains(
+                            "js-sorting-indicator-" + visible
+                        )
+                    );
+                });
 
             if (!isCurrrent || direction === "none") {
                 controller.removeElementData(target, "sort-direction");
@@ -27,7 +37,7 @@ export class TableController extends Stacks.StacksController {
                 controller.setElementData(target, "sort-direction", direction);
             }
         });
-    };
+    }
 
     sort(evt: Event) {
         // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -42,7 +52,8 @@ export class TableController extends Stacks.StacksController {
         // the column slot number of the clicked header
         const colno = getCellSlot(colHead);
 
-        if (colno < 0) { // this shouldn't happen if the clicked element is actually a column head
+        if (colno < 0) {
+            // this shouldn't happen if the clicked element is actually a column head
             return;
         }
 
@@ -52,7 +63,8 @@ export class TableController extends Stacks.StacksController {
 
         // the default behavior when clicking a header is to sort by this column in ascending
         // direction, *unless* it is already sorted that way
-        const direction = this.getElementData(colHead, "sort-direction") === "asc" ? -1 : 1;
+        const direction =
+            this.getElementData(colHead, "sort-direction") === "asc" ? -1 : 1;
 
         const rows = Array.from(table.tBodies[0].rows);
 
@@ -82,9 +94,12 @@ export class TableController extends Stacks.StacksController {
             // unless the to-be-sorted-by value is explicitly provided on the element via this attribute,
             // the value we're using is the cell's text, trimmed of any whitespace
             const explicit = controller.getElementData(cell, "sort-val");
-            const d = typeof explicit === "string" ? explicit : cell.textContent?.trim() ?? '';
+            const d =
+                typeof explicit === "string"
+                    ? explicit
+                    : cell.textContent?.trim() ?? "";
 
-            if ((d !== "") && (`${parseInt(d, 10)}` !== d)) {
+            if (d !== "" && `${parseInt(d, 10)}` !== d) {
                 anyNonInt = true;
             }
             data.push([d, index]);
@@ -94,7 +109,10 @@ export class TableController extends Stacks.StacksController {
         // having the lowest possible value (i.e. sorted to the top if ascending, bottom if descending)
         if (!anyNonInt) {
             data.forEach(function (tuple) {
-                tuple[0] = tuple[0] === "" ? Number.MIN_VALUE : parseInt(tuple[0] as string, 10);
+                tuple[0] =
+                    tuple[0] === ""
+                        ? Number.MIN_VALUE
+                        : parseInt(tuple[0] as string, 10);
             });
         }
 
@@ -129,26 +147,35 @@ export class TableController extends Stacks.StacksController {
         // will cause sorting in descending direction
         this.setCurrentSort(colHead, direction === 1 ? "asc" : "desc");
     }
-
 }
 
-function buildIndex(section: HTMLTableSectionElement): HTMLTableCellElement[][] {
+function buildIndex(
+    section: HTMLTableSectionElement
+): HTMLTableCellElement[][] {
     const result = buildIndexOrGetCellSlot(section);
     if (!(result instanceof Array)) {
-        throw "shouldn't happen"
+        throw "shouldn't happen";
     }
     return result;
 }
 
 function getCellSlot(cell: HTMLTableCellElement): number {
-    if (!(cell.parentElement && cell.parentElement.parentElement instanceof HTMLTableSectionElement)) {
-        throw "invalid table"
+    if (
+        !(
+            cell.parentElement &&
+            cell.parentElement.parentElement instanceof HTMLTableSectionElement
+        )
+    ) {
+        throw "invalid table";
     }
-    const result = buildIndexOrGetCellSlot(cell.parentElement.parentElement, cell);
+    const result = buildIndexOrGetCellSlot(
+        cell.parentElement.parentElement,
+        cell
+    );
     if (typeof result !== "number") {
-        throw "shouldn't happen"
+        throw "shouldn't happen";
     }
-    return result
+    return result;
 }
 
 // Just because a <td> is the 4th *child* of its <tr> doesn't mean it belongs to the 4th *column*
@@ -166,7 +193,10 @@ function getCellSlot(cell: HTMLTableCellElement): number {
 //
 // If the second argument is given, it's a <td> or <th> that we're trying to find, and the algorithm
 // stops as soon as it has found it and the function returns its slot number.
-function buildIndexOrGetCellSlot(section: HTMLTableSectionElement, findCell?: HTMLTableCellElement) {
+function buildIndexOrGetCellSlot(
+    section: HTMLTableSectionElement,
+    findCell?: HTMLTableCellElement
+) {
     const index = [];
     let curRow = section.children[0];
 
@@ -177,13 +207,22 @@ function buildIndexOrGetCellSlot(section: HTMLTableSectionElement, findCell?: HT
     const growingRowsLeft: number[] = [];
 
     // continue while we have actual <tr>'s left *or* we still have rowspan'ed elements that aren't done
-    while (curRow || growingRowsLeft.some(function (e) { return e !== 0; })) {
+    while (
+        curRow ||
+        growingRowsLeft.some(function (e) {
+            return e !== 0;
+        })
+    ) {
         const curIndexRow: HTMLTableCellElement[] = [];
         index.push(curIndexRow);
 
         let curSlot = 0;
         if (curRow) {
-            for (let curCellInd = 0; curCellInd < curRow.children.length; curCellInd++) {
+            for (
+                let curCellInd = 0;
+                curCellInd < curRow.children.length;
+                curCellInd++
+            ) {
                 while (growingRowsLeft[curSlot]) {
                     growingRowsLeft[curSlot]--;
                     curIndexRow[curSlot] = growing[curSlot];
@@ -191,7 +230,7 @@ function buildIndexOrGetCellSlot(section: HTMLTableSectionElement, findCell?: HT
                 }
                 const cell = curRow.children[curCellInd];
                 if (!(cell instanceof HTMLTableCellElement)) {
-                    throw "invalid table"
+                    throw "invalid table";
                 }
                 if (getComputedStyle(cell).display === "none") {
                     continue;
@@ -218,5 +257,7 @@ function buildIndexOrGetCellSlot(section: HTMLTableSectionElement, findCell?: HT
             curRow = curRow.nextElementSibling;
         }
     }
-    return findCell ? -1 : index; /* if findCell was given but we end up here, that means it isn't in this section */
+    return findCell
+        ? -1
+        : index; /* if findCell was given but we end up here, that means it isn't in this section */
 }

--- a/lib/ts/controllers/s-table.ts
+++ b/lib/ts/controllers/s-table.ts
@@ -82,7 +82,7 @@ export class TableController extends Stacks.StacksController {
             // unless the to-be-sorted-by value is explicitly provided on the element via this attribute,
             // the value we're using is the cell's text, trimmed of any whitespace
             const explicit = controller.getElementData(cell, "sort-val");
-            const d = typeof explicit === "string" ? explicit : cell.textContent!.trim();
+            const d = typeof explicit === "string" ? explicit : cell.textContent?.trim() ?? '';
 
             if ((d !== "") && (`${parseInt(d, 10)}` !== d)) {
                 anyNonInt = true;
@@ -117,7 +117,7 @@ export class TableController extends Stacks.StacksController {
         // this is the actual reordering of the table rows
         data.forEach(function (tup) {
             const row = rows[tup[1]];
-            row.parentElement!.removeChild(row);
+            row.parentElement?.removeChild(row);
             if (firstBottomRow) {
                 tbody.insertBefore(row, firstBottomRow);
             } else {
@@ -214,8 +214,8 @@ function buildIndexOrGetCellSlot(section: HTMLTableSectionElement, findCell?: HT
             }
             curSlot++;
         }
-        if (curRow) {
-            curRow = curRow.nextElementSibling!;
+        if (curRow?.nextElementSibling) {
+            curRow = curRow.nextElementSibling;
         }
     }
     return findCell ? -1 : index; /* if findCell was given but we end up here, that means it isn't in this section */

--- a/lib/ts/controllers/s-tooltip.ts
+++ b/lib/ts/controllers/s-tooltip.ts
@@ -45,9 +45,13 @@ export class TooltipController extends BasePopoverController {
      * Attempts to show the tooltip popover so long as no other Stacks-managed popover is
      * present on the page.
      */
-    show(dispatcher: Event|Element|null = null) {
+    show(dispatcher: Event | Element | null = null) {
         // check and see if this controller coexists with a popover
-        const controller = Stacks.application.getControllerForElementAndIdentifier(this.element, "s-popover");
+        const controller =
+            Stacks.application.getControllerForElementAndIdentifier(
+                this.element,
+                "s-popover"
+            );
 
         // if the controller exists and already has a visible popover, don't show the tooltip
         if (controller && (<PopoverController>controller).isVisible) {
@@ -62,7 +66,10 @@ export class TooltipController extends BasePopoverController {
      */
     scheduleShow(dispatcher: Event | Element | null = null) {
         window.clearTimeout(this.activeTimeout);
-        this.activeTimeout = window.setTimeout(() => this.show(dispatcher), 300);
+        this.activeTimeout = window.setTimeout(
+            () => this.show(dispatcher),
+            300
+        );
     }
 
     /**
@@ -70,13 +77,16 @@ export class TooltipController extends BasePopoverController {
      */
     scheduleHide(dispatcher: Event | Element | null = null) {
         window.clearTimeout(this.activeTimeout);
-        this.activeTimeout = window.setTimeout(() => super.hide(dispatcher), 100);
+        this.activeTimeout = window.setTimeout(
+            () => super.hide(dispatcher),
+            100
+        );
     }
 
     /**
      * Cancels the activeTimeout
      */
-     clearActiveTimeout() {
+    clearActiveTimeout() {
         clearTimeout(this.activeTimeout);
     }
 
@@ -84,13 +94,14 @@ export class TooltipController extends BasePopoverController {
      * Applies data-s-tooltip-html-title and title attributes.
      */
     applyTitleAttributes() {
-
         let content: Node;
 
         const htmlTitle = this.data.get("html-title");
         if (htmlTitle) {
             // eslint-disable-next-line no-unsanitized/method
-            content = document.createRange().createContextualFragment(htmlTitle);
+            content = document
+                .createRange()
+                .createContextualFragment(htmlTitle);
         } else {
             const plainTitle = this.element.getAttribute("title");
             if (plainTitle) {
@@ -135,7 +146,10 @@ export class TooltipController extends BasePopoverController {
         if (arrow) {
             popover.appendChild(arrow);
         } else {
-            popover.insertAdjacentHTML("beforeend", `<div class="s-popover--arrow"></div>`);
+            popover.insertAdjacentHTML(
+                "beforeend",
+                `<div class="s-popover--arrow"></div>`
+            );
         }
 
         this.scheduleUpdate();
@@ -148,7 +162,8 @@ export class TooltipController extends BasePopoverController {
      * the page.
      */
     protected bindDocumentEvents() {
-        this.boundHideIfWithin = this.boundHideIfWithin || this.hideIfWithin.bind(this);
+        this.boundHideIfWithin =
+            this.boundHideIfWithin || this.hideIfWithin.bind(this);
 
         document.addEventListener("s-popover:shown", this.boundHideIfWithin);
     }
@@ -186,10 +201,13 @@ export class TooltipController extends BasePopoverController {
     /**
      * Binds mouse events to show/hide on reference element hover
      */
-     private bindKeyboardEvents() {
-        this.boundScheduleShow = this.boundScheduleShow || this.scheduleShow.bind(this);
+    private bindKeyboardEvents() {
+        this.boundScheduleShow =
+            this.boundScheduleShow || this.scheduleShow.bind(this);
         this.boundHide = this.boundHide || this.scheduleHide.bind(this);
-        this.boundHideOnEscapeKeyEvent = this.boundHideOnEscapeKeyEvent || this.hideOnEscapeKeyEvent.bind(this);
+        this.boundHideOnEscapeKeyEvent =
+            this.boundHideOnEscapeKeyEvent ||
+            this.hideOnEscapeKeyEvent.bind(this);
 
         this.referenceElement.addEventListener("focus", this.boundScheduleShow);
         this.referenceElement.addEventListener("blur", this.boundHide);
@@ -198,24 +216,34 @@ export class TooltipController extends BasePopoverController {
     /**
      * Unbinds all mouse events
      */
-     private unbindKeyboardEvents() {
-        this.referenceElement.removeEventListener("focus", this.boundScheduleShow);
+    private unbindKeyboardEvents() {
+        this.referenceElement.removeEventListener(
+            "focus",
+            this.boundScheduleShow
+        );
         this.referenceElement.removeEventListener("blur", this.boundHide);
         document.removeEventListener("keyup", this.boundHideOnEscapeKeyEvent);
     }
-
 
     /**
      * Binds mouse events to show/hide on reference element hover
      */
     private bindMouseEvents() {
-        this.boundScheduleShow = this.boundScheduleShow || this.scheduleShow.bind(this);
+        this.boundScheduleShow =
+            this.boundScheduleShow || this.scheduleShow.bind(this);
         this.boundHide = this.boundHide || this.scheduleHide.bind(this);
-        this.boundClearActiveTimeout = this.boundClearActiveTimeout || this.clearActiveTimeout.bind(this);
+        this.boundClearActiveTimeout =
+            this.boundClearActiveTimeout || this.clearActiveTimeout.bind(this);
 
-        this.referenceElement.addEventListener("mouseover", this.boundScheduleShow);
+        this.referenceElement.addEventListener(
+            "mouseover",
+            this.boundScheduleShow
+        );
         this.referenceElement.addEventListener("mouseout", this.boundHide);
-        this.popoverElement.addEventListener("mouseover", this.boundClearActiveTimeout);
+        this.popoverElement.addEventListener(
+            "mouseover",
+            this.boundClearActiveTimeout
+        );
         this.popoverElement.addEventListener("mouseout", this.boundHide);
     }
 
@@ -223,11 +251,20 @@ export class TooltipController extends BasePopoverController {
      * Unbinds all mouse events
      */
     private unbindMouseEvents() {
-        this.referenceElement.removeEventListener("mouseover", this.boundScheduleShow);
+        this.referenceElement.removeEventListener(
+            "mouseover",
+            this.boundScheduleShow
+        );
         this.referenceElement.removeEventListener("mouseout", this.boundHide);
-        this.referenceElement.removeEventListener("focus", this.boundScheduleShow);
+        this.referenceElement.removeEventListener(
+            "focus",
+            this.boundScheduleShow
+        );
         this.referenceElement.removeEventListener("blur", this.boundHide);
-        this.popoverElement.removeEventListener("mouseover", this.boundClearActiveTimeout);
+        this.popoverElement.removeEventListener(
+            "mouseover",
+            this.boundClearActiveTimeout
+        );
         this.popoverElement.removeEventListener("mouseout", this.boundHide);
     }
 
@@ -236,7 +273,9 @@ export class TooltipController extends BasePopoverController {
      */
     private static generateId() {
         // generate a random number, then convert to a well formatted string
-        return "--stacks-s-tooltip-" + Math.random().toString(36).substring(2, 10);
+        return (
+            "--stacks-s-tooltip-" + Math.random().toString(36).substring(2, 10)
+        );
     }
 }
 
@@ -246,7 +285,11 @@ export class TooltipController extends BasePopoverController {
  * @param html An HTML string to populate the tooltip with.
  * @param options Options for rendering the tooltip.
  */
-export function setTooltipHtml(element: Element, html: string, options?: TooltipOptions) {
+export function setTooltipHtml(
+    element: Element,
+    html: string,
+    options?: TooltipOptions
+) {
     element.setAttribute("data-s-tooltip-html-title", html);
     element.removeAttribute("title");
     applyOptionsAndTitleAttributes(element, options);
@@ -258,7 +301,11 @@ export function setTooltipHtml(element: Element, html: string, options?: Tooltip
  * @param text A plain text string to populate the tooltip with.
  * @param options Options for rendering the tooltip.
  */
-export function setTooltipText(element: Element, text: string, options?: TooltipOptions) {
+export function setTooltipText(
+    element: Element,
+    text: string,
+    options?: TooltipOptions
+) {
     element.setAttribute("title", text);
     element.removeAttribute("data-s-tooltip-html-title");
     applyOptionsAndTitleAttributes(element, options);
@@ -269,17 +316,28 @@ export function setTooltipText(element: Element, text: string, options?: Tooltip
  * @param element The element to add a tooltip to.
  * @param options Options for rendering the tooltip.
  */
-function applyOptionsAndTitleAttributes(element: Element, options?: TooltipOptions) {
+function applyOptionsAndTitleAttributes(
+    element: Element,
+    options?: TooltipOptions
+) {
     if (options && options.placement) {
         element.setAttribute("data-s-tooltip-placement", options.placement);
     }
 
-    const controller = <TooltipController>Stacks.application.getControllerForElementAndIdentifier(element, "s-tooltip");
+    const controller = <TooltipController>(
+        Stacks.application.getControllerForElementAndIdentifier(
+            element,
+            "s-tooltip"
+        )
+    );
 
     if (controller) {
         controller.applyTitleAttributes();
     } else {
         const dataController = element.getAttribute("data-controller");
-        element.setAttribute("data-controller", `${dataController ? dataController : ""} s-tooltip`);
+        element.setAttribute(
+            "data-controller",
+            `${dataController ? dataController : ""} s-tooltip`
+        );
     }
 }

--- a/lib/ts/controllers/s-tooltip.ts
+++ b/lib/ts/controllers/s-tooltip.ts
@@ -173,7 +173,7 @@ export class TooltipController extends BasePopoverController {
      * @param event An event object from s-popover:shown
      */
     private hideIfWithin(event: Event) {
-        if ((<Element>event.target!).contains(this.referenceElement)) {
+        if ((<Element>event.target).contains(this.referenceElement)) {
             this.scheduleHide();
         }
     }

--- a/lib/ts/controllers/s-uploader.ts
+++ b/lib/ts/controllers/s-uploader.ts
@@ -4,7 +4,7 @@ interface FilePreview {
     data?: string | ArrayBuffer;
     name: string;
     type: string;
-};
+}
 
 export class UploaderController extends Stacks.StacksController {
     static targets = ["input", "previews", "uploader"];
@@ -44,33 +44,40 @@ export class UploaderController extends Stacks.StacksController {
         }
 
         const count = this.inputTarget.files.length;
-            this.getDataURLs(this.inputTarget.files, UploaderController.FILE_DISPLAY_LIMIT)
-                .then((res: FilePreview[]) => {
-                    this.handleVisible(true);
-                    const hasMultipleFiles = res.length > 1;
+        this.getDataURLs(
+            this.inputTarget.files,
+            UploaderController.FILE_DISPLAY_LIMIT
+        )
+            .then((res: FilePreview[]) => {
+                this.handleVisible(true);
+                const hasMultipleFiles = res.length > 1;
 
-                    if (hasMultipleFiles) {
-                        const headingElement = document.createElement("div");
-                        headingElement.classList.add("s-uploader--previews-heading");
-                        headingElement.innerText = res.length < count ?
-                            `Showing ${res.length} of ${count} files` : `${count} items`;
-                        this.previewsTarget.appendChild(headingElement);
-                        this.previewsTarget.classList.add("has-multiple");
-                    } else {
-                        this.previewsTarget.classList.remove("has-multiple");
-                    }
-                    res.forEach((file) => this.addFilePreview(file));
-                    this.handleUploaderActive(true);
-                })
-                // TODO consider rendering an error message
-                .catch(() => null);
+                if (hasMultipleFiles) {
+                    const headingElement = document.createElement("div");
+                    headingElement.classList.add(
+                        "s-uploader--previews-heading"
+                    );
+                    headingElement.innerText =
+                        res.length < count
+                            ? `Showing ${res.length} of ${count} files`
+                            : `${count} items`;
+                    this.previewsTarget.appendChild(headingElement);
+                    this.previewsTarget.classList.add("has-multiple");
+                } else {
+                    this.previewsTarget.classList.remove("has-multiple");
+                }
+                res.forEach((file) => this.addFilePreview(file));
+                this.handleUploaderActive(true);
+            })
+            // TODO consider rendering an error message
+            .catch(() => null);
     }
 
     /**
      * Resets the Uploader to initial state
      */
     reset() {
-        this.inputTarget.value = '';
+        this.inputTarget.value = "";
         this.previewsTarget.innerHTML = "";
         this.handleVisible(false);
     }
@@ -81,28 +88,34 @@ export class UploaderController extends Stacks.StacksController {
      */
     private handleVisible(shouldPreview: boolean) {
         const { scope } = this.targets;
-        const hideElements = scope.findAllElements('[data-s-uploader-hide-on-input]');
-        const showElements = scope.findAllElements('[data-s-uploader-show-on-input]');
-        const enableElements = scope.findAllElements('[data-s-uploader-enable-on-input]');
+        const hideElements = scope.findAllElements(
+            "[data-s-uploader-hide-on-input]"
+        );
+        const showElements = scope.findAllElements(
+            "[data-s-uploader-show-on-input]"
+        );
+        const enableElements = scope.findAllElements(
+            "[data-s-uploader-enable-on-input]"
+        );
 
         if (shouldPreview) {
-            hideElements.forEach(el => {
+            hideElements.forEach((el) => {
                 el.classList.add("d-none");
             });
-            showElements.forEach(el => {
+            showElements.forEach((el) => {
                 el.classList.remove("d-none");
             });
-            enableElements.forEach(el => {
+            enableElements.forEach((el) => {
                 el.removeAttribute("disabled");
             });
         } else {
-            hideElements.forEach(el => {
+            hideElements.forEach((el) => {
                 el.classList.remove("d-none");
             });
-            showElements.forEach(el => {
+            showElements.forEach((el) => {
                 el.classList.add("d-none");
             });
-            enableElements.forEach(el => {
+            enableElements.forEach((el) => {
                 el.setAttribute("disabled", "true");
             });
             this.handleUploaderActive(false);
@@ -121,7 +134,7 @@ export class UploaderController extends Stacks.StacksController {
         const previewElement = document.createElement("div");
         let thumbElement;
 
-        if (file.type.match('image/*') && file.data) {
+        if (file.type.match("image/*") && file.data) {
             thumbElement = document.createElement("img");
             thumbElement.src = file.data.toString();
             thumbElement.alt = file.name;
@@ -133,7 +146,7 @@ export class UploaderController extends Stacks.StacksController {
         thumbElement.classList.add("s-uploader--preview-thumbnail");
         previewElement.appendChild(thumbElement);
         previewElement.classList.add("s-uploader--preview");
-        previewElement.setAttribute('data-filename', file.name);
+        previewElement.setAttribute("data-filename", file.name);
         this.previewsTarget.appendChild(previewElement);
     }
 
@@ -154,16 +167,19 @@ export class UploaderController extends Stacks.StacksController {
         const reader = new FileReader();
         const { name, size, type } = file;
 
-        if (size < UploaderController.MAX_FILE_SIZE && type.indexOf("image") > -1) {
+        if (
+            size < UploaderController.MAX_FILE_SIZE &&
+            type.indexOf("image") > -1
+        ) {
             return new Promise((resolve, reject) => {
-                reader.onload = evt => {
+                reader.onload = (evt) => {
                     const res = evt?.target?.result;
                     if (res) {
                         resolve({ data: res, name, type });
                     } else {
                         reject();
                     }
-                }
+                };
                 reader.readAsDataURL(file);
             });
         } else {
@@ -176,11 +192,14 @@ export class UploaderController extends Stacks.StacksController {
      * @param  {FileList|[]} files
      * @returns an array of FilePreview objects from a FileList
      */
-    private getDataURLs(files: FileList, limit: number): Promise<FilePreview[]> {
+    private getDataURLs(
+        files: FileList,
+        limit: number
+    ): Promise<FilePreview[]> {
         const promises = Array.from(files)
             .slice(0, Math.min(limit, files.length))
-            .map(f => this.fileToDataURL(f));
+            .map((f) => this.fileToDataURL(f));
 
         return Promise.all(promises);
     }
-};
+}

--- a/lib/ts/index.ts
+++ b/lib/ts/index.ts
@@ -1,6 +1,14 @@
-import '../css/stacks.less';
-import { ExpandableController, ModalController, PopoverController, TableController, TabListController, TooltipController, UploaderController } from './controllers';
-import { application, StacksApplication } from './stacks';
+import "../css/stacks.less";
+import {
+    ExpandableController,
+    ModalController,
+    PopoverController,
+    TableController,
+    TabListController,
+    TooltipController,
+    UploaderController,
+} from "./controllers";
+import { application, StacksApplication } from "./stacks";
 
 // register all built-in controllers
 application.register("s-expandable-control", ExpandableController);

--- a/lib/ts/stacks.ts
+++ b/lib/ts/stacks.ts
@@ -3,25 +3,31 @@ import * as Stimulus from "stimulus";
 export class StacksApplication extends Stimulus.Application {
     static _initializing = true;
 
-    load(...definitions: Stimulus.Definition[]): void
-    load(definitions: Stimulus.Definition[]): void
-    load(head: Stimulus.Definition | Stimulus.Definition[], ...rest: Stimulus.Definition[]) {
+    load(...definitions: Stimulus.Definition[]): void;
+    load(definitions: Stimulus.Definition[]): void;
+    load(
+        head: Stimulus.Definition | Stimulus.Definition[],
+        ...rest: Stimulus.Definition[]
+    ) {
         const definitions = Array.isArray(head) ? head : [head, ...rest];
 
         for (const definition of definitions) {
             const hasPrefix = /^s-/.test(definition.identifier);
             if (StacksApplication._initializing && !hasPrefix) {
-                throw "Stacks-created Stimulus controller names must start with \"s-\".";
+                throw 'Stacks-created Stimulus controller names must start with "s-".';
             }
             if (!StacksApplication._initializing && hasPrefix) {
-                throw "The \"s-\" prefix on Stimulus controller names is reserved for Stacks-created controllers.";
+                throw 'The "s-" prefix on Stimulus controller names is reserved for Stacks-created controllers.';
             }
         }
 
         super.load(definitions);
     }
 
-    static start(element?: Element, schema?: Stimulus.Schema): StacksApplication {
+    static start(
+        element?: Element,
+        schema?: Stimulus.Schema
+    ): StacksApplication {
         const application = new StacksApplication(element, schema);
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         application.start();
@@ -38,18 +44,26 @@ export const application: Stimulus.Application = StacksApplication.start();
 export class StacksController extends Stimulus.Controller {
     protected getElementData(element: Element, key: string) {
         return element.getAttribute("data-" + this.identifier + "-" + key);
-    };
+    }
     protected setElementData(element: Element, key: string, value: string) {
         element.setAttribute("data-" + this.identifier + "-" + key, value);
-    };
+    }
     protected removeElementData(element: Element, key: string) {
         element.removeAttribute("data-" + this.identifier + "-" + key);
-    };
-    protected triggerEvent<T>(eventName: string, detail?: T, optionalElement?: Element) {
+    }
+    protected triggerEvent<T>(
+        eventName: string,
+        detail?: T,
+        optionalElement?: Element
+    ) {
         const namespacedName = this.identifier + ":" + eventName;
-        let event : CustomEvent<T>;
+        let event: CustomEvent<T>;
         try {
-            event = new CustomEvent(namespacedName, {bubbles: true, cancelable: true, detail: detail});
+            event = new CustomEvent(namespacedName, {
+                bubbles: true,
+                cancelable: true,
+                detail: detail,
+            });
         } catch (ex) {
             // Internet Explorer
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -58,24 +72,30 @@ export class StacksController extends Stimulus.Controller {
         }
         (optionalElement || this.element).dispatchEvent(event);
         return event;
-    };
+    }
 }
 
 // ControllerDefinition/createController/addController is here to make
 // it easier to consume Stimulus from ES5 files (without classes)
-export interface ControllerDefinition { 
+export interface ControllerDefinition {
     [name: string]: unknown;
     targets?: string[];
 }
-export function createController(controllerDefinition: ControllerDefinition): typeof StacksController {
+export function createController(
+    controllerDefinition: ControllerDefinition
+): typeof StacksController {
     // eslint-disable-next-line no-prototype-builtins
     const Controller = controllerDefinition.hasOwnProperty("targets")
-        ? class Controller extends StacksController { static targets = controllerDefinition.targets ?? []}
+        ? class Controller extends StacksController {
+              static targets = controllerDefinition.targets ?? [];
+          }
         : class Controller extends StacksController {};
 
     for (const prop in controllerDefinition) {
         // eslint-disable-next-line no-prototype-builtins
-        const ownPropDescriptor = controllerDefinition.hasOwnProperty(prop) && Object.getOwnPropertyDescriptor(controllerDefinition, prop);
+        const ownPropDescriptor =
+            controllerDefinition.hasOwnProperty(prop) &&
+            Object.getOwnPropertyDescriptor(controllerDefinition, prop);
         if (prop !== "targets" && ownPropDescriptor) {
             Object.defineProperty(
                 Controller.prototype,

--- a/lib/ts/stacks.ts
+++ b/lib/ts/stacks.ts
@@ -63,23 +63,24 @@ export class StacksController extends Stimulus.Controller {
 
 // ControllerDefinition/createController/addController is here to make
 // it easier to consume Stimulus from ES5 files (without classes)
-export interface ControllerDefinition {
-    [name: string]: any;
+export interface ControllerDefinition { 
+    [name: string]: unknown;
     targets?: string[];
 }
 export function createController(controllerDefinition: ControllerDefinition): typeof StacksController {
     // eslint-disable-next-line no-prototype-builtins
     const Controller = controllerDefinition.hasOwnProperty("targets")
-        ? class Controller extends StacksController { static targets = controllerDefinition.targets! }
+        ? class Controller extends StacksController { static targets = controllerDefinition.targets ?? []}
         : class Controller extends StacksController {};
 
     for (const prop in controllerDefinition) {
         // eslint-disable-next-line no-prototype-builtins
-        if (prop !== "targets" && controllerDefinition.hasOwnProperty(prop)) {
+        const ownPropDescriptor = controllerDefinition.hasOwnProperty(prop) && Object.getOwnPropertyDescriptor(controllerDefinition, prop);
+        if (prop !== "targets" && ownPropDescriptor) {
             Object.defineProperty(
                 Controller.prototype,
                 prop,
-                Object.getOwnPropertyDescriptor(controllerDefinition, prop)!
+                ownPropDescriptor
             );
         }
     }

--- a/lib/ts/stacks.ts
+++ b/lib/ts/stacks.ts
@@ -92,8 +92,8 @@ export function createController(
         : class Controller extends StacksController {};
 
     for (const prop in controllerDefinition) {
-        // eslint-disable-next-line no-prototype-builtins
         const ownPropDescriptor =
+            // eslint-disable-next-line no-prototype-builtins
             controllerDefinition.hasOwnProperty(prop) &&
             Object.getOwnPropertyDescriptor(controllerDefinition, prop);
         if (prop !== "targets" && ownPropDescriptor) {

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "strict": true,
         "target": "es5",
-        "lib": ["dom", "es6", "dom.iterable", "scripthost"],  // es6 stuff is polyfilled by stimulus
+        "lib": ["dom", "es6", "dom.iterable", "scripthost"], // es6 stuff is polyfilled by stimulus
         "outDir": "../dist",
         "sourceMap": true,
         "moduleResolution": "node",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "test": "backstop test",
     "approve": "backstop approve",
     "prepublishOnly": "npm run build",
-    "lint:eslint": "eslint .",
-    "lint:prettier": "prettier --check . --end-of-line auto"
+    "lint": "concurrently -n w: npm:lint:*",
+    "lint:ts": "eslint ./lib/ts",
+    "lint:css": "stylelint ./lib/css",
+    "lint:format": "prettier --check ./lib"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
This PR fixes existing issues with our linters and formatters.
Running `npm run lint` now executes `stylelint`, `eslint` and `prettier --check` concurrently.
All checks are now passing in preparation for the [testing PR](https://github.com/StackExchange/Stacks/pull/1194) where we will start running linters (as well as tests) in a github workflow.

### Prettier and Style Formatting
I have experienced a strange behavior running prettier against our less files: the formatter will break the style syntax.
For the time being I have decided to exclude less files from prettier since they already get some format check with stylelint. We might want to revisit this decision though.