### PR TITLE
fix(button): fix base box-shadow styling

### DIFF
--- a/lib/css/components/buttons.less
+++ b/lib/css/components/buttons.less
@@ -4,7 +4,7 @@
     --_bu-bc: transparent;
     --_bu-bg: transparent;
     --_bu-br: var(--br-sm);
-    --_bu-bs: inset 0 var(--su-static1) 0 0 hsla(0, 0, 100%, 0.7);
+    --_bu-bs: none;
     --_bu-fc: var(--theme-button-color);
     --_bu-focus-ring: 0 0 0 var(--su-static4) var(--focus-ring);
     --_bu-fs: var(--fs-body1);
@@ -111,6 +111,8 @@
 
     // MODIFIERS
     &&__filled {
+        --_bu-bs: inset 0 var(--su-static1) 0 0 hsla(0, 0, 100%, 0.7);
+
         border-color: var(--_bu-filled-bc);
         background-color: var(--_bu-filled-bg);
         color: var(--_bu-filled-fc);


### PR DESCRIPTION
The recent refactor of button styling introduced a bug where an inner box shadow was set on the base button styling. This was an unintended change and, since these buttons featured a transparent background, the box shadow would create a rather unpleasant style.

![image](https://user-images.githubusercontent.com/647177/205695774-5ebf1aed-63a1-4397-aa4d-ad5be2f120d3.png)
![image](https://user-images.githubusercontent.com/647177/205695803-fa77590f-97bf-47f7-8319-1f2227aa23fe.png)

This PR fixes this styling bug. Once merged, I'll cut a new patch release.

---

Thanks for the report @abovedave! I've added you as a reviewer for this. Can you take a peek at the deploy preview and let me know if the box shadows render for you as expected?