### PR TITLE
chore(components): cleanup code around standard

### DIFF
--- a/adrs/0001-pseudo-private-custom-properties.md
+++ b/adrs/0001-pseudo-private-custom-properties.md
@@ -33,6 +33,8 @@ Defining a structure for component styles using pseudo-private custom properties
 // This is an example of the expected structure for component-specific styles
 // In some cases, deviations from this structure are warranted if we need to maintain a legacy structure
 .s-component-name {
+    // COMPONENT-SPECIFIC CONSTANTS
+    @cn-transition-duration: 100ms;
     // BASE COMPONENT-SPECIFIC CUSTOM PROPERTIES
     // --_{component-abbreviation}-{property-shorthand}: {value};
     --_cn-bg: var(--blue-500);
@@ -54,6 +56,7 @@ Defining a structure for component styles using pseudo-private custom properties
             --_cn-image-bg: var(--white);
         }
     });
+
     .s-special-parent & {
         --_cn-bg: transparent;
     }
@@ -70,9 +73,11 @@ Defining a structure for component styles using pseudo-private custom properties
     &&__xs {
         --_cn-h: var(--su-static2); // [1] see end of file
     }
+
     &&__sm {
         --_cn-h: var(--su-static12);
     }
+
     // Orientation
     &&__vertical {
         --_cn-fd: column;
@@ -106,6 +111,7 @@ Defining a structure for component styles using pseudo-private custom properties
     // STATIC COMPONENT STYLES
     display: flex;
     position: relative;
+    transition: all @cn-transition-duration;
     vertical-align: bottom;
 }
 

--- a/lib/css/components/activity-indicator.less
+++ b/lib/css/components/activity-indicator.less
@@ -4,20 +4,24 @@
     --_ai-fc: @white;
 
     // CONTEXTUAL STYLES
-    .highcontrast-mode({ --_ai-fc: var(--white); });
+    .highcontrast-mode({
+        --_ai-fc: var(--white);
+    });
 
     // VARIANTS
+    &&__danger {
+        --_ai-bg: var(--red-500);
+        --_ai-focus-ring: var(--focus-ring-error);
+    }
+
     &&__success {
         --_ai-bg: var(--green-500);
         --_ai-focus-ring: var(--focus-ring-success);
     }
+
     &&__warning {
         --_ai-bg: var(--yellow-600);
         --_ai-focus-ring: var(--focus-ring-warning);
-    }
-    &&__danger {
-        --_ai-bg: var(--red-500);
-        --_ai-focus-ring: var(--focus-ring-error);
     }
 
     background-color: var(--_ai-bg);

--- a/lib/css/components/avatars.less
+++ b/lib/css/components/avatars.less
@@ -7,13 +7,13 @@
 
     // CONTEXTUAL STYLES
     .highcontrast-mode({
-        background-color: var(--black);
-        box-shadow: 0 0 0 1px var(--black);
-        color: var(--white);
-
         .s-avatar--letter {
             color: var(--white);
         }
+
+        background-color: var(--black);
+        box-shadow: 0 0 0 1px var(--black);
+        color: var(--white);
     });
 
     // MODIFIERS
@@ -22,36 +22,43 @@
     &&__48 {
         --_av-br: var(--br-md);
     }
+
     &&__96,
     &&__128 {
         --_av-br: calc(var(--br-lg) + var(--br-sm));
         --_av-scale-badge: 3;
     }
+
     &&__24 {
         --_av-size: var(--su-static24);
         --_av-fs-letter: var(--su-static16);
         --_av-scale-badge: 1.1;
     }
+
     &&__32 {
         --_av-size: var(--su-static32);
         --_av-fs-letter: calc(var(--su-static24) - var(--su-static2));
         --_av-scale-badge: 1.3;
     }
+
     &&__48 {
         --_av-size: var(--su-static48);
         --_av-fs-letter: calc(var(--su-static32) + var(--su-static2));
         --_av-scale-badge: 1.6;
     }
+
     &&__64 {
         --_av-size: var(--su-static64);
         --_av-br: var(--br-lg);
         --_av-fs-letter: calc(var(--su-static48) - var(--su-static4));
         --_av-scale-badge: 2.4;
     }
+
     &&__96 {
         --_av-size: var(--su-static96);
         --_av-fs-letter: calc(var(--su-static64) + var(--su-static2));
     }
+
     &&__128 {
         --_av-size: var(--su-static128);
         --_av-fs-letter: calc(var(--su-static96) - var(--su-static8));
@@ -65,15 +72,17 @@
         -webkit-transform: scale(var(--_av-scale-badge));
         transform: scale(var(--_av-scale-badge));
     }
+
     & &--image {
         border-radius: var(--_av-br);
         display: block;
         height: var(--_av-size);
         width: var(--_av-size);
     }
+
     & &--letter {
-        display: block; // Make sure we're treating the letter as a block-level element
         color: @white; // Force a light appearance of text rendering
+        display: block; // Make sure we're treating the letter as a block-level element
         font-size: var(--_av-fs-letter); // Force a font size so the avatar text doesn't get smaller as the window resizes
         font-weight: bold;
         line-height: 1.4; // Guards against some line-height trolling from the parent

--- a/lib/css/components/award-bling.less
+++ b/lib/css/components/award-bling.less
@@ -5,9 +5,11 @@
     &&__gold {
         --_ab-before-bg: var(--gold);
     }
+
     &&__silver {
         --_ab-before-bg: var(--silver);
     }
+
     &&__bronze {
         --_ab-before-bg: var(--bronze);
     }

--- a/lib/css/components/badges.less
+++ b/lib/css/components/badges.less
@@ -35,11 +35,13 @@
         --_ba-as: flex-start;
         --_ba-fs: var(--fs-fine);
     }
+
     &&__xs {
         --_ba-lh: 1.5;
         --_ba-px: var(--su2);
         --_ba-wmn: calc(var(--su-static16) + var(--su-static2));
     }
+
     &&__sm {
         --_ba-lh: 1.8;
         --_ba-px: var(--su4);
@@ -52,16 +54,21 @@
     &&__bronze {
         --_ba-fc: var(--black-700);
 
-        .highcontrast-mode({ --_ba-fc: var(--black-900); });
+        .highcontrast-mode({
+            --_ba-fc: var(--black-900);
+        });
     }
+
     &&__gold {
         --_ba-bc: var(--gold-darker);
         --_ba-bg: var(--gold-lighter);
     }
+
     &&__silver {
         --_ba-bc: var(--silver-darker);
         --_ba-bg: var(--silver-lighter);
     }
+
     &&__bronze {
         --_ba-bc: var(--bronze-darker);
         --_ba-bg: var(--bronze-lighter);
@@ -74,28 +81,35 @@
         --_ba-bc: transparent;
         --_ba-fc: var(--white);
     }
+
     &&__rep,
     &&__rep-down,
     &&__votes:not(&__answered) {
         --_ba-bg: var(--white);
     }
+
     &&__answered {
         --_ba-bg: var(--green-400);
     }
+
     &&__bounty {
         --_ba-bg: var(--blue-600);
     }
+
     &&__important {
         --_ba-bg: var(--red-600);
     }
+
     &&__rep {
         --_ba-bc: var(--green-400);
         --_ba-fc: var(--green-500);
     }
+
     &&__rep-down {
         --_ba-bc: var(--red-400);
         --_ba-fc: var(--red-500);
     }
+
     &&__votes:not(&__answered) {
         --_ba-bc: var(--black-150);
         --_ba-fc: var(--black-700);
@@ -107,6 +121,7 @@
         --_ba-bg: var(--theme-primary-075);
         --_ba-fc: var(--theme-primary-800);
     }
+
     &&__moderator {
         --_ba-bc: var(--theme-secondary-200);
         --_ba-bg: var(--theme-secondary-075);
@@ -125,6 +140,7 @@
             --_ba-before-mt: 0;
             --_ba-before-w: calc(var(--su-static8) - var(--su-static1)); // 7px
         }
+
         &.s-badge__sm {
             --_ba-g: var(--su-static2);
             --_ba-before-h: calc(var(--su-static12) - var(--su-static1)); // 11px
@@ -147,6 +163,7 @@
             mask-size: contain;
         }
     }
+
     &&__staff {
         // Staff badges are always "Stack Overflow Orange"
         --_ba-bc: var(--orange-300);
@@ -161,6 +178,7 @@
             --_ba-bc: transparent;
         }
     }
+
     &&__danger {
         --_ba-bc: var(--red-600);
         --_ba-bg: var(--red-100);
@@ -170,7 +188,9 @@
             --_ba-bg: var(--red-500);
             --_ba-fc: @white;
 
-            .highcontrast-mode({ --_ba-fc: var(--white); });
+            .highcontrast-mode({
+                --_ba-fc: var(--white);
+            });
         }
     }
     &&__info {
@@ -178,11 +198,13 @@
         --_ba-bg: var(--blue-100);
         --_ba-fc: var(--blue-900);
     }
+
     &&__warning {
         --_ba-bc: var(--yellow-600);
         --_ba-bg: var(--yellow-100);
         --_ba-fc: var(--yellow-900);
     }
+
     &&__muted {
         --_ba-bc: var(--black-600);
         --_ba-bg: var(--black-100);
@@ -197,8 +219,8 @@
     // CHILD ELEMENTS
     &--image, // Included with no base class to account for usage in .s-progress__badge
     & &--image {
-        display: inline-flex;
         align-self: center;
+        display: inline-flex;
         margin-right: var(--su1);
         margin-left: calc((var(--su4) + var(--su1)) * -1);
     }

--- a/lib/css/components/breadcrumbs.less
+++ b/lib/css/components/breadcrumbs.less
@@ -8,6 +8,15 @@
     });
 
     // CHILD ELEMENTS
+    & &--divider {
+        .highcontrast-mode({
+            color: var(--fc-light);
+        });
+
+        margin-left: var(--_br-divider-px);
+        margin-right: var(--_br-divider-px);
+    }
+
     & &--item {
         align-items: center;
         display: flex;
@@ -15,12 +24,7 @@
         margin-bottom: var(--su2);
         margin-top: var(--su2);
     }
-    & &--divider {
-        .highcontrast-mode({ color: var(--fc-light); });
 
-        margin-left: var(--_br-divider-px);
-        margin-right: var(--_br-divider-px);
-    }
     & &--link {
         color: var(--_br-link-fc);
 

--- a/lib/css/components/button-groups.less
+++ b/lib/css/components/button-groups.less
@@ -45,11 +45,13 @@
                 border-radius: 0;
             }
         }
+
         &:last-child:not(:only-child) {
             .s-btn:not(:last-child) {
                 border-radius: 0;
             }
         }
+
         &:first-child:not(:only-child) {
             .s-btn:not(:first-child) {
                 border-radius: 0;
@@ -64,6 +66,7 @@
         &:active {
             z-index: var(--zi-active);
         }
+
         &.is-selected,
         &--radio:checked + .s-btn {
             z-index: var(--zi-selected); // When the button is active or selected, it should pop above its siblings

--- a/lib/css/components/buttons.less
+++ b/lib/css/components/buttons.less
@@ -45,6 +45,7 @@
     .dark-mode({
         --_bu-bs: none;
     });
+
     .highcontrast-mode({
         --_bu-bc: currentColor;
         --_bu-filled-bc: var(--_bu-bc);
@@ -61,20 +62,24 @@
         pointer-events: none;
         text-decoration: none;
     }
+
     button &,
     button[type="submit"] &,
     button[type="reset"] & {
         -webkit-appearance: button; // [1]
     }
+
     &.grid {
         display: flex; // Override &&__danger buttons having inline-block by default
     }
+
     &.is-loading {
         .svg-icon:first-child {
             margin-left: -23px;
             opacity: 0; // [2]
         }
     }
+
     &.is-selected,
     .s-btn-group.s-btn-group--radio &--radio:checked + & {
         background-color: var(--_bu-bg-selected);
@@ -84,6 +89,7 @@
         .s-btn--number {
             color: var(--_bu-number-fc-selected);
         }
+
         &.s-btn__filled { // this needs to live here to adapt to radio button-group
             border-color: var(--_bu-filled-bc-selected);
             background-color: var(--_bu-filled-bg-selected);
@@ -104,6 +110,7 @@
             }
         }
     }
+
     &.is-selected:not(:focus),
     .s-btn-group.s-btn-group--radio &--radio:checked:not(:focus) + & {
         box-shadow: none;
@@ -117,6 +124,7 @@
         background-color: var(--_bu-filled-bg);
         color: var(--_bu-filled-fc);
     }
+
     &&__outlined {
         border-color: var(--_bu-outlined-bc);
         background-color: var(--_bu-outlined-bg);
@@ -132,6 +140,7 @@
 
         outline: initial;
     }
+
     &&__link {
         --_bu-baw: 0;
         --_bu-br: 0;
@@ -147,6 +156,7 @@
         &[aria-disabled="true"] {
             --_bu-bg: none;
         }
+
         &.s-btn__dropdown {
             padding-right: 0.9em;
         }
@@ -156,6 +166,7 @@
         font: inherit;
         text-align: inherit;
     }
+
     &&__unset {
         &,
         &:hover,
@@ -192,6 +203,7 @@
 
         padding-right: calc(var(--_bu-p) * 2.5);
     }
+
     &&__icon {
         .svg-icon {
             vertical-align: baseline;
@@ -207,9 +219,11 @@
         --_bu-fs: var(--fs-fine);
         --_bu-p: 0.6em;
     }
+
     &&__sm {
         --_bu-fs: var(--fs-caption);
     }
+
     &&__md {
         --_bu-br: calc(var(--br-sm) + var(--su-static1));
         --_bu-fs: var(--fs-body3);
@@ -223,6 +237,7 @@
             --_bu-filled-bc: transparent;
         });
     }
+
     &&__danger {
         --_bu-bg-active: var(--red-100);
         --_bu-bg-hover: var(--red-050);
@@ -257,6 +272,7 @@
                 --_bu-number-fc: var(--white);
                 --_bu-number-fc-selected: var(--black);
             });
+
             .highcontrast-dark-mode({
                 --_bu-filled-fc: var(--white);
                 --_bu-number-fc: var(--black);
@@ -264,6 +280,7 @@
             });
         }
     }
+
     &&__muted {
         --_bu-bg-active: var(--black-050);
         --_bu-bg-hover: var(--black-025);
@@ -302,6 +319,7 @@
             }
         });
     }
+
     &&__primary {
         --_bu-bg: var(--theme-button-primary-background-color);
         --_bu-bg-active: var(--theme-button-primary-active-background-color);
@@ -325,9 +343,11 @@
             --_bu-number-fc: var(--white);
             --_bu-number-fc-selected: var(--black);
         });
+
         .highcontrast-mode({
             --_bu-bc: transparent;
         });
+
         .highcontrast-dark-mode({
             --_bu-bg: var(--theme-secondary-400);
             --_bu-bg-active: var(--theme-secondary-600);
@@ -344,6 +364,7 @@
             --_bu-bc: transparent;
         });
     }
+
     &&__facebook {
         @_fb-brand: #385499;
         --_bu-bc: transparent;
@@ -355,6 +376,7 @@
         --_bu-fc-hover: var(--_bu-fc);
         --_bu-hc-bc: transparent;
     }
+
     &&__google {
         --_bu-bc: var(--bc-medium);
         --_bu-bg: var(--white);
@@ -365,6 +387,7 @@
         --_bu-fc-hover: var(--black-800);
         --_bu-focus-ring: 0 0 0 var(--su-static4) var(--focus-ring-muted);
     }
+
     &&__github {
         --_bu-bg: var(--black-750);
         --_bu-bg-active: var(--black);
@@ -386,9 +409,11 @@
         line-height: var(--lh-xs);
         background-color: currentColor;
     }
+
     & &--number {
         color: var(--_bu-number-fc);
     }
+
     &--radio { // This lives alongside a .s-btn element. These styles are the equivelent of `.v-visible-sr`
         border: 0;
         clip-path: inset(50%);
@@ -413,6 +438,7 @@
             background-color: var(--_bu-bg-hover);
             color: var(--_bu-fc-hover);
         }
+
         &:active {
             &.s-btn__filled {
                 background-color: var(--_bu-filled-bg-active);
@@ -423,13 +449,13 @@
             color: var(--_bu-fc-active);
         }
     }
+
     &:focus,
     &--radio:focus + & {
         box-shadow: var(--_bu-focus-ring);
         outline: none;
     }
 
-    // STYLES MODIFIED BY COMPONENT-SPECIFIC CUSTOM PROPERTIES
     background-color: var(--_bu-bg);
     border: var(--_bu-baw) solid var(--_bu-bc);
     border-radius: var(--_bu-br);
@@ -438,7 +464,6 @@
     font-size: var(--_bu-fs);
     padding: var(--_bu-p);
 
-    // STATIC COMPONENT STYLES
     cursor: pointer;
     display: inline-block;
     font-family: inherit;

--- a/lib/css/components/code-blocks.less
+++ b/lib/css/components/code-blocks.less
@@ -14,10 +14,12 @@
         .hljs-title {
             color: var(--highlight-literal);
         }
+
         .hljs-bullet,
         .hljs-code {
             color: var(--highlight-punctuation);
         }
+
         .hljs-doctag,
         .hljs-keyword,
         .hljs-meta-keyword,
@@ -28,6 +30,7 @@
         .hljs-selector-tag {
             color: var(--highlight-keyword);
         }
+
         .hljs-name,
         .hljs-number,
         .hljs-quote,
@@ -36,6 +39,7 @@
         .hljs-type {
             color: var(--highlight-namespace);
         }
+
         .hljs-link,
         .hljs-meta-string,
         .hljs-regexp,
@@ -46,33 +50,42 @@
         .hljs-variable {
             color: var(--highlight-variable);
         }
+
         .hljs-addition {
             color: var(--highlight-addition);
         }
+
         .hljs-attr {
             color: var(--highlight-attribute);
         }
+
         .hljs-attribute {
             color: var(--highlight-symbol);
         }
+
         .hljs-comment {
             color: var(--highlight-comment);
         }
+
         .hljs-deletion {
             color: var(--highlight-deletion);
         }
+
         .hljs-emphasis {
             font-style: italic;
         }
+
         .hljs-strong {
             font-weight: bold;
         }
+
         .hljs-subst {
             color: var(--highlight-color);
         }
 
         font-family: inherit;
     }
+
     pre& {
         .s-code-block--line-numbers {
             background-color: var(--_cb-line-numbers-bg);

--- a/lib/css/components/empty-states.less
+++ b/lib/css/components/empty-states.less
@@ -1,12 +1,12 @@
 .s-empty-state {
     // CHILD ELEMENTS
     p {
-        font-size: var(--fs-body1);
-        margin-bottom: var(--su12);
-
         strong {
             color: var(--fc-dark);
         }
+
+        font-size: var(--fs-body1);
+        margin-bottom: var(--su12);
     }
 
     color: var(--fc-light);

--- a/lib/css/components/expandable.less
+++ b/lib/css/components/expandable.less
@@ -1,4 +1,83 @@
-// see http://stackoverflow.com/a/43965099 for how this works:
+.s-expandable { // [1]
+    // COMPONENT-SPECIFIC CONSTANTS
+    @ex-clip-path: polygon(-1000000px -1000000px, 1000000px -1000000px, 1000000px 1000000px, -1000000px 1000000px);
+    @ex-min-expected-height: 10px;
+    @ex-transition-duration: 100ms;
+    // COMPONENT-SPECIFIC CUSTOM PROPERTIES
+    --_ex-after-h: 10px;
+    --_ex-after-hmx: 0;
+    --_ex-after-transition:
+        height @ex-transition-duration linear,
+        max-height 0s @ex-transition-duration linear;
+    --_ex-content-hmx: 1000000px;
+    --_ex-content-mb: 0;
+    --_ex-content-o: unset;
+    --_ex-content-transform: unset;
+    --_ex-content-transition:
+        margin-bottom @ex-transition-duration cubic-bezier(0, 0, 0, 1),
+        transform @ex-transition-duration cubic-bezier(1, 0, 1, 1),
+        opacity @ex-transition-duration cubic-bezier(1, 0, 1, 1);
+
+    &:not(.is-expanded) {
+        --_ex-after-h: 0;
+        --_ex-after-hmx: @ex-min-expected-height;
+        --_ex-after-transition: height @ex-min-expected-height linear;
+        --_ex-content-hmx: 0;
+        --_ex-content-mb: -1500px;
+        --_ex-content-o: 0;
+        --_ex-content-transform: scaleY(0);
+        --_ex-content-transition:
+            margin-bottom @ex-transition-duration cubic-bezier(1, 0, 1, 1),
+            visibility 0s @ex-transition-duration,
+            max-height 0s @ex-transition-duration,
+            transform @ex-transition-duration cubic-bezier(0, 1, 1, 1),
+            opacity @ex-transition-duration cubic-bezier(0, 1, 1, 1);
+
+        & .s-expandable--content {
+            @supports ((-webkit-clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)) or (clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%))) {
+                --_ex-content-o: 1;
+                --_ex-content-transform: none;
+            }
+        }
+
+        -webkit-clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
+        clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
+        overflow: hidden;
+        transition: none;
+    }
+
+    &:after {
+        height: var(--_ex-after-h);
+        max-height: var(--_ex-after-hmx);
+        transition: var(--_ex-after-transition);
+
+        -ms-flex-preferred-size: 0;
+        content: '';
+        flex-basis: 0;
+    }
+
+    & &--content {
+        max-height: var(--_ex-content-hmx);
+        margin-bottom: var(--_ex-content-mb);
+        opacity: var(--_ex-content-o);
+        -webkit-transform: var(--_ex-content-transform);
+        transform: var(--_ex-content-transform);
+
+        -ms-flex-preferred-size: 100%;
+        flex-basis: 100%;
+        -webkit-transform-origin: 0 0;
+        transform-origin: 0 0;
+        transition: var(--_ex-content-transition);
+    }
+
+    align-items: flex-start; // see comment above
+    display: flex;
+    -webkit-clip-path: @ex-clip-path;
+    clip-path: @ex-clip-path;
+    transition: clip-path 0s var(--_ex-transition-duration), -webkit-clip-path 0s var(--_ex-transition-duration);
+}
+
+// [1] see http://stackoverflow.com/a/43965099 for how this works:
 
 // Notes on the clip-path stuff: What we would really like is overflow: hidden during the transition,
 // but not when the element is expanded. Unfortunately, although the CSS spec provides for it, there's
@@ -29,86 +108,9 @@
 // (no longer visible) element itself to remain at the top, thereby forcing the excess pixels to be added
 // above the top, not below the bottom. And because extending content above the document top will not do
 // anything to the document height, there is no jumping during the transition.
-// see custom property "--_ex-transition-duration"
+// see "@ex-transition-duration"
 
 // Per the answer referenced above, the component can only guarantee smooth transitions if above a minimum
 // height and can only guarantee the element will be hidden is below a maximimum height.
 // The minimum height has been set at 10px because that's below the height of a single line of text in an s-description.
-// see custom properties "--_ex-min-expected-height" and "--_ex-content-mb"
-
-.s-expandable {
-    // CONSTANTS
-    --_ex-clip-path: polygon(-1000000px -1000000px, 1000000px -1000000px, 1000000px 1000000px, -1000000px 1000000px);
-    --_ex-min-expected-height: 10px;
-    --_ex-transition-duration: 100ms;
-    // VARIABLES
-    --_ex-after-h: 10px;
-    --_ex-after-hmx: 0;
-    --_ex-after-transition:
-        height var(--_ex-transition-duration) linear,
-        max-height 0s var(--_ex-transition-duration) linear;
-    --_ex-content-hmx: 1000000px;
-    --_ex-content-mb: 0;
-    --_ex-content-o: unset;
-    --_ex-content-transform: unset;
-    --_ex-content-transition:
-        margin-bottom var(--_ex-transition-duration) cubic-bezier(0, 0, 0, 1),
-        transform var(--_ex-transition-duration) cubic-bezier(1, 0, 1, 1),
-        opacity var(--_ex-transition-duration) cubic-bezier(1, 0, 1, 1);
-
-    &:not(.is-expanded) {
-        --_ex-after-h: 0;
-        --_ex-after-hmx: var(--_ex-min-expected-height);
-        --_ex-after-transition: height var(--_ex-min-expected-height) linear;
-        --_ex-content-hmx: 0;
-        --_ex-content-mb: -1500px;
-        --_ex-content-o: 0;
-        --_ex-content-transform: scaleY(0);
-        --_ex-content-transition:
-            margin-bottom var(--_ex-transition-duration) cubic-bezier(1, 0, 1, 1),
-            visibility 0s var(--_ex-transition-duration),
-            max-height 0s var(--_ex-transition-duration),
-            transform var(--_ex-transition-duration) cubic-bezier(0, 1, 1, 1),
-            opacity var(--_ex-transition-duration) cubic-bezier(0, 1, 1, 1);
-
-        & .s-expandable--content {
-            @supports ((-webkit-clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)) or (clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%))) {
-                --_ex-content-o: 1;
-                --_ex-content-transform: none;
-            }
-        }
-
-        -webkit-clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
-        clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
-        overflow: hidden;
-        transition: none;
-    }
-    &:after {
-        height: var(--_ex-after-h);
-        max-height: var(--_ex-after-hmx);
-        transition: var(--_ex-after-transition);
-
-        -ms-flex-preferred-size: 0;
-        content: '';
-        flex-basis: 0;
-    }
-    & &--content {
-        max-height: var(--_ex-content-hmx);
-        margin-bottom: var(--_ex-content-mb);
-        opacity: var(--_ex-content-o);
-        -webkit-transform: var(--_ex-content-transform);
-        transform: var(--_ex-content-transform);
-
-        -ms-flex-preferred-size: 100%;
-        flex-basis: 100%;
-        -webkit-transform-origin: 0 0;
-        transform-origin: 0 0;
-        transition: var(--_ex-content-transition);
-    }
-
-    align-items: flex-start; // see comment above
-    display: flex;
-    -webkit-clip-path: var(--_ex-clip-path);
-    clip-path: var(--_ex-clip-path);
-    transition: clip-path 0s var(--_ex-transition-duration), -webkit-clip-path 0s var(--_ex-transition-duration);
-}
+// see "@ex-min-expected-height" and "--_ex-content-mb"

--- a/lib/css/components/labels.less
+++ b/lib/css/components/labels.less
@@ -5,15 +5,17 @@
     &[for] {
         cursor: pointer;
     }
+
     fieldset[disabled] &,
     .is-disabled & {
-        cursor: not-allowed;
-        opacity: var(--_o-disabled-static);
-
         .s-description {
             opacity: unset;
         }
+
+        cursor: not-allowed;
+        opacity: var(--_o-disabled-static);
     }
+
     .is-readonly & {
         cursor: not-allowed;
     }
@@ -23,12 +25,15 @@
     &&__sm {
         --_la-fs: var(--fs-caption);
     }
+
     &&__md {
         --_la-fs: var(--fs-body3);
     }
+
     &&__lg {
         --_la-fs: var(--fs-title);
     }
+
     &&__xl {
         --_la-fs: var(--fs-headline1);
     }
@@ -51,6 +56,7 @@
             --_la-status-bg: var(--blue-100);
             --_la-status-fc: var(--blue-700);
         }
+
         &__new {
             --_la-status-bg: var(--green-100);
             --_la-status-fc: var(--green-700);
@@ -60,6 +66,7 @@
                 --_la-status-fc: var(--green-800);
             });
         }
+
         &__required {
             --_la-status-bg: var(--red-100);
             --_la-status-fc: var(--red-700);
@@ -81,6 +88,7 @@
         padding: var(--su2) var(--su8);
         vertical-align: text-bottom;
     }
+
     .s-description,
     .s-input-message {
         font-weight: normal;

--- a/lib/css/components/link-previews.less
+++ b/lib/css/components/link-previews.less
@@ -30,6 +30,7 @@
             text-decoration: none;
         }
     }
+
     & &--body {
         *:last-child {
             margin-bottom: 0;
@@ -38,6 +39,7 @@
         font-size: var(--fs-body2);
         padding: var(--su12);
     }
+
     & &--code {
         pre {
             border-radius: 0 !important;
@@ -45,47 +47,54 @@
             max-height: 400px;
         }
     }
+
     & &--details {
         margin-top: var(--_lp-details-mt);
 
         color: var(--black-500);
         font-size: var(--fs-caption);
     }
+
     & &--footer {
         flex-direction: var(--_lp-footer-fd);
 
         background: var(--black-025);
         border-bottom-left-radius: var(--br-sm);
         border-bottom-right-radius: var(--br-sm);
-        border-top: 1px solid var(--bc-medium);
+        border-top: var(--su-static1) solid var(--bc-medium);
         display: flex;
         font-size: var(--fs-caption);
         justify-content: space-between;
         padding: var(--su12);
     }
+
     & &--header {
         background: var(--black-025);
-        border-bottom: 1px solid var(--bc-medium);
+        border-bottom: var(--su-static1) solid var(--bc-medium);
         border-top-left-radius: var(--br-sm);
         border-top-right-radius: var(--br-sm);
         display: flex;
         padding: var(--su12) var(--su8);
     }
+
     & &--icon {
         color: var(--black-800); // Set the default color of the integration's icon. Most likely this will be overridden by the integration icon's native colors.
         margin-right: var(--su8);
     }
+
     & &--misc {
         padding-left: var(--_lp-misc-pl);
         padding-top: var(--_lp-misc-pt);
 
         color: var(--black-500);
     }
+
     & &--title {
         color: var(--black-900);
         font-size: var(--fs-body3);
         font-weight: bold;
     }
+
     & a&--title {
         &:active,
         &:hover{
@@ -94,14 +103,19 @@
                 color: var(--theme-link-color-hover);
             }
         }
+
         &:active,
         &:hover,
         &.s-link__visited:active,
         &.s-link__visited:hover,
         &.s-link__visited:visited {
-            .highcontrast-mode({ text-decoration: underline; });
+            .highcontrast-mode({
+                text-decoration: underline;
+            });
+
             text-decoration: none;
         }
+
         &.s-link__visited:visited {
             color: var(--theme-link-color);
         }
@@ -110,6 +124,7 @@
         cursor: pointer;
         text-decoration: none;
     }
+
     & &--url {
         max-width: 100%;
         overflow: hidden;
@@ -117,7 +132,7 @@
         white-space: nowrap;
     }
 
-    border: 1px solid var(--bc-medium);
+    border: var(--su-static1) solid var(--bc-medium);
     border-radius: var(--br-sm);
     box-shadow: var(--bs-sm);
     text-align: left;

--- a/lib/css/components/menu.less
+++ b/lib/css/components/menu.less
@@ -15,21 +15,24 @@
         height: var(--su-static1);
         margin: var(--su8) 0;
     }
+
     & &--label {
         &.is-disabled {
             --_me-label-cursor: not-allowed;
         }
 
+        border-top: var(--su-static1) solid var(--_me-label-btc);
         cursor: var(--_me-label-cursor);
-        border-top: 1px solid var(--_me-label-btc);
         padding: var(--su12);
     }
+
     & &--title {
         color: var(--black-600);
         font-size: var(--fs-fine);
         padding: var(--su8) var(--su12);
         text-transform: uppercase;
     }
+
     & li + &--title {
         margin-top: var(--su12);
     }

--- a/lib/css/components/modals.less
+++ b/lib/css/components/modals.less
@@ -28,6 +28,7 @@
             .bg-confetti-animated;
         }
     }
+
     &&__full {
         --_mo-hmx: calc(100% - var(--su48));
         --_mo-wmx: calc(100% - var(--su48));
@@ -45,6 +46,7 @@
         color: var(--fc-medium);
         margin-bottom: var(--su24);
     }
+
     & &--close {
         //  [1] To override .s-btn class attributes
         .svg-icon {
@@ -56,6 +58,7 @@
         right: var(--su8);
         top: var(--_mo-close-t);
     }
+
     & &--dialog {
         .dark-mode({
             --_mo-dialog-bg: var(--black-100);
@@ -78,9 +81,11 @@
         will-change: visibility, z-index, opacity, transform; // Not supported by Edge
         z-index: var(--zi-hide); // Make sure it's also below everything so we can't interact with it.
     }
+
     & &--footer {
         margin-top: var(--su24);
     }
+
     & &--header {
         color: var(--_mo-header-fc);
 

--- a/lib/css/components/navigation.less
+++ b/lib/css/components/navigation.less
@@ -3,77 +3,71 @@
     --_na-fw: wrap;
     --_na-p: var(--su2) 0;
     --_na-gap: var(--su4);
+    --_na-item-bg: none;
+    --_na-item-fc: var(--black-600);
+    --_na-item-fs: unset;
+    --_na-item-p: var(--su6) var(--su12);
+    --_na-item-py: var(--su12);
+    --_na-item-ws: nowrap;
+    --_na-item-bg-hover: var(--black-075);
+    --_na-item-fc-hover: var(--_na-item-fc);
+    --_na-item-selected-bg: var(--theme-primary-color);
+    --_na-item-selected-fc: var(--white);
+    --_na-item-selected-bg-hover: var(--theme-primary-600);
+    --_na-title-mt: var(--su16);
+
+    // CONTEXTUAL STYLES
+    .highcontrast-mode({
+        --_na-item-bg-hover: var(--black-600);
+        --_na-item-fc-hover: var(--black-100);
+    });
 
     // MODIFIERS
     &&__scroll {
         --_na-fw: nowrap;
+
         overflow-x: auto;
         @scrollbar-styles();
     }
-    // Sizes
+
     &&__sm {
-        .s-navigation--item {
-            --_na-item-fs: var(--fs-caption);
-            --_na-item-p: var(--su4) var(--su12);
-        }
+        --_na-item-fs: var(--fs-caption);
+        --_na-item-p: var(--su4) var(--su12);
     }
-    // Orientation
+
     &&__vertical {
         --_na-fd: column;
         --_na-gap: 0;
         --_na-p: 0;
-
-        .s-navigation--item {
-            --_na-item-ws: normal;
-        }
+        --_na-item-ws: normal;
     }
 
     // VARIANTS
     &&__muted {
-        .s-navigation--item {
-            &.is-selected {
-                --_na-item-bg: var(--black-050);
-                --_na-item-fc: var(--black-800);
-                --_na-item-bg-hover: var(--_na-item-bg);
-                --_na-item-fc-hover: var(--_na-item-fc);
+        --_na-item-selected-bg: var(--black-050);
+        --_na-item-selected-fc: var(--black-800);
+        --_na-item-selected-bg-hover: var(--_na-item-bg);
 
-                .highcontrast-mode({
-                    --_na-item-bg: var(--black-800);
-                    --_na-item-fc: var(--black-050);
-                });
-            }
-        }
+        .highcontrast-mode({
+            --_na-item-selected-bg: var(--black-800);
+            --_na-item-selected-fc: var(--black-050);
+            --_na-item-selected-bg-hover: var(--black-900);
+        });
     }
 
     // CHILD ELEMENTS
     & &--item {
-        --_na-item-bg: none;
-        --_na-item-fc: var(--black-600);
-        --_na-item-fs: unset;
-        --_na-item-p: var(--su6) var(--su12);
-        --_na-item-py: var(--su12);
-        --_na-item-ws: nowrap;
-        // hover
-        --_na-item-bg-hover: var(--black-075);
-        --_na-item-fc-hover: var(--_na-item-fc);
-
-        .highcontrast-mode({
-            --_na-item-bg-hover: var(--black-600);
-            --_na-item-fc-hover: var(--black-100);
-        });
-
-        // STATES
         &.is-selected {
-            --_na-item-bg: var(--theme-primary-color);
-            --_na-item-fc: var(--white);
-            --_na-item-bg-hover: var(--theme-primary-600);
+            --_na-item-bg: var(--_na-item-selected-bg);
+            --_na-item-fc: var(--_na-item-selected-fc);
+            --_na-item-fc-hover: var(--_na-item-fc);
+            --_na-item-bg-hover: var(--_na-item-selected-bg-hover);
 
             .highcontrast-mode({
                 text-decoration: none;
             });
         }
 
-        // MODIFIERS
         // TODO: include child component class (without variant) on selector
         &__dropdown {
             &:after {
@@ -91,7 +85,6 @@
             padding-right: 2em;
         }
 
-        // INTERACTION
         &:hover,
         &:active {
             background-color: var(--_na-item-bg-hover);
@@ -116,9 +109,8 @@
         position: relative;
         user-select: auto;
     }
-    & &--title {
-        --_na-title-mt: var(--su16);
 
+    & &--title {
         &:first-child {
             --_na-title-mt: 0;
         }

--- a/lib/css/components/notices.less
+++ b/lib/css/components/notices.less
@@ -1,5 +1,4 @@
 .construct-notice-component(@baseClass) {
-    // BASE COMPONENT-SPECIFIC CUSTOM PROPERTIES
     --_no-bc: var(--bc-medium);
     --_no-bg: var(--black-050);
     --_no-fc: var(--fc-medium);
@@ -11,13 +10,16 @@
         .dark-mode({
             --_no-bc: var(--_no-bg);
         });
+
         .highcontrast-mode({
             --_no-bc: currentColor;
         });
+
         .highcontrast-dark-mode({
             --_no-bc: currentColor;
         });
     }
+
     &__important {
         --_no-bc: var(--_no-bg);
         --_no-bg: var(--black-700);
@@ -42,6 +44,7 @@
                 --_no-bg: var(--red-200);
             });
         }
+
         &.@{baseClass}__important {
             --_no-bc: var(--_no-bg);
             --_no-bg: var(--red-500);
@@ -52,12 +55,14 @@
                 --_no-bg: var(--red-400);
                 --_no-fc: var(--black-900);
             });
+
             .highcontrast-dark-mode({
                 --_no-bg: var(--red-500);
                 --_no-fc: var(--white);
             });
         }
     }
+
     &__info {
         --_no-bc: var(--theme-secondary-150);
         --_no-bg: var(--theme-secondary-050);
@@ -69,10 +74,12 @@
             .highcontrast-mode({
                 --_no-bg: var(--theme-secondary-100);
             });
+
             .highcontrast-dark-mode({
                 --_no-bg: var(--theme-secondary-100);
             });
         }
+
         &.@{baseClass}__important {
             --_no-bc: var(--_no-bg);
             --_no-bg: var(--theme-secondary-400);
@@ -83,12 +90,14 @@
                 --_no-bg: var(--theme-secondary-300);
                 --_no-fc: var(--black-900);
             });
+
             .highcontrast-dark-mode({
                 --_no-bg: var(--theme-secondary-400);
                 --_no-fc: var(--white);
             });
         }
     }
+
     &__success {
         --_no-bc: var(--green-200);
         --_no-bg: var(--green-050);
@@ -100,6 +109,7 @@
                 --_no-bg: var(--green-200);
             });
         }
+
         &.@{baseClass}__important {
             --_no-bc: var(--_no-bg);
             --_no-bg: var(--green-400);
@@ -111,12 +121,14 @@
                 --_no-bg: var(--green-500);
                 --_no-fc: var(--white);
             });
+
             .highcontrast-mode({
                 --_no-bg: var(--green-500);
                 --_no-fc: var(--white);
             });
         }
     }
+
     &__warning {
         --_no-bc: var(--yellow-300);
         --_no-bg: var(--yellow-050);
@@ -129,6 +141,7 @@
                 --_no-bg: var(--yellow-200);
             });
         }
+
         &.@{baseClass}__important {
             --_no-bc: var(--_no-bg);
             --_no-bg: var(--yellow-400);
@@ -140,6 +153,7 @@
                 --_no-bg: var(--yellow-600);
                 --_no-fc: var(--white);
             });
+
             .highcontrast-mode({
                 --_no-bg: var(--yellow-700);
                 --_no-fc: var(--white);
@@ -151,17 +165,20 @@
     code {
         background: var(--_no-code-bg, transparent);
     }
+
     & &--btn {
         // TODO: decouple .s-notice--btn from .s-btn
         &:not(:focus) {
             box-shadow: none; // This will prevent default .s-btn box-shadow from showing
         }
+
+        &:active {
+            background: var(--_no-btn-bg-active);
+        }
+
         &:focus,
         &:hover {
             background: var(--_no-btn-bg-focus);
-        }
-        &:active {
-            background: var(--_no-btn-bg-active);
         }
 
         color: inherit;
@@ -189,17 +206,21 @@
         opacity: 0;
         visibility: hidden;
     }
+
     &[aria-hidden="false"] {
         --_no-x-offset: calc(var(--su48) + var(--su1)); // 49px
         opacity: 1;
         visibility: visible;
     }
+
     &.is-pinned { //  If you want to put the banner above the topbar
         z-index: calc(var(--zi-navigation-fixed) + 1);
     }
+
     &__body-pt {
         padding-top: 93px;
     }
+
     & &--container { // When we want to keep hero content capped
         margin: 0 auto;
         max-width: calc(var(--s-step) * 10);
@@ -207,13 +228,12 @@
         width: 100%;
     }
 
-    -webkit-transform: translate3d(0, var(--_no-x-offset), 0);
-    transform: translate3d(0, var(--_no-x-offset), 0);
-
     border-width: var(--su-static1) 0;
     inset: 0 0 auto 0;
     padding: var(--su12);
     position: fixed;
+    -webkit-transform: translate3d(0, var(--_no-x-offset), 0);
+    transform: translate3d(0, var(--_no-x-offset), 0);
     width: 100%;
     z-index: calc(var(--zi-navigation-fixed) - 1); // Tuck below topbar
 }
@@ -232,6 +252,7 @@
     @media (prefers-reduced-motion) {
         transform: none !important;
     }
+
     &[aria-hidden="false"] {
         opacity: 1;
         transform: translate3d(0, 0, 0);

--- a/lib/css/components/progress-bars.less
+++ b/lib/css/components/progress-bars.less
@@ -1,5 +1,7 @@
 .s-progress {
-    // BASE COMPONENT-SPECIFIC CUSTOM PROPERTIES
+    // COMPONENT-SPECIFIC CONSTANTS
+    @pr-circle-circumference: (2 * pi() * 14); // 2πr, r = 14.
+    // COMPONENT-SPECIFIC CUSTOM PROPERTIES
     --_pr-bar: var(--br-sm);
     --_pr-bg: var(--black-200);
     --_pr-h: unset;
@@ -20,17 +22,21 @@
     &&__brand {
         --_pr-bar-bg: var(--orange-500);
     }
+
     &&__bronze {
         --_pr-bar-bg: var(--bronze-lighter);
         --_pr-label-bc: var(--bronze-darker);
     }
+
     &&__gold {
         --_pr-bar-bg: var(--gold-lighter);
         --_pr-label-bc: var(--gold-darker);
     }
+
     &&__info {
         --_pr-bar-bg: var(--blue-500);
     }
+
     &&__silver {
         --_pr-bar-bg: var(--silver-lighter);
         --_pr-label-bc: var(--silver-darker);
@@ -47,6 +53,7 @@
         --_pr-label-d: flex;
         --_pr-label-g: var(--su4);
     }
+
     &&__badge {
         --_pr-label-ai: center;
         --_pr-label-px: 1em;
@@ -58,23 +65,26 @@
             }
         }
     }
+
     &&__circular {
         --_pr-bg: transparent;
         --_pr-size: var(--su-static32);
         --s-progress-value: 0;
-        @s-progress-circle-circumference: (2 * pi() * 14); // 2πr, r = 14.
 
         &.s-progress {
             &__sm {
                 --_pr-size: var(--su-static24);
             }
+
             &__md {
                 --_pr-size: var(--su-static48);
             }
+
             &__lg {
                 --_pr-size: var(--su-static64);
             }
         }
+
         // TODO: consider renaming to `.s-progress--bar`
         .s-progress-bar { // It may necessitate wrapping element in a `&:not(&__circular)`
             circle {
@@ -84,8 +94,8 @@
                 }
                 &:nth-of-type(2) {
                     stroke: currentColor;
-                    stroke-dasharray: @s-progress-circle-circumference; // [1]
-                    stroke-dashoffset: calc(((1 - var(--s-progress-value)) * @s-progress-circle-circumference) * 1px); // Multiply everything by 1px since Safari and Firefox require these to be in pixels
+                    stroke-dasharray: @pr-circle-circumference; // [1]
+                    stroke-dashoffset: calc(((1 - var(--s-progress-value)) * @pr-circle-circumference) * 1px); // Multiply everything by 1px since Safari and Firefox require these to be in pixels
                 }
 
                 fill: none;
@@ -96,6 +106,7 @@
             transform: rotate(270deg); // Make everything originate from the top of the circle
         }
     }
+
     &&__privilege {
         --_pr-bar-bg: var(--green-050);
         --_pr-label-ai: center;
@@ -104,6 +115,7 @@
 
         .highcontrast-mode({ --_pr-bar-bg: var(--green-200); });
     }
+
     // TODO move `.s-progress__stepped` to entirely separate component (or consider deprecating)
     &&__stepped { // There's so little overlap with the base .s-progress that it doesn't make sense as a variant
         background: transparent;
@@ -116,6 +128,7 @@
                         left: 0;
                         right: 50%;
                     }
+
                     &__right {
                         left: 50%;
                         right: 0;
@@ -129,6 +142,7 @@
                 top: calc(var(--su-static8) + var(--su-static1));
                 z-index: var(--zi-base);
             }
+
             &--label { // Override a ton of properties
                 border: 0;
                 border-radius: 0;
@@ -142,27 +156,32 @@
                 width: auto;
                 z-index: var(--zi-base);
             }
+
             &--step {
                 &.is-active {
                     .s-progress {
                         &--bar.s-progress--bar__left {
                             background: var(--theme-secondary-400);
                         }
+
                         &--label {
                             color: var(--fc-dark);
                         }
+
                         &--stop {
                             background: var(--theme-secondary-400);
                             box-shadow: 0 0 0 var(--su-static6) var(--focus-ring);
                         }
                     }
                 }
+
                 &.is-complete {
                     .s-progress {
                         &--bar,
                         &--stop {
                             background: var(--theme-secondary-400);
                         }
+
                         &--label {
                             color: var(--fc-dark);
                         }
@@ -177,6 +196,7 @@
                 flex-shrink: 1;
                 position: relative;
             }
+
             &--stop {
                 .highcontrast-mode({
                     color: var(--white);
@@ -206,6 +226,7 @@
         min-width: var(--su-static6);
         position: relative;
     }
+
     & &--label {
         align-items: var(--_pr-label-ai);
         border: var(--su-static1) solid var(--_pr-label-bc);
@@ -224,6 +245,7 @@
         width: 100%;
         z-index: calc(var(--zi-base) + 2);
     }
+
     & &--segments { // DEPRECATED: AFAICT, this is unused in core (as well as it's intended parent variant class `.s-progress__segmented`)
         li {
             &:not(:first-child):not(:last-child):before {
@@ -231,7 +253,7 @@
                 content: "";
                 display: block;
                 height: 100%;
-                left: calc(var(--su-static) * -1); // -1px
+                left: calc(var(--su-static1) * -1); // -1px
                 position: absolute;
                 top: 0;
                 width: var(--su-static4);

--- a/lib/css/components/prose.less
+++ b/lib/css/components/prose.less
@@ -1,4 +1,9 @@
 .s-prose {
+    // CONSTANTS
+    @pr-spacing: 1.1em;
+    @pr-spacing-condensed: calc(@pr-spacing / 2); // Reduce the base spacing by half in the context of lists, etc.
+    @pr-spoiler-transition: opacity 0.1s ease-in-out;
+    // COMPONENT-SPECIFIC CUSTOM PROPERTIES
     --_pr-fs: calc(var(--su-static16) - var(--su-static1)); // Force a font size that doesn’t change at the smallest breakpoint;
     --_pr-lh: 1.5;
     --_pr-blockquote-ml: 1em;
@@ -12,7 +17,7 @@
     --_pr-h5-fs: var(--fs-body2);
     --_pr-h6-fs: var(--fs-body1);
     --_pr-hr-bg: var(--black-100); // used for both background-color and color properties
-    --_pr-img-mb: var(--_pr-spacing);
+    --_pr-img-mb: @pr-spacing;
     --_pr-kbd-bc: var(--black-300);
     --_pr-kbd-bs: 0 var(--su-static1) var(--su-static1) hsla(210, 8%, 5%, 0.15), inset 0 1px 0 0 @white;
     --_pr-spoiler-cursor: pointer;
@@ -20,13 +25,9 @@
     --_pr-soiler-after-o: unset;
     --_pr-soiler-child-o: 0;
     --_pr-soiler-child-visibility: hidden;
-    // CONSTANTS
-    --_pr-spacing: 1.1em;
-    --_pr-spacing-condensed: calc(var(--_pr-spacing) / 2); // Reduce the base spacing by half in the context of lists, etc.
-    --_pr-spoiler-transition: opacity 0.1s ease-in-out;
     // TEMP HOT FIX FOR .s-editor [1]
-    --s-prose-spacing: var(--_pr-spacing); // TODO remove once addressed in StackExchange/Stacks-Editor
-    --s-prose-spacing-condensed: var(--_pr-spacing-condensed); // TODO remove once addressed in StackExchange/Stacks-Editor
+    --s-prose-spacing: @pr-spacing; // TODO remove once addressed in StackExchange/Stacks-Editor
+    --s-prose-spacing-condensed: @pr-spacing-condensed; // TODO remove once addressed in StackExchange/Stacks-Editor
 
     // CONDITIONAL STYLES
     .dark-mode({
@@ -34,10 +35,12 @@
         --_pr-kbd-btc: @black-500;
         --_pr-kbd-bs: 0 var(--su-static1) var(--su-static1) hsla(210, 8%, 5%, 0.8);
     });
+
     .highcontrast-mode({
         --_pr-blockquote-before-bg: var(--black-600);
         --_pr-hr-bg: var(--black-500);
     });
+
     #stacks-internals #screen-sm({
         --_pr-spoiler-after-t: calc(var(--su8) + var(--su1)); // Adjust the position in the smallest breakpoint
     });
@@ -52,14 +55,17 @@
         --_pr-h4-fs: var(--fs-body3-relative);
         --_pr-h5-fs: var(--fs-body2-relative);
     }
+
     &&__xs {
         --_pr-fs: var(--fs-caption);
         --_pr-lh: var(--lh-sm);
     }
+
     &&__sm {
         --_pr-fs: var(--fs-body1);
         --_pr-lh: var(--lh-md);
     }
+
     &&__md {
         --_pr-fs: var(--fs-body3);
         --_pr-lh: var(--lh-xl);
@@ -67,16 +73,18 @@
 
     // CHILD ELEMENTS
     *:not(.s-code-block) {
+        > a code {
+            color: var(--theme-link-color); // When contained within a link, we want the code to be link-colored
+        }
+
         > code {
             padding: var(--su2) var(--su4);
             color: var(--black-800);
             background-color: var(--black-075);
             border-radius: var(--br-sm);
         }
-        > a code {
-            color: var(--theme-link-color); // When contained within a link, we want the code to be link-colored
-        }
     }
+
     // Last/only child
     blockquote,
     dl,
@@ -100,6 +108,7 @@
             margin-bottom: 0;
         }
     }
+
     // Headings
     blockquote,
     dd,
@@ -127,6 +136,7 @@
             margin-top: 1.6667em;
         }
     }
+
     h1,
     h2,
     h3,
@@ -138,25 +148,31 @@
         font-weight: bold !important;
         margin-bottom: 0.5em;
     }
+
     h1 {
         font-size: var(--_pr-h1-fs);
         margin-bottom: 0.6em;
     }
+
     h2 {
         font-size: var(--_pr-h2-fs);
         margin-bottom: 0.7em;
     }
+
     h3 {
         font-size: var(--_pr-h3-fs);
         margin-bottom: 0.74em;
     }
+
     h4 {
         font-size: var(--_pr-h4-fs);
         margin-bottom: 1em;
     }
+
     h5 {
         font-size: var(--_pr-h5-fs);
     }
+
     h6 {
         font-size: var(--_pr-h6-fs);
     }
@@ -166,12 +182,14 @@
     q {
         quotes: none;
     }
+
     dd,
     dl,
     .s-table-container,
     .s-link-preview {
-        margin-bottom: var(--_pr-spacing); // TODO: make sure this overrides margin set on dd
+        margin-bottom: @pr-spacing; // TODO: make sure this overrides margin set on dd
     }
+
     ol,
     ul {
         blockquote,
@@ -186,6 +204,7 @@
                 margin-bottom: 0;
             }
         }
+
         blockquote,
         dd,
         dl,
@@ -195,28 +214,33 @@
         p,
         table,
         ul {
-            margin-bottom: var(--_pr-spacing-condensed); // Within lists, we shouldn't have so much spacing  in between block-level elements.
+            margin-bottom: @pr-spacing-condensed; // Within lists, we shouldn't have so much spacing  in between block-level elements.
         }
+
         li {
             &:last-child {
                 margin-bottom: 0;
             }
+
             ol,
             ul {
-                margin-top: var(--_pr-spacing-condensed);
+                margin-top: @pr-spacing-condensed;
             }
         }
+
         pre {
-            margin-bottom: calc(var(--_pr-spacing-condensed) + 0.1em); // Add some more spacing on the bottom for a little extra optical alignment
+            margin-bottom: calc(@pr-spacing-condensed + 0.1em); // Add some more spacing on the bottom for a little extra optical alignment
         }
 
-        margin-bottom: var(--_pr-spacing);
+        margin-bottom:@pr-spacing;
         margin-top: 0;
     }
+
     sub,
     sup {
         --_pr-code-fs: 90%;
     }
+
     blockquote {
         --_pr-img-mb: 0;
 
@@ -232,23 +256,27 @@
             top: 0;
             width: var(--su4);
         }
+
         *:last-child {
             margin-bottom: 0;
         }
+
         blockquote {
             --_pr-blockquote-ml: 0; // We don't need the intial indentation on nested blockquotes
         }
 
         color: var(--black-600);
-        margin: var(--_pr-blockquote-mt) 1em var(--_pr-spacing) var(--_pr-blockquote-ml);
+        margin: var(--_pr-blockquote-mt) 1em @pr-spacing var(--_pr-blockquote-ml);
         padding: 0.8em 0.8em 0.8em 1em;
         position: relative;
     }
+
     code {
         font-size: var(--_pr-code-fs);
 
         font-family: var(--ff-mono);
     }
+
     dd {
         &:last-child {
             margin-bottom: 0;
@@ -257,26 +285,31 @@
         margin: 0;
         padding: 0;
     }
+
     dl {
         margin-top: 0;
     }
+
     dt {
         font-weight: bold;
     }
+
     hr {
         background-color: var(--_pr-hr-bg);
         color: var(--_pr-hr-bg); // value set for background-color reused for color intentionally
 
         border: 0;
         height: var(--su-static1);
-        margin-bottom: var(--_pr-spacing);
+        margin-bottom: @pr-spacing;
     }
+
     img {
         margin-bottom: var(--_pr-img-mb);
 
         max-width: 100%;
         vertical-align: bottom;
     }
+
     kbd {
         border: var(--su-static1) solid var(--_pr-kbd-bc);
         border-top-color: var(--_pr-kbd-btc, var(--_pr-kbd-bc));
@@ -294,8 +327,9 @@
         padding: 0.1em 0.6em;
         text-shadow: 0 var(--su-static1) 0 var(--white);
     }
+
     li {
-        --_pr-blockquote-mt: var(--_pr-spacing-condensed);
+        --_pr-blockquote-mt: @pr-spacing-condensed;
         --_pr-img-mb: 0;
 
         pre {
@@ -304,11 +338,13 @@
 
         overflow-wrap: break-word;
     }
+
     p {
         --_pr-img-mb: 0;
 
-        margin-bottom: var(--_pr-spacing);
+        margin-bottom: @pr-spacing;
     }
+
     pre {
         &:not(.s-code-block) {
             code { // Reset the code element when contained within a <pre>
@@ -330,19 +366,21 @@
         }
 
         margin-top: 0;
-        margin-bottom: calc(var(--_pr-spacing) + 0.4em); // Increase this spacing for better optical alignment
+        margin-bottom: calc(@pr-spacing + 0.4em); // Increase this spacing for better optical alignment
         overflow-wrap: normal;
     }
+
     .soundcloud-embed iframe {
         height: 116px;
         max-width: 640px;
         width: 100%;
     }
+
     .spoiler {
         &:after {
             opacity: var(--_pr-soiler-after-o);
             top: var(--_pr-spoiler-after-t);
-            transition: var(--_pr-spoiler-transition);
+            transition: @pr-spoiler-transition;
 
             background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='rgb(132, 141, 149)' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M9 17A8 8 0 119 1a8 8 0 010 16zM8 4v6h2V4H8zm0 8v2h2v-2H8z'%3E%3C/path%3E%3C/svg%3E");
             background-position: center right;
@@ -355,15 +393,17 @@
             position: absolute;
             right: 1em;
         }
+
         &.is-visible {
             --_pr-spoiler-cursor: auto;
             --_pr-soiler-after-o: 0;
             --_pr-soiler-child-o: 1;
             --_pr-soiler-child-visibility: visible;
         }
+
         > * {
             opacity: var(--_pr-soiler-child-o);
-            transition: var(--_pr-spoiler-transition);
+            transition: @pr-spoiler-transition;
             visibility: var(--_pr-soiler-child-visibility); // hidden elements don't respond to mouse events, but still retain their space
         }
 
@@ -374,6 +414,7 @@
         color: var(--black-800);
         min-height: var(--su-static48); // TODO: Let's find a solution that doesn't have a magic number
     }
+
     .youtube-embed { // [2]
         > div {
             iframe {
@@ -381,6 +422,7 @@
                 position: absolute;
                 width: 100%;
             }
+
             height: 35px;
             padding-bottom: 56.25%;
             position: relative;

--- a/lib/css/components/sidebar-widgets.less
+++ b/lib/css/components/sidebar-widgets.less
@@ -1,14 +1,23 @@
 .s-sidebarwidget {
-    // CONSTANTS
-    --_sw-content-px: calc(var(--su16) - var(--su1)); // subtract 1px for border
-    --_sw-content-spacing-inner: var(--su12); // the spacing between two adjacent simple items
-    --_sw-content-spacing-outer: var(--su16); // the spacing at the start/end of a group of simple items, as well as between a complex item and its separator line
-
-    // VARIABLES
+    // COMPONENT-SPECIFIC CONSTANTS
+    @sw-content-px: calc(var(--su16) - var(--su1)); // subtract 1px for border
+    @sw-content-spacing-inner: var(--su12); // the spacing between two adjacent simple items
+    @sw-content-spacing-outer: var(--su16); // the spacing at the start/end of a group of simple items, as well as between a complex item and its separator line
+    // COMPONENT-SPECIFIC CUSTOM PROPERTIES
     --_sw-bc: var(--bc-medium);
     --_sw-after-bc: var(--_sw-bc);
     --_sw-content-bc: var(--bc-light);
     --_sw-header-bc: var(--_sw-content-bc);
+
+    // MODIFIERS
+    &:not(.s-anchors) {
+        a:not(.button):not(.post-tag):not(.s-btn):not(.s-sidebarwidget--action):not(.s-user-card--link) {
+            &,
+            &:visited {
+                color: var(--black-500);
+            }
+        }
+    }
 
     // VARIANTS
     .alternate-color(blue);
@@ -25,19 +34,6 @@
     }
 
     & &--content {
-        &.s-sidebarwidget__items {
-            &,
-            &.s-sidebarwidget__block-items .s-sidebarwidget--item {
-                display: block;
-            }
-
-            padding: calc(var(--_sw-content-spacing-outer) - var(--_sw-content-spacing-inner)) var(--_sw-content-px); // the items themselves provide part of the spacing, so the content padding needs to account for that
-        }
-
-        &:active {
-            outline: none;
-        }
-
         &:not(table) {
             &:not(.s-sidebarwidget__items),
             &:not(.s-sidebarwidget__block-items) .s-sidebarwidget--item {
@@ -45,44 +41,59 @@
             }
         }
 
+        &.s-sidebarwidget__items {
+            &,
+            &.s-sidebarwidget__block-items .s-sidebarwidget--item {
+                display: block;
+            }
+
+            padding: calc(@sw-content-spacing-outer - @sw-content-spacing-inner) @sw-content-px; // the items themselves provide part of the spacing, so the content padding needs to account for that
+        }
+
+        &:active {
+            outline: none;
+        }
+
         border-top: var(--su-static1) solid var(--_sw-content-bc);
         margin: 0;
-        padding: var(--_sw-content-spacing-outer) var(--_sw-content-px);
+        padding: @sw-content-spacing-outer @sw-content-px;
     }
 
     & &--header {
-        &.s-sidebarwidget__expanding-control {
-            &:before {
-                border: calc(var(--su-static4) + var(--su-static1)) solid transparent;
-                border-left-color: var(--bc-darker);
-                border-right-width: 0;
-                content: '';
-                float: left;
-                margin-right: var(--su12);
-                margin-top: calc(calc(var(--lh-base) * 1em) / 2 - 5px); // 1.3 is our standard line height
-                transition: transform 0.3s cubic-bezier(0.4, 0.4, 0.6, 1);
-            }
-
-            &[aria-expanded='true']:before {
-                transform: rotate(90deg);
-            }
-
-            cursor: pointer;
-        }
-
-        &.s-sidebarwidget__small-bold-text {
-            .s-sidebarwidget--action {
-                font-weight: normal;
-                line-height: calc(var(--lh-base) * var(--fs-caption)); // line-height should be the same as in the outside element, so the header and action baselines line up
-            }
-
-            font-size: var(--fs-caption);
-            font-weight: bold;
-        }
-
         &:first-child {
             border-top-left-radius: var(--br-sm);
             border-top-right-radius: var(--br-sm);
+        }
+
+        &.s-sidebarwidget {
+            &__expanding-control {
+                &:before {
+                    border: calc(var(--su-static4) + var(--su-static1)) solid transparent;
+                    border-left-color: var(--bc-darker);
+                    border-right-width: 0;
+                    content: '';
+                    float: left;
+                    margin-right: var(--su12);
+                    margin-top: calc(calc(var(--lh-base) * 1em) / 2 - 5px); // 1.3 is our standard line height
+                    transition: transform 0.3s cubic-bezier(0.4, 0.4, 0.6, 1);
+                }
+
+                &[aria-expanded='true']:before {
+                    transform: rotate(90deg);
+                }
+
+                cursor: pointer;
+            }
+
+            &__small-bold-text {
+                .s-sidebarwidget--action {
+                    font-weight: normal;
+                    line-height: calc(var(--lh-base) * var(--fs-caption)); // line-height should be the same as in the outside element, so the header and action baselines line up
+                }
+
+                font-size: var(--fs-caption);
+                font-weight: bold;
+            }
         }
 
         &:active {
@@ -95,7 +106,7 @@
         font-size: var(--fs-body2);
         font-weight: normal;
         margin: 0;
-        padding: var(--_sw-content-spacing-inner) var(--_sw-content-px);
+        padding: @sw-content-spacing-inner @sw-content-px;
     }
 
     & &--item {
@@ -108,16 +119,18 @@
                     border-left-style: solid;
                     border-left-width: calc(var(--su-static1) * 3); // 3px
                     content: '';
-                    height: calc(100% + var(--_sw-content-spacing-inner));
+                    height: calc(100% + @sw-content-spacing-inner);
                     left: 0;
-                    margin-left: calc(var(--_sw-content-px) * -1 - var(--su-static1)); // the orange selection indicator overlaps with the widget border
-                    margin-top: calc(var(--_sw-content-spacing-inner) / 2 * -1);
+                    margin-left: calc(@sw-content-px * -1 - var(--su-static1)); // the orange selection indicator overlaps with the widget border
+                    margin-top: calc(@sw-content-spacing-inner / 2 * -1);
                     position: absolute;
                 }
 
-                a,
-                a:visited { // TODO: this isn't the best way to go about this. There should be a "is current" highlight without font modification for more complex cases
-                    color: inherit;
+                a { // TODO: this isn't the best way to go about this. There should be a "is current" highlight without font modification for more complex cases
+                    &,
+                    &:visited {
+                        color: inherit;
+                    }
                 }
 
                 color: var(--black);
@@ -126,16 +139,18 @@
             }
         }
 
-        margin: var(--_sw-content-spacing-inner) 0;
+        margin: @sw-content-spacing-inner 0;
     }
 
     & &--subnav {
         li {
             &[aria-current="page"],
             &[aria-current="true"] {
-                a,
-                a:visited {
-                    color: inherit;
+                a {
+                    &,
+                    &:visited {
+                        color: inherit;
+                    }
                 }
 
                 #stacks-internals #bullet-arrow(var(--theme-primary-color));
@@ -166,15 +181,8 @@
         }
 
         border-collapse: separate;
-        border-spacing: var(--_sw-content-spacing-inner);
-        padding: calc(var(--_sw-content-spacing-outer) - var(--_sw-content-spacing-inner)) calc(var(--_sw-content-px) - var(--_sw-content-spacing-inner));
-    }
-
-    &:not(.s-anchors) a:not(.button):not(.s-btn):not(.post-tag):not(&--action):not(.s-user-card--link) {
-        &,
-        &:visited {
-            color: var(--black-500);
-        }
+        border-spacing: @sw-content-spacing-inner;
+        padding: calc(@sw-content-spacing-outer - @sw-content-spacing-inner) calc(@sw-content-px - @sw-content-spacing-inner);
     }
 
     &:before { // [1]
@@ -215,15 +223,15 @@
             --_sw-bc: var(~"--@{name}-700");
         });
 
+        &:after,
+        .s-sidebarwidget--content,
+        .s-sidebarwidget--header {
+            border-color: var(--_sw-bc);
+        }
+
         .s-sidebarwidget--header {
             background-color: var(~"--@{name}-100");
             color: var(--fc-medium);
-        }
-
-        .s-sidebarwidget--header,
-        .s-sidebarwidget--content,
-        &:after {
-            border-color: var(--_sw-bc);
         }
 
         background-color: var(~"--@{name}-050");

--- a/lib/css/components/spinner.less
+++ b/lib/css/components/spinner.less
@@ -7,22 +7,25 @@
         --_sp-baw: var(--su-static1);
         --_sp-size: var(--su-static12);
     }
+
     &&__sm {
         --_sp-baw: var(--su-static2);
         --_sp-size: var(--su-static16);
     }
+
     &&__md {
         --_sp-baw: var(--su-static4);
         --_sp-size: var(--su-static32);
     }
+
     &&__lg {
         --_sp-baw: var(--su-static6);
         --_sp-size: var(--su-static48);
     }
 
     // CHILD ELEMENTS
-    &:before,
-    &:after {
+    &:after,
+    &:before {
         border: var(--_sp-baw) solid currentColor;
 
         border-radius: var(--br-circle);
@@ -31,15 +34,17 @@
         position: absolute;
         width: 100%;
     }
-    &:before {
-        opacity: 0.25;
-        transform: rotate(90deg); // [1]
-    }
+
     &:after {
         border-top-color: transparent;
         border-right-color: transparent;
         border-bottom-color: transparent;
         animation: s-spinner-rotate 0.9s infinite cubic-bezier(0.5, 0.1, 0.5, 0.9);
+    }
+
+    &:before {
+        opacity: 0.25;
+        transform: rotate(90deg); // [1]
     }
 
     height: var(--_sp-size);
@@ -53,8 +58,8 @@
     --_li-offset: 0.6em;
     --_il-size: 1.23076923em;
 
-    &:before,
-    &:after {
+    &:after,
+    &:before {
         border-radius: var(--br-circle);
         border-style: solid;
         border-width: var(--su-static2);
@@ -65,16 +70,18 @@
         top: calc(50% - var(--_li-offset));
         width: var(--_il-size);
     }
-    &:before {
-        border-color: currentColor;
-        opacity: 0.3;
-    }
+
     &:after {
         animation: s-spinner-rotate 0.9s infinite cubic-bezier(0.5, 0.1, 0.5, 0.9);
         border-color: transparent;
         border-left-color: currentColor;
         filter: invert(0); // [1]
         transform-origin: 50% 50% 1px; // [1]
+    }
+
+    &:before {
+        border-color: currentColor;
+        opacity: 0.3;
     }
 
     padding-left: 2.2em;
@@ -92,4 +99,5 @@
 }
 
 // [1] no-op to reduce wobble in Edge. More info: https://github.com/StackExchange/Stacks/blob/d2af26aca06c47e3f1f7a638e49b221a9e28e450/lib/css/components/_stacks-spinner.less#L16-L26
+
 // [2] When within a parent that has text-align: center, the spinner's entire container spins, not just the spinner. Let's force text-align left so things spin internally.

--- a/lib/css/components/tags.less
+++ b/lib/css/components/tags.less
@@ -1,25 +1,24 @@
 .s-tag {
     --_ta-bc: var(--theme-tag-border-color);
+    --_ta-bc-hover: var(--theme-tag-hover-border-color);
+    --_ta-bc-selected: transparent;
     --_ta-bg: var(--theme-tag-background-color);
+    --_ta-bg-hover: var(--theme-tag-hover-background-color);
+    --_ta-bg-selected: var(--theme-secondary-200);
     --_ta-br: var(--br-sm);
     --_ta-fc: var(--theme-tag-color);
+    --_ta-fc-hover: var(--theme-tag-hover-color);
+    --_ta-fc-selected: var(--theme-secondary-900);
     --_ta-fs: var(--fs-caption);
     --_ta-lh: 1.846153846;
     --_ta-pl: var(--_ta-px);
     --_ta-pr: var(--_ta-px);
     --_ta-px: var(--su4);
-    // hover, focus, active
-    --_ta-bc-hover: var(--theme-tag-hover-border-color);
-    --_ta-bg-hover: var(--theme-tag-hover-background-color);
-    --_ta-fc-hover: var(--theme-tag-hover-color);
-    // .is-selected
-    --_ta-bc-selected: transparent;
-    --_ta-bg-selected: var(--theme-secondary-200);
-    --_ta-fc-selected: var(--theme-secondary-900);
 
     // CONTEXTUAL STYLES
     .highcontrast-mode({
         --_ta-bc: currentColor;
+
         text-decoration: none;
     });
 
@@ -30,13 +29,13 @@
         a&:active,
         a&:hover,
         a&:focus {
-            background-color: var(--_ta-bg-selected);
-            border-color: var(--_ta-bc-selected);
-            color: var(--_ta-fc-selected);
-
             .highcontrast-mode({
                 border-color: currentColor;
             });
+
+            background-color: var(--_ta-bg-selected);
+            border-color: var(--_ta-bc-selected);
+            color: var(--_ta-fc-selected);
         }
     }
 
@@ -89,12 +88,15 @@
             -webkit-mask-size: contain;
             mask-size: contain;
         }
+
         position: relative;
     }
+
     &__ignored, // TODO: remove all single `&` ignored styles once core no longer requires them
     &&__ignored {
         --_ta-before-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M3.52 7.38 1.58 9.26A12.38 12.38 0 0 1 0 7s2.63-5.14 7.05-5.14c.66 0 1.28.12 1.86.32L7.44 3.6a3.48 3.48 0 0 0-3.92 3.78ZM5.3 9.99c.5.28 1.1.44 1.71.44 1.94 0 3.5-1.53 3.5-3.43 0-.62-.17-1.21-.47-1.72L8.7 6.6a1.73 1.73 0 0 1-2.08 2.07L5.29 10Zm6.23-6.19A12.7 12.7 0 0 1 14 7s-2.63 5.14-6.95 5.14A6.1 6.1 0 0 1 4 11.3L2.27 13l-1.4-1.36L11.9 1l1.23 1.2-1.6 1.6Z'/%3E%3C/svg%3E");
     }
+
     // moderator overrides other muted and required, required overrides muted
     &&__moderator {
         --_ta-bc: var(--red-200);
@@ -107,6 +109,7 @@
         --_ta-bg-selected: var(--red-200);
         --_ta-fc-selected: var(--red-800);
     }
+
     &&__muted:not(&__moderator):not(&__required) {
         --_ta-bc: transparent;
         --_ta-bg: var(--black-075);
@@ -120,6 +123,7 @@
 
         .highcontrast-mode({ --_ta-bc: currentColor; }); // Specificity has bit us, so we need this override
     }
+
     &&__required:not(&__moderator) {
         --_ta-bc: var(--bc-darker);
         --_ta-bg: var(--black-075);
@@ -160,6 +164,7 @@
         padding: var(--su1);
         width: var(--su-static16);
     }
+
     & &--sponsor { // The small sponsor favicon displayed within a tag
         img,
         .svg-icon {
@@ -179,13 +184,13 @@
         &:hover,
         &:focus,
         &:active {
-            background-color: var(--_ta-bg-hover);
-            border-color: var(--_ta-bc-hover);
-            color: var(--_ta-fc-hover);
-
             .highcontrast-mode({
                 border-color: currentColor;
             });
+
+            background-color: var(--_ta-bg-hover);
+            border-color: var(--_ta-bc-hover);
+            color: var(--_ta-fc-hover);
         }
     }
 

--- a/lib/css/components/toggle-switches.less
+++ b/lib/css/components/toggle-switches.less
@@ -2,29 +2,34 @@
     --_ts-bg: var(--black-300);
     --_ts-bg-ps: left center;
     --_ts-bs-color: transparent;
-    // multiple
     --_ts-multiple-bg: unset;
     --_ts-multiple-fc: var(--black-500);
 
-    // TODO split single and multiple toggle into two seperate components
-    &&__multiple {
+    &&__multiple { // TODO split single and multiple toggle into two seperate components
         input[type="radio"] {
             &:checked {
                 + label {
                     &.s-toggle-switch--label-off {
                         --_ts-multiple-bg: var(--black-500);
                         --_ts-multiple-fc: var(--white);
+
                         .dark-mode({ --_ts-multiple-bg: var(--black-350); });
                     }
+
                     &:not(.s-toggle-switch--label-off) {
                         --_ts-multiple-bg: var(--green-400);
                         --_ts-multiple-fc: @white;
+
                         .highcontrast-mode({ --_ts-multiple-fc: var(--white); });
                     }
                 }
+
                 &:focus + label {
                     --_ts-bs-color: var(--focus-ring-success);
-                    &.s-toggle-switch--label-off { --_ts-bs-color: var(--focus-ring-muted); }
+
+                    &.s-toggle-switch--label-off {
+                        --_ts-bs-color: var(--focus-ring-muted);
+                    }
                 }
             }
 
@@ -33,6 +38,7 @@
             opacity: 0;
             position: absolute;
         }
+
         label {
             background-color: var(--_ts-multiple-bg);
             box-shadow: 0 0 0 var(--su-static4) var(--_ts-bs-color);
@@ -67,10 +73,12 @@
                 --_ts-bs-color: var(--focus-ring-success);
             }
         }
+
         &:focus {
             --_ts-bs-color: var(--focus-ring-muted);
             outline: none;
         }
+
         &[disabled] {
             cursor: default;
         }

--- a/lib/css/components/uploader.less
+++ b/lib/css/components/uploader.less
@@ -1,12 +1,16 @@
 .s-uploader {
+    // COMPONENT-SPECIFIC CONSTANTS
+    --_up-bg-b-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' rx='5' ry='5' stroke='%23000000' stroke-width='8' stroke-dasharray='7%2c 22' stroke-dashoffset='0' stroke-linecap='square'/%3e%3c/svg%3e"); // Keeping this a custom property to save a few bytes
+    // COMPONENT-SPECIFIC CUSTOM PROPERTIES
     --_up-bg: var(--black-025);
     --_up-bg-focus: var(--black-050);
     --_up-bg-bc: var(--black-150);
     --_up-focus-ring-color: var(--focus-ring);
-    --_up-bg-b-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' rx='5' ry='5' stroke='%23000000' stroke-width='8' stroke-dasharray='7%2c 22' stroke-dashoffset='0' stroke-linecap='square'/%3e%3c/svg%3e");
 
     // CONTEXTUAL STYLES
-    .highcontrast-mode({ --_up-bg-bc-hc: var(--black-400); });
+    .highcontrast-mode({
+        --_up-bg-bc-hc: var(--black-400);
+    });
 
     // STATES
     &.has-error,
@@ -16,6 +20,7 @@
             color: var(--_up-link-fc);
         }
     }
+
     &.has-error {
         --_up-bg: var(--red-050);
         --_up-bg-focus: var(--red-100);
@@ -24,6 +29,7 @@
         --_up-focus-ring-color: var(--focus-ring-error);
         --_up-link-fc: var(--red-900);
     }
+
     &.has-success {
         --_up-bg: var(--green-025);
         --_up-bg-focus: var(--green-050);
@@ -32,6 +38,7 @@
         --_up-focus-ring-color: var(--focus-ring-success);
         --_up-link-fc: var(--green-900);
     }
+
     &.has-warning {
         --_up-bg: var(--yellow-050);
         --_up-bg-focus: var(--yellow-100);
@@ -40,14 +47,15 @@
         --_up-focus-ring-color: var(--focus-ring-warning);
         --_up-link-fc: var(--yellow-900);
     }
+
     &.is-active {
         --_up-bg: var(--black-050);
         --_up-bg-bc: var(--black-200);
     }
+
     &.is-disabled {
         opacity: var(--_o-disabled-static);
     }
-
 
     //  CHILD ELEMENTS
     & &--container {
@@ -55,11 +63,11 @@
             -webkit-mask-image: var(--_up-bg-b-image);
             mask-image: var(--_up-bg-b-image);
             background-color: var(--_up-bg-bc-hc-state, var(--_up-bg-bc-hc, var(--_up-bg-bc)));
-            content: '';
             border-radius: var(--br-lg);
+            content: '';
             display: block;
-            position: absolute;
             inset: 0;
+            position: absolute;
         }
 
         align-items: center;
@@ -73,6 +81,7 @@
         position: relative;
         text-align: center;
     }
+
     & &--input {
         &:focus:focus-visible + .s-uploader--container {
             background-color: var(--_up-bg-focus);
@@ -87,12 +96,16 @@
         width: 100%;
         z-index: var(--zi-selected);
     }
+
     & &--preview {
         max-width: 100%;
         pointer-events: none;
     }
+
     & &--preview-thumbnail {
-        .highcontrast-mode({ border: 1px solid var(--black); });
+        .highcontrast-mode({
+            border: var(--su-static1) solid var(--black);
+        });
 
         &:is(img) {
             object-fit: scale-down;
@@ -112,6 +125,7 @@
         text-overflow: ellipsis;
         white-space: nowrap;
     }
+
     & &--previews {
         &.has-multiple {
             display: block;
@@ -119,35 +133,38 @@
             padding: var(--su8) var(--su2);
             width: 100%;
 
-            .s-uploader--preview {
-                align-items: center;
-                display: flex;
-                padding: var(--su6) 0;
-                width: 100%;
+            .s-uploader {
+                &--preview {
+                    align-items: center;
+                    display: flex;
+                    padding: var(--su6) 0;
+                    width: 100%;
 
-                &:after {
-                    content: attr(data-filename);
-                    display: block;
-                    margin-left: var(--su12);
-                    max-width: 100%;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    white-space: nowrap;
+                    &:after {
+                        content: attr(data-filename);
+                        display: block;
+                        margin-left: var(--su12);
+                        max-width: 100%;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                    }
                 }
-            }
-            .s-uploader--preview-thumbnail {
-                color: transparent;
-                height: var(--su-static32);
-                flex-shrink: 0;
-                width: var(--su-static32);
 
-                &:is(img) {
-                    object-fit: cover;
-                }
-                &:not(img) {
-                    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='%23535A60' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M3 3a2 2 0 012-2h6l4 4v10a2 2 0 01-2 2H5a2 2 0 01-2-2V3zm7-1.5V6h4.5L10 1.5z'%3E%3C/path%3E%3C/svg%3E");
-                    background-position: center;
-                    background-repeat: no-repeat;
+                &--preview-thumbnail {
+                    color: transparent;
+                    height: var(--su-static32);
+                    flex-shrink: 0;
+                    width: var(--su-static32);
+
+                    &:is(img) {
+                        object-fit: cover;
+                    }
+                    &:not(img) {
+                        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='%23535A60' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M3 3a2 2 0 012-2h6l4 4v10a2 2 0 01-2 2H5a2 2 0 01-2-2V3zm7-1.5V6h4.5L10 1.5z'%3E%3C/path%3E%3C/svg%3E");
+                        background-position: center;
+                        background-repeat: no-repeat;
+                    }
                 }
             }
         }
@@ -155,18 +172,21 @@
         max-width: 100%;
         text-align: left;
     }
+
     & &--previews-heading {
         color: var(--black-900);
         font-size: var(--fs-body2);
         font-weight: 600;
         padding-bottom: var(--su8);
     }
+
     & &--reset {
         position: absolute;
         right: var(--su8);
         top: var(--su8);
         z-index: var(--zi-active);
     }
+
     // This is for safari shadow DOM
     // see https://github.com/StackExchange/Stacks/pull/690#issuecomment-861028193
     input[type="file"]::file-selector-button {

--- a/lib/css/components/uploader.less
+++ b/lib/css/components/uploader.less
@@ -133,39 +133,37 @@
             padding: var(--su8) var(--su2);
             width: 100%;
 
-            .s-uploader {
-                &--preview {
-                    align-items: center;
-                    display: flex;
-                    padding: var(--su6) 0;
-                    width: 100%;
-
-                    &:after {
-                        content: attr(data-filename);
-                        display: block;
-                        margin-left: var(--su12);
-                        max-width: 100%;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                        white-space: nowrap;
-                    }
+            .s-uploader--preview {
+                &:after {
+                    content: attr(data-filename);
+                    display: block;
+                    margin-left: var(--su12);
+                    max-width: 100%;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
                 }
 
-                &--preview-thumbnail {
-                    color: transparent;
-                    height: var(--su-static32);
-                    flex-shrink: 0;
-                    width: var(--su-static32);
+                align-items: center;
+                display: flex;
+                padding: var(--su6) 0;
+                width: 100%;
+            }
 
-                    &:is(img) {
-                        object-fit: cover;
-                    }
-                    &:not(img) {
-                        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='%23535A60' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M3 3a2 2 0 012-2h6l4 4v10a2 2 0 01-2 2H5a2 2 0 01-2-2V3zm7-1.5V6h4.5L10 1.5z'%3E%3C/path%3E%3C/svg%3E");
-                        background-position: center;
-                        background-repeat: no-repeat;
-                    }
+            .s-uploader--preview-thumbnail {
+                &:is(img) {
+                    object-fit: cover;
                 }
+                &:not(img) {
+                    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='%23535A60' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M3 3a2 2 0 012-2h6l4 4v10a2 2 0 01-2 2H5a2 2 0 01-2-2V3zm7-1.5V6h4.5L10 1.5z'%3E%3C/path%3E%3C/svg%3E");
+                    background-position: center;
+                    background-repeat: no-repeat;
+                }
+
+                color: transparent;
+                height: var(--su-static32);
+                flex-shrink: 0;
+                width: var(--su-static32);
             }
         }
 

--- a/lib/css/components/user-cards.less
+++ b/lib/css/components/user-cards.less
@@ -19,6 +19,7 @@
     &&__deleted {
         --_uc-fc: var(--black-500);
     }
+
     &&__highlighted {
         --_uc-bg: var(--theme-secondary-050);
         --_uc-bar: var(--br-md);
@@ -34,12 +35,13 @@
         --_uc-p: 0;
         --_uc-info-ai: center;
         --_uc-info-fd: row;
-
     }
+
     &&__full {
         --_uc-ai: flex-start;
         --_uc-link-fs: var(--fs-body2);
     }
+
     &&__minimal {
         --_uc-link-ws: nowrap;
         --_uc-rep-fc: var(--black-600);
@@ -52,6 +54,7 @@
         font-size: var(--fs-caption);
         color: var(--black-500);
     }
+
     & &--awards {
         li {
             font-size: var(--fs-caption);
@@ -62,6 +65,7 @@
         display: flex;
         gap: var(--su6);
     }
+
     & &--info {
         align-items: var(--_uc-info-ai);
         flex-direction: var(--_uc-info-fd);
@@ -69,6 +73,7 @@
         display: flex;
         gap: var(--su4);
     }
+
     & &--link {
         font-size: var(--_uc-link-fs);
         white-space: var(--_uc-link-ws);
@@ -78,16 +83,19 @@
         min-width: 0; // Allow things to wrap
         overflow-wrap: break-word;
     }
+
     & &--rep {
         color: var(--_uc-rep-fc);
 
         font-weight: 700;
     }
+
     & &--tags {
         align-items: center;
         min-width: 0; // Allow things to wrap
         flex-wrap: wrap;
     }
+
     & &--time {
         color: var(--_uc-time-fc);
         white-space: var(--_uc-time-ws);
@@ -96,6 +104,7 @@
         grid-column: ~"1 / 3";
         grid-row: ~"1 / 2";
     }
+
     & &--type {
         a {
             color: inherit;


### PR DESCRIPTION
This PR (further) refines and unifies the code style for component `.less` files. 

See the **Examples** section below for expectations around code style.

> **Note**
> The code styles are not **hard** rules. There are circumstances where breaking from convention makes sense. Size modifiers for example are sorted by order of sizes and _not_ alphabetically.

## Examples


<details>
<summary>Components should use Less variables to define private, static variables</summary>

```
.s-component-name  {
    @cn-transition-duration: 100ms;
    --_cn-bg: var(--green-500);
    --_cn-content-transition:
        margin-bottom @cn-transition-duration cubic-bezier(0, 0, 0, 1),
        transform @cn-transition-duration cubic-bezier(1, 0, 1, 1),
        opacity @cn-transition-duration cubic-bezier(1, 0, 1, 1);

    &&__alt {
        --_cn-bg: var(--blue-400);
        --_cn-content-transition: none;
    }

    …
}
```
</details>

<details>
<summary>Each group of styles targeting selector(s) is separated by a space</summary>

```
…
&&__abc {
    .is-warm {
        …
    }

    .is-hot {
        …
    }

    display: none;
}

&&__mno {
    box-shadow: none;
}
…
```
</details>

<details>
<summary>Groupings of selectors are ordered alphabetically</summary>

```

&&__abc {
    …
}

&&__mno {
    …
}

&&__xyz {
    …
}

```
</details>


<details>
<summary>Groupings of selectors that target multiple selectors come before single selectors</summary>

```
a,
&&__mno,
&&__xyz  {
    …
}

&&__abc {
   …
}

&&__mno {
   …
}
```
</details>

<details>
<summary>Style rules should come after nested selectors</summary>

```
a,
&&__mno,
&&__xyz  {
    &.is-active {
        …
    }

    span {
        …
    }

    &:hover {
        …
    }

    color: var(--_cn-child-fc);

    display: flex;
    list-style: none;
}
```
</details>

<details>
<summary>Style rules set by pseudo-private custom variables should be placed before static rules</summary>

```
.s-component-name  {
    …

    background-color: var(--_cn-bg);
    color: var(--_cn-fc);

    display: flex;
    list-style: none;
}
```
</details>


<details>
<summary>Single line comments should be placed on the same line as that the comment applies to</summary>

```
.s-component-name  { // This is a placeholder name
    …

    background-color: var(--_cn-bg); // Can be overridden when nested inside `.s-post-summary`
}
```
</details>

<details>
<summary>Style rules should be sorted alphabetically unless cascade is impacted</summary>

```
.s-component-name  {
    …

    background-color: var(--_cn-bg);

    appearance: none;
    border: var(--su-static1) solid var(--black-400);
    border-left: none;
    box-shadow: none;
    display: table;
}
```
</details>