### PR TITLE
fix(bug): ensure variant shadow only shows on filled btn

### DIFF
--- a/lib/css/components/buttons.less
+++ b/lib/css/components/buttons.less
@@ -25,6 +25,7 @@
     --_bu-filled-bg: var(--theme-button-filled-background-color);
     --_bu-filled-bg-active: var(--theme-button-filled-active-background-color);
     --_bu-filled-bg-selected: var(--theme-button-filled-selected-background-color);
+    --_bu-filled-bs: inset 0 var(--su-static1) 0 0 hsla(0, 0, 100%, 0.7);
     --_bu-filled-fc: var(--theme-button-filled-color);
     --_bu-filled-fc-active: var(--theme-button-filled-hover-color); // Note: hover color used here intentionally
     --_bu-filled-fc-hover: var(--theme-button-filled-hover-color);
@@ -44,6 +45,7 @@
     // CONTEXTUAL STYLES
     .dark-mode({
         --_bu-bs: none;
+        --_bu-filled-bs: var(--_bu-bs);
     });
 
     .highcontrast-mode({
@@ -58,6 +60,7 @@
     &[disabled],
     &[aria-disabled="true"] {
         --_bu-bs: none !important;
+        --_bu-filled-bs: var(--_bu-bs);
         opacity: var(--_o-disabled-static);
         pointer-events: none;
         text-decoration: none;
@@ -118,10 +121,9 @@
 
     // MODIFIERS
     &&__filled {
-        --_bu-bs: inset 0 var(--su-static1) 0 0 hsla(0, 0, 100%, 0.7);
-
         border-color: var(--_bu-filled-bc);
         background-color: var(--_bu-filled-bg);
+        box-shadow: var(--_bu-filled-bs);
         color: var(--_bu-filled-fc);
     }
 
@@ -145,6 +147,7 @@
         --_bu-baw: 0;
         --_bu-br: 0;
         --_bu-bs: none;
+        --_bu-filled-bs: var(--_bu-bs);
         --_bu-focus-ring: none;
         --_bu-p: 0;
 
@@ -176,6 +179,7 @@
             --_bu-bg: none;
             --_bu-br: 0;
             --_bu-bs: none;
+            --_bu-filled-bs: var(--_bu-bs);
             --_bu-fc: unset;
             --_bu-focus-ring: none;
             --_bu-p: 0;
@@ -242,7 +246,6 @@
         --_bu-bg-active: var(--red-100);
         --_bu-bg-hover: var(--red-050);
         --_bu-bg-selected: var(--red-200);
-        --_bu-bs: inset 0 var(--su-static1) 0 0 hsla(0, 0%, 100%, 0.4);
         --_bu-fc: var(--red-600);
         --_bu-fc-active: var(--_bu-fc);
         --_bu-fc-hover: var(--red-700);
@@ -254,6 +257,7 @@
         --_bu-filled-bg-active: var(--red-700);
         --_bu-filled-bg-hover: var(--red-600);
         --_bu-filled-bg-selected: var(--red-800);
+        --_bu-filled-bs: inset 0 var(--su-static1) 0 0 hsla(0, 0%, 100%, 0.4);
         --_bu-filled-fc: var(--white);
         --_bu-filled-fc-active: var(--_bu-filled-fc);
         --_bu-filled-fc-hover: var(--_bu-filled-fc);
@@ -285,7 +289,6 @@
         --_bu-bg-active: var(--black-050);
         --_bu-bg-hover: var(--black-025);
         --_bu-bg-selected: var(--black-075);
-        --_bu-bs: inset 0 var(--su-static1) 0 0 hsla(0, 0%, 100%, 0.4);
         --_bu-fc: var(--black-500);
         --_bu-fc-active: var(--_bu-fc);
         --_bu-fc-hover: var(--black-600);
@@ -297,6 +300,7 @@
         --_bu-filled-bg-active: var(--black-200);
         --_bu-filled-bg-hover: var(--black-150);
         --_bu-filled-bg-selected: var(--black-350);
+        --_bu-filled-bs: inset 0 var(--su-static1) 0 0 hsla(0, 0%, 100%, 0.4);
         --_bu-filled-fc: var(--black-700);
         --_bu-filled-fc-active: var(--_bu-filled-fc);
         --_bu-filled-fc-hover: var(--_bu-filled-fc);


### PR DESCRIPTION
Addresses https://meta.stackexchange.com/questions/384776/search-has-an-extra-border-in-the-topbar

---

The [`.s-btn` refactor](https://github.com/StackExchange/Stacks/pull/1038) that went out with Stacks [v1.6.0](https://github.com/StackExchange/Stacks/releases/tag/v1.6.0) (and modified in [v1.6.3](https://github.com/StackExchange/Stacks/releases/tag/v1.6.3)) introduced an issue where an inset box shadow would be rendered when it shouldn't. This PR resolves that issue.

![small viewport search button in topbar showing an inset box shadow](https://i.stack.imgur.com/192FB.jpg)
