### PR TITLE
Add support for linking to future Razor component docs

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -6,6 +6,7 @@ const highlightPlugin = require("./plugins/highlight");
 const iconPlugin = require("./plugins/icons");
 const tipPlugin = require("./plugins/tip");
 const markdownPlugin = require("./plugins/markdown");
+const codeblockTabsPlugin = require("./plugins/codeblock-tabs");
 
 module.exports = function(eleventyConfig) {
   eleventyConfig.setQuietMode(true); // Reduce the console output
@@ -15,6 +16,7 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(iconPlugin);
   eleventyConfig.addPlugin(headerPlugin);
   eleventyConfig.addPlugin(tipPlugin);
+  eleventyConfig.addPlugin(codeblockTabsPlugin);
 
   // Version shortcode
   eleventyConfig.addLiquidShortcode("version", function() {

--- a/docs/_includes/layouts/page.html
+++ b/docs/_includes/layouts/page.html
@@ -23,9 +23,16 @@
                 https://stackoverflow.com/questions/38723559/flex-item-exceeds-its-container
             {% endcomment %}
             <div class="flex--item fl-grow1 ws1">
-                {% if js or figma %}
+                {% if js or figma or razor %}
                     <div class="stacks-badged d-flex g8 ai-center">
                         <h1 class="stacks-h1 flex--item mb0 mr-auto">{{ title }}</h1>
+
+                        {% if razor %}
+                            <a href="{{ razor }}" class="d-flex fc-white" target="_blank">
+                                <div class="stacks-badge-dotnet--icon blr-sm p4">{% icon "Checkmark" %}</div>
+                                <div class="stacks-badge-dotnet--text d-flex flex__center brr-sm px8 py4">Razor</div>
+                            </a>
+                        {% endif %}
 
                         {% if js %}
                             <a href="{{ "/product/guidelines/javascript" }}" class="d-flex fc-white">
@@ -37,7 +44,7 @@
                         {% if figma %}
                             <a href="{{ figma }}" class="d-flex fc-white theme-light__forced">
                                 <div class="bg-black-700 blr-sm p4">
-                                    <svg aria-hidden="true" class="svg-icon iconFigma native" width="18" height="18" viewBox="0 0 18 18"><path d="M6 18a3 3 0 0 0 3-3v-3H6a3 3 0 0 0 0 6Z" fill="#0ACF83"/><path d="M3 9a3 3 0 0 1 3-3h3v6H6a3 3 0 0 1-3-3Z" fill="#A259FF"/><path d="M3 3a3 3 0 0 1 3-3h3v6H6a3 3 0 0 1-3-3Z" fill="#F24E1E"/><path d="M9 0h3a3 3 0 0 1 0 6H9V0Z" fill="#FF7262"/><path d="M15 9a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" fill="#1ABCFE"/></svg>
+                                    {% icon "Figma", "native" %}
                                 </div>
                                 <div class="d-flex flex__center bg-black-500 brr-sm px8 py4">Figma</div>
                             </a>

--- a/docs/assets/less/stacks-documentation.less
+++ b/docs/assets/less/stacks-documentation.less
@@ -197,6 +197,15 @@
     color: var(--fc-light);
 }
 
+// -- Custom dotnet badge colors
+// follows the dotnet brand guidelines at https://github.com/dotnet/brand/blob/main/dotnet-brand-guidelines.pdf
+.stacks-badge-dotnet--icon {
+    background-color: #2b0b98;
+}
+.stacks-badge-dotnet--text {
+    background-color: #512bd4;
+}
+
 //  $$  PARAGRAPHS
 //  ----------------------------------------------------------------------------
 .stacks-copy {

--- a/docs/plugins/codeblock-tabs.js
+++ b/docs/plugins/codeblock-tabs.js
@@ -1,0 +1,14 @@
+module.exports = {
+    configFunction(eleventyConfig) {
+        // Header shortcode
+        eleventyConfig.addLiquidShortcode(
+            "codeblock-tabs",
+            function (razorUrl) {
+                return `<ul class="s-navigation s-navigation__muted mb4">
+                    <li><span class="s-navigation--item is-selected">CSS</span></li>
+                    <li><a href="${razorUrl}" class="s-navigation--item" target="_blank">Razor</a></li>
+                </ul>`;
+            }
+        );
+    },
+};

--- a/docs/product/components/activity-indicator.html
+++ b/docs/product/components/activity-indicator.html
@@ -2,6 +2,7 @@
 layout: page
 title: Activity indicator
 description: Stacks provides a small jewel for indicating new activity.
+razor: https://razor.stackoverflow.design/components/activityindicator
 ---
 <section class="stacks-section">
     {% header "h2", "Classes" %}
@@ -30,6 +31,7 @@ description: Stacks provides a small jewel for indicating new activity.
     {% header "h2", "Examples" %}
     {% header "h3", "Default" %}
     <p class="stacks-copy">By default, our indicator has no positioning attached to it. Depending on your context, you can modify the activity indicator’s positioning using any combination of atomic classes. Since our activity indicator has no inherent semantic meaning, make sure to include <a href="{{ '/product/base/visibility/' | url }}">visually-hidden, screenreader-only</a> text with the <code class="stacks-code">v-visible-sr</code> class.</p>
+    {% codeblock-tabs "https://razor.stackoverflow.design/components/activityindicator#default" %}
     <div class="stacks-preview">
 {% highlight html %}
 <div class="s-activity-indicator">
@@ -127,6 +129,7 @@ description: Stacks provides a small jewel for indicating new activity.
 
     {% header "h3", "Variations" %}
     <p class="stacks-copy">Stacks also provides alternative styling for success, warning, and danger states.</p>
+    {% codeblock-tabs "https://razor.stackoverflow.design/components/activityindicator#states" %}
     <div class="stacks-preview">
 {% highlight html %}
 <div class="s-activity-indicator s-activity-indicator__success">

--- a/docs/product/components/buttons.html
+++ b/docs/product/components/buttons.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Buttons
+razor: https://razor.stackoverflow.design/components/button/
 figma: https://www.figma.com/file/rknusKtqsY7iUI9Ng7PNDS/Buttons
 description: Buttons are user interface elements which allows users to take actions throughout the project. It is important that they have ample click space and help communicate the importance of their actions.
 ---

--- a/docs/product/components/modals.html
+++ b/docs/product/components/modals.html
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Modals
+razor: https://razor.stackoverflow.design/components/modal/
 js: true
 figma: https://www.figma.com/file/B1IIlRbtGvReNCILI7HNVL/Modals
 description: Modals are dialog overlays that prevent the user from interacting with the rest of the website until an action is taken or the dialog is dismissed. Modals are purposefully disruptive and should be used thoughtfully and sparingly.


### PR DESCRIPTION
Sample PR that adds support for linking out to a separate Razor components docs site. Two different approaches have been taken here. We can easily keep one or both. Both approaches likely need some design love.

## Page badge
Added to Activity indicator, Buttons, Modals pages as examples:

![image](https://user-images.githubusercontent.com/14169651/210639989-c5398996-e0b2-4617-a421-63d00360bb13.png)

## Codeblock "tab"
A fake "tab" that simply links you to the correct sub-section in the external docs. Good for pointing to a specific area on a page. Added to the Activity indicator page as an example.

![image](https://user-images.githubusercontent.com/14169651/210640209-a3d5741c-2588-4031-a2fa-be5e2fcfbe64.png)
