### PR TITLE
removed flashing scroll bar when expanding content

### DIFF
--- a/lib/css/components/expandable.less
+++ b/lib/css/components/expandable.less
@@ -13,10 +13,6 @@
     --_ex-content-mb: 0;
     --_ex-content-o: unset;
     --_ex-content-transform: unset;
-    --_ex-content-transition:
-        margin-bottom @ex-transition-duration cubic-bezier(0, 0, 0, 1),
-        transform @ex-transition-duration cubic-bezier(1, 0, 1, 1),
-        opacity @ex-transition-duration cubic-bezier(1, 0, 1, 1);
 
     &:not(.is-expanded) {
         --_ex-after-h: 0;
@@ -26,12 +22,6 @@
         --_ex-content-mb: -1500px;
         --_ex-content-o: 0;
         --_ex-content-transform: scaleY(0);
-        --_ex-content-transition:
-            margin-bottom @ex-transition-duration cubic-bezier(1, 0, 1, 1),
-            visibility 0s @ex-transition-duration,
-            max-height 0s @ex-transition-duration,
-            transform @ex-transition-duration cubic-bezier(0, 1, 1, 1),
-            opacity @ex-transition-duration cubic-bezier(0, 1, 1, 1);
 
         & .s-expandable--content {
             @supports ((-webkit-clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)) or (clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%))) {


### PR DESCRIPTION
Opening this pull request because of legacy code in CSS and also the reaction to #1224 

I already tried to fix this issue when it was reported here #1142.

**expandable.less** code was changed a lot (during adding local component custom properties and cleanup code initiative) so this PR is fixing only scrollbar issue.

I think there is a lot of outdated code (used to fix browser bugs, but that is no longer current) so I think this "component" can be simplified even more, and I'm happy to get into it.