### PR TITLE
update Stimulus to latest

### DIFF
--- a/docs/assets/js/global.jquery.ts
+++ b/docs/assets/js/global.jquery.ts
@@ -1,0 +1,2 @@
+// @ts-expect-error
+global.$ = require("jquery");

--- a/docs/assets/js/index.ts
+++ b/docs/assets/js/index.ts
@@ -4,10 +4,9 @@ import "./controllers/docs-resizer";
 import * as Stacks from "../../../lib/ts/index";
 
 // @ts-expect-error
-global.$ = require("jquery");
-// @ts-expect-error
 global.Stacks = Stacks;
 
+import "./global.jquery";
 import "./global.search";
 import "./global.navigation";
 import "./global.hamburger";

--- a/lib/ts/stacks.ts
+++ b/lib/ts/stacks.ts
@@ -1,4 +1,4 @@
-import * as Stimulus from "stimulus";
+import * as Stimulus from "@hotwired/stimulus";
 
 export class StacksApplication extends Stimulus.Application {
     static _initializing = true;

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "compilerOptions": {
         "strict": true,
-        "target": "es5",
-        "lib": ["dom", "es6", "dom.iterable", "scripthost"], // es6 stuff is polyfilled by stimulus
+        "target": "es6",
+        "lib": ["dom", "es6", "dom.iterable", "scripthost"],
         "outDir": "../dist",
         "sourceMap": true,
         "moduleResolution": "node",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.6.7",
       "license": "MIT",
       "dependencies": {
-        "@popperjs/core": "^2.11.6",
-        "stimulus": "^2.0.0"
+        "@hotwired/stimulus": "^3.2.1",
+        "@popperjs/core": "^2.11.6"
       },
       "devDependencies": {
         "@11ty/eleventy": "^1.0.2",
@@ -429,6 +429,11 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/@hotwired/stimulus": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.1.tgz",
+      "integrity": "sha512-HGlzDcf9vv/EQrMJ5ZG6VWNs8Z/xMN+1o2OhV1gKiSG6CqZt5MCBB1gRg5ILiN3U0jEAxuDTNPRfBcnZBDmupQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -962,6 +967,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@stimulus/core/-/core-2.0.0.tgz",
       "integrity": "sha512-ff70GafKtzc8zQ1/cG+UvL06GcifPWovf2wBEdjLMh9xO2GOYURO3y2RYgzIGYUIBefQwyfX2CLfJdZFJrEPTw==",
+      "dev": true,
       "dependencies": {
         "@stimulus/mutation-observers": "^2.0.0"
       }
@@ -969,12 +975,14 @@
     "node_modules/@stimulus/multimap": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@stimulus/multimap/-/multimap-2.0.0.tgz",
-      "integrity": "sha512-pMBCewkZCFVB3e5mEMoyO9+9aKzHDITmf3OnPun51YWxlcPdHcwbjqm1ylK63fsoduIE+RowBpFwFqd3poEz4w=="
+      "integrity": "sha512-pMBCewkZCFVB3e5mEMoyO9+9aKzHDITmf3OnPun51YWxlcPdHcwbjqm1ylK63fsoduIE+RowBpFwFqd3poEz4w==",
+      "dev": true
     },
     "node_modules/@stimulus/mutation-observers": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@stimulus/mutation-observers/-/mutation-observers-2.0.0.tgz",
       "integrity": "sha512-kx4VAJdPhIGBQKGIoUDC2tupEKorG3A+ckc2b1UiwInKTMAC1axOHU8ebcwhaJIxRqIrs8//4SJo9YAAOx6FEg==",
+      "dev": true,
       "dependencies": {
         "@stimulus/multimap": "^2.0.0"
       }
@@ -982,7 +990,8 @@
     "node_modules/@stimulus/webpack-helpers": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@stimulus/webpack-helpers/-/webpack-helpers-2.0.0.tgz",
-      "integrity": "sha512-D6tJWsAC024MwGEIKlUVYU8Ln87mlrmiwHvYAjipg+s8H4eLxUMQ3PZkWyPevfipH+oR3leuHsjYsK1gN5ViQA=="
+      "integrity": "sha512-D6tJWsAC024MwGEIKlUVYU8Ln87mlrmiwHvYAjipg+s8H4eLxUMQ3PZkWyPevfipH+oR3leuHsjYsK1gN5ViQA==",
+      "dev": true
     },
     "node_modules/@testing-library/dom": {
       "version": "8.19.1",
@@ -11168,6 +11177,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stimulus/-/stimulus-2.0.0.tgz",
       "integrity": "sha512-xipy7BS5TVpg4fX6S8LhrYZp7cmHGjmk09WSAiVx1gF5S5g43IWsuetfUhIk8HfHUG+4MQ9nY0FQz4dRFLs/8w==",
+      "dev": true,
       "dependencies": {
         "@stimulus/core": "^2.0.0",
         "@stimulus/webpack-helpers": "^2.0.0"
@@ -12864,6 +12874,11 @@
       "integrity": "sha512-FNBhxhkI18qDA+SbUc6560d8N20WWBdUjalTKeZExV4eQaPAreEXQILj8QpAuBWJMUC4pD0/MzdEyI3+urJlSQ==",
       "dev": true
     },
+    "@hotwired/stimulus": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.1.tgz",
+      "integrity": "sha512-HGlzDcf9vv/EQrMJ5ZG6VWNs8Z/xMN+1o2OhV1gKiSG6CqZt5MCBB1gRg5ILiN3U0jEAxuDTNPRfBcnZBDmupQ=="
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -13295,6 +13310,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@stimulus/core/-/core-2.0.0.tgz",
       "integrity": "sha512-ff70GafKtzc8zQ1/cG+UvL06GcifPWovf2wBEdjLMh9xO2GOYURO3y2RYgzIGYUIBefQwyfX2CLfJdZFJrEPTw==",
+      "dev": true,
       "requires": {
         "@stimulus/mutation-observers": "^2.0.0"
       }
@@ -13302,12 +13318,14 @@
     "@stimulus/multimap": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@stimulus/multimap/-/multimap-2.0.0.tgz",
-      "integrity": "sha512-pMBCewkZCFVB3e5mEMoyO9+9aKzHDITmf3OnPun51YWxlcPdHcwbjqm1ylK63fsoduIE+RowBpFwFqd3poEz4w=="
+      "integrity": "sha512-pMBCewkZCFVB3e5mEMoyO9+9aKzHDITmf3OnPun51YWxlcPdHcwbjqm1ylK63fsoduIE+RowBpFwFqd3poEz4w==",
+      "dev": true
     },
     "@stimulus/mutation-observers": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@stimulus/mutation-observers/-/mutation-observers-2.0.0.tgz",
       "integrity": "sha512-kx4VAJdPhIGBQKGIoUDC2tupEKorG3A+ckc2b1UiwInKTMAC1axOHU8ebcwhaJIxRqIrs8//4SJo9YAAOx6FEg==",
+      "dev": true,
       "requires": {
         "@stimulus/multimap": "^2.0.0"
       }
@@ -13315,7 +13333,8 @@
     "@stimulus/webpack-helpers": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@stimulus/webpack-helpers/-/webpack-helpers-2.0.0.tgz",
-      "integrity": "sha512-D6tJWsAC024MwGEIKlUVYU8Ln87mlrmiwHvYAjipg+s8H4eLxUMQ3PZkWyPevfipH+oR3leuHsjYsK1gN5ViQA=="
+      "integrity": "sha512-D6tJWsAC024MwGEIKlUVYU8Ln87mlrmiwHvYAjipg+s8H4eLxUMQ3PZkWyPevfipH+oR3leuHsjYsK1gN5ViQA==",
+      "dev": true
     },
     "@testing-library/dom": {
       "version": "8.19.1",
@@ -21044,6 +21063,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stimulus/-/stimulus-2.0.0.tgz",
       "integrity": "sha512-xipy7BS5TVpg4fX6S8LhrYZp7cmHGjmk09WSAiVx1gF5S5g43IWsuetfUhIk8HfHUG+4MQ9nY0FQz4dRFLs/8w==",
+      "dev": true,
       "requires": {
         "@stimulus/core": "^2.0.0",
         "@stimulus/webpack-helpers": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@popperjs/core": "^2.11.6",
-    "stimulus": "^2.0.0"
+    "@hotwired/stimulus": "^3.2.1",
+    "@popperjs/core": "^2.11.6"
   },
   "devDependencies": {
     "@11ty/eleventy": "^1.0.2",


### PR DESCRIPTION
Aside from the actual upgrade to Stimulus 3, this requires a few other changes. Most importantly, TypeScript compilation can no longer target ES5 because Stimulus dropped support for Internet Explorer. This technically makes this a breaking change (but it should be the only one; feature-wise, Stimulus 3 is backwards-compatible to Stimulus 2).

The switch to ES6 also had an effect on how imports are reordered during transpilation, which required a minor change to the documentation code to ensure that jQuery is available before global.search.js is executed.

Final note, just because I got confused by it myself initially: Stimulus 2 temporarily still exists as a (transitive) dev dependency because Stacks depends on itself (via stacks-editor).