### PR TITLE
fix: allow independent stacks-dynamic/static compilation

### DIFF
--- a/lib/css/stacks-dynamic.less
+++ b/lib/css/stacks-dynamic.less
@@ -17,13 +17,6 @@
 //  --  SET BASIC STYLES FOR BODY
 @import "base/body.less";
 
-//  --  COMPONENTS
-@import "components/buttons.less";
-@import "components/link-previews.less";
-@import "components/notices.less";
-@import "components/tags.less";
-@import "components/pagination.less";
-
 //  --  LESS CONSTANTS AND MIXINS
 @import "exports/exports.less";
 

--- a/lib/css/stacks-static.less
+++ b/lib/css/stacks-static.less
@@ -22,6 +22,7 @@
 @import "components/award-bling.less";
 @import "components/avatars.less";
 @import "components/badges.less";
+@import "components/buttons.less";
 @import "components/empty-states.less";
 @import "components/block-link.less";
 @import "components/breadcrumbs.less";
@@ -32,10 +33,13 @@
 @import "components/inputs.less";
 @import "components/labels.less";
 @import "components/link.less";
+@import "components/link-previews.less";
 @import "components/menu.less";
 @import "components/modals.less";
 @import "components/navigation.less";
+@import "components/notices.less";
 @import "components/page-titles.less";
+@import "components/pagination.less";
 @import "components/popovers.less";
 @import "components/post-summary.less";
 @import "components/progress-bars.less";
@@ -43,6 +47,7 @@
 @import "components/sidebar-widgets.less";
 @import "components/spinner.less";
 @import "components/table.less";
+@import "components/tags.less";
 @import "components/toggle-switches.less";
 @import "components/topbar.less";
 @import "components/uploader.less";


### PR DESCRIPTION
`button.less` relies on styles from `.s-link()`. Because `.s-link` styles are included via `stacks-static.less` and `.s-btn` styles are included via from `stacks-dynamic.less`, we couldn't render `stacks-dynamic.less` independently (as we do in Core). h/t @balpha

Now that all components use CSS custom properties instead of Less variables for custom theming, we no longer need to include these component styles in `stacks-dynamic.less`. This PR moves any remaining component styles from `stacks-dynamic.less` to `stacks-static.less`.