### PR TITLE
test(avatar): add accessibility tests for s-avatar variations

### DIFF
--- a/lib/test/s-avatar.test.ts
+++ b/lib/test/s-avatar.test.ts
@@ -1,0 +1,72 @@
+import { html, fixture, expect } from "@open-wc/testing";
+import { screen } from "@testing-library/dom";
+import "../ts/index";
+
+// TODO abstract to a helper file… maybe create a helper function to test in all themes
+const colorThemes = ["theme-dark", "theme-light"];
+const baseThemes = ["", "theme-highcontrast"];
+
+const avatarStyles = {
+    sizes: ["24", "32", "48", "64", "96", "128"],
+    children: ["image", "letter"],
+};
+
+const makeTest = ({ testid, theme, classes, child = "" }) => {
+    it(`a11y: ${testid} styles in should be accessible`, async () => {
+        await fixture(html`<a
+            href="#"
+            class="s-avatar${classes}"
+            data-testid="${testid}"
+        >
+            <div
+                class="${child === "letter" ? "s-avatar--letter" : "d-none"}"
+                aria-hidden="true"
+            >
+                S
+            </div>
+            <img
+                class="${child === "image" ? "s-avatar--image" : "d-none"}"
+                src="https://picsum.photos/48"
+                alt="team logo"
+            />
+            <span class="v-visible-sr">Stack Overflow</span>
+        </a>`);
+
+        document.body.className = "";
+        document.body.classList.add(...theme);
+        const avatar = screen.getByTestId(testid);
+        // TODO add conditional option for high contrast mode to test against AAA
+        await expect(avatar).to.be.accessible();
+    });
+};
+
+describe("s-avatar", () => {
+    // Test default, high contrast themes
+    baseThemes.forEach((baseTheme) => {
+        // Test light, dark theme
+        colorThemes.forEach((colorTheme) => {
+            const testidBase = `s-avatar-${baseTheme ? `${baseTheme}-` : ""
+                }${colorTheme}`;
+            const theme = [baseTheme, colorTheme].filter(Boolean);
+
+            // Test each size
+            ["", ...avatarStyles.sizes].forEach((size) => {
+                const sizeClasses = size ? ` s-avatar__${size}` : "";
+                const classesSize = ` ${sizeClasses}`;
+                const testidSize = `${testidBase}-${size}`;
+
+                // Test each size with each child
+                ["", ...avatarStyles.children].forEach((child) => {
+                    const testidChildren = `${testidSize}${child ? `-with-${child}` : ""
+                        }`;
+                    makeTest({
+                        child,
+                        classes: classesSize,
+                        testid: testidChildren,
+                        theme,
+                    });
+                });
+            });
+        });
+    });
+});

--- a/lib/test/s-avatar.test.ts
+++ b/lib/test/s-avatar.test.ts
@@ -45,8 +45,9 @@ describe("s-avatar", () => {
     baseThemes.forEach((baseTheme) => {
         // Test light, dark theme
         colorThemes.forEach((colorTheme) => {
-            const testidBase = `s-avatar-${baseTheme ? `${baseTheme}-` : ""
-                }${colorTheme}`;
+            const testidBase = `s-avatar-${
+                baseTheme ? `${baseTheme}-` : ""
+            }${colorTheme}`;
             const theme = [baseTheme, colorTheme].filter(Boolean);
 
             // Test each size
@@ -57,8 +58,9 @@ describe("s-avatar", () => {
 
                 // Test each size with each child
                 ["", ...avatarStyles.children].forEach((child) => {
-                    const testidChildren = `${testidSize}${child ? `-with-${child}` : ""
-                        }`;
+                    const testidChildren = `${testidSize}${
+                        child ? `-with-${child}` : ""
+                    }`;
                     makeTest({
                         child,
                         classes: classesSize,


### PR DESCRIPTION
See also https://github.com/StackExchange/Stacks/pull/1217, https://github.com/StackExchange/Stacks/pull/1239

---

In the process of writing accessibility tests for the `s-btn` component, I figured I could also provide a PoC for a more typical (aka simpler) component. This is that.

This PR adds accessibility tests for (nearly) all permutations of the `s-avatar` component.