### PR TITLE
fix(link): match pre-refactor :visited style rules

### DIFF
--- a/lib/css/components/badges.less
+++ b/lib/css/components/badges.less
@@ -230,16 +230,6 @@
         text-decoration: none;
     }
 
-    a& {
-        &,
-        &:active,
-        &:focus,
-        &:hover,
-        &:visited {
-            color: var(--_ba-fc);
-        }
-    }
-
     align-self: var(--_ba-as);
     background-color: var(--_ba-bg);
     border: var(--su-static1) solid var(--_ba-bc);

--- a/lib/css/components/link.less
+++ b/lib/css/components/link.less
@@ -13,6 +13,21 @@ a,
 
     // STATES
     &.s-link {
+        &__danger,
+        &__grayscale,
+        &__inherit,
+        &__muted,
+        &__visited {
+            &:visited {
+                &:active,
+                &:hover {
+                    color: var(--_li-fc-hover);
+                }
+
+                color: var(--_li-fc-visited);
+            }
+        }
+
         // MODIFIERS
         &__dropdown {
             &:after {
@@ -71,14 +86,7 @@ a,
     // INTERACTION
     &:active,
     &:hover {
-        &,
-        &:visited {
-            color: var(--_li-fc-hover);
-        }
-    }
-
-    &:visited {
-        color: var(--_li-fc-visited);
+        color: var(--_li-fc-hover);
     }
 
     color: var(--_li-fc);

--- a/lib/css/components/tags.less
+++ b/lib/css/components/tags.less
@@ -28,8 +28,7 @@
         a&,
         a&:active,
         a&:hover,
-        a&:focus,
-        a&:visited {
+        a&:focus {
             .highcontrast-mode({
                 border-color: currentColor;
             });
@@ -192,10 +191,6 @@
             background-color: var(--_ta-bg-hover);
             border-color: var(--_ta-bc-hover);
             color: var(--_ta-fc-hover);
-        }
-
-        &:visited {
-            color: var(--_ta-fc);
         }
     }
 


### PR DESCRIPTION
Prior to the .s-link refactor, `:visited` styles were only applied to modifier/variant classes (see https://github.com/StackExchange/Stacks/blob/30a1a41c8e4b87e6af516313df8b162e3768987b/lib/css/components/links.less). This commit matches that in refactored styles.