### PR TITLE
fix(post-summary): rm !important on content-menu-button

### DIFF
--- a/lib/css/components/post-summary.less
+++ b/lib/css/components/post-summary.less
@@ -206,8 +206,12 @@
                 margin: 0 !important;
             }
 
-            padding: var(--su8) !important; // To override .s-btn class attributes
-            position: absolute !important; // To override .s-btn class attributes
+            &,
+            &.s-btn { // To override .s-btn class attributes
+                padding: var(--su8);
+                position: absolute;
+            }
+
             right: var(--su8);
             top: var(--su8);
         }


### PR DESCRIPTION
We have `!important` on CSS rules on `.s-post-summary--content-menu-button` that seems unnecessary. The `!important` makes it hard to override these rules when we need to. This PR gets rid of `!important` and adds a little safe-guard to ensure the rules apply.

I'm really just creating this PR for a paper trail.