### PR TITLE
fix(card): target `:last-child` for margin reset

### DIFF
--- a/docs/product/components/cards.html
+++ b/docs/product/components/cards.html
@@ -20,18 +20,18 @@ description: Cards are used to group similar concepts and tasks together to make
             <div class="s-card wmx3 mb12">
                 <h2 class="fs-body3 lh-sm fc-dark">Base card title</h2>
                 <p class="fs-body1 fc-medium">This is a description of the card’s content.</p>
-                <p class="d-flex gx4">
+                <div class="d-flex gx4">
                     <button class="flex--item s-btn s-btn__primary s-btn__sm">Call to action</button>
                     <button class="flex--item s-btn s-btn__sm">Cancel</button>
-                </p>
+                </div>
             </div>
             <div class="s-card">
                 <h2 class="fs-body3 lh-sm fc-dark">Base card title</h2>
                 <p class="fs-body2 fc-medium">This is a description of the card’s content. Sometimes the description is two or three sentences.</p>
-                <p class="d-flex gx4">
+                <div class="d-flex gx4">
                     <button class="flex--item s-btn s-btn__primary s-btn__sm">Call to action</button>
                     <button class="flex--item s-btn s-btn__sm">Cancel</button>
-                </p>
+                </div>
             </div>
         </div>
     </div>

--- a/lib/css/components/cards.less
+++ b/lib/css/components/cards.less
@@ -17,7 +17,7 @@
     }
 
     // CHILD ELEMENTS
-    p:last-of-type {
+    :last-child {
         margin-bottom: 0;
     }
 

--- a/lib/css/components/cards.less
+++ b/lib/css/components/cards.less
@@ -17,7 +17,7 @@
     }
 
     // CHILD ELEMENTS
-    :last-child {
+    > :last-child {
         margin-bottom: 0;
     }
 


### PR DESCRIPTION
This PR targets `.s-card :last-child` instead of the previous `.s-card p:last-of-type` for a margin reset. This will allow us to use whatever element we feel is appropriate for the last child and still have the margin reset applied.

cc and h/t @balpha

> **Note**
> This is a breaking styling change and will require us to comb through Core when updating the Stacks dependencies to ensure styling is applied as expected.