### PR TITLE
fix(a11y): apply browser-default focus styles to reset links/buttons

### DIFF
--- a/docs/product/components/buttons.html
+++ b/docs/product/components/buttons.html
@@ -501,7 +501,7 @@ description: Buttons are user interface elements which allows users to take acti
                     <td class="va-middle">
                         <code class="flex--item stacks-code">.s-btn__unset</code>
                     </td>
-                    <td class="va-middle">Removes all styling from a button including its focus state.</td>
+                    <td class="va-middle">Removes all styling from a button and reverts focus states to browser default.</td>
                     <td class="va-middle"><button class="s-btn s-btn__unset ws-nowrap" type="button">Unset button</button></td>
                 </tr>
                 <tr>

--- a/lib/css/components/buttons.less
+++ b/lib/css/components/buttons.less
@@ -140,10 +140,10 @@
     &&__unset {
         &:focus,
         &:focus-visible {
-            outline-style: auto;
+            outline: revert;
         }
 
-        outline: initial;
+        outline: revert;
     }
 
     &&__link {

--- a/lib/css/components/buttons.less
+++ b/lib/css/components/buttons.less
@@ -140,10 +140,8 @@
     &&__unset {
         &:focus,
         &:focus-visible {
-            outline: revert;
+            outline-style: auto;
         }
-
-        outline: revert;
     }
 
     &&__link {
@@ -170,6 +168,7 @@
         .s-link();
         display: inline;
         font: inherit;
+        outline: revert;
         text-align: inherit;
     }
 
@@ -191,6 +190,8 @@
             font: unset;
             user-select: auto;
         }
+
+        outline: initial;
     }
 
     // Pseudo-elements and child-based modifiers

--- a/lib/css/components/link.less
+++ b/lib/css/components/link.less
@@ -1,5 +1,5 @@
 // TODO we *really* shouldn't be apply styles directly onto `<a>` like this, but
-// it's tech debt that'll take some doing in comsumer's code to pay down.
+// it's tech debt that'll take some doing in consumer's code to pay down.
 a,
 .s-link {
     --_li-fc: var(--theme-link-color);
@@ -105,7 +105,7 @@ a,
 .s-link {
     button& {
         &:focus {
-            outline: none;
+            outline: revert;
         }
 
         appearance: none;


### PR DESCRIPTION
`.s-btn__link`, ~~`.s-btn__unset`~~ and `button.s-link` don't have focus styles, but they should! This PR remedies that.

### Before (has focus)
![focused button.s-link element with no visible indication it's focus](https://user-images.githubusercontent.com/647177/223519182-686aa578-50e9-47d5-ae74-30dfeebd7489.png)

### After (has focus)
![focused button.s-link element with a focus ring to indicate it's focused](https://user-images.githubusercontent.com/647177/223519299-0d3779f5-8437-412b-9b68-5e5422789126.png)

h/t @collincchoy for reporting! See this [codepen](https://codepen.io/collincchoy/pen/OJoxNbr) for a demonstration of the problem