### PR TITLE
CCX-1303: Add s-truncation controller

### DIFF
--- a/docs/assets/js/entry.truncation.js
+++ b/docs/assets/js/entry.truncation.js
@@ -1,0 +1,15 @@
+$(document).ready(function() {
+    var exampleContainer = document.querySelector(".js-truncation-example");
+    var truncateToggle = document.querySelector(".js-truncation-toggle");
+    var truncateLength = document.querySelector(".js-truncation-length");
+
+    // Toggle truncation with the "Truncate" checkbox
+    truncateToggle.addEventListener("click", (event) => {
+        Stacks.toggleTruncation(exampleContainer, event.target.checked);
+    });
+
+    // Sets the s-truncation element's data-s-truncation-length attribute to the input's new value
+    truncateLength.addEventListener("input", (event) => {
+        exampleContainer.dataset.sTruncationLength = event.target.value;
+    });
+});

--- a/docs/product/base/truncation.html
+++ b/docs/product/base/truncation.html
@@ -3,6 +3,9 @@ layout: page
 title: Truncation
 description: Stacks provides utility classes for various types of truncation.
 ---
+<!-- Additional javascript -->
+<script src="{{ "/assets/dist/entry.truncation.js" | url }}" defer></script>
+
 <section class="stacks-section">
     {% header "h2", "Classes" %}
     <div class="overflow-x-auto mb32" tabindex="0">
@@ -39,6 +42,39 @@ description: Stacks provides utility classes for various types of truncation.
                     <td><code class="stacks-code">.v-truncate-fade__lg</code></td>
                     <td><code class="stacks-code">.v-truncate-fade</code></td>
                     <td>Increases the amount of visible text.</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    {% header "h2", "JavaScript" %}
+    <p class="stacks-copy">Optionally, you can use the <code class="stacks-code">s-truncation</code> component to limit the length of text in an element, while retaining as much of the original markup as possible. It's an useful option when dealing with elements that contain more than just plain text, which aren't truncated by the regular CSS classes.</p>
+
+    {% header "h3", "Attributes" %}
+    <div class="overflow-x-auto mb32" tabindex="0">
+        <table class="wmn4 s-table s-table__bx-simple">
+            <thead>
+                <tr>
+                    <th class="s-table--cell5" scope="col">Attribute</th>
+                    <th class="s-table--cell2" scope="col">Applied to</th>
+                    <th scope="col">Description</th>
+                </tr>
+            </thead>
+            <tbody class="fs-caption">
+                <tr>
+                    <th scope="row"><code class="stacks-code">data-controller="s-truncation"</code></th>
+                    <td>Controller element</td>
+                    <td class="p8">Wires up the element to the truncate controller.</td>
+                </tr>
+                <tr>
+                    <th scope="row"><code class="stacks-code">data-s-truncation-length="[x]"</code></th>
+                    <td>Controller element</td>
+                    <td class="p8">Sets the character limit for the text inside the element</td>
+                </tr>
+                <tr>
+                    <th scope="row"><code class="stacks-code">data-s-truncation-truncated="[true|false]"</code></th>
+                    <td>Controller element</td>
+                    <td class="p8">Sets the trucation state for the element. Default is <code class="stacks-code">false</code></code></td>
                 </tr>
             </tbody>
         </table>
@@ -107,4 +143,41 @@ description: Stacks provides utility classes for various types of truncation.
             </div> 
         </div>
     </div>
+
+    {% header "h3", "JavaScript Examples" %}
+    <p class="stacks-copy">CSS offers truncation on arbitrarily-long strings. This can help sanitize user-inputted things like bios, locations, or display names. In order for text truncation to work, it should be applied to a block-level element. Truncation can only apply to text/strings, not arbitrary block-level elements.</p>
+
+    <div class="stacks-preview">
+        {% highlight html %}
+<div data-controller="s-truncation" data-s-truncation-length="130">
+    …
+</div>
+        {% endhighlight %}
+        <div class="stacks-preview--example d-grid grid__6 gx12">
+            <div class="grid--col4">
+                <div data-controller="s-truncation" data-s-truncation-length="130" data-s-truncation-truncated="false" class="js-truncation-example">
+                    <p>In <a href="https://www.destroyallsoftware.com/talks/wat">Gary Bernhardt's Wat talk</a> from 2012 there's this example:</p>
+                    {% highlight javascript %}
+> new Array(16).join("wat" + 1);
+> "wat1wat1wat1wat1wat1wat1wat1wat1wat1wat1wat1wat1wat1wat1wat1" 
+> 
+> new Array(16).join("wat" - 1) + " Batman!";
+> "NaNNaNNaNNaNNaNNaNNaNNaNNaNNaNNaNNaNNaNNaNNaN Batman!" 
+                    {% endhighlight %}
+    
+                    <p class="mt12">So allow me to paraphrase an earlier remark in the presentation:</p>
+                    <blockquote class="bg-black-025 pl12 py4 ml16 bl">Exactly, right!? Like, what is even going on? I <span class="fs-italic">don't even understand</span> what person would think that any of this is a good idea!</blockquote>
+                </div>
+            </div>
+            <div class="grid--col2">
+                <div class="d-grid grid__2 g8 ai-center">
+                    <label class="grid--item s-label" for="content-length">Content length</label>
+                    <input class="grid--item s-input js-truncation-length" type="number" value="130" autocomplete="off">
+                    <label class="grid--item s-label" for="toggle-example">Truncate</label>
+                    <input class="grid--item s-toggle-switch js-truncation-toggle" id="toggle-truncate" type="checkbox" autocomplete="off">
+                </div>
+            </div>
+        </div>
+    </div>
+
 </section>

--- a/lib/components/truncation/truncation.ts
+++ b/lib/components/truncation/truncation.ts
@@ -1,0 +1,265 @@
+import * as Stacks from "../../stacks";
+
+/**
+ * Truncates the element's content length while respecting the original markup.
+ * 
+ * @description
+ * Useful when dealing with nested elements that can't be easily truncated with
+ * pure CSS, like `<pre>` blocks.
+ * 
+ * Note that whitespace-only text nodes between elements are hard hard to predict and handle
+ * correctly.
+ * 
+ * As such, off-by-a-few errors in the final length are to be expected
+ * 
+ * @example Turns
+ * ``` html
+ *         <div>
+ *            <p>Here's a <a href="…">Truncation</a> example<p>
+ *         </div>
+ * ```
+ * into
+ * ``` html
+ *         <div data-controller="s-truncation" data-s-truncation-length="15" data-s-truncation-truncated="true">
+ *            <p>Here's a <a href="…">Trunc…</a><p>
+ *         </div>
+ * ```
+ */
+export class TruncationController extends Stacks.StacksController {
+    static targets = [];
+
+    /**
+     * Content length desired
+     */
+    private maxLength: number | undefined;
+
+    /**
+     * Content length after the last truncation
+     */
+    private truncatedLength: number | undefined;
+
+    /**
+     * The document [Range](https://developer.mozilla.org/en-US/docs/Web/API/Range)
+     * encompassing the element to be truncated
+     */
+    private parentRange: Range | undefined;
+
+    /**
+     * A [DocumentFragment](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment)
+     * containing the original, untruncated content
+     */
+    private originalContent: DocumentFragment | undefined;
+
+    /**
+     * A [DocumentFragment](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment)
+     * containing the results of the last truncation
+     */
+    private truncatedContent: DocumentFragment | undefined;
+
+    /**
+     * [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) tracking changes to the parent element's sttributes
+     */
+    private attributeObserver!: MutationObserver;
+
+    /**
+     * Current truncation state
+     */
+    private isTruncated = false;
+
+    /**
+     * Sets up the truncator properties, configures the {@link attributeObserver}
+     * to track changes to the desired maximum length, and truncates the content if necessary
+     */
+    initialize() {
+        this.parentRange = document.createRange();
+        this.parentRange.selectNodeContents(this.element);
+        this.originalContent = this.parentRange.cloneContents();
+        this._parseMaxLengthAttribute();
+
+        // Track changes to the desired maximum length and triggers a new truncation if necessary
+        const config = { attributes: true };
+        this.attributeObserver = new MutationObserver(this._updateMaxLengthAndTruncate);
+        this.attributeObserver.observe(this.element, config);
+
+        // If we have a set maximum length shorter than current content, start truncating
+        if (this.maxLength) {
+            const originalCopy = (<HTMLElement>this.element).innerText;
+            if (originalCopy.length >= this.maxLength && this.data.get("truncated") === "true") {
+                this.truncate();
+            }
+        }
+
+    }
+
+    /**
+     * Reads and validates the `length` data attribute for the controlled element
+     */
+    private _parseMaxLengthAttribute() {
+        const maxLengthAttr = this.data.get("length");
+        this.maxLength = undefined;
+
+        if (maxLengthAttr) {
+            const parsedMaxLength = parseInt(maxLengthAttr, 10);
+
+            if (isNaN(parsedMaxLength)) {
+                throw `[${this.data.getAttributeNameForKey("length")}] attribute is invalid: "${maxLengthAttr}"`;
+            }
+
+            this.maxLength = parsedMaxLength;
+        }
+    }
+
+    /**
+     * Handles changes to the controlled element observed by {@link attributeObserver}. If the length has changed and we're truncated, triggers a new truncation for the new length
+     * @param mutationList The list of recent changes to the observed element
+     */
+    private _updateMaxLengthAndTruncate = (mutationList:MutationRecord[]) => {
+        for (const mutation of mutationList) {
+            if (mutation.type === "attributes" && mutation.attributeName == this.data.getAttributeNameForKey("length")) {
+                this._parseMaxLengthAttribute();
+
+                if (this.maxLength && this.isTruncated)
+                {
+                    this.truncate();
+                }
+            }
+        }
+    };
+
+    /**
+     * Truncates the content
+     */
+    truncate() {
+        this._toggle(true);
+    }
+
+    /**
+     * Restores the original content
+     */
+    restore() {
+        this._toggle(false);
+    }
+
+    /**
+     * Toggles element's copy between full length or its truncated version
+     * @param shouldTruncate Optional parameter that forces truncation on the element or toggles it if left undefined
+     */
+    private _toggle(shouldTruncate?: boolean | undefined) {
+        if (!this.maxLength || !this.parentRange || !this.originalContent) {
+            return;
+        }
+
+        // figure out the current state, from either the instance property or the element attribute
+        const currentlyTruncated = this.isTruncated ?? this.data.get("truncated") === "true";
+
+        // If we changed the desired length, our last truncation results should be discarded
+        if (this.truncatedLength != this.maxLength) {
+            this.truncatedContent = undefined;
+        }
+
+        if (typeof shouldTruncate === "undefined") {
+            shouldTruncate = !currentlyTruncated;
+        } else if (shouldTruncate == currentlyTruncated && !(shouldTruncate && !this.truncatedContent)) {
+            // if we're already at the desired state, do nothing
+            return;
+        }
+
+        let toInsert = this.originalContent;
+
+        if (shouldTruncate) {
+            if (!this.truncatedContent) {
+                let truncatedRange :Range;
+
+                // We're retruncating and can't use the original parent range, because it's pointing to
+                // truncated content. So copy the stored original content and set the range to that
+                if (currentlyTruncated) {
+                    truncatedRange = document.createRange();
+                    const originalContentNode = document.importNode(this.originalContent, true);
+                    truncatedRange.selectNodeContents(originalContentNode);
+                } else {
+                    truncatedRange = this.parentRange.cloneRange();
+                }
+
+
+                let totalLen = 0;
+                let node = truncatedRange.startContainer.firstChild;
+    
+                // Go through each child node until we find the one that takes us over the desired length
+                // Once it's found, truncates its content to comply with the max length and set the range
+                // boundary to that element
+                while (node) {
+                    if (node.textContent) {
+                        const trimmed = node.textContent.replace(/(^\s{2,}|\s{2,}$)/g, "");
+    
+                        if (totalLen + trimmed.length >= this.maxLength) {
+                            if (node.nodeType == Node.TEXT_NODE) {
+                                const truncatePosition = this.maxLength - totalLen - 1;
+                                node.textContent = trimmed.substring(0, truncatePosition).trimEnd() + "…";
+    
+                                truncatedRange.setEndAfter(node);
+                                break;
+                            } else {
+                                node = node.firstChild;
+    
+                                continue;
+                            }
+                        }
+    
+                        totalLen = totalLen + trimmed.length;
+                    }
+    
+                    node = node.nextSibling;
+                }
+
+                // The range now encompasses all the elements that fit in the desired content
+                // Make a copy of those nodes, to set as the new content for the parent element
+                this.truncatedContent = truncatedRange.cloneContents();
+                this.truncatedLength = this.maxLength;
+            }
+
+            toInsert = this.truncatedContent;
+        }
+
+        // Set's the controlled element's content and properties to reflect the desired truncation state
+        this.data.set("truncated", shouldTruncate.toString());
+        this.isTruncated = shouldTruncate;
+        this.parentRange.deleteContents();
+
+        const newContent = document.importNode(toInsert, true);
+        this.parentRange.insertNode(newContent);
+}
+}
+
+/**
+ * Helper to manually truncate an s-truncation element via external JS
+ * @param element the element the `data-controller="s-truncation"` attribute is on
+ */
+export function truncateContent(element: HTMLElement) {
+    toggleTruncation(element, true);
+}
+
+/**
+ * Helper to manually restore the original content of an s-truncation element via external JS
+ * @param element the element the `data-controller="s-truncation"` attribute is on
+ */
+export function restoreContent(element: HTMLElement) {
+    toggleTruncation(element, false);
+}
+
+/**
+ * Helper to manually toggle truncation on an s-truncation element via external JS
+ * @param element the element the `data-controller="s-truncation"` attribute is on
+ * @param show whether to force a truncation or a restore of the element's content; toggles truncation if left undefined
+ */
+export function toggleTruncation(element: HTMLElement, truncate?: boolean | undefined) {
+    const controller = Stacks.application.getControllerForElementAndIdentifier(
+        element,
+        "s-truncation"
+    ) as TruncationController;
+
+    if (!controller) {
+        throw "Unable to get s-truncation controller from element";
+    }
+
+    truncate ? controller.truncate() : controller.restore();
+}

--- a/lib/controllers.ts
+++ b/lib/controllers.ts
@@ -31,3 +31,9 @@ export {
     TooltipController,
 } from "./components/popover/tooltip";
 export { UploaderController } from "./components/uploader/uploader";
+export {
+    TruncationController,
+    toggleTruncation,
+    restoreContent,
+    truncateContent
+} from "./components/truncation/truncation";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,6 +9,7 @@ import {
     ToastController,
     TooltipController,
     UploaderController,
+    TruncationController
 } from "./controllers";
 import { application, StacksApplication } from "./stacks";
 
@@ -22,6 +23,7 @@ application.register("s-popover", PopoverController);
 application.register("s-table", TableController);
 application.register("s-tooltip", TooltipController);
 application.register("s-uploader", UploaderController);
+application.register("s-truncation", TruncationController);
 
 // finalize the application to guard our controller namespace
 StacksApplication.finalize();


### PR DESCRIPTION
# What is this?
This new `s-truncation` controller can be used to control the total length of an element's content, while respecting its original markup. It's especially useful when content truncation is needed in containers containing elements that aren't properly handled by the regular `.v-truncate[x]`, like when they have bottom padding, or `overflow: auto`. A couple of examples:

- **Code Blocks**
  The `.s-code-block` elements have a `overflow: auto` rule which prevent them from being truncated at all by the parent element. So this:

  ``` html
  <div class="v-truncate2">
    <p>Here's a code example:</p>
    <pre class="s-code-block">
      <code>
        if (myVariable == true)
        {
          return true;
        {
        else if (myVariable == false)
        {
          return false;
        }
      </code>
    </pre>
    <p>It's my best work!</p>
  </div>
  ```

  results in no truncation at all:
  ![image](https://user-images.githubusercontent.com/68292774/227596699-817a5705-f0e3-4c38-b021-24d8f6cf3050.png)

- **Bottom padding**
  Any truncated elements with a bottom padding will show the rest of their content, after the original truncation:

  ``` html
  <div class="pb12 v-truncate2">
    Regardless of length, this text will be truncated to 2 lines, vertically. But because of the bottom padding, content after truncation still appears
  </div>
  ```

  results in a weird layout:
  ![image](https://user-images.githubusercontent.com/68292774/227597789-58cb70fb-88aa-41cd-97d7-ad5576f358ff.png)

# Usage
The new controller allows you to control the total length of the copy inside the element, while respecting its markup, preserving the original look but cutting down on size. We ran into the need for something like this on Collectives, where we wanted to show a summary of a rendered post, which the Post Summary component doesn't currently do.

To use the controller you'll need to set the `data-controller` and `data-s-truncation-length` attributes:

``` html
<div data-controller="s-truncation" data-s-truncation-length="130">
    …
</div>
```

Which then turns this:
![image](https://user-images.githubusercontent.com/68292774/227599591-55b20d17-56ce-47b3-aa52-96b5bbd936a7.png)

Into:
![image](https://user-images.githubusercontent.com/68292774/227599676-dd8dd707-7efc-424d-b9af-f0aff52ae25e.png)

# Known Issues
There are 2 main technical issues with this initial version

## Flickering on load
Because truncation will only happen once Stimulus/Stacks instantiates the element, it's possible that if a truncated element is immediately visible on the page, the user could see it flicker after the page load and the truncator does its thing, cutting down the content.

I'm not sure how to get around the issue. Regardless of how fast the truncation logic becomes, the Controller initialization happens late enough in the page load to make it visible. Any suggestions would be appreciated!

## Off-by-a-few errors
The truncation logic works by traversing text nodes, which include all the white-space between HTML elements, and those are hard to handle correctly, given the wide variety of corner cases. So to keep things fast enough, the truncator ignores all-whitespace nodes and will trim down 2+ whitespace strings at the beginning and end of the node.

So for long enough, complex enough elements, the final content length may be off by a few characters, compared to what you'd get when truncating the parent's `innerText`, which is the target we're aiming for.

Hidden elements can also throw off the count.

## Note on structure
Beyond that, this is also a Stacks controller that is not really attached to a Component, but which extends a regular atomic typography class. That being the case, I wasn't totally sure where to put the files, and where to add the documentation. I'm happy to rearrange things if needed.

---
Context:
Jira: https://stackoverflow.atlassian.net/browse/CCX-1303
Slack: https://stackexchange.slack.com/archives/C27RWNQN9/p1668793893216629