### PR TITLE
test(award-bling):  add visual, a11y tests

### DIFF
--- a/lib/components/award-bling/award-bling.a11y.test.ts
+++ b/lib/components/award-bling/award-bling.a11y.test.ts
@@ -1,0 +1,17 @@
+import { defaultOptions, runComponentTests } from "../../test/test-utils";
+import "../../index";
+
+describe("award-bling", () => {
+    runComponentTests({
+        type: "a11y",
+        baseClass: "s-award-bling",
+        variants: ["gold", "silver", "bronze"],
+        children: {
+            default: `100 <div class="v-visible-sr">award</div>`,
+        },
+        options: {
+            ...defaultOptions,
+            includeNullVariant: false,
+        },
+    });
+});

--- a/lib/components/award-bling/award-bling.visual.test.ts
+++ b/lib/components/award-bling/award-bling.visual.test.ts
@@ -1,0 +1,26 @@
+import { defaultOptions, runComponentTests } from "../../test/test-utils";
+import { html } from "@open-wc/testing";
+import "../../index";
+
+describe("anchors", () => {
+    runComponentTests({
+        type: "visual",
+        baseClass: "s-award-bling",
+        variants: ["gold", "silver", "bronze"],
+        children: {
+            default: `100 <div class="v-visible-sr">award</div>`,
+        },
+        options: {
+            ...defaultOptions,
+            includeNullVariant: false,
+        },
+        template: ({ component, testid }) => html`
+            <div
+                class="d-inline-flex ai-center jc-center hs1 ws1 p8"
+                data-testid="${testid}"
+            >
+                ${component}
+            </div>
+        `,
+    });
+});

--- a/screenshots/Chromium/baseline/s-award-bling-dark-bronze.png
+++ b/screenshots/Chromium/baseline/s-award-bling-dark-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd0e88b193d029667bb18cd3fb49dd569d401581ce5e563971d3a416e8900b0c
+size 1149

--- a/screenshots/Chromium/baseline/s-award-bling-dark-gold.png
+++ b/screenshots/Chromium/baseline/s-award-bling-dark-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:027bce831067c135f3bd08ec7d66f36a099367a5ea2195f928d3d5647100dcf5
+size 1151

--- a/screenshots/Chromium/baseline/s-award-bling-dark-silver.png
+++ b/screenshots/Chromium/baseline/s-award-bling-dark-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09040b960dd59b72ab99a6909c14362717045fffebcaf2802db26cb6301d73ee
+size 1162

--- a/screenshots/Chromium/baseline/s-award-bling-highcontrast-dark-bronze.png
+++ b/screenshots/Chromium/baseline/s-award-bling-highcontrast-dark-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb2453ec73648816de46ac1dfe5841fdf015e686800b54e3a52c7a07e04b2b7f
+size 1090

--- a/screenshots/Chromium/baseline/s-award-bling-highcontrast-dark-gold.png
+++ b/screenshots/Chromium/baseline/s-award-bling-highcontrast-dark-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06058d88904c690898d4cf9dc6aca4285a7c68a7fe0bd9133f7f9a5db4e01d5c
+size 1036

--- a/screenshots/Chromium/baseline/s-award-bling-highcontrast-dark-silver.png
+++ b/screenshots/Chromium/baseline/s-award-bling-highcontrast-dark-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba91dac5b664e1bb367355f3a5a55214e498a6fe2def58f13563f64278fe0058
+size 1062

--- a/screenshots/Chromium/baseline/s-award-bling-highcontrast-light-bronze.png
+++ b/screenshots/Chromium/baseline/s-award-bling-highcontrast-light-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3f245922884632bb2625522ac6452218d40cc765b399ecd23b3146acf197222
+size 1113

--- a/screenshots/Chromium/baseline/s-award-bling-highcontrast-light-gold.png
+++ b/screenshots/Chromium/baseline/s-award-bling-highcontrast-light-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0373f37c04f897e67e680ab61a4ce7f9d2fac6f95a13469e20590020a55faede
+size 1081

--- a/screenshots/Chromium/baseline/s-award-bling-highcontrast-light-silver.png
+++ b/screenshots/Chromium/baseline/s-award-bling-highcontrast-light-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16d3551def989d33e7bb652cf30cab2900193595a1dbd86f4cb0544323e4e261
+size 1105

--- a/screenshots/Chromium/baseline/s-award-bling-light-bronze.png
+++ b/screenshots/Chromium/baseline/s-award-bling-light-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc7774bc83648e3427e7f9a293174eeb5c83bd623b82e5aea6ab8d3d47c875ff
+size 1127

--- a/screenshots/Chromium/baseline/s-award-bling-light-gold.png
+++ b/screenshots/Chromium/baseline/s-award-bling-light-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:396146db1cb8504b115f189b01eca171d00928d83a989f2f5ca1f531aeba0f78
+size 1093

--- a/screenshots/Chromium/baseline/s-award-bling-light-silver.png
+++ b/screenshots/Chromium/baseline/s-award-bling-light-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13e7b8582c527d52dbdb198f05406921fb04f74e62cf3dbcbac216b769fa9ce0
+size 1126

--- a/screenshots/Firefox/baseline/s-award-bling-dark-bronze.png
+++ b/screenshots/Firefox/baseline/s-award-bling-dark-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f072ee3ec7af6edb00ec3a58b9b228fb850c3fbdb52bbbc735bf63646491989c
+size 1401

--- a/screenshots/Firefox/baseline/s-award-bling-dark-gold.png
+++ b/screenshots/Firefox/baseline/s-award-bling-dark-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2902e09dd2b83455a724a29ae6a8b911e7c1ccddcf80e9f44e117e5295bd4c62
+size 1410

--- a/screenshots/Firefox/baseline/s-award-bling-dark-silver.png
+++ b/screenshots/Firefox/baseline/s-award-bling-dark-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33dafefd245ab6665bb6600befe5f58c0b3deb303f4d8e8716bdc942bcc2dd50
+size 1398

--- a/screenshots/Firefox/baseline/s-award-bling-highcontrast-dark-bronze.png
+++ b/screenshots/Firefox/baseline/s-award-bling-highcontrast-dark-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f91b5097ba7d064ea210e55c6ebfcb2d1e2f1ae38611528ea565f96fecb4eea
+size 1296

--- a/screenshots/Firefox/baseline/s-award-bling-highcontrast-dark-gold.png
+++ b/screenshots/Firefox/baseline/s-award-bling-highcontrast-dark-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb57f5a774b68b2e99088cbeab3c3bb937cf01a10a86636b2c1668eb76546bd4
+size 1273

--- a/screenshots/Firefox/baseline/s-award-bling-highcontrast-dark-silver.png
+++ b/screenshots/Firefox/baseline/s-award-bling-highcontrast-dark-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bee99943c0b242f7c1000614fbc8a80c0a1f2d20af6ea1aaa8f1998ed096f5c1
+size 1285

--- a/screenshots/Firefox/baseline/s-award-bling-highcontrast-light-bronze.png
+++ b/screenshots/Firefox/baseline/s-award-bling-highcontrast-light-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ca62adc3a99a34ccdad7f321e85573acd81f5899e457270be41d5264dddbdbe
+size 1385

--- a/screenshots/Firefox/baseline/s-award-bling-highcontrast-light-gold.png
+++ b/screenshots/Firefox/baseline/s-award-bling-highcontrast-light-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c2fbd9035aee24ffac724ea4e82357053eb4c3d1f7d5b3e8086fb8339042a9d
+size 1389

--- a/screenshots/Firefox/baseline/s-award-bling-highcontrast-light-silver.png
+++ b/screenshots/Firefox/baseline/s-award-bling-highcontrast-light-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a55093343735c5444b337feb4c71a061529898a6eab482c2a8cf6b7e18063407
+size 1410

--- a/screenshots/Firefox/baseline/s-award-bling-light-bronze.png
+++ b/screenshots/Firefox/baseline/s-award-bling-light-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2d05c5c6e3a42e395758d32249c23a9ab19aebc8e6db53a662b3a344c5c7aac
+size 1395

--- a/screenshots/Firefox/baseline/s-award-bling-light-gold.png
+++ b/screenshots/Firefox/baseline/s-award-bling-light-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aff90d18eef19ba0e3d59f77758d545e977b636bb59dd7ddc69bb4d2ef1572ac
+size 1285

--- a/screenshots/Firefox/baseline/s-award-bling-light-silver.png
+++ b/screenshots/Firefox/baseline/s-award-bling-light-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a89ea969c1a05188678ae051171decf1b68ab8803fecfc238b5c2d5367ab4738
+size 1403

--- a/screenshots/Webkit/baseline/s-award-bling-dark-bronze.png
+++ b/screenshots/Webkit/baseline/s-award-bling-dark-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36bb519815fbbd0772fd8ccaa5870f1c4d4268b7bbc1064b95edd1e7ef282ad6
+size 1252

--- a/screenshots/Webkit/baseline/s-award-bling-dark-gold.png
+++ b/screenshots/Webkit/baseline/s-award-bling-dark-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96d1c85ec57bb528ca0650117ae61e0cbf4b6169f840dcc401d000d7e44cbf5f
+size 1261

--- a/screenshots/Webkit/baseline/s-award-bling-dark-silver.png
+++ b/screenshots/Webkit/baseline/s-award-bling-dark-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f00f7cef5ccafa0f0ad5399a31ab028f566eb6c93eee52f67453c42363edb9bd
+size 1251

--- a/screenshots/Webkit/baseline/s-award-bling-highcontrast-dark-bronze.png
+++ b/screenshots/Webkit/baseline/s-award-bling-highcontrast-dark-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b7b49bbc5b8a199ae80bf6a1ca93315cbe8ec1d3d8ad5e89a54630b7c7f221c
+size 1209

--- a/screenshots/Webkit/baseline/s-award-bling-highcontrast-dark-gold.png
+++ b/screenshots/Webkit/baseline/s-award-bling-highcontrast-dark-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e245a6a7847d91fb3a872bf831d9b2c2ced60a5fe7c6ed8455f6f02a17905752
+size 1217

--- a/screenshots/Webkit/baseline/s-award-bling-highcontrast-dark-silver.png
+++ b/screenshots/Webkit/baseline/s-award-bling-highcontrast-dark-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e283f1d853298735a3ad580656e6f8583828935809f0d3d56f9426431cc3677f
+size 1212

--- a/screenshots/Webkit/baseline/s-award-bling-highcontrast-light-bronze.png
+++ b/screenshots/Webkit/baseline/s-award-bling-highcontrast-light-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f94c098491a6290b9e34bee067200d4b9998eda47fa1c08ff9957876b0df4d16
+size 1092

--- a/screenshots/Webkit/baseline/s-award-bling-highcontrast-light-gold.png
+++ b/screenshots/Webkit/baseline/s-award-bling-highcontrast-light-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3bb19ad3d8ea4efe072dc56abf36854ddcc3ba6f84e9f692286b2164a722d48
+size 1084

--- a/screenshots/Webkit/baseline/s-award-bling-highcontrast-light-silver.png
+++ b/screenshots/Webkit/baseline/s-award-bling-highcontrast-light-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88aa901c7bc91fd942b466cd8867a55dcc01ab92db4fe84b6f190fba85bb8cba
+size 1086

--- a/screenshots/Webkit/baseline/s-award-bling-light-bronze.png
+++ b/screenshots/Webkit/baseline/s-award-bling-light-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0511f611e51ca93b3745a0e5756a40788756f42d83cc5cf623b1f37516f0616f
+size 1125

--- a/screenshots/Webkit/baseline/s-award-bling-light-gold.png
+++ b/screenshots/Webkit/baseline/s-award-bling-light-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d8cff20d97fce1bc166269ccafd6139f23ab693079129e22b4fa7e34dad29ea
+size 1101

--- a/screenshots/Webkit/baseline/s-award-bling-light-silver.png
+++ b/screenshots/Webkit/baseline/s-award-bling-light-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7ebd52437a8d1c95ce39701a9115d759730db6ac27ca7e6c679fe15ee5a823a
+size 1124


### PR DESCRIPTION
This PR adds visual and accessibility tests for the `s-award-bling` component.