### PR TITLE
test(block-link): add a11y, visual tests

### DIFF
--- a/lib/components/block-link/block-link.a11y.test.ts
+++ b/lib/components/block-link/block-link.a11y.test.ts
@@ -1,0 +1,73 @@
+import { html } from "@open-wc/testing";
+import { defaultOptions, runComponentTests } from "../../test/test-utils";
+import "../../index";
+
+const blockLinkTemplate = ({ component, testid, testidModifier }: {
+    component: unknown,
+    testid: string,
+    testidModifier?: string,
+}) => html`<div
+    class="d-inline-flex ai-center jc-center hs1 ws2 p8"
+    data-testid="${testid}${testidModifier ? `-${testidModifier}` : ""}"
+>
+    ${component}
+</div>`
+
+describe("block-link", () => {
+    // Base block link
+    runComponentTests({
+        type: "a11y",
+        baseClass: "s-block-link",
+        modifiers: {
+            global: ["is-selected"],
+        },
+        children: {
+            default: `block link`,
+        },
+        template: blockLinkTemplate,
+    });
+
+    // Base + danger
+    runComponentTests({
+        type: "a11y",
+        baseClass: "s-block-link",
+        modifiers: {
+            primary: ["danger"],
+        },
+        children: {
+            default: `block link`,
+        },
+        options: {
+            ...defaultOptions,
+            includeNullModifier: false,
+        },
+        skippedTestids: [
+            "s-block-link-dark-danger",
+        ],
+        template: blockLinkTemplate,
+    });
+
+    // All left and rignt variants
+    runComponentTests({
+        type: "a11y",
+        baseClass: "s-block-link",
+        variants: ["left is-selected", "right is-selected"],
+        modifiers: {
+            primary: ["danger"],
+        },
+        children: {
+            default: `block link`,
+        },
+        options: {
+            ...defaultOptions,
+            includeNullVariant: false,
+        },
+        skippedTestids: [
+            "s-block-link-dark-left-is-selected-danger",
+            "s-block-link-dark-right-is-selected-danger",
+            "s-block-link-light-left-is-selected-danger",
+            "s-block-link-light-right-is-selected-danger",
+        ],
+        template: blockLinkTemplate,
+    });
+});

--- a/lib/components/block-link/block-link.a11y.test.ts
+++ b/lib/components/block-link/block-link.a11y.test.ts
@@ -8,7 +8,7 @@ const blockLinkTemplate = ({ component, testid }: any) => html`<div
     data-testid="${testid}"
 >
     ${component}
-</div>`
+</div>`;
 
 describe("block-link", () => {
     // Base block link
@@ -38,9 +38,7 @@ describe("block-link", () => {
             ...defaultOptions,
             includeNullModifier: false,
         },
-        skippedTestids: [
-            "s-block-link-dark-danger",
-        ],
+        skippedTestids: ["s-block-link-dark-danger"],
         template: blockLinkTemplate,
     });
 

--- a/lib/components/block-link/block-link.a11y.test.ts
+++ b/lib/components/block-link/block-link.a11y.test.ts
@@ -2,13 +2,10 @@ import { html } from "@open-wc/testing";
 import { defaultOptions, runComponentTests } from "../../test/test-utils";
 import "../../index";
 
-const blockLinkTemplate = ({ component, testid, testidModifier }: {
-    component: unknown,
-    testid: string,
-    testidModifier?: string,
-}) => html`<div
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const blockLinkTemplate = ({ component, testid }: any) => html`<div
     class="d-inline-flex ai-center jc-center hs1 ws2 p8"
-    data-testid="${testid}${testidModifier ? `-${testidModifier}` : ""}"
+    data-testid="${testid}"
 >
     ${component}
 </div>`

--- a/lib/components/block-link/block-link.visual.test.ts
+++ b/lib/components/block-link/block-link.visual.test.ts
@@ -8,7 +8,7 @@ const blockLinkTemplate = ({ component, testid }: any) => html`<div
     data-testid="${testid}"
 >
     ${component}
-</div>`
+</div>`;
 
 describe("block-link", () => {
     // Base block link

--- a/lib/components/block-link/block-link.visual.test.ts
+++ b/lib/components/block-link/block-link.visual.test.ts
@@ -2,13 +2,10 @@ import { html } from "@open-wc/testing";
 import { defaultOptions, runComponentTests } from "../../test/test-utils";
 import "../../index";
 
-const blockLinkTemplate = ({ component, testid, testidModifier }: {
-    component: unknown,
-    testid: string,
-    testidModifier?: string,
-}) => html`<div
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const blockLinkTemplate = ({ component, testid }: any) => html`<div
     class="d-inline-flex ai-center jc-center hs1 ws2 p8"
-    data-testid="${testid}${testidModifier ? `-${testidModifier}` : ""}"
+    data-testid="${testid}"
 >
     ${component}
 </div>`

--- a/lib/components/block-link/block-link.visual.test.ts
+++ b/lib/components/block-link/block-link.visual.test.ts
@@ -1,0 +1,64 @@
+import { html } from "@open-wc/testing";
+import { defaultOptions, runComponentTests } from "../../test/test-utils";
+import "../../index";
+
+const blockLinkTemplate = ({ component, testid, testidModifier }: {
+    component: unknown,
+    testid: string,
+    testidModifier?: string,
+}) => html`<div
+    class="d-inline-flex ai-center jc-center hs1 ws2 p8"
+    data-testid="${testid}${testidModifier ? `-${testidModifier}` : ""}"
+>
+    ${component}
+</div>`
+
+describe("block-link", () => {
+    // Base block link
+    runComponentTests({
+        type: "visual",
+        baseClass: "s-block-link",
+        modifiers: {
+            global: ["is-selected"],
+        },
+        children: {
+            default: `block link`,
+        },
+        template: blockLinkTemplate,
+    });
+
+    // Base + danger
+    runComponentTests({
+        type: "visual",
+        baseClass: "s-block-link",
+        modifiers: {
+            primary: ["danger"],
+        },
+        children: {
+            default: `block link`,
+        },
+        options: {
+            ...defaultOptions,
+            includeNullModifier: false,
+        },
+        template: blockLinkTemplate,
+    });
+
+    // All left and rignt variants
+    runComponentTests({
+        type: "visual",
+        baseClass: "s-block-link",
+        variants: ["left is-selected", "right is-selected"],
+        modifiers: {
+            primary: ["danger"],
+        },
+        children: {
+            default: `block link`,
+        },
+        options: {
+            ...defaultOptions,
+            includeNullVariant: false,
+        },
+        template: blockLinkTemplate,
+    });
+});

--- a/screenshots/Chromium/baseline/s-block-link-dark-danger.png
+++ b/screenshots/Chromium/baseline/s-block-link-dark-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:866e20a2e070f129fd31a50b307048c4ec72dd972d03e513c934aa3076a5a632
+size 1458

--- a/screenshots/Chromium/baseline/s-block-link-dark-is-selected.png
+++ b/screenshots/Chromium/baseline/s-block-link-dark-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d81114f3e9717ea2459130b6861463e53df8a0f3876a28ac896a059fa800f9a0
+size 1551

--- a/screenshots/Chromium/baseline/s-block-link-dark-left-is-selected-danger.png
+++ b/screenshots/Chromium/baseline/s-block-link-dark-left-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b5853e6049282e545cd4ab4202762d5603ca61a8a714b2bd91e9ae9a19ebfd1
+size 1409

--- a/screenshots/Chromium/baseline/s-block-link-dark-left-is-selected.png
+++ b/screenshots/Chromium/baseline/s-block-link-dark-left-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c314c2d2cccd4d29a6eddad31349bc718825e358e23dd852a99aef72b9f40518
+size 1584

--- a/screenshots/Chromium/baseline/s-block-link-dark-right-is-selected-danger.png
+++ b/screenshots/Chromium/baseline/s-block-link-dark-right-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3aefe7aef50b69483c1843d1e927c49f25614765059779402fbffda4231ddf8d
+size 1410

--- a/screenshots/Chromium/baseline/s-block-link-dark-right-is-selected.png
+++ b/screenshots/Chromium/baseline/s-block-link-dark-right-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e373ecfed13da8fc489ba01cb0fb6f74f30a9ff35223c541ae206893f6c07d9d
+size 1586

--- a/screenshots/Chromium/baseline/s-block-link-dark.png
+++ b/screenshots/Chromium/baseline/s-block-link-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7142944919cbf1352e8152140da51443903a2a33320c0f6c6113f10eafc9eb1
+size 1550

--- a/screenshots/Chromium/baseline/s-block-link-highcontrast-dark-danger.png
+++ b/screenshots/Chromium/baseline/s-block-link-highcontrast-dark-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4aa878d050ccec68cfd7e04cbd68e807da4846f4288667038611279f393d92d
+size 1543

--- a/screenshots/Chromium/baseline/s-block-link-highcontrast-dark-is-selected.png
+++ b/screenshots/Chromium/baseline/s-block-link-highcontrast-dark-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7390ad65d95e9f55eb311771a0db496ccd2410b4474b2eb6746b3a53a077bef3
+size 1468

--- a/screenshots/Chromium/baseline/s-block-link-highcontrast-dark-left-is-selected-danger.png
+++ b/screenshots/Chromium/baseline/s-block-link-highcontrast-dark-left-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a32eed4fd8d5947cde987a39f556c583f9cff9a02657eada8bde0c5225ee36b9
+size 1549

--- a/screenshots/Chromium/baseline/s-block-link-highcontrast-dark-left-is-selected.png
+++ b/screenshots/Chromium/baseline/s-block-link-highcontrast-dark-left-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03a13d07716fcea2f17b44996aeb958846baa5580bfba2c71188d1e323b022bb
+size 1499

--- a/screenshots/Chromium/baseline/s-block-link-highcontrast-dark-right-is-selected-danger.png
+++ b/screenshots/Chromium/baseline/s-block-link-highcontrast-dark-right-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:924382e8b23ddf19edb4bb078bdb99d4f03ec1a9d7436e2e7b2c4d4e6e2f1ff4
+size 1550

--- a/screenshots/Chromium/baseline/s-block-link-highcontrast-dark-right-is-selected.png
+++ b/screenshots/Chromium/baseline/s-block-link-highcontrast-dark-right-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:970edef5b4708ee24d010accc02e85e1214f724d66e10acbe5c5eb29326013a0
+size 1498

--- a/screenshots/Chromium/baseline/s-block-link-highcontrast-dark.png
+++ b/screenshots/Chromium/baseline/s-block-link-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26a87232f7f826fe338a37f4a4465ee6fe08af094801c57653e6d0b0d2560004
+size 1536

--- a/screenshots/Chromium/baseline/s-block-link-highcontrast-light-danger.png
+++ b/screenshots/Chromium/baseline/s-block-link-highcontrast-light-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79dcb2efabf8b276fcd8c3fafdcd2ca9b0c5590147489b5be7a6f2d9c7540550
+size 1526

--- a/screenshots/Chromium/baseline/s-block-link-highcontrast-light-is-selected.png
+++ b/screenshots/Chromium/baseline/s-block-link-highcontrast-light-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:234e110708dc2c20d9ade3ec5fadbdc95f710b2b1b4259d003b95a1f51d25614
+size 1497

--- a/screenshots/Chromium/baseline/s-block-link-highcontrast-light-left-is-selected-danger.png
+++ b/screenshots/Chromium/baseline/s-block-link-highcontrast-light-left-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:217164358d6b694030111c2d1ea01c7f4b74a47dfee4fe3cd5690e10f32ea9ca
+size 1542

--- a/screenshots/Chromium/baseline/s-block-link-highcontrast-light-left-is-selected.png
+++ b/screenshots/Chromium/baseline/s-block-link-highcontrast-light-left-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5523445feaf92aa8c1e303bb7ed9dd686c3d8d48ec4b9affc8e21739123c6e29
+size 1521

--- a/screenshots/Chromium/baseline/s-block-link-highcontrast-light-right-is-selected-danger.png
+++ b/screenshots/Chromium/baseline/s-block-link-highcontrast-light-right-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e9995a81ef709416a82851fb2938f5c8c369ef999ee750cc62504e45d15a6a4
+size 1543

--- a/screenshots/Chromium/baseline/s-block-link-highcontrast-light-right-is-selected.png
+++ b/screenshots/Chromium/baseline/s-block-link-highcontrast-light-right-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02e5b4574ca10b703cfe5d69844dd4ed7ba3692f5418fe95d1a4e9d211b06581
+size 1523

--- a/screenshots/Chromium/baseline/s-block-link-highcontrast-light.png
+++ b/screenshots/Chromium/baseline/s-block-link-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95a2b63997bc151eff3a2a37bcdd959f9e5c06113c091f6aedb99f5b7563ac15
+size 1545

--- a/screenshots/Chromium/baseline/s-block-link-light-danger.png
+++ b/screenshots/Chromium/baseline/s-block-link-light-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1be38adda89ab37916323bec6816f1ca64ea81a17be1f5ec901097b471a9ab09
+size 1534

--- a/screenshots/Chromium/baseline/s-block-link-light-is-selected.png
+++ b/screenshots/Chromium/baseline/s-block-link-light-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9698ccb9311c347d8f8a275dbd98b80c9104c1f698aebc68325ad87dc629b8f6
+size 1529

--- a/screenshots/Chromium/baseline/s-block-link-light-left-is-selected-danger.png
+++ b/screenshots/Chromium/baseline/s-block-link-light-left-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:194ea38fc8b309684eac65e4b0cf046dd2197f766171ed423c38c5b946d16c0f
+size 1523

--- a/screenshots/Chromium/baseline/s-block-link-light-left-is-selected.png
+++ b/screenshots/Chromium/baseline/s-block-link-light-left-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbf9427645c43b38af5d5f67f899d984388fb637f912c521a6d7ae187778dec6
+size 1557

--- a/screenshots/Chromium/baseline/s-block-link-light-right-is-selected-danger.png
+++ b/screenshots/Chromium/baseline/s-block-link-light-right-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95a80967df5b80e2f062c6add988349ea426aa37ab836a5959f5d388605357d1
+size 1524

--- a/screenshots/Chromium/baseline/s-block-link-light-right-is-selected.png
+++ b/screenshots/Chromium/baseline/s-block-link-light-right-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:818f5952eb0f46eb01d63a1c37fba050623c4f4938ae0ce917979a44ba462167
+size 1546

--- a/screenshots/Chromium/baseline/s-block-link-light.png
+++ b/screenshots/Chromium/baseline/s-block-link-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7435f28bbf2f364af8114595e7f14089acf18cb5b618cbc672a61c942f51679d
+size 1568

--- a/screenshots/Firefox/baseline/s-block-link-dark-danger.png
+++ b/screenshots/Firefox/baseline/s-block-link-dark-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7644058eb15a277552f0e796982c3d6cdde2ce89bf154e80f712361cb0aa7f5d
+size 1892

--- a/screenshots/Firefox/baseline/s-block-link-dark-is-selected.png
+++ b/screenshots/Firefox/baseline/s-block-link-dark-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f3e63a61ff1869d5c97cdf9b794beb4a7f7935cdfe575585a6a92c13c73b1e1
+size 2075

--- a/screenshots/Firefox/baseline/s-block-link-dark-left-is-selected-danger.png
+++ b/screenshots/Firefox/baseline/s-block-link-dark-left-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86484a0ff782874a576ed9214dc314712d0fdf750a89900df33cac835b39b6ff
+size 1928

--- a/screenshots/Firefox/baseline/s-block-link-dark-left-is-selected.png
+++ b/screenshots/Firefox/baseline/s-block-link-dark-left-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6d9d0aec523f3393ecac2296882a7427424c1a8e9427a32ff7d30442edcabc9
+size 2070

--- a/screenshots/Firefox/baseline/s-block-link-dark-right-is-selected-danger.png
+++ b/screenshots/Firefox/baseline/s-block-link-dark-right-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11cf578338e085f7a72420204648d544394ae35e8e427a714b2301f0d486e538
+size 1943

--- a/screenshots/Firefox/baseline/s-block-link-dark-right-is-selected.png
+++ b/screenshots/Firefox/baseline/s-block-link-dark-right-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a2a250641a1b9f4db29ad282b7797288b72ca2d6f85a2b7c12e4b32c36b9ffa
+size 2079

--- a/screenshots/Firefox/baseline/s-block-link-dark.png
+++ b/screenshots/Firefox/baseline/s-block-link-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1c6c69596c29d7ba75ba0a0a2698659702362df49cbd5cfaa6fe653fca69315
+size 2034

--- a/screenshots/Firefox/baseline/s-block-link-highcontrast-dark-danger.png
+++ b/screenshots/Firefox/baseline/s-block-link-highcontrast-dark-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c6b33e23791207fcd1b66692b8a3e8ee0a4e6b88a17451b6908aa9becc050c1
+size 2087

--- a/screenshots/Firefox/baseline/s-block-link-highcontrast-dark-is-selected.png
+++ b/screenshots/Firefox/baseline/s-block-link-highcontrast-dark-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fe3b6b5ed2c75395eb69935ba1bc8f284b6c8769372bbddf1f87b0d43e888ed
+size 2076

--- a/screenshots/Firefox/baseline/s-block-link-highcontrast-dark-left-is-selected-danger.png
+++ b/screenshots/Firefox/baseline/s-block-link-highcontrast-dark-left-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f0163d818d2fa9ca5b39aaaa277d89bb4b8d19d64fbedc828e6aaa40baa799f
+size 2089

--- a/screenshots/Firefox/baseline/s-block-link-highcontrast-dark-left-is-selected.png
+++ b/screenshots/Firefox/baseline/s-block-link-highcontrast-dark-left-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f333a02069474ba354c1073e62a6113e987cf5ffc6c01ef6a464cdd5c5d72728
+size 2067

--- a/screenshots/Firefox/baseline/s-block-link-highcontrast-dark-right-is-selected-danger.png
+++ b/screenshots/Firefox/baseline/s-block-link-highcontrast-dark-right-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:773fa7282baad35707a325f5a22c27c290dabd0f8520111e0ff7f5de2c87a6b5
+size 2097

--- a/screenshots/Firefox/baseline/s-block-link-highcontrast-dark-right-is-selected.png
+++ b/screenshots/Firefox/baseline/s-block-link-highcontrast-dark-right-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:305d57091f04a66568358bee9c3c568cbbac778f36faf5e6ffed56ec037b6f7e
+size 2076

--- a/screenshots/Firefox/baseline/s-block-link-highcontrast-dark.png
+++ b/screenshots/Firefox/baseline/s-block-link-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:526892f4cf475141f7ebbbb0cf114d231afb41fc3b3fd11947448dfcd21844a3
+size 2064

--- a/screenshots/Firefox/baseline/s-block-link-highcontrast-light-danger.png
+++ b/screenshots/Firefox/baseline/s-block-link-highcontrast-light-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c4a9c8e50f7095867793903f6eb8d756b43333c62e6deeffc285ed0bbe78da8
+size 2045

--- a/screenshots/Firefox/baseline/s-block-link-highcontrast-light-is-selected.png
+++ b/screenshots/Firefox/baseline/s-block-link-highcontrast-light-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a80457e4b6a231f601e2d6e0985afcaf1b5bf926d31fc9ab19414e653390b4e
+size 2015

--- a/screenshots/Firefox/baseline/s-block-link-highcontrast-light-left-is-selected-danger.png
+++ b/screenshots/Firefox/baseline/s-block-link-highcontrast-light-left-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13b3781067ee3c56ff1476ad23bfa6bc710ad0448f1abb03c54938c7b1011570
+size 2056

--- a/screenshots/Firefox/baseline/s-block-link-highcontrast-light-left-is-selected.png
+++ b/screenshots/Firefox/baseline/s-block-link-highcontrast-light-left-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2b6deb39589cb0e34114601fa502164e694caaa023bf8c6dd717c43fe2a0d90
+size 2010

--- a/screenshots/Firefox/baseline/s-block-link-highcontrast-light-right-is-selected-danger.png
+++ b/screenshots/Firefox/baseline/s-block-link-highcontrast-light-right-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:450e93e1922ff2b69972dd12874eb7ce126fd376fee2d795b60aa819515f03fd
+size 2065

--- a/screenshots/Firefox/baseline/s-block-link-highcontrast-light-right-is-selected.png
+++ b/screenshots/Firefox/baseline/s-block-link-highcontrast-light-right-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92a8b3ca91d030d34b242b26ed734d19b30717a18abc0604bd5f453d67202014
+size 2018

--- a/screenshots/Firefox/baseline/s-block-link-highcontrast-light.png
+++ b/screenshots/Firefox/baseline/s-block-link-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6818dff7a50318c85e8b4fd766ec60dde693fb6f90aa0ab0f2e73c47eb966a9e
+size 2032

--- a/screenshots/Firefox/baseline/s-block-link-light-danger.png
+++ b/screenshots/Firefox/baseline/s-block-link-light-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7a72067e834688d0345a745b9365fdeccca82fb167d21032f8b90a9a92438a8
+size 2008

--- a/screenshots/Firefox/baseline/s-block-link-light-is-selected.png
+++ b/screenshots/Firefox/baseline/s-block-link-light-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:820a854ce5d75c0671eaf34253484ac0f0e359b48cdc1c66bee9eb904afaad14
+size 2042

--- a/screenshots/Firefox/baseline/s-block-link-light-left-is-selected-danger.png
+++ b/screenshots/Firefox/baseline/s-block-link-light-left-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c699156516718f24ddf0bd917eba22513b056b0bb69f276231edc13ef858a47
+size 2011

--- a/screenshots/Firefox/baseline/s-block-link-light-left-is-selected.png
+++ b/screenshots/Firefox/baseline/s-block-link-light-left-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e798c8c3924cedd8ad4ca1392c78c6e552830002def001fdb95db408d18c4cf3
+size 2037

--- a/screenshots/Firefox/baseline/s-block-link-light-right-is-selected-danger.png
+++ b/screenshots/Firefox/baseline/s-block-link-light-right-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19c24e1f4ee40ebfde3e1867f9da0c5908cf02698d55a9dc6683f114b5832abb
+size 2025

--- a/screenshots/Firefox/baseline/s-block-link-light-right-is-selected.png
+++ b/screenshots/Firefox/baseline/s-block-link-light-right-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f56cd38226b42a4f30987a9181af4bce468ea0c7bdbbd18492214edac5f456f
+size 2046

--- a/screenshots/Firefox/baseline/s-block-link-light.png
+++ b/screenshots/Firefox/baseline/s-block-link-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:530794ad412471b414e7236cf5e70de1fb1f5d1db4b4f8a26981915c67aa9d56
+size 2017

--- a/screenshots/Webkit/baseline/s-block-link-dark-danger.png
+++ b/screenshots/Webkit/baseline/s-block-link-dark-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73bc9eae328957ac8c6978bec34f0d532c35d986d0dd4a19e6568ed7d01b525b
+size 1861

--- a/screenshots/Webkit/baseline/s-block-link-dark-is-selected.png
+++ b/screenshots/Webkit/baseline/s-block-link-dark-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1f7023565c4a59fe42c58d670b26b025b726f2a09f603da49f8903993203d1b
+size 2169

--- a/screenshots/Webkit/baseline/s-block-link-dark-left-is-selected-danger.png
+++ b/screenshots/Webkit/baseline/s-block-link-dark-left-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccb918b7f2fd8d586c0fe54b1285ef6b0e155c53df9b5b3843031d2eebadf6c1
+size 1956

--- a/screenshots/Webkit/baseline/s-block-link-dark-left-is-selected.png
+++ b/screenshots/Webkit/baseline/s-block-link-dark-left-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc3be5b341e70bcfed5d00360259a72adc8c6d2b9e253d8f1c7205c3990a45d5
+size 2180

--- a/screenshots/Webkit/baseline/s-block-link-dark-right-is-selected-danger.png
+++ b/screenshots/Webkit/baseline/s-block-link-dark-right-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8728545b6f8009f12de885b7ad66598d0b861befaa3c88c5b318af69b62e4bd
+size 1953

--- a/screenshots/Webkit/baseline/s-block-link-dark-right-is-selected.png
+++ b/screenshots/Webkit/baseline/s-block-link-dark-right-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf8da2294df35021cb170aef5b8a9a283a4406c8a89f61255f0a5583a07f6ee5
+size 2177

--- a/screenshots/Webkit/baseline/s-block-link-dark.png
+++ b/screenshots/Webkit/baseline/s-block-link-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c36e221197ffe69704a5f9327ce4bb4fe4228978a27f16ff56e36d05f7dbea3
+size 2003

--- a/screenshots/Webkit/baseline/s-block-link-highcontrast-dark-danger.png
+++ b/screenshots/Webkit/baseline/s-block-link-highcontrast-dark-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34d814b11d40f8c8e109c916ecc0b2426b723ace31c51fd14834c8cbd9b7fbce
+size 2022

--- a/screenshots/Webkit/baseline/s-block-link-highcontrast-dark-is-selected.png
+++ b/screenshots/Webkit/baseline/s-block-link-highcontrast-dark-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdb77091c3efde96673589f90557b99bfa598e2aee34a47ee6c5228a7dfb0837
+size 2053

--- a/screenshots/Webkit/baseline/s-block-link-highcontrast-dark-left-is-selected-danger.png
+++ b/screenshots/Webkit/baseline/s-block-link-highcontrast-dark-left-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:699c90e5733f5ff5e296806a959f008c5153eea7bf832db9a49806c1269530cb
+size 2128

--- a/screenshots/Webkit/baseline/s-block-link-highcontrast-dark-left-is-selected.png
+++ b/screenshots/Webkit/baseline/s-block-link-highcontrast-dark-left-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37a2252477f7620ea862e63c9cc2da82fe039418416806515b3d6f69b180827c
+size 2080

--- a/screenshots/Webkit/baseline/s-block-link-highcontrast-dark-right-is-selected-danger.png
+++ b/screenshots/Webkit/baseline/s-block-link-highcontrast-dark-right-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:064d37ee1b576b04a11733f50a38ffaf05493b21748a2c715bd84463e6100ad3
+size 2131

--- a/screenshots/Webkit/baseline/s-block-link-highcontrast-dark-right-is-selected.png
+++ b/screenshots/Webkit/baseline/s-block-link-highcontrast-dark-right-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80ad8aaf196c889fde8c82004b15a3d5cbc3029dcf40473ba3e0e308e1212964
+size 2079

--- a/screenshots/Webkit/baseline/s-block-link-highcontrast-dark.png
+++ b/screenshots/Webkit/baseline/s-block-link-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec128a14daba41c49b2dc143b4813258a5d37b713269ef78fbf7ceb86effe73d
+size 2002

--- a/screenshots/Webkit/baseline/s-block-link-highcontrast-light-danger.png
+++ b/screenshots/Webkit/baseline/s-block-link-highcontrast-light-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b508acec6a9dcd93c1aef0524b8847107d895092ac666fceffa25e77d2f63e3d
+size 1959

--- a/screenshots/Webkit/baseline/s-block-link-highcontrast-light-is-selected.png
+++ b/screenshots/Webkit/baseline/s-block-link-highcontrast-light-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:901eaf8a4f136f87335b088aef6752430131b69649924089d7340889a54d215a
+size 2032

--- a/screenshots/Webkit/baseline/s-block-link-highcontrast-light-left-is-selected-danger.png
+++ b/screenshots/Webkit/baseline/s-block-link-highcontrast-light-left-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f806bc21e93ca84062c4a7f11e70528360d072f4c40b65d0fa20c26182d02a9d
+size 2115

--- a/screenshots/Webkit/baseline/s-block-link-highcontrast-light-left-is-selected.png
+++ b/screenshots/Webkit/baseline/s-block-link-highcontrast-light-left-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb76a6b2b477d8e42751d04dbbe4979918dd8ccc099d102686f58ef53b7cb577
+size 2018

--- a/screenshots/Webkit/baseline/s-block-link-highcontrast-light-right-is-selected-danger.png
+++ b/screenshots/Webkit/baseline/s-block-link-highcontrast-light-right-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:970d9ba8174e0e9d728f58f16e64309f46e450b4a79b9679adac2bd6588bd935
+size 2118

--- a/screenshots/Webkit/baseline/s-block-link-highcontrast-light-right-is-selected.png
+++ b/screenshots/Webkit/baseline/s-block-link-highcontrast-light-right-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d2cad6e3a4c7cd32c83d5bd33d3f23811632f3c0641ee69bdfb4d5748927a4c
+size 2019

--- a/screenshots/Webkit/baseline/s-block-link-highcontrast-light.png
+++ b/screenshots/Webkit/baseline/s-block-link-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45314fa283b876fd5184ac98a10b9bfcc7f64f345bc2b79bf2aa90f4dc4dff20
+size 1937

--- a/screenshots/Webkit/baseline/s-block-link-light-danger.png
+++ b/screenshots/Webkit/baseline/s-block-link-light-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75ac2b713654bcd449fe3be664ac6a8cc14e681103da8775a855ac8392f88918
+size 1955

--- a/screenshots/Webkit/baseline/s-block-link-light-is-selected.png
+++ b/screenshots/Webkit/baseline/s-block-link-light-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61f4e6fd889c83a304e6337b64bcc7a3dc8df350b928799082cebb5f018931c7
+size 2099

--- a/screenshots/Webkit/baseline/s-block-link-light-left-is-selected-danger.png
+++ b/screenshots/Webkit/baseline/s-block-link-light-left-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c50264c2df511397c3deb7138e1b35350d968b3e9d313a331c27436821b300bf
+size 2145

--- a/screenshots/Webkit/baseline/s-block-link-light-left-is-selected.png
+++ b/screenshots/Webkit/baseline/s-block-link-light-left-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b147ad089c9283434e0be7a0943c0008a06f0058ebb4b2a2878aeaec943b9040
+size 2107

--- a/screenshots/Webkit/baseline/s-block-link-light-right-is-selected-danger.png
+++ b/screenshots/Webkit/baseline/s-block-link-light-right-is-selected-danger.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0923e9605b43d6bed03295c860ec8a78abaa4f4a87ec3beb3ac3cb5b4600945
+size 2134

--- a/screenshots/Webkit/baseline/s-block-link-light-right-is-selected.png
+++ b/screenshots/Webkit/baseline/s-block-link-light-right-is-selected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:761a5080645af1540a8318fb4d57acf9af9151168a5e8660471f2adb91afada1
+size 2107

--- a/screenshots/Webkit/baseline/s-block-link-light.png
+++ b/screenshots/Webkit/baseline/s-block-link-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14efaa6ca3dd7160f7167c3b7d3f696dd4db4cd79d8dd9017ccec010c0930909
+size 1968


### PR DESCRIPTION
This PR adds visual and accessibility tests for the `s-block-link` component.