### PR TITLE
chore(post-summary): use opacity for ignores/deleted states

### DIFF
--- a/lib/components/post-summary/post-summary.less
+++ b/lib/components/post-summary/post-summary.less
@@ -50,12 +50,18 @@
     &&__ignored {
         --_ps-has-answers-bc: var(--black-300);
         --_ps-has-answers-bg: transparent;
-        --_ps-has-answers-fc: var(--black-500);
+        --_ps-has-answers-fc: var(--_ps-state-fc);
         --_ps-has-accepted-answers-bc: transparent;
-        --_ps-has-accepted-answers-bg: var(--black-075);
-        --_ps-has-accepted-answers-fc: var(--black-600);
+        --_ps-has-accepted-answers-bg: var(--black-050);
+        --_ps-has-accepted-answers-fc: var(--_ps-state-fc);
         --_ps-meta-tags-tag-bg: var(--black-050);
+        --_ps-meta-tags-tag-fc: var(--_ps-state-fc);
         --_ps-state-fc: var(--black-500);
+
+        .s-post-summary--content > *:not(.s-post-summary--content-menu-button),
+        .s-post-summary--stats > *:not(.s-badge__danger) {
+            opacity: 0.75;
+        }
 
         .s-post-summary--meta-tags {
             a, // TODO: remove rule for `a` once Core replaces `.post-tag` with `.s-tag`
@@ -65,8 +71,11 @@
                 &:active,
                 &:hover,
                 &:focus {
+                    .highcontrast-mode({
+                        border-color: currentColor;
+                    });
+
                     background-color: var(--_ps-meta-tags-tag-bg);
-                    border-color: transparent;
                     color: var(--black-600);
                 }
             }
@@ -92,6 +101,8 @@
 
     &&__deleted {
         --_ps-bg: var(--red-025);
+        --_ps-has-accepted-answers-bg: var(--black-075);
+        --_ps-has-accepted-answers-fc: var(--black-600);
         --_ps-meta-tags-tag-bg: var(--black-075);
 
         .is-deleted,


### PR DESCRIPTION
This PR updates the post summary component to de-emphasize the _ignored_ and _deleted_ states using opacity. It addresses [issues raised by the Meta community](https://meta.stackexchange.com/questions/382047/my-brain-cannot-ignore-the-ignored-questions-due-to-contrast-change-please-chan/385181#385181). 

supersedes https://github.com/StackExchange/Stacks/pull/1362

<details>
<summary>Screenshots (ignored)</summary>

### Before

![image](https://github.com/StackExchange/Stacks/assets/647177/1e00dadf-1182-4934-b79e-8ec9c928f4ab)
![image](https://github.com/StackExchange/Stacks/assets/647177/18f858d4-2a87-4c96-b890-86d64292750c)

### After

![image](https://github.com/StackExchange/Stacks/assets/647177/a1f6d5f7-5eea-468e-9b33-4771cbd8b240)
![image](https://github.com/StackExchange/Stacks/assets/647177/0b911104-7492-41a9-896a-a041c3e2ff80)

</details>

<details>
<summary>Screenshots (deleted)</summary>

### Before

![image](https://github.com/StackExchange/Stacks/assets/647177/8fc7300b-a5bb-49c5-8154-2bae1e34b475)
![image](https://github.com/StackExchange/Stacks/assets/647177/c9d6c72b-bd15-4a7e-aa0e-5268065032b0)

### After

![image](https://github.com/StackExchange/Stacks/assets/647177/c09c72d6-b8ed-4dff-a94c-c4119713dd4d)
![image](https://github.com/StackExchange/Stacks/assets/647177/43498818-141a-4449-8d14-2355bdfa724f)

</details>