### PR TITLE
fix(post-summary): ignored/deleted state opacity targeting

### DIFF
--- a/lib/components/post-summary/post-summary.less
+++ b/lib/components/post-summary/post-summary.less
@@ -58,9 +58,20 @@
         --_ps-meta-tags-tag-fc: var(--_ps-state-fc);
         --_ps-state-fc: var(--black-500);
 
-        .s-post-summary--content > *:not(.s-post-summary--content-menu-button),
+        .s-post-summary--content > *:not(.s-post-summary--content-menu-button):not(.s-post-summary--meta):not(.s-popover),
+        .s-post-summary--meta > *:not(.s-post-summary--meta-tags) > *,
         .s-post-summary--stats > *:not(.s-badge__danger) {
             opacity: 0.75;
+        }
+
+        .s-post-summary--meta .s-post-summary--meta-tags {
+            > ul > li > a,
+            > a,
+            .post-tag,
+            .s-tag,
+            .s-user-card {
+                opacity: 0.75;
+            }
         }
 
         .s-post-summary--meta-tags {

--- a/lib/components/post-summary/post-summary.less
+++ b/lib/components/post-summary/post-summary.less
@@ -2,6 +2,7 @@
     // --_ps-state-* are custom properties to broadly override colors for a given post summary state
     --_ps-bb: var(--su1) solid var(--bc-light);
     --_ps-bg: unset;
+    --_ps-o: unset;
     // Child components
     --_ps-content-excerpt-fc: var(--_ps-state-fc, var(--fc-medium));
     --_ps-content-title-a-fc: var(--_ps-state-fc, var(--theme-post-title-color));
@@ -48,6 +49,7 @@
     // VARIANTS
     &&__deleted,
     &&__ignored {
+        --_ps-o: 0.75;
         --_ps-has-answers-bc: var(--black-300);
         --_ps-has-answers-bg: transparent;
         --_ps-has-answers-fc: var(--_ps-state-fc);
@@ -57,22 +59,6 @@
         --_ps-meta-tags-tag-bg: var(--black-050);
         --_ps-meta-tags-tag-fc: var(--_ps-state-fc);
         --_ps-state-fc: var(--black-500);
-
-        .s-post-summary--content > *:not(.s-post-summary--content-menu-button):not(.s-post-summary--meta):not(.s-popover),
-        .s-post-summary--meta > *:not(.s-post-summary--meta-tags) > *,
-        .s-post-summary--stats > *:not(.s-badge__danger) {
-            opacity: 0.75;
-        }
-
-        .s-post-summary--meta .s-post-summary--meta-tags {
-            > ul > li > a,
-            > a,
-            .post-tag,
-            .s-tag,
-            .s-user-card {
-                opacity: 0.75;
-            }
-        }
 
         .s-post-summary--meta-tags {
             a, // TODO: remove rule for `a` once Core replaces `.post-tag` with `.s-tag`
@@ -196,6 +182,10 @@
         }
 
         &--content {
+            > *:not(.s-post-summary--content-menu-button):not(.s-post-summary--meta):not(.s-popover) {
+                opacity: var(--_ps-o);
+            }
+
             flex-grow: 1;
             max-width: 100%;
         }
@@ -284,6 +274,10 @@
         }
 
         &--meta {
+            > *:not(.s-post-summary--meta-tags) > * {
+                opacity: var(--_ps-o);
+            }
+
             .s-user-card {
                 flex-wrap: wrap;
                 justify-content: flex-end;
@@ -299,12 +293,23 @@
         }
 
         &--meta-tags {
+            > ul > li > a,
+            > a,
+            .post-tag,
+            .s-tag {
+                opacity: var(--_ps-o);
+            }
+
             display: flex;
             flex-wrap: wrap;
             gap: var(--su4);
         }
 
         &--stats {
+            > *:not(.s-badge__danger) {
+                opacity: var(--_ps-o);
+            }
+    
             align-items: var(--_ps-stats-ai);
             color: var(--_ps-stats-fc);
             flex-direction: var(--_ps-stats-fd);


### PR DESCRIPTION
Addresses this opacity issue reported on [Meta](https://meta.stackexchange.com/questions/389374/wrong-z-index-for-tag-popup-when-the-question-has-an-ignored-tag):

> After [this](https://meta.stackexchange.com/questions/382047/my-brain-cannot-ignore-the-ignored-questions-due-to-contrast-change-please-chan) was fixed, I tested it a bit, and noticed this behavior:
> ![Tag popup is below other content](https://github.com/StackExchange/Stacks/assets/647177/f86225d5-4fac-42a7-adfb-17080485e6d3)
> When there is an ignored tag and the question is grayed out, the tag popup is below/behind the other page contents due to wrong z-index. (And also the popup itself shouldn't be grayed out.)