### PR TITLE
Update to naming guidelines

### DIFF
--- a/docs/brand/copywriting/naming.html
+++ b/docs/brand/copywriting/naming.html
@@ -68,7 +68,7 @@ description: Quick guidelines for using Stack Overflow and our product names.
 
     {% header "h3", "Knowledge Reuse" %}
 
-    <p class="stacks-copy">“Knowledge reuse” is a term we use frequently in reference to Stack Overflow for Teams as something it facilitates. It can be lowercase the majority of the time, except when refering to our <a href="https://stackoverflowteams.com/c/stack-overflow/questions/12132" title="Employees only have access to this">{% icon "Lock", "va-middle", "14" %} propritary metric</a>, in which case use “Knowledge Reuse”.</p>
+    <p class="stacks-copy">“Knowledge reuse” is a term we use frequently in reference to Stack Overflow for Teams as something it facilitates. It can be lowercase the majority of the time, except when referring to our <a href="https://stackoverflowteams.com/c/stack-overflow/questions/12132" title="Employees only have access to this">{% icon "Lock", "va-middle", "14" %} proprietary metric</a>, in which case use “Knowledge Reuse”.</p>
 
     {% header "h4", "Examples" %}
 

--- a/docs/brand/copywriting/naming.html
+++ b/docs/brand/copywriting/naming.html
@@ -4,10 +4,6 @@ title: Naming guidelines
 description: Quick guidelines for using Stack Overflow and our product names.
 ---
 
-{% tip, "", "mbn32" %}
-For products not listed here, follow the patterns for <a href="#articles-vs.-articles">Articles</a> and <a href="#collectives-vs.-collectives">Collectives</a> as applicable.
-{% endtip %}
-
 <section class="stacks-section">
     {% header "h2", "Stack Overflow" %}
     <table class="s-table s-table__lg fs-body2 va-top w100 wmx6 mb48">
@@ -70,55 +66,31 @@ For products not listed here, follow the patterns for <a href="#articles-vs.-art
         <li>Don’t use ‘Private Q&A’ when referring to our product suite for marketing and promotional efforts outside of our core stackoverflow.com audience.</li>
     </ul>
 
-    {% header "h2", "Collectives on Stack Overflow" %}
+    {% header "h3", "Knowledge Reuse" %}
 
-    {% header "h3", "Capitalization" %}
+    <p class="stacks-copy">“Knowledge reuse” is a term we use frequently in reference to Stack Overflow for Teams as something it facilitates. It can be lowercase the majority of the time, except when refering to our <a href="https://stackoverflowteams.com/c/stack-overflow/questions/12132" title="Employees only have access to this">{% icon "Lock", "va-middle", "14" %} propritary metric</a>, in which case use “Knowledge Reuse”.</p>
 
-    {% header "h4", "Headers, subheaders, and tabs" %}
+    {% header "h4", "Examples" %}
 
     <ul class="stacks-list">
-        <li>Do follow the <a href="/content/guidelines/grammar-and-mechanics/#use-sentence-casing">capitalization rules</a> for headers, sub-headers, and menu tabs.</li>
-        <li>Use sentence case for all headings (Sentence case involves capitalizing the first word, first word of a subtitle, and all proper nouns.)</li>
-        <li>Capitalize the first word of a heading</li>
-        <li>Capitalize proper or trademarked nouns (names of products, people, or specific companies)
-        <li>Lowercase for everything else</li>
+        <li>“Unlike simply sharing information, <strong>knowledge reuse</strong> takes collaboration a step further by creating a system where ideas are shared, quickly accessed, improved upon, and then put back into the system.”</li>
+        <li>“We have calculated your <strong>Knowledge Reuse</strong> metric as…”</li>
     </ul>
 
-    <table class="s-table s-table__lg fs-body2 va-top w100 wmx6 mb48">
-        <thead>
-            <th class="btw0 bxw0 bbw3 bbw3 bc-red-2 fc-red-500 bg-transparent fs-body1 s-table--cell6">{% icon "Clear", "mtn1 mbn1" %} Don’t</th>
-            <th class="btw0 bxw0 bbw3 bc-green-2 fc-green-500 bg-transparent fs-body1 s-table--cell6">{% icon "Checkmark", "mtn1 mbn1" %} Do</th>
-        </thead>
-        <tbody>
-            <tr>
-                <td>User Roles</td>
-                <td>User roles</td>
-            </tr>
-        </tbody>
-    </table>
+    {% header "h3", "Communities & Community" %}
 
-   {% header "h4", "Product and feature names" %} 
+    <p class="stacks-copy">“Communities” and “Community” are capitalized when referring to the Stack Overflow for Teams feature.</p>
 
-    <p class="stacks-copy">
-        If a product or feature isn’t unique to Stack Overflow, <strong>don’t</strong> capitalize it (blogs, pages, etc.) If it is unique to Stack Overflow as its own product, <strong>do</strong> capitalize it. 
-    </p>
+    {% header "h4", "Examples" %}
 
-    <table class="s-table s-table__lg fs-body2 va-top w100 wmx6 mb48">
-        <thead>
-            <th class="btw0 bxw0 bbw3 bbw3 bc-red-2 fc-red-500 bg-transparent fs-body1 s-table--cell6">{% icon "Clear", "mtn1 mbn1" %} Don’t</th>
-            <th class="btw0 bxw0 bbw3 bc-green-2 fc-green-500 bg-transparent fs-body1 s-table--cell6">{% icon "Checkmark", "mtn1 mbn1" %} Do</th>
-        </thead>
-        <tbody>
-            <tr>
-                <td>As soon as it’s ready, put your <strong class="fc-red-500">Blog Post</strong> up</td>
-                <td>As soon as it’s ready, put your <strong class="fc-green-500">blog post</strong> up</td>
-            </tr>
-        </tbody>
-    </table>
+    <ul class="stacks-list">
+        <li>With <strong>Communities</strong> you can help your teammates know what's trending, who's sharing knowledge, and where there's opportunity to contribute or learn around specific areas of interest.</li>
+        <li>Subscribe to a <strong>Community</strong> and get notifications for new questions and answers.</li>
+    </ul>
 
-    {% header "h3", "Specific products and features " %}
+    {% header "h2", "Collectives on Stack Overflow" %}
 
-    {% header "h4", "Trade Mark" %} 
+    {% header "h3", "Trade Mark" %} 
 
     <ul class="stacks-list">
         <li>We have trademarked “Collectives™ on Stack Overflow”.</li>
@@ -143,7 +115,7 @@ For products not listed here, follow the patterns for <a href="#articles-vs.-art
         </tbody>
     </table>
 
-    {% header "h4", "…on Stack Overflow" %} 
+    {% header "h3", "…on Stack Overflow" %} 
 
     <ul class="stacks-list">
         <li>Use … “on Stack Overflow” sparingly.</li>
@@ -168,7 +140,7 @@ For products not listed here, follow the patterns for <a href="#articles-vs.-art
         </tbody>
     </table>
 
-    {% header "h4", "Collectives vs. collectives" %} 
+    {% header "h3", "Collectives vs. collectives" %} 
 
     <p class="stacks-copy">When do you capitalize the C in “Collective(s)”?</p>
 
@@ -200,6 +172,54 @@ For products not listed here, follow the patterns for <a href="#articles-vs.-art
             <tr>
                 <td>A company’s <strong class="fc-red-500">Collective</strong> page will be located at the top right of the screen</td>
                 <td>A company’s <strong class="fc-green-500">collective</strong> page will be located at the top right of the screen</td>
+            </tr>
+        </tbody>
+    </table>
+
+    {% header "h2", "Capitalization" %}
+    
+    {% header "h3", "Headers, subheaders, and tabs" %}
+    
+    <ul class="stacks-list">
+        <li>Do follow the <a href="/content/guidelines/grammar-and-mechanics/#use-sentence-casing">capitalization rules</a> for headers, sub-headers, and menu tabs.</li>
+        <li>Use sentence case for all headings (Sentence case involves capitalizing the first word, first word of a subtitle, and all proper nouns.)</li>
+        <li>Capitalize the first word of a heading</li>
+        <li>Capitalize proper or trademarked nouns (names of products, people, or specific companies)
+        <li>Lowercase for everything else</li>
+    </ul>
+    
+    <table class="s-table s-table__lg fs-body2 va-top w100 wmx6 mb48">
+        <thead>
+            <th class="btw0 bxw0 bbw3 bbw3 bc-red-2 fc-red-500 bg-transparent fs-body1 s-table--cell6">{% icon "Clear", "mtn1 mbn1" %} Don’t</th>
+            <th class="btw0 bxw0 bbw3 bc-green-2 fc-green-500 bg-transparent fs-body1 s-table--cell6">{% icon "Checkmark", "mtn1 mbn1" %} Do</th>
+        </thead>
+        <tbody>
+            <tr>
+                <td>User Roles</td>
+                <td>User roles</td>
+            </tr>
+        </tbody>
+    </table>
+    
+    {% header "h3", "Product and feature names" %}
+    
+    <p class="stacks-copy">
+        If a product or feature isn’t unique to Stack Overflow, <strong>don’t</strong> capitalize it (blogs, pages, etc.) If it is unique to Stack Overflow as its own product, <strong>do</strong> capitalize it.
+    </p>
+    
+    <table class="s-table s-table__lg fs-body2 va-top w100 wmx6 mb48">
+        <thead>
+            <th class="btw0 bxw0 bbw3 bbw3 bc-red-2 fc-red-500 bg-transparent fs-body1 s-table--cell6">{% icon "Clear", "mtn1 mbn1" %} Don’t</th>
+            <th class="btw0 bxw0 bbw3 bc-green-2 fc-green-500 bg-transparent fs-body1 s-table--cell6">{% icon "Checkmark", "mtn1 mbn1" %} Do</th>
+        </thead>
+        <tbody>
+            <tr>
+                <td>As soon as it’s ready, put your <strong class="fc-red-500">Blog Post</strong> up</td>
+                <td>As soon as it’s ready, put your <strong class="fc-green-500">blog post</strong> up</td>
+            </tr>
+            <tr>
+                <td>content health</td>
+                <td>Content Health</td>
             </tr>
         </tbody>
     </table>
@@ -260,4 +280,5 @@ For products not listed here, follow the patterns for <a href="#articles-vs.-art
             </tr>
         </tbody>
     </table>
+
 </section>

--- a/docs/brand/copywriting/naming.html
+++ b/docs/brand/copywriting/naming.html
@@ -84,7 +84,7 @@ description: Quick guidelines for using Stack Overflow and our product names.
     {% header "h4", "Examples" %}
 
     <ul class="stacks-list">
-        <li>With <strong>Communities</strong> you can help your teammates know what's trending, who's sharing knowledge, and where there's opportunity to contribute or learn around specific areas of interest.</li>
+        <li>With <strong>Communities</strong> you can help your teammates know what’s trending, who’s sharing knowledge, and where there’s opportunity to contribute or learn around specific areas of interest.</li>
         <li>Subscribe to a <strong>Community</strong> and get notifications for new questions and answers.</li>
     </ul>
 


### PR DESCRIPTION
Rearranged the page to move `Capitalization` and `Specific products and features` from under Collectives, as they apply to all products.

Additionally, adds guidance for:

* Knowledge reuse
* Communities on Teams
* Content Health