### PR TITLE
test(expandable): add visual, a11y tests

### DIFF
--- a/lib/components/expandable/expandable.a11y.test.ts
+++ b/lib/components/expandable/expandable.a11y.test.ts
@@ -23,6 +23,5 @@ describe("expandable", () => {
                 <div><p>After expandable content</p></div>
             </div>
         `,
-
     });
 });

--- a/lib/components/expandable/expandable.a11y.test.ts
+++ b/lib/components/expandable/expandable.a11y.test.ts
@@ -1,0 +1,28 @@
+import { html } from "@open-wc/testing";
+import { runComponentTests } from "../../test/test-utils";
+import "../../index";
+
+describe("expandable", () => {
+    runComponentTests({
+        type: "a11y",
+        baseClass: "s-expandable",
+        modifiers: {
+            global: ["is-expanded"],
+        },
+        children: {
+            default: `
+                <div class="s-expandable--content">
+                    <p class="mb8">Expandable: Lorem ipsum dolor sit amet, ex iudicabit necessitatibus usu, cetero laboramus concludaturque mel no, facilisis posidonium cu cum. Pro ex senserit dissentiunt, imperdiet intellegam at sed, ex pri dicit eruditi convenire. Est harum movet gubergren ei, errem dictas evertitur ea sit, at mei oratio eligendi. Ad vis legere possit, vis ne ipsum democritum appellantur. Nullam ancillae iudicabit his ad.</p>
+                </div>
+            `,
+        },
+        template: ({ component, testid }) => html`
+            <div class="ws2 p8" data-testid="${testid}">
+                <div><p>Before expandable content</p></div>
+                ${component}
+                <div><p>After expandable content</p></div>
+            </div>
+        `,
+
+    });
+});

--- a/lib/components/expandable/expandable.visual.test.ts
+++ b/lib/components/expandable/expandable.visual.test.ts
@@ -23,6 +23,5 @@ describe("expandable", () => {
                 <div><p>After expandable content</p></div>
             </div>
         `,
-
     });
 });

--- a/lib/components/expandable/expandable.visual.test.ts
+++ b/lib/components/expandable/expandable.visual.test.ts
@@ -1,0 +1,28 @@
+import { html } from "@open-wc/testing";
+import { runComponentTests } from "../../test/test-utils";
+import "../../index";
+
+describe("expandable", () => {
+    runComponentTests({
+        type: "visual",
+        baseClass: "s-expandable",
+        modifiers: {
+            global: ["is-expanded"],
+        },
+        children: {
+            default: `
+                <div class="s-expandable--content">
+                    <p class="mb8">Expandable: Lorem ipsum dolor sit amet, ex iudicabit necessitatibus usu, cetero laboramus concludaturque mel no, facilisis posidonium cu cum. Pro ex senserit dissentiunt, imperdiet intellegam at sed, ex pri dicit eruditi convenire. Est harum movet gubergren ei, errem dictas evertitur ea sit, at mei oratio eligendi. Ad vis legere possit, vis ne ipsum democritum appellantur. Nullam ancillae iudicabit his ad.</p>
+                </div>
+            `,
+        },
+        template: ({ component, testid }) => html`
+            <div class="ws2 p8" data-testid="${testid}">
+                <div><p>Before expandable content</p></div>
+                ${component}
+                <div><p>After expandable content</p></div>
+            </div>
+        `,
+
+    });
+});

--- a/screenshots/Chromium/baseline/s-expandable-dark-is-expanded.png
+++ b/screenshots/Chromium/baseline/s-expandable-dark-is-expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50e4467f691080d9a7a156b704a5865a908a099bd4bfeca6a0bb34de667b0779
+size 27215

--- a/screenshots/Chromium/baseline/s-expandable-dark.png
+++ b/screenshots/Chromium/baseline/s-expandable-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e2f82ae35650e96993720a26115d37e892234d74ca6bb70545c19aaf9bae6ad
+size 4393

--- a/screenshots/Chromium/baseline/s-expandable-highcontrast-dark-is-expanded.png
+++ b/screenshots/Chromium/baseline/s-expandable-highcontrast-dark-is-expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69215fc7026466f3e470402c5dc1297613e31d115e66eb7c2746c7a9248cac3b
+size 27752

--- a/screenshots/Chromium/baseline/s-expandable-highcontrast-dark.png
+++ b/screenshots/Chromium/baseline/s-expandable-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdb305ced7c2e79e6d31f13faf503cb49ba98dbb6a8740f7b2f30dbb97fd8a3a
+size 4193

--- a/screenshots/Chromium/baseline/s-expandable-highcontrast-light-is-expanded.png
+++ b/screenshots/Chromium/baseline/s-expandable-highcontrast-light-is-expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7306d98ae826abb7cc0d2e0dc478874513abb830cd3e7296b68563dce8902287
+size 27601

--- a/screenshots/Chromium/baseline/s-expandable-highcontrast-light.png
+++ b/screenshots/Chromium/baseline/s-expandable-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a22268ad6ca73976a438da7032026d97a0f92091dbe53cd0783069fff2cfcf2b
+size 4282

--- a/screenshots/Chromium/baseline/s-expandable-light-is-expanded.png
+++ b/screenshots/Chromium/baseline/s-expandable-light-is-expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2de01e285d0e1e51639350077147a0227978fa05b50febaea32b8a16f94e7e3a
+size 28195

--- a/screenshots/Chromium/baseline/s-expandable-light.png
+++ b/screenshots/Chromium/baseline/s-expandable-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e6b4f87d38c004367b5830f13e2521ebba1d7b03c918f9ddb6e2f8cc11faf56
+size 4477

--- a/screenshots/Firefox/baseline/s-expandable-dark-is-expanded.png
+++ b/screenshots/Firefox/baseline/s-expandable-dark-is-expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c16e25f931a651805cdf68207d2622988f653866fac1e269ee486729c8b0e60c
+size 27703

--- a/screenshots/Firefox/baseline/s-expandable-dark.png
+++ b/screenshots/Firefox/baseline/s-expandable-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41ee9f07dac7d54919943f15e898b1d1ffe7cb14258c17ce84b99b0315caaad0
+size 4438

--- a/screenshots/Firefox/baseline/s-expandable-highcontrast-dark-is-expanded.png
+++ b/screenshots/Firefox/baseline/s-expandable-highcontrast-dark-is-expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:daf967436904bddeefa8c56682916f03e0acbb3299bee14e9bdb2738b1a23520
+size 28186

--- a/screenshots/Firefox/baseline/s-expandable-highcontrast-dark.png
+++ b/screenshots/Firefox/baseline/s-expandable-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b0e48851fe2735f988309baa6e6ba954a83db0137480a8f7246a6c5c4e3f4e5
+size 4592

--- a/screenshots/Firefox/baseline/s-expandable-highcontrast-light-is-expanded.png
+++ b/screenshots/Firefox/baseline/s-expandable-highcontrast-light-is-expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1a97178853155c3396821205ae5a1538ed493c460e097bbc7d963be1681827f
+size 28019

--- a/screenshots/Firefox/baseline/s-expandable-highcontrast-light.png
+++ b/screenshots/Firefox/baseline/s-expandable-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08e61462e8772a8c2bcbc0803322d6fe7ad2d454c7716f3c5cabc54d506abe61
+size 4577

--- a/screenshots/Firefox/baseline/s-expandable-light-is-expanded.png
+++ b/screenshots/Firefox/baseline/s-expandable-light-is-expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbf1ab86901c2a666144daf3d3c05343347af4933182dfb38609925f83780c24
+size 28363

--- a/screenshots/Firefox/baseline/s-expandable-light.png
+++ b/screenshots/Firefox/baseline/s-expandable-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3400c54234a26dfa90248501a4269754f7a02c3e67ec73c0ca84b0caeb0bb696
+size 4576

--- a/screenshots/Webkit/baseline/s-expandable-dark-is-expanded.png
+++ b/screenshots/Webkit/baseline/s-expandable-dark-is-expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9816262b254efa567febfc47bb2c6ea815f0522fff4f360c519b9845e21f0bbe
+size 12729

--- a/screenshots/Webkit/baseline/s-expandable-dark.png
+++ b/screenshots/Webkit/baseline/s-expandable-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:421db0475d1069ebb7d65c9fcf557dc8e5a607fa5b327f5048c192fb8410fb4a
+size 2621

--- a/screenshots/Webkit/baseline/s-expandable-highcontrast-dark-is-expanded.png
+++ b/screenshots/Webkit/baseline/s-expandable-highcontrast-dark-is-expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c0e2fdbf93c88d88114afa87d781da7c4fe9aaa530b55fd824b9a4bcd623c17
+size 11544

--- a/screenshots/Webkit/baseline/s-expandable-highcontrast-dark.png
+++ b/screenshots/Webkit/baseline/s-expandable-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2258b34e51493c7fc4e897f077e0765dde2d91fe768a070d6493b1b2920bde2
+size 2336

--- a/screenshots/Webkit/baseline/s-expandable-highcontrast-light-is-expanded.png
+++ b/screenshots/Webkit/baseline/s-expandable-highcontrast-light-is-expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84976388c6d367fa4be912d7c76a12d102da997f9ccfe57682607d47acb6d135
+size 12599

--- a/screenshots/Webkit/baseline/s-expandable-highcontrast-light.png
+++ b/screenshots/Webkit/baseline/s-expandable-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb5e9ecdf31608f0ef659d77e256d1f97136f9241f3e85e44ac91f10ff8d127b
+size 2575

--- a/screenshots/Webkit/baseline/s-expandable-light-is-expanded.png
+++ b/screenshots/Webkit/baseline/s-expandable-light-is-expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0df44229f539ab48ea2721fbf656ce3bcd55e4198ef5555bd75adcdf0639416
+size 11381

--- a/screenshots/Webkit/baseline/s-expandable-light.png
+++ b/screenshots/Webkit/baseline/s-expandable-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab6596fb4eaaf6572a6d45aefa7d3a781b89a55b013ee641e30274f345e4ddd1
+size 2385


### PR DESCRIPTION
This PR adds visual and accessibility tests for the `s-expandable` component.