### PR TITLE
feat(typography): add ow-anywhere atomic class

### DIFF
--- a/docs/_data/typography.json
+++ b/docs/_data/typography.json
@@ -214,6 +214,11 @@
       "define": "Restores overflow wrapping behavior."
     },
     {
+      "class": "ow-anywhere",
+      "output": "overflow-wrap: anywhere;",
+      "define": "Breaks a string of characters at any point when no other acceptable break points are available and does not hyphenate the break."
+    },
+    {
       "class": "ow-break-word",
       "output": "overflow-wrap: break-word;",
       "define": "Breaks a word to a new line only if the entire word cannot be placed on its own line without overflowing."

--- a/lib/atomic/typography.less
+++ b/lib/atomic/typography.less
@@ -198,6 +198,10 @@ p {
     overflow-wrap: normal !important;
 }
 
+.ow-anaywhere {
+    overflow-wrap: anywhere !important;
+}
+
 .ow-break-word {
     overflow-wrap: break-word !important;
 }

--- a/lib/atomic/typography.less
+++ b/lib/atomic/typography.less
@@ -198,7 +198,7 @@ p {
     overflow-wrap: normal !important;
 }
 
-.ow-anaywhere {
+.ow-anywhere {
     overflow-wrap: anywhere !important;
 }
 


### PR DESCRIPTION
Does what it says on the tin. Adds `.ow-anywhere` atomic class. Enjoy!

https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap#values