### PR TITLE
test(pagination): add a11y, visual tests

### DIFF
--- a/lib/components/pagination/pagination.a11y.test.ts
+++ b/lib/components/pagination/pagination.a11y.test.ts
@@ -1,0 +1,25 @@
+import { runComponentTests } from "../../test/test-utils";
+import "../../index";
+
+describe("pagination", () => {
+    runComponentTests({
+        type: "a11y",
+        baseClass: "s-pagination",
+        children: {
+            default: `
+                <a class="s-pagination--item" href="#">Prev</a>
+                <a class="s-pagination--item" href="#">1</a>
+                <span class="s-pagination--item is-selected" aria-current="page">2</span>
+                <a class="s-pagination--item" href="#">3</a>
+                <span class="s-pagination--item s-pagination--item__clear">…</span>
+                <a class="s-pagination--item" href="#">100</a>
+                <a class="s-pagination--item" href="#">Next</a>
+            `,
+        },
+        // TODO: Most of those skipped tests should be fixed by the new Stacks 2.0 palette
+        skippedTestids: [
+            "s-pagination-dark",
+            "s-pagination-light",
+        ],
+    });
+});

--- a/lib/components/pagination/pagination.a11y.test.ts
+++ b/lib/components/pagination/pagination.a11y.test.ts
@@ -17,9 +17,6 @@ describe("pagination", () => {
             `,
         },
         // TODO: Most of those skipped tests should be fixed by the new Stacks 2.0 palette
-        skippedTestids: [
-            "s-pagination-dark",
-            "s-pagination-light",
-        ],
+        skippedTestids: ["s-pagination-dark", "s-pagination-light"],
     });
 });

--- a/lib/components/pagination/pagination.visual.test.ts
+++ b/lib/components/pagination/pagination.visual.test.ts
@@ -1,0 +1,24 @@
+import { html } from "@open-wc/testing";
+import { runComponentTests } from "../../test/test-utils";
+import "../../index";
+
+describe("pagination", () => {
+    runComponentTests({
+        type: "visual",
+        baseClass: "s-pagination",
+        children: {
+            default: `
+                <a class="s-pagination--item" href="#">Prev</a>
+                <a class="s-pagination--item" href="#">1</a>
+                <span class="s-pagination--item is-selected" aria-current="page">2</span>
+                <a class="s-pagination--item" href="#">3</a>
+                <span class="s-pagination--item s-pagination--item__clear">…</span>
+                <a class="s-pagination--item" href="#">100</a>
+                <a class="s-pagination--item" href="#">Next</a>
+            `,
+        },
+        template: ({ component, testid }) => html`
+            <div class="d-inline-block p8" data-testid="${testid}">${component}</div>
+        `,
+    });
+});

--- a/lib/components/pagination/pagination.visual.test.ts
+++ b/lib/components/pagination/pagination.visual.test.ts
@@ -18,7 +18,9 @@ describe("pagination", () => {
             `,
         },
         template: ({ component, testid }) => html`
-            <div class="d-inline-block p8" data-testid="${testid}">${component}</div>
+            <div class="d-inline-block p8" data-testid="${testid}">
+                ${component}
+            </div>
         `,
     });
 });

--- a/screenshots/Chromium/baseline/s-pagination-dark.png
+++ b/screenshots/Chromium/baseline/s-pagination-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0189f7c847fe5f3fd928c68bffdacd5effbecf4a15286dec39360e734cec22cb
+size 2886

--- a/screenshots/Chromium/baseline/s-pagination-highcontrast-dark.png
+++ b/screenshots/Chromium/baseline/s-pagination-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7154c3da85a4452874ce2727648d374b0073e5b38b23f3b6f6171779eb38e660
+size 2858

--- a/screenshots/Chromium/baseline/s-pagination-highcontrast-light.png
+++ b/screenshots/Chromium/baseline/s-pagination-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f6f15fa7bef41ed1a3c4850a4e487501d07a61afd388cbdb190860757316260
+size 2889

--- a/screenshots/Chromium/baseline/s-pagination-light.png
+++ b/screenshots/Chromium/baseline/s-pagination-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dec9e09ef8798b20084c275057ce111f8b933e34fcc9cff7ea903f0c1798f76
+size 2893

--- a/screenshots/Firefox/baseline/s-pagination-dark.png
+++ b/screenshots/Firefox/baseline/s-pagination-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2973352f99d75885bb0eb6df7bbd1724d1e14625aaca914d2535bae9cca55b51
+size 3459

--- a/screenshots/Firefox/baseline/s-pagination-highcontrast-dark.png
+++ b/screenshots/Firefox/baseline/s-pagination-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1397e417fab2dc468ee51250372d7924270b76970ce8ddb7841a7193617974b8
+size 3507

--- a/screenshots/Firefox/baseline/s-pagination-highcontrast-light.png
+++ b/screenshots/Firefox/baseline/s-pagination-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfb274d6f064a7974274a3c12f9822ca269310053747f06733da1cd78317e903
+size 3520

--- a/screenshots/Firefox/baseline/s-pagination-light.png
+++ b/screenshots/Firefox/baseline/s-pagination-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a458637f5ba8a5639a00e7008a73a1f5d5cbf66649c7ae68612858869d49f1b9
+size 3475

--- a/screenshots/Webkit/baseline/s-avatar-dark-image.png
+++ b/screenshots/Webkit/baseline/s-avatar-dark-image.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b996d7211907595e735c34fd1c34dbfe22744e2977debdf5abb7658673c6e16a
-size 808
+oid sha256:8aa3c35cbcbe9c49050e7102e24a5368e909f99b3f2a83760f54314e4133bb5d
+size 813

--- a/screenshots/Webkit/baseline/s-pagination-dark.png
+++ b/screenshots/Webkit/baseline/s-pagination-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00c245157933b2f107ab8ef778609c079f2209b086165c80fef14e910c78ece2
+size 2408

--- a/screenshots/Webkit/baseline/s-pagination-highcontrast-dark.png
+++ b/screenshots/Webkit/baseline/s-pagination-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e96c342cd54fb9c107cf4b3ccd09dfe6cc7421ccb5af98ac6aa37e8cd47f6679
+size 2361

--- a/screenshots/Webkit/baseline/s-pagination-highcontrast-light.png
+++ b/screenshots/Webkit/baseline/s-pagination-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abba887c93d5ccd4238518e6d88948dcd59bac01162f34128fd341f520061375
+size 2412

--- a/screenshots/Webkit/baseline/s-pagination-light.png
+++ b/screenshots/Webkit/baseline/s-pagination-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a417ba9ac098928fac1622d035434734a89d73493a7e346026d9213bb73ba3c
+size 2372


### PR DESCRIPTION
This PR adds visual and accessibility tests for the `.s-pagination` component.

> **Note**
> This includes a regeneration of an avatar test image. It looks identical to me, but it got regenerated, so here it is 🤷‍♂️