### PR TITLE
test(spinner): add a11y; visual tests

### DIFF
--- a/lib/components/spinner/spinner.a11y.test.ts
+++ b/lib/components/spinner/spinner.a11y.test.ts
@@ -1,0 +1,15 @@
+import { runComponentTests } from "../../test/test-utils";
+import "../../index";
+
+describe("spinner", () => {
+    runComponentTests({
+        type: "a11y",
+        baseClass: "s-spinner",
+        modifiers: {
+            primary: ["xs", "sm", "md", "lg"],
+        },
+        children: {
+            default: `<div class="v-visible-sr">Loading…</div>`,
+        },
+    });
+});

--- a/lib/components/spinner/spinner.visual.test.ts
+++ b/lib/components/spinner/spinner.visual.test.ts
@@ -1,0 +1,45 @@
+import { html } from "@open-wc/testing";
+import { runComponentTests } from "../../test/test-utils";
+import "../../index";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const template = ({ component, testid }: any) => html`
+    <div class="d-inline-block p8" data-testid="${testid}">
+        ${component}
+    </div>
+`;
+describe("spinner", () => {
+    // default, sizes
+    runComponentTests({
+        type: "visual",
+        baseClass: "s-spinner",
+        modifiers: {
+            primary: ["xs", "sm", "md", "lg"],
+        },
+        children: {
+            default: `<div class="v-visible-sr">Loading…</div>`,
+        },
+        template,
+    });
+    // applied font color
+    runComponentTests({
+        type: "visual",
+        baseClass: "s-spinner",
+        modifiers: {
+            global: ["fc-theme-primary"],
+        },
+        children: {
+            default: `<div class="v-visible-sr">Loading…</div>`,
+        },
+        template,
+    });
+    // .is-loading
+    runComponentTests({
+        type: "visual",
+        baseClass: "is-loading",
+        children: {
+            default: `Loading…`,
+        },
+        template,
+    });
+});

--- a/lib/components/spinner/spinner.visual.test.ts
+++ b/lib/components/spinner/spinner.visual.test.ts
@@ -4,9 +4,7 @@ import "../../index";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const template = ({ component, testid }: any) => html`
-    <div class="d-inline-block p8" data-testid="${testid}">
-        ${component}
-    </div>
+    <div class="d-inline-block p8" data-testid="${testid}">${component}</div>
 `;
 describe("spinner", () => {
     // default, sizes

--- a/screenshots/Chromium/baseline/is-loading-dark.png
+++ b/screenshots/Chromium/baseline/is-loading-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2cccc170f6b676c48422880bf0a801da66804c67b18bf57c467053bd9da59c2
+size 1572

--- a/screenshots/Chromium/baseline/is-loading-highcontrast-dark.png
+++ b/screenshots/Chromium/baseline/is-loading-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8799d7359102058de0676c1c9188f942991ff4ad869d2e6003416f8e3ad89287
+size 1459

--- a/screenshots/Chromium/baseline/is-loading-highcontrast-light.png
+++ b/screenshots/Chromium/baseline/is-loading-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:366ac2e3c392a8052e3a00955183315594e389428231570c8b604e4f76306d93
+size 1472

--- a/screenshots/Chromium/baseline/is-loading-light.png
+++ b/screenshots/Chromium/baseline/is-loading-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c329231dc336ea333e1482397c3c67ecf12272961a387535296936e0ad32ad1d
+size 1499

--- a/screenshots/Chromium/baseline/s-spinner-dark-fc-theme-primary.png
+++ b/screenshots/Chromium/baseline/s-spinner-dark-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afe470bdb9f08e38263d743a70ce4fd8dfe60afea431fbbde4f910a32c9ec251
+size 763

--- a/screenshots/Chromium/baseline/s-spinner-dark-lg.png
+++ b/screenshots/Chromium/baseline/s-spinner-dark-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89a778cee1db66ffd248aefbb071dc4f40ab60111b1b30cffdee264adf395798
+size 1692

--- a/screenshots/Chromium/baseline/s-spinner-dark-md.png
+++ b/screenshots/Chromium/baseline/s-spinner-dark-md.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5748319d526f76560875894c1cd3ee66a27dcf7c259f9b38268a428a0060f0ba
+size 1160

--- a/screenshots/Chromium/baseline/s-spinner-dark-sm.png
+++ b/screenshots/Chromium/baseline/s-spinner-dark-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e7ba40bd09115add04f9c1e852bbfe7c1ff1029aa55debf09477a003e6cde2b
+size 561

--- a/screenshots/Chromium/baseline/s-spinner-dark-xs.png
+++ b/screenshots/Chromium/baseline/s-spinner-dark-xs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fee9d808ba706c9516bf5f7cf8dab6789a39fbe5c6d657380fb82130fc63ca8b
+size 407

--- a/screenshots/Chromium/baseline/s-spinner-dark.png
+++ b/screenshots/Chromium/baseline/s-spinner-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfd01aed9c00cd9bb05100a35fed60461145cde37dad6a4d6d2d67f070679ea2
+size 838

--- a/screenshots/Chromium/baseline/s-spinner-highcontrast-dark-fc-theme-primary.png
+++ b/screenshots/Chromium/baseline/s-spinner-highcontrast-dark-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7468be2c5f0a74fa38af2cc66acc2cf1b3de8b26c8942916f800ad4cf0be5455
+size 806

--- a/screenshots/Chromium/baseline/s-spinner-highcontrast-dark-lg.png
+++ b/screenshots/Chromium/baseline/s-spinner-highcontrast-dark-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c62bc45011f8fca72b97455568fedcb47f19a49a81298d79dd589f01fc747f0
+size 1492

--- a/screenshots/Chromium/baseline/s-spinner-highcontrast-dark-md.png
+++ b/screenshots/Chromium/baseline/s-spinner-highcontrast-dark-md.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33d1d063494be9626a1e9be47ab3908d41331fcf1132e5a5580538ec813ae7e5
+size 1043

--- a/screenshots/Chromium/baseline/s-spinner-highcontrast-dark-sm.png
+++ b/screenshots/Chromium/baseline/s-spinner-highcontrast-dark-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53f8d024adc8f887dd626620db43bc4fa386ce51a2e68060c9500b4503ce21d5
+size 550

--- a/screenshots/Chromium/baseline/s-spinner-highcontrast-dark-xs.png
+++ b/screenshots/Chromium/baseline/s-spinner-highcontrast-dark-xs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:baf4ba772e488c0ca686104d4b87abe05c53ded3c76475177ab7356c0e2473da
+size 371

--- a/screenshots/Chromium/baseline/s-spinner-highcontrast-dark.png
+++ b/screenshots/Chromium/baseline/s-spinner-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24d7091b2f4a07cf08226d7c2abe6486f60641ba92d3255aac4216b72293858f
+size 755

--- a/screenshots/Chromium/baseline/s-spinner-highcontrast-light-fc-theme-primary.png
+++ b/screenshots/Chromium/baseline/s-spinner-highcontrast-light-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c058e31191de75bdaf1ae25e1cc6f8a3b82dc1df0ffe5780020d61c76d6e5263
+size 754

--- a/screenshots/Chromium/baseline/s-spinner-highcontrast-light-lg.png
+++ b/screenshots/Chromium/baseline/s-spinner-highcontrast-light-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:169cf198a41980b63e2d5ae84874dca99dcbaff8fd992031911361fdc66210b5
+size 1354

--- a/screenshots/Chromium/baseline/s-spinner-highcontrast-light-md.png
+++ b/screenshots/Chromium/baseline/s-spinner-highcontrast-light-md.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e97dd79749c7310eb04b0be380ead45d9c47d2ce38644da1c6aaf3cc98e7050c
+size 941

--- a/screenshots/Chromium/baseline/s-spinner-highcontrast-light-sm.png
+++ b/screenshots/Chromium/baseline/s-spinner-highcontrast-light-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:307dc8e9a685858ea7f2118f8ac092d14d62915dfdd5cac60316dcbea7ef7bbb
+size 504

--- a/screenshots/Chromium/baseline/s-spinner-highcontrast-light-xs.png
+++ b/screenshots/Chromium/baseline/s-spinner-highcontrast-light-xs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b8e60d8cdbe9dd40fb0d061ee1b7cd407155a94e46f6f6eee501887f15022bc
+size 358

--- a/screenshots/Chromium/baseline/s-spinner-highcontrast-light.png
+++ b/screenshots/Chromium/baseline/s-spinner-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f63072d8eed9990dd62e845218a11ded494060d385395d661b4f4c3af0702434
+size 691

--- a/screenshots/Chromium/baseline/s-spinner-light-fc-theme-primary.png
+++ b/screenshots/Chromium/baseline/s-spinner-light-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e2cc1961f7846948baf1d928cf5c514d00d9853c34dd7dbbe3e601085e0ac79
+size 704

--- a/screenshots/Chromium/baseline/s-spinner-light-lg.png
+++ b/screenshots/Chromium/baseline/s-spinner-light-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:439b84e97f37d04d60d3ea8751b1fa7288c45beac748568f49ff2deafe8e5e90
+size 1430

--- a/screenshots/Chromium/baseline/s-spinner-light-md.png
+++ b/screenshots/Chromium/baseline/s-spinner-light-md.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a51d293fb9496f5c819d1c16a796512d099e6725eb366f6b2ff1c541818387d4
+size 1003

--- a/screenshots/Chromium/baseline/s-spinner-light-sm.png
+++ b/screenshots/Chromium/baseline/s-spinner-light-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed6badba0d055278f1a744c7261b35077e6174988bc8a8496c57e9e633e14cb0
+size 519

--- a/screenshots/Chromium/baseline/s-spinner-light-xs.png
+++ b/screenshots/Chromium/baseline/s-spinner-light-xs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1dab60ef5cd760cc4d1ddd6ab102517c8b777a8bb865f1a06875902b0d816a7
+size 375

--- a/screenshots/Chromium/baseline/s-spinner-light.png
+++ b/screenshots/Chromium/baseline/s-spinner-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a2527345983ebb8d5a745a7644c3b10021b9ae0103cfcab2f751e15958784a2
+size 728

--- a/screenshots/Firefox/baseline/is-loading-dark.png
+++ b/screenshots/Firefox/baseline/is-loading-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a7802dc58a38da34a59def9f862eb217b7c9347f0b42afb3d182503a3db6f6c
+size 1503

--- a/screenshots/Firefox/baseline/is-loading-highcontrast-dark.png
+++ b/screenshots/Firefox/baseline/is-loading-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a43207e8ac2722e1e59e401ebcde0235f0dc85e6ab65ca70b281643620c8100f
+size 1533

--- a/screenshots/Firefox/baseline/is-loading-highcontrast-light.png
+++ b/screenshots/Firefox/baseline/is-loading-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:183052b9697ab9e726acd1bc7eafc900239316e493f10723e9d2ef2db3cec6ad
+size 1497

--- a/screenshots/Firefox/baseline/is-loading-light.png
+++ b/screenshots/Firefox/baseline/is-loading-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d6be74f5b2660531eeb70e6091fccfe7771789f54dbf93322045fa88d66dcc2
+size 1512

--- a/screenshots/Firefox/baseline/s-spinner-dark-fc-theme-primary.png
+++ b/screenshots/Firefox/baseline/s-spinner-dark-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08749d770cbff473660ffe0c504bf2b37b4847597301af24ab5f15060fa4ca96
+size 706

--- a/screenshots/Firefox/baseline/s-spinner-dark-lg.png
+++ b/screenshots/Firefox/baseline/s-spinner-dark-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ee6be05345c588bbe61a6cf520a6e7c6e22afe25f8446805f7f6c130debe27b
+size 1373

--- a/screenshots/Firefox/baseline/s-spinner-dark-md.png
+++ b/screenshots/Firefox/baseline/s-spinner-dark-md.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3316561a73f581194dd0f33113ad57b1d315bbeece456f0d6b0d26a9da41e5cb
+size 938

--- a/screenshots/Firefox/baseline/s-spinner-dark-sm.png
+++ b/screenshots/Firefox/baseline/s-spinner-dark-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c09c51a39b3a125e0c57f3d34f4f49dcf8b0ba99bc56c92722e8d2b1618cafcb
+size 398

--- a/screenshots/Firefox/baseline/s-spinner-dark-xs.png
+++ b/screenshots/Firefox/baseline/s-spinner-dark-xs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac2fe5d6502719fc55aa80a6bbe0186c2eb24a999b68c2e523e4681f4757393d
+size 361

--- a/screenshots/Firefox/baseline/s-spinner-dark.png
+++ b/screenshots/Firefox/baseline/s-spinner-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdf37f79a3b444d6b09b658029a3ad54f9de5912f702aa70ad8181d4e8c6601b
+size 714

--- a/screenshots/Firefox/baseline/s-spinner-highcontrast-dark-fc-theme-primary.png
+++ b/screenshots/Firefox/baseline/s-spinner-highcontrast-dark-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6056d476a70b0e18da75fb751d70e30780164c11ad2d34711d90238c0c54d545
+size 678

--- a/screenshots/Firefox/baseline/s-spinner-highcontrast-dark-lg.png
+++ b/screenshots/Firefox/baseline/s-spinner-highcontrast-dark-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0b894506fec8643819e95ee36b679a9d99a245095765fe5c7a0c7db21b124e7
+size 1346

--- a/screenshots/Firefox/baseline/s-spinner-highcontrast-dark-md.png
+++ b/screenshots/Firefox/baseline/s-spinner-highcontrast-dark-md.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1efb1f3ee2f11ce749346c7679aca84cec02b033d63d3810066324c8e73840d2
+size 961

--- a/screenshots/Firefox/baseline/s-spinner-highcontrast-dark-sm.png
+++ b/screenshots/Firefox/baseline/s-spinner-highcontrast-dark-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16f2afa9a51d81f54e33a56a381c758107677329b4fa390c4fa35be7d75527f7
+size 404

--- a/screenshots/Firefox/baseline/s-spinner-highcontrast-dark-xs.png
+++ b/screenshots/Firefox/baseline/s-spinner-highcontrast-dark-xs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a80091f9b2b66b56c5ea7209c65b5873f89bcbc19fef009242a12ac966aca63c
+size 392

--- a/screenshots/Firefox/baseline/s-spinner-highcontrast-dark.png
+++ b/screenshots/Firefox/baseline/s-spinner-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25595f07ba4a781597d837ea5e86b840a41da0bde409f729f6cecdab97d359db
+size 742

--- a/screenshots/Firefox/baseline/s-spinner-highcontrast-light-fc-theme-primary.png
+++ b/screenshots/Firefox/baseline/s-spinner-highcontrast-light-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9d6bff96a58a8577da2e3f127d96b0b69ee4d34f3631fbf6cfe68e704a447da
+size 772

--- a/screenshots/Firefox/baseline/s-spinner-highcontrast-light-lg.png
+++ b/screenshots/Firefox/baseline/s-spinner-highcontrast-light-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e512b2cd4dfa2f282de706748e31cc5a98ca466051716a0d18107c9cd408843
+size 1401

--- a/screenshots/Firefox/baseline/s-spinner-highcontrast-light-md.png
+++ b/screenshots/Firefox/baseline/s-spinner-highcontrast-light-md.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6930c27c941bdc058a5152f86cd0d40907a06ffb7e87f75622c6b97f659ff2e5
+size 1026

--- a/screenshots/Firefox/baseline/s-spinner-highcontrast-light-sm.png
+++ b/screenshots/Firefox/baseline/s-spinner-highcontrast-light-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f33544c484a936e197b456c048e6ab8a6253e6b07f61ae609c9b872f9a86767
+size 420

--- a/screenshots/Firefox/baseline/s-spinner-highcontrast-light-xs.png
+++ b/screenshots/Firefox/baseline/s-spinner-highcontrast-light-xs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0adb8399da0996a7a23a84cf6d90f2cd1720902c9c64add8b81e286f0e665de
+size 385

--- a/screenshots/Firefox/baseline/s-spinner-highcontrast-light.png
+++ b/screenshots/Firefox/baseline/s-spinner-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb0080ffcb1f2149b5f85f048b9dd9d442bc0a4e62ef71fed29e49c5dd481192
+size 724

--- a/screenshots/Firefox/baseline/s-spinner-light-fc-theme-primary.png
+++ b/screenshots/Firefox/baseline/s-spinner-light-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f043fb6570a1b6614788c3a5cb96af600f09a85968f62445c186502376eb2fb
+size 756

--- a/screenshots/Firefox/baseline/s-spinner-light-lg.png
+++ b/screenshots/Firefox/baseline/s-spinner-light-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1198f5aa74db89db536953086308623911cfb99587038a1a2dc807995585fd5c
+size 1480

--- a/screenshots/Firefox/baseline/s-spinner-light-md.png
+++ b/screenshots/Firefox/baseline/s-spinner-light-md.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a3067b167aa50211b0dd2c033e1767eb8177e095779d1f4349035b23f01e931
+size 1065

--- a/screenshots/Firefox/baseline/s-spinner-light-sm.png
+++ b/screenshots/Firefox/baseline/s-spinner-light-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7bd35fbaacb60e825779cb83cbbf263c618b217218dbd0166c685b4a9f2c6bdc
+size 438

--- a/screenshots/Firefox/baseline/s-spinner-light-xs.png
+++ b/screenshots/Firefox/baseline/s-spinner-light-xs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c71d9df745dc24dd0c7fb00975bde47b523aa547cbfb05f1f735f07e1fbe36f
+size 393

--- a/screenshots/Firefox/baseline/s-spinner-light.png
+++ b/screenshots/Firefox/baseline/s-spinner-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1cd4a82a04c415579e6a38d504a0e7c30d6eded0cebaa908f6fdffafe05cbd8
+size 757

--- a/screenshots/Webkit/baseline/is-loading-dark.png
+++ b/screenshots/Webkit/baseline/is-loading-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a6a7385cfb745617925dffeb2c5e20a1c059da47eb87afcd842ffd27ea8c7dc
+size 1506

--- a/screenshots/Webkit/baseline/is-loading-highcontrast-dark.png
+++ b/screenshots/Webkit/baseline/is-loading-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9532ff7bc1bfb2498cda2e9e716e1e2f8f1a28141ee53862e479c9d98baf707a
+size 1388

--- a/screenshots/Webkit/baseline/is-loading-highcontrast-light.png
+++ b/screenshots/Webkit/baseline/is-loading-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4ad8804715930d8552f2770b51ecf1946fc2f99d8a68f9026958dd7ffc2ef09
+size 1411

--- a/screenshots/Webkit/baseline/is-loading-light.png
+++ b/screenshots/Webkit/baseline/is-loading-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10465c1034096ba8d081c61ff2f4b69c69e3d32f86060f3107f029afc210e1cd
+size 1420

--- a/screenshots/Webkit/baseline/s-spinner-dark-fc-theme-primary.png
+++ b/screenshots/Webkit/baseline/s-spinner-dark-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89f285e1f4c235b70d48a547aefe16d59697743ae1b01a7a60b235de6c633439
+size 795

--- a/screenshots/Webkit/baseline/s-spinner-dark-lg.png
+++ b/screenshots/Webkit/baseline/s-spinner-dark-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3c18e5c0b9c6850ff96095c38efb6ac670a7fc01a95a42ed5acc5532390cb9b
+size 1761

--- a/screenshots/Webkit/baseline/s-spinner-dark-md.png
+++ b/screenshots/Webkit/baseline/s-spinner-dark-md.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2e75a679d5dc1e298d0aaf99dc2a218569a90ce8710531563162c551266fb52
+size 1192

--- a/screenshots/Webkit/baseline/s-spinner-dark-sm.png
+++ b/screenshots/Webkit/baseline/s-spinner-dark-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef067c59263c97af50ef3c04a02db1a0545d45d65884aa3f428fb72acf64ca1f
+size 600

--- a/screenshots/Webkit/baseline/s-spinner-dark-xs.png
+++ b/screenshots/Webkit/baseline/s-spinner-dark-xs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fde89828f3ae5dff413e36b74774207be028d800bcfafd0f1f83f7fa937b005a
+size 398

--- a/screenshots/Webkit/baseline/s-spinner-dark.png
+++ b/screenshots/Webkit/baseline/s-spinner-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc6046213cbd6fefa092eb29c03d738e2c21e7fcc9a448b4c8e5b71b7cb1f281
+size 854

--- a/screenshots/Webkit/baseline/s-spinner-highcontrast-dark-fc-theme-primary.png
+++ b/screenshots/Webkit/baseline/s-spinner-highcontrast-dark-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca495f5013651d0a569e381ddb835077216ba59fe1ba0eddbbf37d7773969790
+size 807

--- a/screenshots/Webkit/baseline/s-spinner-highcontrast-dark-lg.png
+++ b/screenshots/Webkit/baseline/s-spinner-highcontrast-dark-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2dd592f6e740c657271c3d5c5ca82e8b90cbb168e21dc9c9ac4df4853a570912
+size 1708

--- a/screenshots/Webkit/baseline/s-spinner-highcontrast-dark-md.png
+++ b/screenshots/Webkit/baseline/s-spinner-highcontrast-dark-md.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e617084df7aacc4039296bd2d8de89327151dc911d5f9687a131673db5c47ceb
+size 1117

--- a/screenshots/Webkit/baseline/s-spinner-highcontrast-dark-sm.png
+++ b/screenshots/Webkit/baseline/s-spinner-highcontrast-dark-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4128cacc2aa46fff580af9ad494bda0595dd5f4638745612eabba98106ead178
+size 526

--- a/screenshots/Webkit/baseline/s-spinner-highcontrast-dark-xs.png
+++ b/screenshots/Webkit/baseline/s-spinner-highcontrast-dark-xs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1aa61b8de8d845787a23990deb8d4cbb5aa09bdc5cfb84d7da11c659404592e8
+size 342

--- a/screenshots/Webkit/baseline/s-spinner-highcontrast-dark.png
+++ b/screenshots/Webkit/baseline/s-spinner-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e698f018f0b98428f67293332b96dc050bd98f2e2fdab98fc424ff98d2d9b5b
+size 818

--- a/screenshots/Webkit/baseline/s-spinner-highcontrast-light-fc-theme-primary.png
+++ b/screenshots/Webkit/baseline/s-spinner-highcontrast-light-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e31534c58ac6b24422f6af4745794a4e6ce2d64ad780b83cc34a02deb4c3f721
+size 807

--- a/screenshots/Webkit/baseline/s-spinner-highcontrast-light-lg.png
+++ b/screenshots/Webkit/baseline/s-spinner-highcontrast-light-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea4c91e63cdd78589f09d4c4ac0a9240d9dc256a2febe017bc7d3ade351bf07b
+size 1614

--- a/screenshots/Webkit/baseline/s-spinner-highcontrast-light-md.png
+++ b/screenshots/Webkit/baseline/s-spinner-highcontrast-light-md.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d35937a910f708e23a700b1620f1bec422a44268df5f8abf5ecd1cc8f098484
+size 1104

--- a/screenshots/Webkit/baseline/s-spinner-highcontrast-light-sm.png
+++ b/screenshots/Webkit/baseline/s-spinner-highcontrast-light-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dfb1957eb973fd7699446e3cf12d0d279e5ba039ab5b371b2e5a13acdad1216
+size 513

--- a/screenshots/Webkit/baseline/s-spinner-highcontrast-light-xs.png
+++ b/screenshots/Webkit/baseline/s-spinner-highcontrast-light-xs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66496dba58eeb7404c227657f0843b726f54e9483590b1797d4225823714147a
+size 355

--- a/screenshots/Webkit/baseline/s-spinner-highcontrast-light.png
+++ b/screenshots/Webkit/baseline/s-spinner-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd6e3b3e0d25736840146364d8652c386b6468a0872b49e48d21834f9c78fe25
+size 800

--- a/screenshots/Webkit/baseline/s-spinner-light-fc-theme-primary.png
+++ b/screenshots/Webkit/baseline/s-spinner-light-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69f5034fca0d58341ed4f6e6cf0d68d3d0f323dad65fce869e5c96f4a4a26cfb
+size 747

--- a/screenshots/Webkit/baseline/s-spinner-light-lg.png
+++ b/screenshots/Webkit/baseline/s-spinner-light-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09e42a76e51580e1fdae35c989d91885f7b98c1e2c1e04e68b51ed57cec36c69
+size 1630

--- a/screenshots/Webkit/baseline/s-spinner-light-md.png
+++ b/screenshots/Webkit/baseline/s-spinner-light-md.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c434773b25584613964418d2faa302f104298814a8e6a93f66c4fcf0e67f6db
+size 1119

--- a/screenshots/Webkit/baseline/s-spinner-light-sm.png
+++ b/screenshots/Webkit/baseline/s-spinner-light-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f06c1780a20df6e0b584eb2f33f8365dd83275a0f14229df5354d663b50ba15a
+size 534

--- a/screenshots/Webkit/baseline/s-spinner-light-xs.png
+++ b/screenshots/Webkit/baseline/s-spinner-light-xs.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cff0d8f7442964029fa1ba087834fd0a629c109e1e2066b59139a544f23184a3
+size 376

--- a/screenshots/Webkit/baseline/s-spinner-light.png
+++ b/screenshots/Webkit/baseline/s-spinner-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b682115bce4eb859b7d638452551f2ec0ae46cae92e5766c1c6ff9b3d020aa3
+size 810


### PR DESCRIPTION
This PR adds visual and accessibility tests for the `.s-spinner` component.