### PR TITLE
test(a11y): add ability to pass custom APCA threshold to axe-apca

### DIFF
--- a/lib/test/axe-apca/README.md
+++ b/lib/test/axe-apca/README.md
@@ -42,9 +42,9 @@ To set custom thresholds for APCA checks, follow these steps:
 
 
 ```js
-const customAPCAThreshold = (fontSize) => {
+const customConformanceThresholdFn = (fontSize) => {
     return parseFloat(fontSize) >= 32 ? 45 : 60;
 };
 
-registerAxeAPCA('custom', customAPCAThreshold);
+registerAxeAPCA('custom', customConformanceThresholdFn);
 ```

--- a/lib/test/axe-apca/README.md
+++ b/lib/test/axe-apca/README.md
@@ -42,8 +42,11 @@ To set custom thresholds for APCA checks, follow these steps:
 
 
 ```js
-const customConformanceThresholdFn = (fontSize) => {
-    return parseFloat(fontSize) >= 32 ? 45 : 60;
+const customConformanceThresholdFn = (fontSize, fontWeight) => {
+    const size = parseFloat(fontSize);
+    const weight = parseFloat(fontWeight);
+
+    return size >= 32 || weight > 700 ? 45 : 60;
 };
 
 registerAxeAPCA('custom', customConformanceThresholdFn);

--- a/lib/test/axe-apca/README.md
+++ b/lib/test/axe-apca/README.md
@@ -20,6 +20,7 @@ npm install --save-dev axe-core axe-apca
 import axe from "axe-core";
 import { registerAxeAPCA } from 'axe-apca';
 
+// TODO update to include custom conformance level
 registerAxeAPCA('bronze'); // or registerAxeAPCA('silver');
 
  // consider turning off default WCAG 2.1 AA color contrast rules when using APCA

--- a/lib/test/axe-apca/README.md
+++ b/lib/test/axe-apca/README.md
@@ -20,7 +20,6 @@ npm install --save-dev axe-core axe-apca
 import axe from "axe-core";
 import { registerAxeAPCA } from 'axe-apca';
 
-// TODO update to include custom conformance level
 registerAxeAPCA('bronze'); // or registerAxeAPCA('silver');
 
  // consider turning off default WCAG 2.1 AA color contrast rules when using APCA
@@ -32,4 +31,20 @@ axe.configure({
     if (err) throw err;
     console.log(results);
 });
+```
+
+### Using custom APCA thresholds
+
+To set custom thresholds for APCA checks, follow these steps:
+
+1. Use `custom` as the first argument when calling `registerAxeAPCA`.
+1. Provide a function as the second argument, optionally accepting `fontSize` and `fontWeight` arguments.
+
+
+```js
+const customAPCAThreshold = (fontSize) => {
+    return parseFloat(fontSize) >= 32 ? 45 : 60;
+};
+
+registerAxeAPCA('custom', customAPCAThreshold);
 ```

--- a/lib/test/axe-apca/src/axe-apca.test.ts
+++ b/lib/test/axe-apca/src/axe-apca.test.ts
@@ -13,6 +13,7 @@ const runAxe = async (el: HTMLElement): Promise<AxeResults> => {
 };
 
 describe("axe-apca", () => {
+    // TODO update to test custom conformance level
     describe("bronze conformance level", () => {
         beforeEach(() => {
             registerAxeAPCA("bronze");

--- a/lib/test/axe-apca/src/axe-apca.test.ts
+++ b/lib/test/axe-apca/src/axe-apca.test.ts
@@ -15,11 +15,13 @@ const runAxe = async (el: HTMLElement): Promise<AxeResults> => {
 describe("axe-apca", () => {
     describe("custom conformance level", () => {
         beforeEach(() => {
-            const getAPCACustomThreshold = (fontSize: string): number | null => {
+            const customConformanceThresholdFn = (
+                fontSize: string
+            ): number | null => {
                 return parseFloat(fontSize) >= 32 ? 45 : 60;
             };
-            
-            registerAxeAPCA("custom", getAPCACustomThreshold);
+
+            registerAxeAPCA("custom", customConformanceThresholdFn);
         });
 
         it("should check for APCA accessibility contrast violations", async () => {

--- a/lib/test/axe-apca/src/axe-apca.ts
+++ b/lib/test/axe-apca/src/axe-apca.ts
@@ -192,15 +192,19 @@ const colorContrastAPCABronzeConformanceCheck =
 const colorContrastAPCASilverRule = generateColorContrastAPCARule("silver");
 const colorContrastAPCABronzeRule = generateColorContrastAPCARule("bronze");
 
-const registerAxeAPCA = (conformanceLevel: ConformanceLevel, customAPCAThreshold?: ConformanceThresholdFn) => {
+const registerAxeAPCA = (
+    conformanceLevel: ConformanceLevel,
+    customConformanceThresholdFn?: ConformanceThresholdFn
+) => {
     axe.configure({
         rules: [generateColorContrastAPCARule(conformanceLevel)],
         checks: [
             generateColorContrastAPCAConformanceCheck(
                 conformanceLevel,
-                customAPCAThreshold || (conformanceLevel === "silver"
-                    ? getAPCASilverPlusThreshold
-                    : getAPCABronzeThreshold)
+                customConformanceThresholdFn ||
+                    (conformanceLevel === "silver"
+                        ? getAPCASilverPlusThreshold
+                        : getAPCABronzeThreshold)
             ),
         ],
     });

--- a/lib/test/axe-apca/src/axe-apca.ts
+++ b/lib/test/axe-apca/src/axe-apca.ts
@@ -12,6 +12,13 @@ type Color = {
     toHexString: () => string;
 };
 
+type ConformanceLevel = "bronze" | "silver" | "custom";
+
+type ConformanceThresholdFn = (
+    fontSize: string,
+    fontWeight: string
+) => number | null;
+
 declare module "axe-core" {
     const commons: {
         color: {
@@ -89,10 +96,7 @@ const getAPCABronzeThreshold = (fontSize: string): number | null => {
 
 const generateColorContrastAPCAConformanceCheck = (
     conformanceLevel: string,
-    conformanceThresholdFn: (
-        fontSize: string,
-        fontWeight: string
-    ) => number | null
+    conformanceThresholdFn: ConformanceThresholdFn
 ): Check => ({
     id: `color-contrast-apca-${conformanceLevel}-conformance`,
     metadata: {
@@ -188,15 +192,15 @@ const colorContrastAPCABronzeConformanceCheck =
 const colorContrastAPCASilverRule = generateColorContrastAPCARule("silver");
 const colorContrastAPCABronzeRule = generateColorContrastAPCARule("bronze");
 
-const registerAxeAPCA = (conformanceLevel: "bronze" | "silver") => {
+const registerAxeAPCA = (conformanceLevel: ConformanceLevel, customAPCAThreshold?: ConformanceThresholdFn) => {
     axe.configure({
         rules: [generateColorContrastAPCARule(conformanceLevel)],
         checks: [
             generateColorContrastAPCAConformanceCheck(
                 conformanceLevel,
-                conformanceLevel === "bronze"
-                    ? getAPCABronzeThreshold
-                    : getAPCASilverPlusThreshold
+                customAPCAThreshold || (conformanceLevel === "silver"
+                    ? getAPCASilverPlusThreshold
+                    : getAPCABronzeThreshold)
             ),
         ],
     });

--- a/lib/test/test-utils.ts
+++ b/lib/test/test-utils.ts
@@ -329,7 +329,7 @@ const runComponentTest = ({
             axe.configure({
                 rules: [
                     // for non-high contrast, we disable WCAG 2.1 AA (4.5:1)
-                    // and use APCA bronze level instead
+                    // and use a Stacks-specific APCA custom level instead
                     { id: "color-contrast", enabled: false },
                     {
                         id: "color-contrast-apca-custom",

--- a/lib/test/test-utils.ts
+++ b/lib/test/test-utils.ts
@@ -6,18 +6,7 @@ import axe from "axe-core";
 import registerAxeAPCA from "./axe-apca";
 
 const getAPCAStacksThreshold = (fontSize: string): number | null => {
-    const size = parseFloat(fontSize);
-
-    // APCA Bronze Level Conformance
-    // https://readtech.org/ARC/tests/visual-readability-contrast/?tn=criterion
-    switch (true) {
-        case size >= 32:
-            return 45;
-        case size >= 16:
-            return 60;
-        default:
-            return 75;
-    }
+    return parseFloat(fontSize) >= 32 ? 45 : 60;
 };
 
 registerAxeAPCA("custom", getAPCAStacksThreshold);
@@ -343,7 +332,7 @@ const runComponentTest = ({
                     // and use APCA bronze level instead
                     { id: "color-contrast", enabled: false },
                     {
-                        id: "color-contrast-apca-bronze",
+                        id: "color-contrast-apca-custom",
                         enabled: !highcontrast,
                     },
                     // for high contrast, we check against WCAG 2.1 AAA (7:1)

--- a/lib/test/test-utils.ts
+++ b/lib/test/test-utils.ts
@@ -5,7 +5,22 @@ import type { TemplateResult } from "lit-html";
 import axe from "axe-core";
 import registerAxeAPCA from "./axe-apca";
 
-registerAxeAPCA("bronze");
+const getAPCAStacksThreshold = (fontSize: string): number | null => {
+    const size = parseFloat(fontSize);
+
+    // APCA Bronze Level Conformance
+    // https://readtech.org/ARC/tests/visual-readability-contrast/?tn=criterion
+    switch (true) {
+        case size >= 32:
+            return 45;
+        case size >= 16:
+            return 60;
+        default:
+            return 75;
+    }
+};
+
+registerAxeAPCA("custom", getAPCAStacksThreshold);
 
 const colorThemes = ["dark", "light"];
 const baseThemes = ["", "highcontrast"];

--- a/lib/test/test-utils.ts
+++ b/lib/test/test-utils.ts
@@ -5,11 +5,11 @@ import type { TemplateResult } from "lit-html";
 import axe from "axe-core";
 import registerAxeAPCA from "./axe-apca";
 
-const getAPCAStacksThreshold = (fontSize: string): number | null => {
+const customConformanceThresholdFn = (fontSize: string): number | null => {
     return parseFloat(fontSize) >= 32 ? 45 : 60;
 };
 
-registerAxeAPCA("custom", getAPCAStacksThreshold);
+registerAxeAPCA("custom", customConformanceThresholdFn);
 
 const colorThemes = ["dark", "light"];
 const baseThemes = ["", "highcontrast"];


### PR DESCRIPTION
Addresses [STACKS-388](https://stackoverflow.atlassian.net/browse/STACKS-388).

This PR modifies `registerAxeAPCA` to:
1. Accept `custom` as a conformance level
2. Accept an optional custom threshold function for the second argument

It also updates `lib/test/test-utils.ts` to use a custom APCA threshold of Lc 60 for all fontSize < 32.