### PR TITLE
don't apply color override to links in the `s-user-card--type` area

### DIFF
--- a/lib/components/sidebar-widget/sidebar-widget.less
+++ b/lib/components/sidebar-widget/sidebar-widget.less
@@ -11,7 +11,7 @@
 
     // MODIFIERS
     &:not(.s-anchors) {
-        a:not(.button):not(.post-tag):not(.s-btn):not(.s-sidebarwidget--action):not(.s-user-card--link) {
+        a:not(.button):not(.post-tag):not(.s-btn):not(.s-sidebarwidget--action):not(.s-user-card--link):not(.s-user-card--type > .s-link) {
             &,
             &:visited {
                 color: var(--black-500);


### PR DESCRIPTION
Allow the links to set set their own style/inherit from parent styles

The `.s-user-card--type` style is currently used exclusively for Collectives membership badges and there are cases where we want the link color to inherit from the parent elements instead of always being gray.