### PR TITLE
test(table): add a11y; visual tests

### DIFF
--- a/lib/components/table/table.a11y.test.ts
+++ b/lib/components/table/table.a11y.test.ts
@@ -7,28 +7,31 @@ const template = ({ component, testid }: any) => html`
     <div class="s-table-container p8" data-testid="${testid}">${component}</div>
 `;
 
-const rows = [{
-    displayName: "Sponge",
-    fullName: "Bobby Geometrislacks",
-    progress: 10,
-    active: true,
-}, {
-    displayName: "Patty",
-    fullName: "Pat Supernova",
-    progress: 50,
-    active: true,
-// }, {
-//     displayName: "Crustoph",
-//     fullName: "Eugene Harold K",
-//     progress: 75,
-//     active: false, // TODO reintroduce once disabled rows pass contrast requirements
-}, {
-    displayName: "SCheeks",
-    fullName: "Sandra C.",
-    progress: 100,
-    active: true,
-}];
-
+const rows = [
+    {
+        displayName: "Sponge",
+        fullName: "Bobby Geometrislacks",
+        progress: 10,
+        active: true,
+    },
+    {
+        displayName: "Patty",
+        fullName: "Pat Supernova",
+        progress: 50,
+        active: true,
+        // }, {
+        //     displayName: "Crustoph",
+        //     fullName: "Eugene Harold K",
+        //     progress: 75,
+        //     active: false, // TODO reintroduce once disabled rows pass contrast requirements
+    },
+    {
+        displayName: "SCheeks",
+        fullName: "Sandra C.",
+        progress: 100,
+        active: true,
+    },
+];
 
 const children = {
     default: `
@@ -45,7 +48,9 @@ const children = {
             </tr>
         </thead>
         <tbody>
-            ${rows.map((row, i) => `
+            ${rows
+                .map(
+                    (row, i) => `
                 <tr class="${row.active ? "" : "is-disabled"}">
                     <th scope="row">
                         <label class="v-visible-sr" for="check-${i}">bulk</label>
@@ -56,12 +61,18 @@ const children = {
                     <td class="s-table--progress">${row.progress}</td>
                     <td class="s-table--progress-bar">
                         <div class="s-progress bg-white">
-                            <div class="s-progress--bar bg-blue-400" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${row.progress}" aria-label="progressbar" style="width: ${row.progress}%"></div>
+                            <div class="s-progress--bar bg-blue-400" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${
+                                row.progress
+                            }" aria-label="progressbar" style="width: ${
+                                row.progress
+                            }%"></div>
                         </div>
                     </td>
                     <td><a class="s-link" href="#">Add</a></td>
                 </tr>
-            `).join("")}
+            `
+                )
+                .join("")}
         </tbody>
         <tfoot class="s-table--totals">
             <tr>
@@ -96,7 +107,7 @@ describe("table", () => {
             "s-table-highcontrast-light-sortable",
             "s-table-highcontrast-light-stripes-lg-sortable",
             "s-table-highcontrast-light-stripes-sm-sortable",
-            "s-table-highcontrast-light-stripes-sortable"
+            "s-table-highcontrast-light-stripes-sortable",
         ],
     });
 });

--- a/lib/components/table/table.a11y.test.ts
+++ b/lib/components/table/table.a11y.test.ts
@@ -1,0 +1,102 @@
+import { html } from "@open-wc/testing";
+import { runComponentTests } from "../../test/test-utils";
+import "../../index";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const template = ({ component, testid }: any) => html`
+    <div class="s-table-container p8" data-testid="${testid}">${component}</div>
+`;
+
+const rows = [{
+    displayName: "Sponge",
+    fullName: "Bobby Geometrislacks",
+    progress: 10,
+    active: true,
+}, {
+    displayName: "Patty",
+    fullName: "Pat Supernova",
+    progress: 50,
+    active: true,
+// }, {
+//     displayName: "Crustoph",
+//     fullName: "Eugene Harold K",
+//     progress: 75,
+//     active: false, // TODO reintroduce once disabled rows pass contrast requirements
+}, {
+    displayName: "SCheeks",
+    fullName: "Sandra C.",
+    progress: 100,
+    active: true,
+}];
+
+
+const children = {
+    default: `
+        <thead>
+            <tr>
+                <th scope="col" class="s-table--bulk">
+                    <label class="v-visible-sr" for="check">bulk action</label>
+                    <input type="checkbox" class="s-checkbox" id="check">
+                </th>
+                <th scope="col">Display Name</th>
+                <th scope="col">Full name</th>
+                <th scope="col" colspan="2">Progress</th>
+                <th scope="col"><span>class="v-visible-sr">Bar</span></th>
+            </tr>
+        </thead>
+        <tbody>
+            ${rows.map((row, i) => `
+                <tr class="${row.active ? "" : "is-disabled"}">
+                    <th scope="row">
+                        <label class="v-visible-sr" for="check-${i}">bulk</label>
+                        <input type="checkbox" class="s-checkbox" id="check-${i}">
+                    </th>
+                    <td>${row.displayName}</td>
+                    <td>${row.fullName}</td>
+                    <td class="s-table--progress">${row.progress}</td>
+                    <td class="s-table--progress-bar">
+                        <div class="s-progress bg-white">
+                            <div class="s-progress--bar bg-blue-400" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${row.progress}" aria-label="progressbar" style="width: ${row.progress}%"></div>
+                        </div>
+                    </td>
+                    <td><a class="s-link" href="#">Add</a></td>
+                </tr>
+            `).join("")}
+        </tbody>
+        <tfoot class="s-table--totals">
+            <tr>
+                <td scope="row"><span class="v-visible-sr">Empty</span></td>
+                <th scope="row" class="ta-left">Totals</th>
+                <td><span class="v-visible-sr">Empty</span></td>
+                <td colspan="2">160</td>
+                <td><span class="v-visible-sr">Empty</span></td>
+            </tr>
+        </tfoot>
+    `,
+};
+
+describe("table", () => {
+    // default, sizes
+    runComponentTests({
+        type: "a11y",
+        baseClass: "s-table",
+        variants: ["stripes"],
+        modifiers: {
+            primary: ["sm", "lg"],
+            secondary: ["b0", "bx", "bx-simple", "sortable"],
+            // global: ["ta-center", "ta-left", "ta-justify", "ta-right", "va-bottom", "va-middle", "va-top"], // Removing these modifiers *for now* since they create so many test images and would slow testing
+        },
+        tag: "table",
+        children,
+        template,
+        // TODO resolve HC contrast issues with `.s-table.s-table__sortable thead th` sortable
+        skippedTestids: [
+            "s-table-highcontrast-light-lg-sortable",
+            "s-table-highcontrast-light-sm-sortable",
+            "s-table-highcontrast-light-sortable",
+            "s-table-highcontrast-light-stripes-lg-sortable",
+            "s-table-highcontrast-light-stripes-sm-sortable",
+            "s-table-highcontrast-light-stripes-sortable"
+        ],
+    });
+});

--- a/lib/components/table/table.visual.test.ts
+++ b/lib/components/table/table.visual.test.ts
@@ -7,27 +7,32 @@ const template = ({ component, testid }: any) => html`
     <div class="s-table-container p8" data-testid="${testid}">${component}</div>
 `;
 
-const rows = [{
-    displayName: "Sponge",
-    fullName: "Bobby Geometrislacks",
-    progress: 10,
-    active: true,
-}, {
-    displayName: "Patty",
-    fullName: "Pat Supernova",
-    progress: 50,
-    active: true,
-}, {
-    displayName: "Crustoph",
-    fullName: "Eugene Harold K",
-    progress: 75,
-    active: false,
-}, {
-    displayName: "SCheeks",
-    fullName: "Sandra C.",
-    progress: 100,
-    active: true,
-}];
+const rows = [
+    {
+        displayName: "Sponge",
+        fullName: "Bobby Geometrislacks",
+        progress: 10,
+        active: true,
+    },
+    {
+        displayName: "Patty",
+        fullName: "Pat Supernova",
+        progress: 50,
+        active: true,
+    },
+    {
+        displayName: "Crustoph",
+        fullName: "Eugene Harold K",
+        progress: 75,
+        active: false,
+    },
+    {
+        displayName: "SCheeks",
+        fullName: "Sandra C.",
+        progress: 100,
+        active: true,
+    },
+];
 
 const children = {
     default: `
@@ -44,7 +49,9 @@ const children = {
             </tr>
         </thead>
         <tbody>
-            ${rows.map((row, i) => `
+            ${rows
+                .map(
+                    (row, i) => `
                 <tr class="${row.active ? "" : "is-disabled"}">
                     <th scope="row">
                         <label class="v-visible-sr" for="check-${i}">bulk</label>
@@ -55,12 +62,18 @@ const children = {
                     <td class="s-table--progress">${row.progress}</td>
                     <td class="s-table--progress-bar">
                         <div class="s-progress bg-white">
-                            <div class="s-progress--bar bg-blue-400" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${row.progress}" aria-label="progressbar" style="width: ${row.progress}%"></div>
+                            <div class="s-progress--bar bg-blue-400" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${
+                                row.progress
+                            }" aria-label="progressbar" style="width: ${
+                                row.progress
+                            }%"></div>
                         </div>
                     </td>
                     <td><a class="s-link" href="#">Add</a></td>
                 </tr>
-            `).join("")}
+            `
+                )
+                .join("")}
         </tbody>
         <tfoot class="s-table--totals">
             <tr>

--- a/lib/components/table/table.visual.test.ts
+++ b/lib/components/table/table.visual.test.ts
@@ -1,0 +1,92 @@
+import { html } from "@open-wc/testing";
+import { runComponentTests } from "../../test/test-utils";
+import "../../index";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const template = ({ component, testid }: any) => html`
+    <div class="s-table-container p8" data-testid="${testid}">${component}</div>
+`;
+
+const rows = [{
+    displayName: "Sponge",
+    fullName: "Bobby Geometrislacks",
+    progress: 10,
+    active: true,
+}, {
+    displayName: "Patty",
+    fullName: "Pat Supernova",
+    progress: 50,
+    active: true,
+}, {
+    displayName: "Crustoph",
+    fullName: "Eugene Harold K",
+    progress: 75,
+    active: false,
+}, {
+    displayName: "SCheeks",
+    fullName: "Sandra C.",
+    progress: 100,
+    active: true,
+}];
+
+const children = {
+    default: `
+        <thead>
+            <tr>
+                <th scope="col" class="s-table--bulk">
+                    <label class="v-visible-sr" for="check">bulk action</label>
+                    <input type="checkbox" class="s-checkbox" id="check">
+                </th>
+                <th scope="col">Display Name</th>
+                <th scope="col">Full name</th>
+                <th scope="col" colspan="2">Progress</th>
+                <th scope="col"><span>class="v-visible-sr">Bar</span></th>
+            </tr>
+        </thead>
+        <tbody>
+            ${rows.map((row, i) => `
+                <tr class="${row.active ? "" : "is-disabled"}">
+                    <th scope="row">
+                        <label class="v-visible-sr" for="check-${i}">bulk</label>
+                        <input type="checkbox" class="s-checkbox" id="check-${i}">
+                    </th>
+                    <td>${row.displayName}</td>
+                    <td>${row.fullName}</td>
+                    <td class="s-table--progress">${row.progress}</td>
+                    <td class="s-table--progress-bar">
+                        <div class="s-progress bg-white">
+                            <div class="s-progress--bar bg-blue-400" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${row.progress}" aria-label="progressbar" style="width: ${row.progress}%"></div>
+                        </div>
+                    </td>
+                    <td><a class="s-link" href="#">Add</a></td>
+                </tr>
+            `).join("")}
+        </tbody>
+        <tfoot class="s-table--totals">
+            <tr>
+                <td scope="row"><span class="v-visible-sr">Empty</span></td>
+                <th scope="row" class="ta-left">Totals</th>
+                <td><span class="v-visible-sr">Empty</span></td>
+                <td colspan="2">160</td>
+                <td><span class="v-visible-sr">Empty</span></td>
+            </tr>
+        </tfoot>
+    `,
+};
+
+describe("table", () => {
+    // default, sizes
+    runComponentTests({
+        type: "visual",
+        baseClass: "s-table",
+        variants: ["stripes"],
+        modifiers: {
+            primary: ["sm", "lg"],
+            secondary: ["b0", "bx", "bx-simple", "sortable"],
+            // global: ["ta-center", "ta-left", "ta-justify", "ta-right", "va-bottom", "va-middle", "va-top"], // Removing these modifiers *for now* since they create so many test images and would slow testing
+        },
+        tag: "table",
+        children,
+        template,
+    });
+});

--- a/screenshots/Chromium/baseline/s-table-dark-b0.png
+++ b/screenshots/Chromium/baseline/s-table-dark-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:947e7e474921c6b1d2b1183b03bd9ee2001a6df19caf3cee30dac7e12ed6b317
+size 23886

--- a/screenshots/Chromium/baseline/s-table-dark-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-dark-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bba8cfdb0785543488e77911c665cc78921347d5f554688ab07c8a735e1fe601
+size 23988

--- a/screenshots/Chromium/baseline/s-table-dark-bx.png
+++ b/screenshots/Chromium/baseline/s-table-dark-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29137528b9f4056c2856bc1ccf5557fbb504b0cedd4dc988d35cb2fd3d54e716
+size 24181

--- a/screenshots/Chromium/baseline/s-table-dark-lg-b0.png
+++ b/screenshots/Chromium/baseline/s-table-dark-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b39ead3562c8a1a7e7452003a19d3e6f387483e6f1d95e3bcb60f7b8880be26b
+size 23800

--- a/screenshots/Chromium/baseline/s-table-dark-lg-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-dark-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56bec4526ce0b8a70c64392321857f46c79e4ffd3d53f330f87bdfba674427c5
+size 23916

--- a/screenshots/Chromium/baseline/s-table-dark-lg-bx.png
+++ b/screenshots/Chromium/baseline/s-table-dark-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c778d9c4c55a0e9ff71926ab6c658e170aa48461f079c8c781706d9e4630472
+size 24039

--- a/screenshots/Chromium/baseline/s-table-dark-lg-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-dark-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd2309f8d11afa06ec5a3c4a4396a6143a0afb0f034baa783381a594582f5b38
+size 24284

--- a/screenshots/Chromium/baseline/s-table-dark-lg.png
+++ b/screenshots/Chromium/baseline/s-table-dark-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8c02367ebf69f42c88c6498c0f3da0263c68516fdcfb608afbf0e690cd316bc
+size 24243

--- a/screenshots/Chromium/baseline/s-table-dark-sm-b0.png
+++ b/screenshots/Chromium/baseline/s-table-dark-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be070afd5e3e3ee5933769058af652e719a5bce52c3a799f28ea4d9b04ff089c
+size 22815

--- a/screenshots/Chromium/baseline/s-table-dark-sm-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-dark-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c72758ee36cd5183364179e0e9389a7b0d3fb36ae3a42680f276fa77bef7d054
+size 22920

--- a/screenshots/Chromium/baseline/s-table-dark-sm-bx.png
+++ b/screenshots/Chromium/baseline/s-table-dark-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a6b8b28ad01d64f73b2b624c1230e5856e02e423d71b584cff538a912643990
+size 23042

--- a/screenshots/Chromium/baseline/s-table-dark-sm-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-dark-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f9cb2396c38b51bc330d00c67f3a42a002533e702ca6a448d267b4664aee3b8
+size 23263

--- a/screenshots/Chromium/baseline/s-table-dark-sm.png
+++ b/screenshots/Chromium/baseline/s-table-dark-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b95ad8c22c10f94e1fcf042f28caddeadf776918a101ed3eca16659cfd7b316
+size 23195

--- a/screenshots/Chromium/baseline/s-table-dark-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-dark-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5efd8df81f0ae40d50f4329bb3376261355da2174850137848a1ec419b8ef3a4
+size 24411

--- a/screenshots/Chromium/baseline/s-table-dark-stripes-b0.png
+++ b/screenshots/Chromium/baseline/s-table-dark-stripes-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e19787fc0b1c89552770f1c0656afb6b89318ffcd0b0e46ed38bd36fa69f6a6c
+size 23950

--- a/screenshots/Chromium/baseline/s-table-dark-stripes-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-dark-stripes-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a060f90a58e1983637d7b0083a63d94a48d0339221e7847afd57dc691e0bc1e7
+size 24058

--- a/screenshots/Chromium/baseline/s-table-dark-stripes-bx.png
+++ b/screenshots/Chromium/baseline/s-table-dark-stripes-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4d722ea726cd93fd64ee2d4f753a48df946373fc7825a85b766046a51b4b6da
+size 24166

--- a/screenshots/Chromium/baseline/s-table-dark-stripes-lg-b0.png
+++ b/screenshots/Chromium/baseline/s-table-dark-stripes-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a10e593d80836917b42e34a3de3171f9714186588c956738c0c9138ba0dd091
+size 23910

--- a/screenshots/Chromium/baseline/s-table-dark-stripes-lg-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-dark-stripes-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a496928b64dcb74e37453983a0dfc4b8e73c9bec50fcfbf479bd6c46a7d5098d
+size 24037

--- a/screenshots/Chromium/baseline/s-table-dark-stripes-lg-bx.png
+++ b/screenshots/Chromium/baseline/s-table-dark-stripes-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26642d481fb423563355fba1f367a75f967eaa75ebdd71ea7ec4658e2a68d15c
+size 24113

--- a/screenshots/Chromium/baseline/s-table-dark-stripes-lg-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-dark-stripes-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:555f941d55f8d0dc86bf987783d10dfb828bcb54f8425a488689f5393a952ac0
+size 24317

--- a/screenshots/Chromium/baseline/s-table-dark-stripes-lg.png
+++ b/screenshots/Chromium/baseline/s-table-dark-stripes-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77cfbf17e00ce72564db276f2b8ec3377f420d6e09fd3cc3a80d1e54a84223b1
+size 24309

--- a/screenshots/Chromium/baseline/s-table-dark-stripes-sm-b0.png
+++ b/screenshots/Chromium/baseline/s-table-dark-stripes-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aab77590f0fda58ef15b5709c60ca4d8ee61cf0101910530b9ce421bbc37c900
+size 22902

--- a/screenshots/Chromium/baseline/s-table-dark-stripes-sm-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-dark-stripes-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0095b70b728ee5eb49c697ba58647f5289564f67f7a5b4b36572fb3976c32a0d
+size 23006

--- a/screenshots/Chromium/baseline/s-table-dark-stripes-sm-bx.png
+++ b/screenshots/Chromium/baseline/s-table-dark-stripes-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21b391b7099cad5baa54fb4ede10004aeec79314df92fd3ab923f84a551f323f
+size 23164

--- a/screenshots/Chromium/baseline/s-table-dark-stripes-sm-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-dark-stripes-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f887b8164ccffdd27b12ad4563c8b7caa639957c984daec6add9071ef5ece6c7
+size 23272

--- a/screenshots/Chromium/baseline/s-table-dark-stripes-sm.png
+++ b/screenshots/Chromium/baseline/s-table-dark-stripes-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:708955b0f6e51e433bd8cb84d63b0a719761c5e424f30f3e68b1dd21f514d47d
+size 23321

--- a/screenshots/Chromium/baseline/s-table-dark-stripes-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-dark-stripes-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a1c8ac1e6970c3f2ef6242fb163130c98d6aaf860b04d8a53942460aa720f68
+size 24394

--- a/screenshots/Chromium/baseline/s-table-dark-stripes.png
+++ b/screenshots/Chromium/baseline/s-table-dark-stripes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d95556fe23b60e0646cd6f58f63f8ae405335c6c8f4b40367dbbfb1aec9fa916
+size 24387

--- a/screenshots/Chromium/baseline/s-table-dark.png
+++ b/screenshots/Chromium/baseline/s-table-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e98812164784a2733591864e7e6be1d84907ac2b4a76644f68058565ab1d09b1
+size 24384

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-b0.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c25fc2df11950bba9f5f28cd7cdd54be1e09d3f8389fb2116eb5f74b5dfeecea
+size 24210

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0de82055db17536ec65125d1caf61d6efe7c4f8315113d839b617ebf08caa72e
+size 24322

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-bx.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8eedb268893c7c638f0c0176352d8fb791f3d8ebd395e10adc58066491edcf2c
+size 24466

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-lg-b0.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4894c1f21639de9104445086b5531164f7f00d2c368772289a6688cf2ad9ae2a
+size 24240

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-lg-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9ca897019d3dcf0a228fb32665b68e49c4bc2c91823122e9e3db53834931138
+size 24352

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-lg-bx.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be068eadefe9178c192fc4fe18552e8156ed75a7836d3e67ae8314525b699f54
+size 24496

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-lg-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2659af584171d428adb5d0296578a31044c78f60e6515480a842b907c567c897
+size 24693

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-lg.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37e423c5e66050a53d81a5fb26cc9bd1492a507209477da35a7583ac85ab47d5
+size 24582

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-sm-b0.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a159b558793913938bff3c8bcaef0935c2b6800a7e12f35361c1ca9246da42da
+size 23217

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-sm-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1848a36feb2b1cdca7ba8d1f19939227cca3255734407ef6b39c50612c7674e
+size 23329

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-sm-bx.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a26cc13076cd2eb52dda93c9a398190e04141881d35d3426e47c6e150bc6dbbd
+size 23428

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-sm-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e749a3c686a3681d95e6e0c6cdb2979b7826079acabb2e38fdb2d0724233b67
+size 23775

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-sm.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c97793b622ff8d68b12c50dbc9871320e83b60f240a799b242d96d6743d6f4d0
+size 23646

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e447b5916e3b87ddf7de1fd01592580dcdf4a0302dc8409e2ef19569ebdd9407
+size 24765

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-b0.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a8a238da4610c46dade73aa8a7d6d1bcffa286c055f14653d1030c91bed01e9
+size 24357

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebd05f054de654f7ac809e5a29b46ec917a4561f0e4bc42c7f6d55bd855199ce
+size 24470

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-bx.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31cb32efc14acb0ee5cc63d45e79100c009e1983ae7bbe9acc34c3d73569d513
+size 24640

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-lg-b0.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7eb5e0a6bd058e3183b64318341d2dbaf8a2c33893d4c4bfe23ceb61d84f67be
+size 24348

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-lg-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81c110772653ef49bee302d96252b787613905224e0f1d431826b4da60282227
+size 24469

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-lg-bx.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd3604638481760d016cd384b8d94b698c74cf2424cdb27f092204e4c1fd1a85
+size 24544

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-lg-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8eccf7e64d4b8e63d107afcf51908f80420104ff669d52d7f038f7496eaa3202
+size 24782

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-lg.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e21290ce2ddb6c0aa2cd8119656227c13657b0a8a9b81a4a658832dc00eb824e
+size 24752

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-sm-b0.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d5df18387fe4e96b4e636699c88e4e2787593c8c5fdbbc47e2810628ffca63f
+size 23317

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-sm-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e79aa6fc687a585abe0808ba4e280aa3863f40c9a8d292f37265372fe9b962b
+size 23420

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-sm-bx.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:036a6c93f617b2de91b772fc03bbd80ce42b1ea3ed04b3f80b3ca5241c9ffce3
+size 23621

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-sm-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f520180da76d3677b1b67438803c397788c2b3ccce224eb369dcd1408df7c67
+size 23825

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-sm.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14dd13440b749a947d1656b0bea47a5e5a3fd32eeb1451a78c7dab923f5a680f
+size 23830

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c1ed416e47de26e781268bce29f3826ef4663f14e218d16545a43128977edb0
+size 24872

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark-stripes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:baa28dc87f526b1e66f6271d0be55c1db254bcdaf5f2bbd043d13f26d2a7332f
+size 24839

--- a/screenshots/Chromium/baseline/s-table-highcontrast-dark.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1aac2b4467adb033d58c03fd7cefaaccf2e605dbd204fa4d58e282a29a1818e4
+size 24714

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-b0.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a02e8c2abaaf9ec83a805af020e89164064f6178beac66d2af628004c8305363
+size 24385

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99db363594aeadbfd42692cdca77cb8504e814a54e2663ff3d1ed0c306ce7059
+size 24483

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-bx.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:905d11eb7008c96328066111a78dad08a127289ebefea0779e0ff0624d9ae65e
+size 24546

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-lg-b0.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:863b3d062e36d2c0f2b98d544004c94668f477521994e6aaab59fba5b8b7e838
+size 24228

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-lg-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73b46344ca78c9b2d56ab47678b7eb7f41fd621251cb164fba396c461fd9422a
+size 24350

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-lg-bx.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c11d0c412141dcc3d846379764b944fae7d8d3e78103f611c6f48e7726b19a9f
+size 24469

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-lg-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55ae57743c90c4b0106adff9a26f76b42ef2b3c83cd9045661b788c97c33ec4a
+size 24689

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-lg.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e344eab7e9393abe0cd0b6098f719459299cea0189e9be046817bf85ba9f5bc5
+size 24642

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-sm-b0.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26fbe48c72a7b834bb95f0ea5909ae2f36f80578411ca9551dd147eba4a21154
+size 23424

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-sm-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70438f1f20cfe126a2fa0bf30b50e597d5e5e7fcc5f9de20e9ef6c1a53d401ca
+size 23524

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-sm-bx.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d6ed91ebadcf520bbfe441760e51d3d3ac3267bb02e541980113e8472423907
+size 23474

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-sm-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c36c192f352b58b1041527bf3553398b9dd94f86b4675d80d4fd2d10fa93ba2c
+size 23702

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-sm.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc902adfe6d2a0754ef8ab32ad707eea0c06b634870058f565d2b1c0e2c1c5ff
+size 23627

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20b77db7cd5d8c4b9dd48e20ccd8c773c8f4ac5f2a4a08819685d81cf084a1de
+size 24767

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-b0.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6db3b09468e1bc0b8f2ae9d1eed3283c6bf99f06c2916564527a561dbb3167d3
+size 24521

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40072c987b6ee9ff904b77480653f2ffeb8d50664b9f25ad3cc26456dd3bed90
+size 24602

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-bx.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:620c57dae5e79c1a083d5ee086f08a6c153cc1a65cf5e4809c2689616fb91ecf
+size 24622

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-lg-b0.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:575b6e673a985b2d1de08a5873f08aa98d4c38096cb006176a359c67faa92f12
+size 24373

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-lg-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8e8b6b83b175a549707eb64202dc7474217c3cb5232cee99c1c5df7bf5455ee
+size 24494

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-lg-bx.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d31661254b3cb02e2c04e880df11af553a97435f362aecfab810504cf3f6cfc
+size 24531

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-lg-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc194242b02228cb876cdace0284de12fff9851666688d3c252ae430ca732390
+size 24806

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-lg.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddeae7ad7f62f640f04c3b049afafb58a65e5ebb0b9087868529b902c391cb7d
+size 24723

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-sm-b0.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:957b24ec65297a58b601c8bcf0d81ca1c0a94250559be78f97e701c611eaf6b6
+size 23537

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-sm-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:190cde4f00e0f8d27b70f4ced948dbacf22754d117454c941478fd4df6b089dd
+size 23621

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-sm-bx.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac959c8aaf6216d0cb6e115bf84b6f694c7a3bdbf3bd05adf32eafc3c3a7025b
+size 23526

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-sm-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98288b9ba07112c1343df1d7f8861100a7ebdd44e78d2f2062ed314395374e19
+size 23777

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-sm.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fe94a4c94f445a0324d669d299caf2086d134c8b8c6b1707227ecada6f6d7b9
+size 23690

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4035437ff14f76c27404c8e8874af2f835ddd012979495e9b95e1587fd49b8c7
+size 24939

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light-stripes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b9633ae1644be8ab96c1f6c9ec109988cc84f864f0523561fbe06e6ccd2acc7
+size 24847

--- a/screenshots/Chromium/baseline/s-table-highcontrast-light.png
+++ b/screenshots/Chromium/baseline/s-table-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dd15c8f85b583c2cf9e4ae5dca803ac93319a4b058641f7d87d8ecafa62369a
+size 24773

--- a/screenshots/Chromium/baseline/s-table-light-b0.png
+++ b/screenshots/Chromium/baseline/s-table-light-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72eec5eaa02a3ac6c1fe6f6f872d472955526a036a5e8c66248caed4b6d7ecb6
+size 23927

--- a/screenshots/Chromium/baseline/s-table-light-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-light-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40e2ade6efc4a621d85cf90c364a5e75923a00161f3e092de0d8df49088f87f5
+size 24035

--- a/screenshots/Chromium/baseline/s-table-light-bx.png
+++ b/screenshots/Chromium/baseline/s-table-light-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:daf9634a4fe6b91855f678b1338ff8ab96921a763f72a6b18e62c65ced2c0801
+size 24127

--- a/screenshots/Chromium/baseline/s-table-light-lg-b0.png
+++ b/screenshots/Chromium/baseline/s-table-light-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84bae34b534bfddd1e2d26a1a559140a4a7472df0bd05f8ccbbe8dbbb3558901
+size 23845

--- a/screenshots/Chromium/baseline/s-table-light-lg-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-light-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06886bdd0cb874db0c43ad7c307220dc33ab00ac79d22f77f61aee0c35a35d6d
+size 23965

--- a/screenshots/Chromium/baseline/s-table-light-lg-bx.png
+++ b/screenshots/Chromium/baseline/s-table-light-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b92a3abf37d0103815723d63c340a8079ce6e1a44651316b2f5d88549d87dcb
+size 24093

--- a/screenshots/Chromium/baseline/s-table-light-lg-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-light-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f24196e555f47209219a465786cbe86c6de751db440b72f22114499500d3cf3
+size 24165

--- a/screenshots/Chromium/baseline/s-table-light-lg.png
+++ b/screenshots/Chromium/baseline/s-table-light-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be99b009442f6436d20d5ab7e8cb0ad7c621a8a35bb1137c8ab10dc4d5f16406
+size 24266

--- a/screenshots/Chromium/baseline/s-table-light-sm-b0.png
+++ b/screenshots/Chromium/baseline/s-table-light-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bd1fc9bd1ad448975bc7a92c4e717c200b1feac3a6d74840bfb42c4e3384894
+size 22932

--- a/screenshots/Chromium/baseline/s-table-light-sm-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-light-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:320b4cf24475fd93e290393fb73b74753ea258a77c5cad5528928cac1d681ebd
+size 23036

--- a/screenshots/Chromium/baseline/s-table-light-sm-bx.png
+++ b/screenshots/Chromium/baseline/s-table-light-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62255c7f4edc06c3e8b3f604913fa33495ad94b4bbd5921b948ae95aa61dd89c
+size 22992

--- a/screenshots/Chromium/baseline/s-table-light-sm-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-light-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4299a2f577f465cdfe97d2d3b8eebfea56ffbe6dcde773147a9f40b95953581b
+size 23092

--- a/screenshots/Chromium/baseline/s-table-light-sm.png
+++ b/screenshots/Chromium/baseline/s-table-light-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17f82be54e9d7706dc85b8589e675af215d2103dc91f1eda31e6947250f3f824
+size 23145

--- a/screenshots/Chromium/baseline/s-table-light-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-light-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b13bc4eee8faf93d15a80b842496d016173c3ba613f5caddd8780e760d34f400
+size 24233

--- a/screenshots/Chromium/baseline/s-table-light-stripes-b0.png
+++ b/screenshots/Chromium/baseline/s-table-light-stripes-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b130483fe9716bde75acdcb17546894b3cba80404651105718e9125e8a642d58
+size 24064

--- a/screenshots/Chromium/baseline/s-table-light-stripes-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-light-stripes-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94ab6cc38918f5b3c85afa651d523b3fcdb15cd27758b712d8f830e4d113f8f2
+size 24157

--- a/screenshots/Chromium/baseline/s-table-light-stripes-bx.png
+++ b/screenshots/Chromium/baseline/s-table-light-stripes-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:357505481e1bf0055c739184d0753165bb95c5b07b5e81cfc0016ec13dc768f9
+size 24155

--- a/screenshots/Chromium/baseline/s-table-light-stripes-lg-b0.png
+++ b/screenshots/Chromium/baseline/s-table-light-stripes-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0ae721cb829993408ea1db0b64bb9aef9dff9eca864abe49389db11ff7729e1
+size 23977

--- a/screenshots/Chromium/baseline/s-table-light-stripes-lg-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-light-stripes-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2168bf8942a4cd1dd04f9e9daac48df17ab9e291b7ac1282fb53b3991d52c949
+size 24102

--- a/screenshots/Chromium/baseline/s-table-light-stripes-lg-bx.png
+++ b/screenshots/Chromium/baseline/s-table-light-stripes-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da310cd8d12b04fd9ee6c452602675de788c2b333ca12c1d9f9dbad6b0017875
+size 24128

--- a/screenshots/Chromium/baseline/s-table-light-stripes-lg-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-light-stripes-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9934618de267369a925e18da588050fa3a070c95818da5030b17325b115b413b
+size 24263

--- a/screenshots/Chromium/baseline/s-table-light-stripes-lg.png
+++ b/screenshots/Chromium/baseline/s-table-light-stripes-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc601ce84fc2b582647280d5af663898381ca2d43c6d704701e2c2e382051b5a
+size 24290

--- a/screenshots/Chromium/baseline/s-table-light-stripes-sm-b0.png
+++ b/screenshots/Chromium/baseline/s-table-light-stripes-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:182ef32e306a26258098e000411b4ef0aba6c7680e3e8a5390b25ba9baaefcc8
+size 23064

--- a/screenshots/Chromium/baseline/s-table-light-stripes-sm-bx-simple.png
+++ b/screenshots/Chromium/baseline/s-table-light-stripes-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91d7f554490449e2e998654311bf6b7c9ed364254297a8cbcaf0947f277a3333
+size 23154

--- a/screenshots/Chromium/baseline/s-table-light-stripes-sm-bx.png
+++ b/screenshots/Chromium/baseline/s-table-light-stripes-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fab3331522574841af284c121806206572eac140d47780322d18c8baf90c9542
+size 23059

--- a/screenshots/Chromium/baseline/s-table-light-stripes-sm-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-light-stripes-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60ca346bde00e2e3630f45246a823662d54a5e3426896fda6cc2210bbbb5922e
+size 23196

--- a/screenshots/Chromium/baseline/s-table-light-stripes-sm.png
+++ b/screenshots/Chromium/baseline/s-table-light-stripes-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6411523b8d1431dd03fb48f5530dc40d6985693e7c0d8bc7dbfdc7eae81f1600
+size 23208

--- a/screenshots/Chromium/baseline/s-table-light-stripes-sortable.png
+++ b/screenshots/Chromium/baseline/s-table-light-stripes-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49365f472a4d14ca338d34b0aa52e76e506189ef041447c3ea2d0be529858ddb
+size 24360

--- a/screenshots/Chromium/baseline/s-table-light-stripes.png
+++ b/screenshots/Chromium/baseline/s-table-light-stripes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb346163b4aa325ab36bde58c44e9593cfb1c73fc3ab8983b13a45b108d4fa10
+size 24368

--- a/screenshots/Chromium/baseline/s-table-light.png
+++ b/screenshots/Chromium/baseline/s-table-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c5f65c70a6d620167732e3fe71d890a7503d39e331b6a558287e96e94cacad6
+size 24326

--- a/screenshots/Firefox/baseline/s-table-dark-b0.png
+++ b/screenshots/Firefox/baseline/s-table-dark-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5d10367acfcf64b8390ca533a8669de922b0fb0443214cd21d8e5194b95f516
+size 27151

--- a/screenshots/Firefox/baseline/s-table-dark-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-dark-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cef117c6bc707ff4439e74ce3265b18f4f915da323f074057655da9eb03a728
+size 27249

--- a/screenshots/Firefox/baseline/s-table-dark-bx.png
+++ b/screenshots/Firefox/baseline/s-table-dark-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d7d9ec38ff67aa7aa99d4dcd6df0f431dbfb2d8b037afe501845202247b24fb
+size 27331

--- a/screenshots/Firefox/baseline/s-table-dark-lg-b0.png
+++ b/screenshots/Firefox/baseline/s-table-dark-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae4c9c879de7d1c2bdf2ba4778c3c93cf7478efc5bb22aa91c247c988e374b19
+size 28263

--- a/screenshots/Firefox/baseline/s-table-dark-lg-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-dark-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fe48968de1fa77351adacd09f08e87c19a90d7f637c07feb065c9f519f89fe1
+size 28430

--- a/screenshots/Firefox/baseline/s-table-dark-lg-bx.png
+++ b/screenshots/Firefox/baseline/s-table-dark-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a04761ddf827826c2a3bac78a9eabd8b835ab64ad9d5b5d2cf60cd5867b6fe0
+size 28445

--- a/screenshots/Firefox/baseline/s-table-dark-lg-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-dark-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c70e9fb27c0b515c0968ace7dccc7c5c81a06063cf73e8f26e6fc300cc51534a
+size 31953

--- a/screenshots/Firefox/baseline/s-table-dark-lg.png
+++ b/screenshots/Firefox/baseline/s-table-dark-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a439e25aee848b77f16fb32702a6cf5051b7d62ce957feec88967925915c56cf
+size 31923

--- a/screenshots/Firefox/baseline/s-table-dark-sm-b0.png
+++ b/screenshots/Firefox/baseline/s-table-dark-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9eee2dd6d1c5ab4638e8870d39712e1b3dd29a04306f9d8c25d806fbfb3c788b
+size 25852

--- a/screenshots/Firefox/baseline/s-table-dark-sm-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-dark-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8aa82fab47fb78d5a951fe4689df083e5aa255cf03876d48910049f6cac99f5b
+size 25963

--- a/screenshots/Firefox/baseline/s-table-dark-sm-bx.png
+++ b/screenshots/Firefox/baseline/s-table-dark-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77e8085ef6a624542e37c7b855038aabc905bce9bb1cd6ee0255a94a8bcf7fbc
+size 26093

--- a/screenshots/Firefox/baseline/s-table-dark-sm-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-dark-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52ea74cacbf0311fd2e95e2b8dd6fd0807152a4a6d38dc8d8e9648e3c8337d1a
+size 28176

--- a/screenshots/Firefox/baseline/s-table-dark-sm.png
+++ b/screenshots/Firefox/baseline/s-table-dark-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5332517770bd563f2d7cfebc26932b1aa043175dc6032ce5d5b31e3756a6036
+size 28091

--- a/screenshots/Firefox/baseline/s-table-dark-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-dark-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:114064c8e8cdbd0550d7c483c1188379c7abfc82b3b666e192dc18802df38a00
+size 30147

--- a/screenshots/Firefox/baseline/s-table-dark-stripes-b0.png
+++ b/screenshots/Firefox/baseline/s-table-dark-stripes-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a1d1cb2d9e79e21e563b13cb670aee913f72de691125182e02b0fc83e435a8c
+size 27211

--- a/screenshots/Firefox/baseline/s-table-dark-stripes-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-dark-stripes-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8712eff02f0992778766acdf4681a1cea9d848718c48b227a28a2726d9cf37e0
+size 27320

--- a/screenshots/Firefox/baseline/s-table-dark-stripes-bx.png
+++ b/screenshots/Firefox/baseline/s-table-dark-stripes-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:793252ae5e6ae3b33007d2fa8a13f60206a4ab438cd15ad865eb1c48e68e87ec
+size 27448

--- a/screenshots/Firefox/baseline/s-table-dark-stripes-lg-b0.png
+++ b/screenshots/Firefox/baseline/s-table-dark-stripes-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17491253a9000f91795d9fbe1b5c9baeb02606d8e1cb1bf1ec802d00acb002a2
+size 28309

--- a/screenshots/Firefox/baseline/s-table-dark-stripes-lg-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-dark-stripes-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca076911cb5782b03b58dfe0a5c7c153b278534919f13ec2c02c61aa633f5483
+size 28446

--- a/screenshots/Firefox/baseline/s-table-dark-stripes-lg-bx.png
+++ b/screenshots/Firefox/baseline/s-table-dark-stripes-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50b524e46ee01f4c20e09f39b3586bd7f417523dc77db3d277680cd790427bb8
+size 28490

--- a/screenshots/Firefox/baseline/s-table-dark-stripes-lg-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-dark-stripes-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3dfdd36cfec1fabcf9632981e03f974f1c5c27c77bbebb189ded7dab2f4b9c6
+size 31750

--- a/screenshots/Firefox/baseline/s-table-dark-stripes-lg.png
+++ b/screenshots/Firefox/baseline/s-table-dark-stripes-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e7ced0964ad596a9d055e90acff8f65e6dc5315b96802fb26e9185de9dd17c0
+size 31696

--- a/screenshots/Firefox/baseline/s-table-dark-stripes-sm-b0.png
+++ b/screenshots/Firefox/baseline/s-table-dark-stripes-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46000db6f95cef75c91b494f187614ba5b444309c0fd4365356f5e43e77c1cee
+size 25871

--- a/screenshots/Firefox/baseline/s-table-dark-stripes-sm-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-dark-stripes-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efc849d343e9f27c05c758466261aa2d6e00b2abf9eb6015e04bfd0d9e84b1d5
+size 25996

--- a/screenshots/Firefox/baseline/s-table-dark-stripes-sm-bx.png
+++ b/screenshots/Firefox/baseline/s-table-dark-stripes-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c03b6fafaf99f9015a27c17d4363d73fe7af40da77ab1cb749e8f04c574de215
+size 26177

--- a/screenshots/Firefox/baseline/s-table-dark-stripes-sm-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-dark-stripes-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01ba9058942b00a3b5b7f1563eb96369fcd0823e754818bef35a0dcb15643c2a
+size 28019

--- a/screenshots/Firefox/baseline/s-table-dark-stripes-sm.png
+++ b/screenshots/Firefox/baseline/s-table-dark-stripes-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82c50cb9bd5bba3ff14166aa9a88fea2802648f698ed599b4c8bb0a598725b22
+size 27963

--- a/screenshots/Firefox/baseline/s-table-dark-stripes-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-dark-stripes-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50d12099d2ad0d954caea13db49c7538f8fc58e08661a7661632ebf83634b195
+size 29957

--- a/screenshots/Firefox/baseline/s-table-dark-stripes.png
+++ b/screenshots/Firefox/baseline/s-table-dark-stripes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cefec984d217b314fc2b56a1c2e12f5c43a5529ccc014bd4a27f28e0c64ff902
+size 29916

--- a/screenshots/Firefox/baseline/s-table-dark.png
+++ b/screenshots/Firefox/baseline/s-table-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a9bfe7efa27d618f263a6a571b8150a833782888ffd483bd361658b726ba54e
+size 30078

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-b0.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:855c25d6dbc23fc8368d08f44119c536aebe8a55ccd1ccad456c9536e22d5c62
+size 26991

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bd54e807a2c25994353464daaafa373004c8566a03544e9044af3e9548be153
+size 27080

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-bx.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0a962d00eaf05390afbd89af0d335885b41e17d315275042bdd222ec32090a2
+size 27431

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-lg-b0.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db4c876901bdc0b51bd3cd6702b3739985a2a3d0ce7da49379e5efd4f9f3e7ad
+size 28017

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-lg-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71077b084356933c00ef2ad8e86dd3c0123478ff2885bdcb50665497186f92a2
+size 28140

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-lg-bx.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:645fb2ea5043d285b38dade917d412d7919bf9db3a7ed85be82131f95a198cae
+size 28531

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-lg-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81bf6aeac003424fdc2b4886f92755da35ee6b3ceafe45b1d0acc6000602642f
+size 32048

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-lg.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f40f607fd97f22c1928e54905372b023779357a046b6bfc42bca2db99c9827ad
+size 32002

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-sm-b0.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ff3abda35b144c156bf64e618fb292634a69308f260e66fbef8d5bcfbaad6f9
+size 25736

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-sm-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f36a778dcd1d2e7d7306c533cb2c92137342095b7b15eadca2f7405f12c1908c
+size 25848

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-sm-bx.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01e1987f9ca840b18dd31512601469972d8b76af1e692ae357283d6c6c0f54e5
+size 26331

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-sm-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07014101e4face169d9715f6f446eeafec7ed96b03d6b24d316efb23b4fe45df
+size 28328

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-sm.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73066ae324644d87df392799d48ed918fc5951e1fa198bfcc4f0fc3af86574c7
+size 28252

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd8abdd022faef29c95bd10e32a3d1166303d4cc93d8708c51c8096702e12ddf
+size 30304

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-b0.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dbde1e8ead4641cc79d4d2761bbb41a1abf588d5e1f1f18b39c45f9ad72036b
+size 27139

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62e6d9b0cc216fa9ad8f922058828a65ef03380e812e6c94664b67420b101331
+size 27234

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-bx.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4f5100ba3e10dfcb53f149d242e5b16e292fd76b2444adc7166fdeb0e0fbc88
+size 27563

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-lg-b0.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:723ecbd47d0668ed07d4edd87a1b4c7b67a4f779b30a8a59bab94b4464c8e50c
+size 28143

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-lg-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2e142d797f91310ec446c1b33c2d465ed778108bc4095af8bd85b0614d5355d
+size 28275

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-lg-bx.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd1236cd0fec08bb0ea1c987149956be75b0779df37fcd3d6bfd92d0e93ab4a7
+size 28648

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-lg-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:574e30cb47fa4e465024fbd74c452ebe1b947911eb127f943e24574ba5cc557e
+size 32009

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-lg.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f71c343c36ccbd56dcd7833304963316391313d2c701e0d908a27126e90ae50
+size 31917

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-sm-b0.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7277e9e686ff4b1a45172fde3946c3937e5ddbd21a11a89fb9a83a0ef44c1eca
+size 25802

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-sm-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b6e462746706c27964786da1700ab1f10e7b9a4bc685e2545d29f0ae684abae
+size 25927

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-sm-bx.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0e434ab975ec1d666201cca885e09c1eb5f03e5d34818b5cb76d65f3bcc6738
+size 26488

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-sm-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45c6edb20f3b34ffdfbea3f6b359345d89042f12ea5fe49356e9132168393a57
+size 28255

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-sm.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28ea6eb14d4b4297f0157ec910ba7bbec1dc087e57ca71f28a7657492a7fc128
+size 28190

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:580ce95cea65eca25f02737b525f514b82f21e783e73bae493f668155593257b
+size 30235

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark-stripes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d1516611e2a581f99f36dda1dcb089d92c80f85e30995711a433d2000d078dc
+size 30171

--- a/screenshots/Firefox/baseline/s-table-highcontrast-dark.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ef7e8c417c89af188d29c269b92c2d2e79589f9c80cdced13f6e100de927583
+size 30222

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-b0.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db7c3bbb60d7c1c3b2471cb97c3d2fe666075a4747769d074666563186faa227
+size 27193

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13db0d9a1c2bd5c4468a3dcd4d4da5f78d7e2b189f0d22e4e5fe3eb67d73fc28
+size 27284

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-bx.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ecd24cc7693634d6768bc2ecfa5f0dc95ed7a03c8db124dcb7f18dcce129adb
+size 27306

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-lg-b0.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdcf847da2473e468966e15a0c2382d7f3015629f7d5b6d52e94c730ee20eae0
+size 28258

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-lg-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47f07795bfab1edc19540b7d9a6c4c2591079a37639c18ea8bcf5f87aa91a867
+size 28398

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-lg-bx.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:152c5ca87cbe1f24cf791ee61510e044adf66f692ffb98b71994c2889f733d47
+size 28413

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-lg-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3d3bfd39bca05efb07d052dcfc9c2e0bc150086a5d6b498c1f524dba948f3c2
+size 31859

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-lg.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31b6a1fc470717a589bc24da4f7f2e2a81dd028ad7845d470d157dcdfef20ef6
+size 31891

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-sm-b0.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32ecf78a505d38d117999f5ea7c3311a96deb0de0a92a5e9b4d72838afb0a5d6
+size 25909

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-sm-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63d6de509be4fd2cffe53b901e0c6d77ef3b6e5f42e20dbecc33bf28b6e810c6
+size 26029

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-sm-bx.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2980031c37a2111eb882e6124b67be877b0cf3a359ece8d4afb525a4cdd19746
+size 26208

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-sm-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7b4db5c95fff2664e554c57d41b14a2cb00427d7ba9d57e76616b38e77fb3f6
+size 28131

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-sm.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cfb73645ba88d370ae811e4a2f99b47c84d6f51a757d13f5b06d0e856279f1a
+size 28134

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ccd1a78d4e5730837ed3f0ee1a25fe5fe059531fdbd2fda98529990523ce1b1
+size 29978

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-b0.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf1d0ef5f3e17fe29952ac8b1bd909c2a3e06eb40180093c85f79af015aec427
+size 27355

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d32e9ec58f982b28b81c5746d1e69544e7f3d37e7750f4f2783a9d04d1af81e
+size 27430

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-bx.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:442016e787930573a35fffea5a56143006b38517d5474ce08002eb7987d592d0
+size 27391

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-lg-b0.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9628fd3f3bda6a291ec3f2786456546235ef71be820fe68c4ecbad02d6925caf
+size 28395

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-lg-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042bf9ccbfea72aa306dcda99f1d0e95f5b5d3df9cb51448807faa8021fcaaca
+size 28545

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-lg-bx.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccfa678aeb10f177c1831db572f038880ab2fda6af3b956fb04c79c65934a898
+size 28372

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-lg-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1bd79dd15206b5ad3bd4f1377df7824b87f0356ec2dfbd265334907afb1e11e
+size 31863

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-lg.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd1d23ada937bf47a3fda72e8c3442a45d4995c215ef2ed92ce236adbf633485
+size 31617

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-sm-b0.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c29de3315b0e68788806ed99429a567562591a3be627b538d1ddb447e9289c3
+size 26040

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-sm-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e17eecd2eb4dfb29ba1775fd82151f77e0969ed8d778336c0ba9a7a7e01e017
+size 26158

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-sm-bx.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3b53d1587723be11fab39c7fb0f62fdc3c0a84611d939ba1b82bd3699c879de
+size 26175

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-sm-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b81caf064174eac5e32e48c60b1ca5d8f8febdfe2ef1f46ca8e33d5119c80624
+size 28153

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-sm.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71f88b7fba11f2079505162f5b13c846697132db19b6ad6cd249d0460f1ae952
+size 27951

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e779f83747faef948bbad722fff470f8f5f0843418eadd85d39f57eab76c6004
+size 30064

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light-stripes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:557e908e096817ce169ada435f69dd67df1f3b4c17195203c4fb0ec210c0a6bf
+size 29832

--- a/screenshots/Firefox/baseline/s-table-highcontrast-light.png
+++ b/screenshots/Firefox/baseline/s-table-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:584d38d2300bfd38ced89dc60b5bd636bd51ad891cdd0b6651b841db5e4e7f96
+size 30012

--- a/screenshots/Firefox/baseline/s-table-light-b0.png
+++ b/screenshots/Firefox/baseline/s-table-light-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c23ed0009dd9ba580b1a205d82de0739bf3c4340c3cf1df0b50dbc15b66baad
+size 26904

--- a/screenshots/Firefox/baseline/s-table-light-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-light-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7198f88c220afa232fc4eee53bf56a403f417bd5b8ebbd52318256a382300bfb
+size 26990

--- a/screenshots/Firefox/baseline/s-table-light-bx.png
+++ b/screenshots/Firefox/baseline/s-table-light-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc682b714f5b8696c94b113faf5f7c115d017212df952c1ec71eff7c7b1ab957
+size 27037

--- a/screenshots/Firefox/baseline/s-table-light-lg-b0.png
+++ b/screenshots/Firefox/baseline/s-table-light-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:670db40bfbbdb45e5f53af3515b93bee4abaaf28be7c62bd7563d5da7c4a1254
+size 27948

--- a/screenshots/Firefox/baseline/s-table-light-lg-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-light-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8c895a72b63e43122d3bb84069c7a1e8469895ff0815585393479f65ac7159e
+size 28078

--- a/screenshots/Firefox/baseline/s-table-light-lg-bx.png
+++ b/screenshots/Firefox/baseline/s-table-light-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:974d3ed34ca877e09d4209f558042efe09d21f926d0974764cf4f700a0129fd0
+size 28150

--- a/screenshots/Firefox/baseline/s-table-light-lg-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-light-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c49171358e42f1a7f0636429793d80eba03a3e758db16dd0a74662c80ef11933
+size 31432

--- a/screenshots/Firefox/baseline/s-table-light-lg.png
+++ b/screenshots/Firefox/baseline/s-table-light-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5678def6614bcac0343b0ee8426976dd6528dfe8a6c56432aaa540e58884590a
+size 31557

--- a/screenshots/Firefox/baseline/s-table-light-sm-b0.png
+++ b/screenshots/Firefox/baseline/s-table-light-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:083281c7e8a4693ad9681fd8705e0bbf42d784000a69b9601f4a9e5f010b0e45
+size 25572

--- a/screenshots/Firefox/baseline/s-table-light-sm-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-light-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6fc7d2d23a93c958543c28b9fb7a9bec314de75acf661bd31d69e0219f5c523
+size 25683

--- a/screenshots/Firefox/baseline/s-table-light-sm-bx.png
+++ b/screenshots/Firefox/baseline/s-table-light-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:252ad0116c7b1bf41824a08d9202dd88b7559671acdfa24584f61c25f506bdb9
+size 25805

--- a/screenshots/Firefox/baseline/s-table-light-sm-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-light-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0f067aa0f144e96a8050c8fbea989247f2f832f10db49ab2186b71576b51f96
+size 27760

--- a/screenshots/Firefox/baseline/s-table-light-sm.png
+++ b/screenshots/Firefox/baseline/s-table-light-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28ece28235817544dd4f7b045733507a1b81eca5ffdab462b8c199bf43f17685
+size 27832

--- a/screenshots/Firefox/baseline/s-table-light-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-light-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc189966087dc8d1ecad8043595ea703f4e4788f204b1f8eee4cd5ba02f4f5d6
+size 29725

--- a/screenshots/Firefox/baseline/s-table-light-stripes-b0.png
+++ b/screenshots/Firefox/baseline/s-table-light-stripes-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80415ecc770e683c46718d6bb4ff54a22a7cfcfeadc7716e197b5ef37df93570
+size 27067

--- a/screenshots/Firefox/baseline/s-table-light-stripes-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-light-stripes-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acc5f46bb93afed5c144a7540b158d0a7d4b0b9af02fdc7058d643706831d174
+size 27169

--- a/screenshots/Firefox/baseline/s-table-light-stripes-bx.png
+++ b/screenshots/Firefox/baseline/s-table-light-stripes-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef40956e51e4c4dfd1fa1beb4e6c9802bc4b39abc026a9c4f2440f357fee7e36
+size 27110

--- a/screenshots/Firefox/baseline/s-table-light-stripes-lg-b0.png
+++ b/screenshots/Firefox/baseline/s-table-light-stripes-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4484410c8793e5be5fe923a3c0cea82ae52735bd117528b223ab1f523c6adf9a
+size 28121

--- a/screenshots/Firefox/baseline/s-table-light-stripes-lg-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-light-stripes-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c16c7a67d4bb4b1e51c909646ffe533540f072f1eb4d2147256c5280a2731ad
+size 28252

--- a/screenshots/Firefox/baseline/s-table-light-stripes-lg-bx.png
+++ b/screenshots/Firefox/baseline/s-table-light-stripes-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec5d15dc46b1187cf945208c69bf997403af093a03a77cba81116df773617d87
+size 28144

--- a/screenshots/Firefox/baseline/s-table-light-stripes-lg-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-light-stripes-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:635f8e7b2a2fcd8bf768abf19369950ba8015db08b6c856e50f50b85d94b8bd2
+size 31415

--- a/screenshots/Firefox/baseline/s-table-light-stripes-lg.png
+++ b/screenshots/Firefox/baseline/s-table-light-stripes-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51d50210ccf5f4612f830321dc4ea72f585911285dae1b477ad7c04f127877d0
+size 31272

--- a/screenshots/Firefox/baseline/s-table-light-stripes-sm-b0.png
+++ b/screenshots/Firefox/baseline/s-table-light-stripes-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ffcdbc44e62d74786283a237eaaf4fb68e661a028e49b0813a1780531c9deb1
+size 25750

--- a/screenshots/Firefox/baseline/s-table-light-stripes-sm-bx-simple.png
+++ b/screenshots/Firefox/baseline/s-table-light-stripes-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e47ed20d7fff8a1faadca4b534060cc96be0fc097bd4096ed2e509d7bd1a5aa
+size 25863

--- a/screenshots/Firefox/baseline/s-table-light-stripes-sm-bx.png
+++ b/screenshots/Firefox/baseline/s-table-light-stripes-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c44185adb80882a73ab7f2aea839069d7fa4c1056f1f9c4ffdf79179c5d0cdf
+size 25836

--- a/screenshots/Firefox/baseline/s-table-light-stripes-sm-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-light-stripes-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe460eec6dae3d7fe6a465d65844616d6923a38842d408b700dc69efabf55216
+size 27766

--- a/screenshots/Firefox/baseline/s-table-light-stripes-sm.png
+++ b/screenshots/Firefox/baseline/s-table-light-stripes-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb42d9b80f7c22c6896365715c06b52d2ec2913051cdf8823fbb4fdc42bd0a16
+size 27605

--- a/screenshots/Firefox/baseline/s-table-light-stripes-sortable.png
+++ b/screenshots/Firefox/baseline/s-table-light-stripes-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e1251c640ae833eabba8b8c8fda19384746cb3163da1e554a6847d3e47a9ae1
+size 29726

--- a/screenshots/Firefox/baseline/s-table-light-stripes.png
+++ b/screenshots/Firefox/baseline/s-table-light-stripes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad2dcdcbfaa09c2458fd0c120686db685e8da1913bcf5d27a414761e0749ee83
+size 29621

--- a/screenshots/Firefox/baseline/s-table-light.png
+++ b/screenshots/Firefox/baseline/s-table-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b50533f1c31fb5b98b558527c7c1a394cbaa58d7d1672e8981441fb4c7940d1
+size 29778

--- a/screenshots/Webkit/baseline/s-table-dark-b0.png
+++ b/screenshots/Webkit/baseline/s-table-dark-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33936709ec369089bed6bcb0d0fb30cb358642655e3a04df90022ababf6993c4
+size 18782

--- a/screenshots/Webkit/baseline/s-table-dark-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-dark-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75d93f57447d8e186101007f83948bdc79ac43236f1ab2c4e92d18ed421b36d5
+size 18844

--- a/screenshots/Webkit/baseline/s-table-dark-bx.png
+++ b/screenshots/Webkit/baseline/s-table-dark-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42359959b783f7fe9e6a93c4d5764fd93e0e4b4354d8d0523bda295e9c04e4fa
+size 19072

--- a/screenshots/Webkit/baseline/s-table-dark-lg-b0.png
+++ b/screenshots/Webkit/baseline/s-table-dark-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67e33b5976b81f2f08d0a658b3f66cdbe598e5f1a494ad1e461f61d7614b0878
+size 19159

--- a/screenshots/Webkit/baseline/s-table-dark-lg-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-dark-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0757d4e0edfb0b648350f5a8a66bb6f9c829d4437ab6b45b7841a960255575a6
+size 19215

--- a/screenshots/Webkit/baseline/s-table-dark-lg-bx.png
+++ b/screenshots/Webkit/baseline/s-table-dark-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44c3ab1e68396882d93d1232ab99fc29bcb4e35105a5eeca0e43411153f7ee3c
+size 19462

--- a/screenshots/Webkit/baseline/s-table-dark-lg-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-dark-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d05aae01589dbe8e5a99a931848d028f540dcad46e88347a9f2badd385e6c098
+size 19567

--- a/screenshots/Webkit/baseline/s-table-dark-lg.png
+++ b/screenshots/Webkit/baseline/s-table-dark-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:130578ddbc151c88b24d4d27317c3ea8b07b5102b11bd8cd5fc4a8eb4c6d98b5
+size 19643

--- a/screenshots/Webkit/baseline/s-table-dark-sm-b0.png
+++ b/screenshots/Webkit/baseline/s-table-dark-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d82273480c7c8f7ae1587a2aae3fd08bec6c10302e6bc0a02cdef06ac90bc5d
+size 18388

--- a/screenshots/Webkit/baseline/s-table-dark-sm-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-dark-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9fa949406c4c5aaa7e3f1e7c63808bda89b542a4cd3526105cdd28288e6c8fa
+size 18421

--- a/screenshots/Webkit/baseline/s-table-dark-sm-bx.png
+++ b/screenshots/Webkit/baseline/s-table-dark-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db50433f92710fc442567e7672ef44a3b3f2a07bac71e01f31cbb488c648ffd8
+size 18644

--- a/screenshots/Webkit/baseline/s-table-dark-sm-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-dark-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:715ac52e7719cd49f912254c5311facc6acbf952633b63b5111e6f65e93a335a
+size 18675

--- a/screenshots/Webkit/baseline/s-table-dark-sm.png
+++ b/screenshots/Webkit/baseline/s-table-dark-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8628ec1b894099bfc27891435ce03314385aa8d2895152599892b632467d3802
+size 18752

--- a/screenshots/Webkit/baseline/s-table-dark-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-dark-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:778eb9fccf97924b684aac33e3118099c45a47a01c35a82762105b5cb04f7465
+size 19128

--- a/screenshots/Webkit/baseline/s-table-dark-stripes-b0.png
+++ b/screenshots/Webkit/baseline/s-table-dark-stripes-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fb923d996ce6bb70a9cdc896dbb18dcde1375f30ef11419ebdbce3aa5a596c1
+size 18856

--- a/screenshots/Webkit/baseline/s-table-dark-stripes-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-dark-stripes-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b47b255ee7171f05f4a4379828ac4c73b5e6147558934655f82777cfb6995dd0
+size 18926

--- a/screenshots/Webkit/baseline/s-table-dark-stripes-bx.png
+++ b/screenshots/Webkit/baseline/s-table-dark-stripes-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4deddf8986b38660f6842fbca65b2bbb33faef4b6037e66b105e308a1119c86
+size 19130

--- a/screenshots/Webkit/baseline/s-table-dark-stripes-lg-b0.png
+++ b/screenshots/Webkit/baseline/s-table-dark-stripes-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:394659125b0b1d4dc1376b2ea088ebf58ea4d78a79d82d762ba438d8388527c4
+size 19220

--- a/screenshots/Webkit/baseline/s-table-dark-stripes-lg-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-dark-stripes-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b415000c572be4ab67a6df2911824bf7567ab0bb62122804c5aacc72e24b155e
+size 19303

--- a/screenshots/Webkit/baseline/s-table-dark-stripes-lg-bx.png
+++ b/screenshots/Webkit/baseline/s-table-dark-stripes-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff8c4a69d0ac24189e8ad962e377db3b6ee42757615413e3019dcac7b2911e76
+size 19509

--- a/screenshots/Webkit/baseline/s-table-dark-stripes-lg-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-dark-stripes-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d40109bac3b4eba404de34afad582253d2a38cad425f4cf3b05a118e9d6ea28
+size 19688

--- a/screenshots/Webkit/baseline/s-table-dark-stripes-lg.png
+++ b/screenshots/Webkit/baseline/s-table-dark-stripes-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8937a4c2bf0e12d564844e69ca00d8682e6dc91fa22b795b5a39cabf2aa8469f
+size 19771

--- a/screenshots/Webkit/baseline/s-table-dark-stripes-sm-b0.png
+++ b/screenshots/Webkit/baseline/s-table-dark-stripes-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dda82ce972b1f4c2f58699a5ee37273ee623d3be7a19ef6d712021357e7032b2
+size 18438

--- a/screenshots/Webkit/baseline/s-table-dark-stripes-sm-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-dark-stripes-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6585558270471d4c716ac4bdbba59dd6d6506c0d27b36fc071cd67aa81abd33
+size 18487

--- a/screenshots/Webkit/baseline/s-table-dark-stripes-sm-bx.png
+++ b/screenshots/Webkit/baseline/s-table-dark-stripes-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1cb0c90a50f248abddf557b5e9deffd9c68d53b152e3b7c4d5eafeeab61d8596
+size 18704

--- a/screenshots/Webkit/baseline/s-table-dark-stripes-sm-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-dark-stripes-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eebd44dee78df0ffe24c648fbce61d8426e54a3d68aa3fef18f99f68ed65bade
+size 18827

--- a/screenshots/Webkit/baseline/s-table-dark-stripes-sm.png
+++ b/screenshots/Webkit/baseline/s-table-dark-stripes-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3fc1a0dc6f6a67b1611ca054eaab41b130935e212b479f9849856accd210d6b0
+size 18908

--- a/screenshots/Webkit/baseline/s-table-dark-stripes-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-dark-stripes-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6dbbe30614d7cdce543977cf8c7b7d6dbca94cb91ec27591c658ccc48c122d9
+size 19251

--- a/screenshots/Webkit/baseline/s-table-dark-stripes.png
+++ b/screenshots/Webkit/baseline/s-table-dark-stripes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f02a36f8d12630fac63caee6bac616ee40bad56653d54f9f1a2311db52a6a918
+size 19338

--- a/screenshots/Webkit/baseline/s-table-dark.png
+++ b/screenshots/Webkit/baseline/s-table-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f8560c3ad160780485acce08f67a34a65279b8ce903d350b413a7ecdb8cf0e3
+size 19198

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-b0.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fa1a6700d90cea06c46547e0ff49875cfcacd0a341195f6514998336dd2ba5c
+size 17410

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b0f1dab6fec2db8ae2e7fd46affa3e4a55cd004cdfd24241d8fc8959a977d88
+size 17480

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-bx.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c853f766cff59d1460fa58589c074ebbfa8e72345622bfef58439a2b2cf8b474
+size 18580

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-lg-b0.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d48c9771175d0d25099652f09e8ce8fb4b70ac7ec9ea719cb7c0257347867a1
+size 17658

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-lg-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5505f11e3d8053c460d7a674b314cbbe8d6417a4e934bce3688adda92ba8cbfe
+size 17724

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-lg-bx.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7561db8a4cd3dd11074645d59579a315ad77d0e135806366b3626f37f5f6bbbe
+size 18952

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-lg-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17a2b2f420f915a58e686db1f3d581d1fb64bac98f1c45547f83fd1df162bae0
+size 19426

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-lg.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a51a74e13739ae3165234471de86aa4eb6385d71f8e202a75649d95b23f9d39c
+size 19451

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-sm-b0.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba8fc9def987440fe95490d9029842dc7e3400784cecb253e99acd4101d2a727
+size 17169

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-sm-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99f8d9eb2ce631976f6d0d9cdfc2266a8820e696e17f567f563c90f0af2ddabd
+size 17236

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-sm-bx.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7ca2110d12071a8aa67827ed9a629c8740186ddefe6ef395b2f43ce50d3c2a7
+size 18222

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-sm-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec9d56c8c7eead530282f0bf8b91e36db0413ea417cd4a87dc4c2c5377b1087e
+size 18614

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-sm.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da281bcab6f1661cd10e18e8b8062094328a503cf72a1e2eafa0ac9195e5a26d
+size 18634

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab204114a46e3139ca5ce1e7b0b1268dd127a0e0ed281b74ffdf0a91518b8d98
+size 18967

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-b0.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:adb4f79edfaacadab152ba541b09107eb8ed650628155cc535bf8165404c2cfa
+size 17927

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bf6235c8b5296d22d503cdb8ae40cbd91a0023972d54b760e42cc75cc99c234
+size 17989

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-bx.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e673fb1da3210476a8988be2984c2b903f59e6e3e69ceff9036fb34fb759a6d
+size 19002

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-lg-b0.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1dd306237c93a4a92601d40092177cc6d32c60a4b656b909dde9da0f5e926ee5
+size 18224

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-lg-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67f3ff34c702472bf258fa0a59c8341db1d6bee8db84480f9264061d790f1ac7
+size 18278

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-lg-bx.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c56c83706b905bd382da6efc5969ba99a789a153186df66dc1f3a911ee19bd48
+size 19403

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-lg-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:add02511463491a3c1a07c0e87b9277e641f68b2da34a185a0836a33ccf0a35d
+size 19633

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-lg.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4e3b1e0116de5fe10b250066eda8e6428988810ac9580b0597a3ecd51175de2
+size 19704

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-sm-b0.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69b888ad763b9e73b49b0deb38490c20b312f92b948ded9853b635579a6ae65f
+size 17641

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-sm-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70cbbe1d96cedf068cf167e0e2a03f733ecafa00a053199c013967dc1cfd53d5
+size 17700

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-sm-bx.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1651565f739ef723bbf4d2d746644cad42885831422cb92b60a26e89cb5b7a5
+size 18611

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-sm-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:053f2e920b541a49d74f11fd375e4029ed7407dc00580ab8e90869e9019e594a
+size 18789

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-sm.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3443247290a29d955ed8a5b754475df5f4dd46fa5c457f6c10d940bf082eec5
+size 18838

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e0a0be1f137669b07ff09339e9be6f8eae73a01a33c2c26456c6b98cb35b165
+size 19189

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark-stripes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af82ea5727d4e5212cc24f737be1473e556a006fd1fbbfd75abe158cba0dd9bb
+size 19262

--- a/screenshots/Webkit/baseline/s-table-highcontrast-dark.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e48fcde757bb02958c0576d65c74c500046d8400b497b2ad9ac87bf0d22d84e
+size 18993

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-b0.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77a816006bcf98e765d8f7b4f0c1c193db69869a44b6509a3fed73cc489a69fc
+size 18777

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94a0477678be5b6d603169ddaf2e712a3a57d02b73015a7da7f3751716d3b0c9
+size 18829

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-bx.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc94f1f80c90ca2efb9493d79ede09771b58e736cd7b942947328d5e1023ae19
+size 19172

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-lg-b0.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b499b6858fc83d9230d1c7f8133bf860758c5f824576ebed43eb5c1b0f342b7
+size 19180

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-lg-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef79936cfbf53766a23da9be84de929e7856d59460cf433a777e94a76ba86b6b
+size 19237

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-lg-bx.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cccca48b921c2e5682a18635a9cea877ce8d288a1ad349020d0a93711c07545
+size 19556

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-lg-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:501debc736f42bea91604360e686aaea2c04c6ff76ce39d35c400c27b315b146
+size 19830

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-lg.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8c5a567c17908ecd203791b3e5ac463b313f080f30755e2619e13c93362a713
+size 19814

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-sm-b0.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbd258566169cab6226d7d3e0beea085db0aaa6392926747f4cd3ab807e07b15
+size 18425

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-sm-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3a34356ca8659ded7cac73ff4186088fe6b6e3632327f98321670cb01823483
+size 18474

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-sm-bx.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fff2f549e2466450cae8d36c71a2d983546c9cae733cde9b5e4bf5f9e202fb3b
+size 18719

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-sm-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f70230830faad199ab62e9e755edfe7c417da83b7aad6a385ff6169692aea31
+size 18967

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-sm.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9ebe96c3110642e20224f0be547b19b9c118c463d9e947cff05fd8930edd6e1
+size 18955

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa48b396df3942d68d9c1fa634040bff94d35bc7190f7b011516b5921d559157
+size 19394

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-b0.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:644873d8b3cfa88a04b52b7286b159323b6fd031886bd4a5557b7ac1b6fed331
+size 18885

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf69ac84738f137284aebc49cacda078f2dd618c894473bb4bc5d64c9d953968
+size 18917

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-bx.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce329800e80b11844ef81fc7d994a02daa15a6d9f334784d183cf5a416598bee
+size 19224

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-lg-b0.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7c58bd071639bbabdbee6063d1f13e80e68e78e91e17ab725e70a1526720ff8
+size 19289

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-lg-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fa0340d54238d6cd3eb700c7c9082edeff01fe0fc3bbaca3de710037578336e
+size 19349

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-lg-bx.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a9bd3818dca66a913f6823df0f22ff8bdb187e295abe5ebcf68b7575d461b3f
+size 19611

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-lg-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d3452ecded66e8e85583272715eb182984bf9eed711ef86f0ba6a3985b4de0a
+size 19903

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-lg.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34eb977cc576e49e4ed9ec9104bb544c6c30eb15d20dd08664470f180834b85f
+size 19892

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-sm-b0.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9befd00373a8277dca0424d4bb3bd657ea90a4db5face8e227ead9dea94be135
+size 18506

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-sm-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab3a29df039159844e7455001ad576f4e606050a775cc560ac6b006a4dc623d3
+size 18555

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-sm-bx.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:134e3ceb337cf477211958d56a373a3e4b001891c7b35f088ed64c742adeeac8
+size 18771

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-sm-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a8407e535bb18a69222f7060905dc2c8e394bd6df47163a72713923cbb520e4
+size 19011

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-sm.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:193442b769a3b661cc0daf6a85bcc0494251902105555ce64d7cb3a4ef020de0
+size 19010

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6dffd274de3e0d538f49682469bc97ee86fe031c17a64846fc0db6dfa1b261fe
+size 19445

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light-stripes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8d15bee5db6b880b56d29ae3e2f9aa7b4b1060d8c64110e1dc95f84d91bb93f
+size 19438

--- a/screenshots/Webkit/baseline/s-table-highcontrast-light.png
+++ b/screenshots/Webkit/baseline/s-table-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ec8d4e0a7c11471b7a870795a98883eda7b93676e593f9c076c6fe878a9ec43
+size 19381

--- a/screenshots/Webkit/baseline/s-table-light-b0.png
+++ b/screenshots/Webkit/baseline/s-table-light-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83cec6e562ffd76e82bd041ae50f243e40d7209ba18b56c4ec59935dbebdcdb7
+size 18388

--- a/screenshots/Webkit/baseline/s-table-light-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-light-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f33487342e6b79f80944b8ff39f05f12ee4de7ff0acff499bee9ab734fe50d7
+size 18436

--- a/screenshots/Webkit/baseline/s-table-light-bx.png
+++ b/screenshots/Webkit/baseline/s-table-light-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:555c14209968a15854a906f25339259c1fae23aa4f04e753a01c2d35284ccdbf
+size 18753

--- a/screenshots/Webkit/baseline/s-table-light-lg-b0.png
+++ b/screenshots/Webkit/baseline/s-table-light-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38f27dbecc7d63516be6769e7a57d5edf2f5855b3ab66e716a4847dd32c05809
+size 18806

--- a/screenshots/Webkit/baseline/s-table-light-lg-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-light-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52ced8d04d728babd26ff0e8c698d784f462d88ab67a7a5bb746f71b91fe1052
+size 18877

--- a/screenshots/Webkit/baseline/s-table-light-lg-bx.png
+++ b/screenshots/Webkit/baseline/s-table-light-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97c0332e725ea4a466c71221f1ef0bc9477a6057e598ebb4810e369829473337
+size 19158

--- a/screenshots/Webkit/baseline/s-table-light-lg-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-light-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac3f6e0757802649fbe9b1e3928b7df42113c6afbf7d365531330e2d27caf5af
+size 19394

--- a/screenshots/Webkit/baseline/s-table-light-lg.png
+++ b/screenshots/Webkit/baseline/s-table-light-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:742932169347eb53ebfcc955ed89b498659535cb9ccdb22b24b6a88e043ad814
+size 19472

--- a/screenshots/Webkit/baseline/s-table-light-sm-b0.png
+++ b/screenshots/Webkit/baseline/s-table-light-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bfedd172da393c580aa010b488804a290e997474630758e06bf5b6ad8971301
+size 18054

--- a/screenshots/Webkit/baseline/s-table-light-sm-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-light-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c4c8fba729ba5eb240d0dfe237b149feb5500f4a807ddec3b197e0df63eb8bf
+size 18108

--- a/screenshots/Webkit/baseline/s-table-light-sm-bx.png
+++ b/screenshots/Webkit/baseline/s-table-light-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bb52070f1b0b3e7421eaa1b90ede1d8ab1e64799514cb1ff39f2673c7986988
+size 18369

--- a/screenshots/Webkit/baseline/s-table-light-sm-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-light-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89ba1be50996f366a9a7c427c1472ee1bbb28a8b46bc196827a25cb32bb64049
+size 18541

--- a/screenshots/Webkit/baseline/s-table-light-sm.png
+++ b/screenshots/Webkit/baseline/s-table-light-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0304443adeb0925ea7d313e09fcf4b3cb063dd749c2356c1ff7028ff85719a1
+size 18608

--- a/screenshots/Webkit/baseline/s-table-light-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-light-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49a2c6dadbefdaf86a76a28bf2e3315e5743b04f8e4bd9d8f2e31ea13bc35774
+size 18938

--- a/screenshots/Webkit/baseline/s-table-light-stripes-b0.png
+++ b/screenshots/Webkit/baseline/s-table-light-stripes-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1ab92c45447f411dcdd31241538395f1d53a21accac5a02d5668e2aa0d5117f
+size 18444

--- a/screenshots/Webkit/baseline/s-table-light-stripes-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-light-stripes-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c69516fa6a7516b3220d4fcea57484a522e0b8674dbce16e738c2e12a00b5d79
+size 18497

--- a/screenshots/Webkit/baseline/s-table-light-stripes-bx.png
+++ b/screenshots/Webkit/baseline/s-table-light-stripes-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ba29be37f14b34ae996c716d46cdfa60e2596d78aac3a47601b1e90d5df2578
+size 18865

--- a/screenshots/Webkit/baseline/s-table-light-stripes-lg-b0.png
+++ b/screenshots/Webkit/baseline/s-table-light-stripes-lg-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4b8cba21ff874d1507a7d227b3e6c1ea597da3d2bccf501e2b2a3628a8ff089
+size 18885

--- a/screenshots/Webkit/baseline/s-table-light-stripes-lg-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-light-stripes-lg-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:693e9077b4cfa0a8abb92334fbbf58e6070f585c76546fdf3ae212b6736b4573
+size 18952

--- a/screenshots/Webkit/baseline/s-table-light-stripes-lg-bx.png
+++ b/screenshots/Webkit/baseline/s-table-light-stripes-lg-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c60d618c26281211e3af0827f91e5d5785156a5c0b72951ae0a4d36e01ccb1be
+size 19259

--- a/screenshots/Webkit/baseline/s-table-light-stripes-lg-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-light-stripes-lg-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdb31683ff207f38dc8199f5bb84f3b2c03a12ad5d8fc60030bf4febda62412a
+size 19532

--- a/screenshots/Webkit/baseline/s-table-light-stripes-lg.png
+++ b/screenshots/Webkit/baseline/s-table-light-stripes-lg.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fb9f24248f5022632d2080c3ace0269f537957c4b035f447f33e296cd95a27d
+size 19606

--- a/screenshots/Webkit/baseline/s-table-light-stripes-sm-b0.png
+++ b/screenshots/Webkit/baseline/s-table-light-stripes-sm-b0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:293fddac26bdfe825d4e571bb0acc7d7c7b89b0bb70b5c9ef6072d47d14c1c4d
+size 18117

--- a/screenshots/Webkit/baseline/s-table-light-stripes-sm-bx-simple.png
+++ b/screenshots/Webkit/baseline/s-table-light-stripes-sm-bx-simple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5287fe732f5e23633f13fb5e9956d9dc5d59096eda19585abc1ce6361015fd2b
+size 18164

--- a/screenshots/Webkit/baseline/s-table-light-stripes-sm-bx.png
+++ b/screenshots/Webkit/baseline/s-table-light-stripes-sm-bx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6b285aff4ec9588eeddfc7ccc2ec50dcefb160e1bdf01f2f80a6c4abfe00154
+size 18473

--- a/screenshots/Webkit/baseline/s-table-light-stripes-sm-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-light-stripes-sm-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3a705bbbf53cdc5bf8d01f9ad9a205c9e1528e1385e034743895aaa0d240de3
+size 18625

--- a/screenshots/Webkit/baseline/s-table-light-stripes-sm.png
+++ b/screenshots/Webkit/baseline/s-table-light-stripes-sm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77e6a6061df2fd74a2a0c9b5cc990bf0636105b2f8edd129f0abd255571ca773
+size 18707

--- a/screenshots/Webkit/baseline/s-table-light-stripes-sortable.png
+++ b/screenshots/Webkit/baseline/s-table-light-stripes-sortable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6432bd36f27e9841cb72fa96d9ef41d81097acced56ce37dc8aa72d9703dbbae
+size 19074

--- a/screenshots/Webkit/baseline/s-table-light-stripes.png
+++ b/screenshots/Webkit/baseline/s-table-light-stripes.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff0abd123927ee8618464db69d2b6ee4296473153b5526686092da8975a80563
+size 19138

--- a/screenshots/Webkit/baseline/s-table-light.png
+++ b/screenshots/Webkit/baseline/s-table-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fdc7175d1dc11bb49fe34c5c2d6837725eea61bbc404ce64af004dc5b31571ff
+size 19007


### PR DESCRIPTION
This PR adds visual and accessibility tests for the `.s-table` component.