### PR TITLE
test(empty-state): add a11y; visual tests

### DIFF
--- a/lib/components/empty-state/empty-state.a11y.test.ts
+++ b/lib/components/empty-state/empty-state.a11y.test.ts
@@ -1,0 +1,17 @@
+import { html } from "@open-wc/testing";
+import { SpotEmptyXL } from "@stackoverflow/stacks-icons";
+import { runComponentTests } from "../../test/test-utils";
+import "../../index";
+
+describe("empty-state", () => {
+    runComponentTests({
+        type: "a11y",
+        baseClass: "s-empty-state",
+        children: {
+            default: `${SpotEmptyXL}<p class="mt24"><strong>Hello!</strong> This is a wonderful empty state component.</p>`,
+        },
+        template: ({ component, testid }) => html`
+            <div class="ws3 p16" data-testid="${testid}">${component}</div>
+        `,
+    });
+});

--- a/lib/components/empty-state/empty-state.visual.test.ts
+++ b/lib/components/empty-state/empty-state.visual.test.ts
@@ -1,0 +1,17 @@
+import { html } from "@open-wc/testing";
+import { SpotEmptyXL } from "@stackoverflow/stacks-icons";
+import { runComponentTests } from "../../test/test-utils";
+import "../../index";
+
+describe("empty-state", () => {
+    runComponentTests({
+        type: "visual",
+        baseClass: "s-empty-state",
+        children: {
+            default: `${SpotEmptyXL}<p class="mt24"><strong>Hello!</strong> This is a wonderful empty state component.</p>`,
+        },
+        template: ({ component, testid }) => html`
+            <div class="ws3 p16" data-testid="${testid}">${component}</div>
+        `,
+    });
+});

--- a/screenshots/Chromium/baseline/s-empty-state-dark.png
+++ b/screenshots/Chromium/baseline/s-empty-state-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29175eca934d55812cb392c2fd6edaed16efab578788529e7c661b68b6ac71d4
+size 10831

--- a/screenshots/Chromium/baseline/s-empty-state-highcontrast-dark.png
+++ b/screenshots/Chromium/baseline/s-empty-state-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3cff1ed7025834ee9b4b24955ba1dc9900cbfcb7a555365fc35ecad21947b4dc
+size 10615

--- a/screenshots/Chromium/baseline/s-empty-state-highcontrast-light.png
+++ b/screenshots/Chromium/baseline/s-empty-state-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9eea05816051ca26fa2850b5ea47aa2df6a6eda781df141f9ebf94d2766ffd96
+size 10558

--- a/screenshots/Chromium/baseline/s-empty-state-light.png
+++ b/screenshots/Chromium/baseline/s-empty-state-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84e6b9d0763fcffdce9ce459cb4e254e825d0009cae50303b839e736217342d0
+size 10562

--- a/screenshots/Firefox/baseline/s-empty-state-dark.png
+++ b/screenshots/Firefox/baseline/s-empty-state-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0babf37f642d8c149fc134e58199a69d784cd540311a19c59e6254f3547d3358
+size 12720

--- a/screenshots/Firefox/baseline/s-empty-state-highcontrast-dark.png
+++ b/screenshots/Firefox/baseline/s-empty-state-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07c4384486bd74cba9f6242c5d0586489024d86e04de5440c2268f4bb2c66665
+size 12511

--- a/screenshots/Firefox/baseline/s-empty-state-highcontrast-light.png
+++ b/screenshots/Firefox/baseline/s-empty-state-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3aabeee38f89bb0504b0348b8adc955f4be9a20e4d62afa01136d9de7b456cc
+size 12378

--- a/screenshots/Firefox/baseline/s-empty-state-light.png
+++ b/screenshots/Firefox/baseline/s-empty-state-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ed14ae4340834cbc4d6464d87710006b5386eba27098d8989f437a3312b4977
+size 12350

--- a/screenshots/Webkit/baseline/s-empty-state-dark.png
+++ b/screenshots/Webkit/baseline/s-empty-state-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:215a31a34f7e0cb434a9b6f497993beda077b9420b95f17ab3d07517b1ad61d1
+size 9937

--- a/screenshots/Webkit/baseline/s-empty-state-highcontrast-dark.png
+++ b/screenshots/Webkit/baseline/s-empty-state-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f87d44aebcd38943b4d624f9ae431ab35374acdba4cd2802c3b69ef998964f0a
+size 9647

--- a/screenshots/Webkit/baseline/s-empty-state-highcontrast-light.png
+++ b/screenshots/Webkit/baseline/s-empty-state-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2bfe7a0036f38b52176666ba109eb15bca9ae75a0ee716b9fa2e13874e2f05e
+size 9253

--- a/screenshots/Webkit/baseline/s-empty-state-light.png
+++ b/screenshots/Webkit/baseline/s-empty-state-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5eb50ffd2945ad9669ec3308600081034a7fd23cac11673a5964e169025918cd
+size 9195


### PR DESCRIPTION
This PR adds visual and accessibility tests for the `.s-empty-state` component.