### PR TITLE
test(progress-bar): add a11y; visual tests

### DIFF
--- a/docs/product/components/progress-bars.html
+++ b/docs/product/components/progress-bars.html
@@ -196,7 +196,7 @@ description: A component that visually communicates the completion of a task or 
     <div class="stacks-preview">
 {% highlight html %}
 <div class="s-progress s-progress__circular" style="--s-progress-value: .75">
-    <svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75">
+    <svg class="s-progress-bar" role="progressbar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75">
         <circle cx="16" cy="16" r="14"></circle>
         <circle cx="16" cy="16" r="14"></circle>
     </svg>
@@ -205,35 +205,35 @@ description: A component that visually communicates the completion of a task or 
         <div class="stacks-preview--example">
             <div class="d-flex fw-wrap g16">
                 <div class="flex--item s-progress s-progress__circular s-progress__sm fc-blue-500" style="--s-progress-value: 0">
-                    <svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                    <svg class="s-progress-bar" role="progressbar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
                         <circle cx="16" cy="16" r="14"></circle>
                         <circle cx="16" cy="16" r="14"></circle>
                     </svg>
                 </div>
 
                 <div class="flex--item s-progress s-progress__circular fc-orange-400" style="--s-progress-value: .5">
-                    <svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50">
+                    <svg class="s-progress-bar" role="progressbar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="50">
                         <circle cx="16" cy="16" r="14"></circle>
                         <circle cx="16" cy="16" r="14"></circle>
                     </svg>
                 </div>
 
                 <div class="flex--item s-progress s-progress__circular s-progress__md fc-green-400" style="--s-progress-value: .75">
-                    <svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75">
+                    <svg class="s-progress-bar" role="progressbar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75">
                         <circle cx="16" cy="16" r="14"></circle>
                         <circle cx="16" cy="16" r="14"></circle>
                     </svg>
                 </div>
 
                 <div class="flex--item s-progress s-progress__circular s-progress__lg fc-red-500" style="--s-progress-value: .94">
-                    <svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="94">
+                    <svg class="s-progress-bar" role="progressbar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="94">
                         <circle cx="16" cy="16" r="14"></circle>
                         <circle cx="16" cy="16" r="14"></circle>
                     </svg>
                 </div>
 
                 <div class="flex--item s-progress s-progress__circular s-progress__lg fc-blue-500" style="--s-progress-value: 1">
-                    <svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100">
+                    <svg class="s-progress-bar" role="progressbar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100">
                         <circle cx="16" cy="16" r="14"></circle>
                         <circle cx="16" cy="16" r="14"></circle>
                     </svg>

--- a/lib/components/progress-bar/progress-bar.a11y.test.ts
+++ b/lib/components/progress-bar/progress-bar.a11y.test.ts
@@ -1,0 +1,175 @@
+import { html } from "@open-wc/testing";
+import { IconAchievementsSm, IconCheckmarkSm } from "@stackoverflow/stacks-icons/icons";
+import { defaultOptions, runComponentTests } from "../../test/test-utils";
+import "../../index";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const template = ({ component, testid }: any) => html`
+    <div class="d-flex ai-center jc-center p8 ws2" data-testid="${testid}">${component}</div>
+`;
+
+const steppedItems = [{
+    complete: true,
+    label: "Select plan"
+}, {
+    complete: true,
+    label: "Team name"
+}, {
+    active: true,
+    label: "Payment"
+}, {
+    label: "Create account"
+}];
+
+const getChildren = (type: string) => {
+    switch (type) {
+        case "badge":
+            return `<div class="s-progress--label" id="example-label">
+                <div class="s-badge--label">Electorate</div>
+            </div>
+            <div class="s-progress--bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" aria-labelledby="example-label" style="width: 75%;"></div>`;
+        case "circular":
+            return `<svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75">
+                <circle cx="16" cy="16" r="14"></circle>
+                <circle cx="16" cy="16" r="14"></circle>
+            </svg>`;
+        case "privilege":
+            return `
+                <div class="s-progress--label" id="progress-label">
+                    ${IconAchievementsSm}
+                    Access Review Queues
+                </div>
+                <div class="s-progress--bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" aria-labelledby="progress-label" style="width: 75%;"></div>
+            `;
+        case "segmented":
+            return `
+                <div class="s-progress--bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" aria-label="…" style="width: 75%;"></div>
+                <ol class="s-progress--segments">
+                    <li></li><li></li><li></li>
+                </ol>
+            `;
+        case "stepped":
+            return steppedItems.map((step, i) => {
+                return `
+                    <div
+                        class="
+                            s-progress--step
+                            ${step.active ? "is-active" : ""}
+                            ${step.complete ? "is-complete" : ""}
+                        "
+                    >
+                        <a href="#" class="s-progress--stop">
+                            ${step.complete ? IconCheckmarkSm : ""}
+                        </a>
+                        ${i > 0 ? '<div class="s-progress--bar s-progress--bar__left"></div>' : ""}
+
+                        ${i < steppedItems.length - 1 ? '<div class="s-progress--bar s-progress--bar__right"></div>' : ""}
+                        <a class="s-progress--label">${step.label}</a>
+                    </div>
+                `;
+                }).join("");
+        default:
+            return `<div class="s-progress--bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" aria-label="progress" style="width: 75%"></div>`;
+    }
+}
+describe("progress-bar", () => {
+    // Base
+    runComponentTests({
+        type: "a11y",
+        baseClass: "s-progress",
+        variants: ["brand", "info"],
+        children: {
+            default: getChildren("")
+        },
+        template
+    });
+
+    // Badge
+    runComponentTests({
+        type: "a11y",
+        baseClass: "s-progress",
+        variants: ["badge"],
+        modifiers: {
+            primary: ["gold", "silver", "bronze"]
+        },
+        children: {
+            default: getChildren("badge")
+        },
+        template,
+        options: {
+            ...defaultOptions,
+            includeNullVariant: false,
+            includeNullModifier: false
+        }
+    });
+
+    // Circular
+    runComponentTests({
+        type: "a11y",
+        baseClass: "s-progress",
+        variants: ["circular"],
+        modifiers: {
+            global: ["fc-green-400", "fc-theme-primary"]
+        },
+        children: {
+            default: getChildren("circular")
+        },
+        template,
+        attributes: {
+            style: "--s-progress-value: .75"
+        },
+        options: {
+            ...defaultOptions,
+            includeNullVariant: false,
+            includeNullModifier: false
+        }
+    });
+
+    // Privilege
+    runComponentTests({
+        type: "a11y",
+        baseClass: "s-progress",
+        variants: ["privilege"],
+        children: {
+            default: getChildren("privilege")
+        },
+        template,
+        options: {
+            ...defaultOptions,
+            includeNullVariant: false,
+        }
+    });
+
+    // Segmented
+    runComponentTests({
+        type: "a11y",
+        baseClass: "s-progress",
+        variants: ["segmented"],
+        children: {
+            default: getChildren("segmented")
+        },
+        template,
+        options: {
+            ...defaultOptions,
+            includeNullVariant: false,
+        }
+    });
+
+    // Stepped
+    runComponentTests({
+        type: "a11y",
+        baseClass: "s-progress",
+        variants: ["stepped"],
+        children: {
+            default: getChildren("stepped")
+        },
+        template: ({ component, testid }) => html`
+            <div class="d-block p8 ws5" data-testid="${testid}">${component}</div>
+        `,
+        options: {
+            ...defaultOptions,
+            includeNullVariant: false,
+        }
+        // TODO add skipped test ids
+    });
+});

--- a/lib/components/progress-bar/progress-bar.a11y.test.ts
+++ b/lib/components/progress-bar/progress-bar.a11y.test.ts
@@ -1,25 +1,35 @@
 import { html } from "@open-wc/testing";
-import { IconAchievementsSm, IconCheckmarkSm } from "@stackoverflow/stacks-icons/icons";
+import {
+    IconAchievementsSm,
+    IconCheckmarkSm,
+} from "@stackoverflow/stacks-icons/icons";
 import { defaultOptions, runComponentTests } from "../../test/test-utils";
 import "../../index";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const template = ({ component, testid }: any) => html`
-    <div class="d-flex ai-center jc-center p8 ws2" data-testid="${testid}">${component}</div>
+    <div class="d-flex ai-center jc-center p8 ws2" data-testid="${testid}">
+        ${component}
+    </div>
 `;
 
-const steppedItems = [{
-    complete: true,
-    label: "Select plan"
-}, {
-    complete: true,
-    label: "Team name"
-}, {
-    active: true,
-    label: "Payment"
-}, {
-    label: "Create account"
-}];
+const steppedItems = [
+    {
+        complete: true,
+        label: "Select plan",
+    },
+    {
+        complete: true,
+        label: "Team name",
+    },
+    {
+        active: true,
+        label: "Payment",
+    },
+    {
+        label: "Create account",
+    },
+];
 
 const getChildren = (type: string) => {
     switch (type) {
@@ -29,7 +39,7 @@ const getChildren = (type: string) => {
             </div>
             <div class="s-progress--bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" aria-labelledby="example-label" style="width: 75%;"></div>`;
         case "circular":
-            return `<svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75">
+            return `<svg class="s-progress-bar" role="progressbar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75">
                 <circle cx="16" cy="16" r="14"></circle>
                 <circle cx="16" cy="16" r="14"></circle>
             </svg>`;
@@ -49,8 +59,9 @@ const getChildren = (type: string) => {
                 </ol>
             `;
         case "stepped":
-            return steppedItems.map((step, i) => {
-                return `
+            return steppedItems
+                .map((step, i) => {
+                    return `
                     <div
                         class="
                             s-progress--step
@@ -60,18 +71,30 @@ const getChildren = (type: string) => {
                     >
                         <a href="#" class="s-progress--stop">
                             ${step.complete ? IconCheckmarkSm : ""}
+                            <span class="v-visible-sr">${step.label} ${
+                                step.complete ? "complete" : "incomplete"
+                            }</span>
                         </a>
-                        ${i > 0 ? '<div class="s-progress--bar s-progress--bar__left"></div>' : ""}
+                        ${
+                            i > 0
+                                ? '<div class="s-progress--bar s-progress--bar__left"></div>'
+                                : ""
+                        }
 
-                        ${i < steppedItems.length - 1 ? '<div class="s-progress--bar s-progress--bar__right"></div>' : ""}
+                        ${
+                            i < steppedItems.length - 1
+                                ? '<div class="s-progress--bar s-progress--bar__right"></div>'
+                                : ""
+                        }
                         <a class="s-progress--label">${step.label}</a>
                     </div>
                 `;
-                }).join("");
+                })
+                .join("");
         default:
             return `<div class="s-progress--bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" aria-label="progress" style="width: 75%"></div>`;
     }
-}
+};
 describe("progress-bar", () => {
     // Base
     runComponentTests({
@@ -79,9 +102,9 @@ describe("progress-bar", () => {
         baseClass: "s-progress",
         variants: ["brand", "info"],
         children: {
-            default: getChildren("")
+            default: getChildren(""),
         },
-        template
+        template,
     });
 
     // Badge
@@ -90,17 +113,17 @@ describe("progress-bar", () => {
         baseClass: "s-progress",
         variants: ["badge"],
         modifiers: {
-            primary: ["gold", "silver", "bronze"]
+            primary: ["gold", "silver", "bronze"],
         },
         children: {
-            default: getChildren("badge")
+            default: getChildren("badge"),
         },
         template,
         options: {
             ...defaultOptions,
             includeNullVariant: false,
-            includeNullModifier: false
-        }
+            includeNullModifier: false,
+        },
     });
 
     // Circular
@@ -109,20 +132,20 @@ describe("progress-bar", () => {
         baseClass: "s-progress",
         variants: ["circular"],
         modifiers: {
-            global: ["fc-green-400", "fc-theme-primary"]
+            global: ["fc-green-400", "fc-theme-primary"],
         },
         children: {
-            default: getChildren("circular")
+            default: getChildren("circular"),
         },
         template,
         attributes: {
-            style: "--s-progress-value: .75"
+            style: "--s-progress-value: .75",
         },
         options: {
             ...defaultOptions,
             includeNullVariant: false,
-            includeNullModifier: false
-        }
+            includeNullModifier: false,
+        },
     });
 
     // Privilege
@@ -131,13 +154,13 @@ describe("progress-bar", () => {
         baseClass: "s-progress",
         variants: ["privilege"],
         children: {
-            default: getChildren("privilege")
+            default: getChildren("privilege"),
         },
         template,
         options: {
             ...defaultOptions,
             includeNullVariant: false,
-        }
+        },
     });
 
     // Segmented
@@ -146,13 +169,13 @@ describe("progress-bar", () => {
         baseClass: "s-progress",
         variants: ["segmented"],
         children: {
-            default: getChildren("segmented")
+            default: getChildren("segmented"),
         },
         template,
         options: {
             ...defaultOptions,
             includeNullVariant: false,
-        }
+        },
     });
 
     // Stepped
@@ -161,15 +184,17 @@ describe("progress-bar", () => {
         baseClass: "s-progress",
         variants: ["stepped"],
         children: {
-            default: getChildren("stepped")
+            default: getChildren("stepped"),
         },
         template: ({ component, testid }) => html`
-            <div class="d-block p8 ws5" data-testid="${testid}">${component}</div>
+            <div class="d-block p8 ws5" data-testid="${testid}">
+                ${component}
+            </div>
         `,
         options: {
             ...defaultOptions,
             includeNullVariant: false,
-        }
+        },
         // TODO add skipped test ids
     });
 });

--- a/lib/components/progress-bar/progress-bar.visual.test.ts
+++ b/lib/components/progress-bar/progress-bar.visual.test.ts
@@ -1,25 +1,35 @@
 import { html } from "@open-wc/testing";
-import { IconAchievementsSm, IconCheckmarkSm } from "@stackoverflow/stacks-icons/icons";
+import {
+    IconAchievementsSm,
+    IconCheckmarkSm,
+} from "@stackoverflow/stacks-icons/icons";
 import { defaultOptions, runComponentTests } from "../../test/test-utils";
 import "../../index";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const template = ({ component, testid }: any) => html`
-    <div class="d-flex ai-center jc-center p8 ws2" data-testid="${testid}">${component}</div>
+    <div class="d-flex ai-center jc-center p8 ws2" data-testid="${testid}">
+        ${component}
+    </div>
 `;
 
-const steppedItems = [{
-    complete: true,
-    label: "Select plan"
-}, {
-    complete: true,
-    label: "Team name"
-}, {
-    active: true,
-    label: "Payment"
-}, {
-    label: "Create account"
-}];
+const steppedItems = [
+    {
+        complete: true,
+        label: "Select plan",
+    },
+    {
+        complete: true,
+        label: "Team name",
+    },
+    {
+        active: true,
+        label: "Payment",
+    },
+    {
+        label: "Create account",
+    },
+];
 
 const getChildren = (type: string) => {
     switch (type) {
@@ -29,7 +39,7 @@ const getChildren = (type: string) => {
             </div>
             <div class="s-progress--bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" aria-labelledby="example-label" style="width: 75%;"></div>`;
         case "circular":
-            return `<svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75">
+            return `<svg class="s-progress-bar" role="progressbar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75">
                 <circle cx="16" cy="16" r="14"></circle>
                 <circle cx="16" cy="16" r="14"></circle>
             </svg>`;
@@ -49,8 +59,9 @@ const getChildren = (type: string) => {
                 </ol>
             `;
         case "stepped":
-            return steppedItems.map((step, i) => {
-                return `
+            return steppedItems
+                .map((step, i) => {
+                    return `
                     <div
                         class="
                             s-progress--step
@@ -60,18 +71,30 @@ const getChildren = (type: string) => {
                     >
                         <a href="#" class="s-progress--stop">
                             ${step.complete ? IconCheckmarkSm : ""}
+                            <span class="v-visible-sr">${step.label} ${
+                                step.complete ? "complete" : "incomplete"
+                            }</span>
                         </a>
-                        ${i > 0 ? '<div class="s-progress--bar s-progress--bar__left"></div>' : ""}
+                        ${
+                            i > 0
+                                ? '<div class="s-progress--bar s-progress--bar__left"></div>'
+                                : ""
+                        }
 
-                        ${i < steppedItems.length - 1 ? '<div class="s-progress--bar s-progress--bar__right"></div>' : ""}
+                        ${
+                            i < steppedItems.length - 1
+                                ? '<div class="s-progress--bar s-progress--bar__right"></div>'
+                                : ""
+                        }
                         <a class="s-progress--label">${step.label}</a>
                     </div>
                 `;
-                }).join("");
+                })
+                .join("");
         default:
             return `<div class="s-progress--bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" aria-label="progress" style="width: 75%"></div>`;
     }
-}
+};
 describe("progress-bar", () => {
     // Base
     runComponentTests({
@@ -79,9 +102,9 @@ describe("progress-bar", () => {
         baseClass: "s-progress",
         variants: ["brand", "info"],
         children: {
-            default: getChildren("")
+            default: getChildren(""),
         },
-        template
+        template,
     });
 
     // Badge
@@ -90,17 +113,17 @@ describe("progress-bar", () => {
         baseClass: "s-progress",
         variants: ["badge"],
         modifiers: {
-            primary: ["gold", "silver", "bronze"]
+            primary: ["gold", "silver", "bronze"],
         },
         children: {
-            default: getChildren("badge")
+            default: getChildren("badge"),
         },
         template,
         options: {
             ...defaultOptions,
             includeNullVariant: false,
-            includeNullModifier: false
-        }
+            includeNullModifier: false,
+        },
     });
 
     // Circular
@@ -109,20 +132,20 @@ describe("progress-bar", () => {
         baseClass: "s-progress",
         variants: ["circular"],
         modifiers: {
-            global: ["fc-green-400", "fc-theme-primary"]
+            global: ["fc-green-400", "fc-theme-primary"],
         },
         children: {
-            default: getChildren("circular")
+            default: getChildren("circular"),
         },
         template,
         attributes: {
-            style: "--s-progress-value: .75"
+            style: "--s-progress-value: .75",
         },
         options: {
             ...defaultOptions,
             includeNullVariant: false,
-            includeNullModifier: false
-        }
+            includeNullModifier: false,
+        },
     });
 
     // Privilege
@@ -131,13 +154,13 @@ describe("progress-bar", () => {
         baseClass: "s-progress",
         variants: ["privilege"],
         children: {
-            default: getChildren("privilege")
+            default: getChildren("privilege"),
         },
         template,
         options: {
             ...defaultOptions,
             includeNullVariant: false,
-        }
+        },
     });
 
     // Segmented
@@ -146,13 +169,13 @@ describe("progress-bar", () => {
         baseClass: "s-progress",
         variants: ["segmented"],
         children: {
-            default: getChildren("segmented")
+            default: getChildren("segmented"),
         },
         template,
         options: {
             ...defaultOptions,
             includeNullVariant: false,
-        }
+        },
     });
 
     // Stepped
@@ -161,14 +184,16 @@ describe("progress-bar", () => {
         baseClass: "s-progress",
         variants: ["stepped"],
         children: {
-            default: getChildren("stepped")
+            default: getChildren("stepped"),
         },
         template: ({ component, testid }) => html`
-            <div class="d-block p8 ws5" data-testid="${testid}">${component}</div>
+            <div class="d-block p8 ws5" data-testid="${testid}">
+                ${component}
+            </div>
         `,
         options: {
             ...defaultOptions,
             includeNullVariant: false,
-        }
+        },
     });
 });

--- a/lib/components/progress-bar/progress-bar.visual.test.ts
+++ b/lib/components/progress-bar/progress-bar.visual.test.ts
@@ -1,0 +1,174 @@
+import { html } from "@open-wc/testing";
+import { IconAchievementsSm, IconCheckmarkSm } from "@stackoverflow/stacks-icons/icons";
+import { defaultOptions, runComponentTests } from "../../test/test-utils";
+import "../../index";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const template = ({ component, testid }: any) => html`
+    <div class="d-flex ai-center jc-center p8 ws2" data-testid="${testid}">${component}</div>
+`;
+
+const steppedItems = [{
+    complete: true,
+    label: "Select plan"
+}, {
+    complete: true,
+    label: "Team name"
+}, {
+    active: true,
+    label: "Payment"
+}, {
+    label: "Create account"
+}];
+
+const getChildren = (type: string) => {
+    switch (type) {
+        case "badge":
+            return `<div class="s-progress--label" id="example-label">
+                <div class="s-badge--label">Electorate</div>
+            </div>
+            <div class="s-progress--bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" aria-labelledby="example-label" style="width: 75%;"></div>`;
+        case "circular":
+            return `<svg class="s-progress-bar" viewbox="0 0 32 32" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75">
+                <circle cx="16" cy="16" r="14"></circle>
+                <circle cx="16" cy="16" r="14"></circle>
+            </svg>`;
+        case "privilege":
+            return `
+                <div class="s-progress--label" id="progress-label">
+                    ${IconAchievementsSm}
+                    Access Review Queues
+                </div>
+                <div class="s-progress--bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" aria-labelledby="progress-label" style="width: 75%;"></div>
+            `;
+        case "segmented":
+            return `
+                <div class="s-progress--bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" aria-label="…" style="width: 75%;"></div>
+                <ol class="s-progress--segments">
+                    <li></li><li></li><li></li>
+                </ol>
+            `;
+        case "stepped":
+            return steppedItems.map((step, i) => {
+                return `
+                    <div
+                        class="
+                            s-progress--step
+                            ${step.active ? "is-active" : ""}
+                            ${step.complete ? "is-complete" : ""}
+                        "
+                    >
+                        <a href="#" class="s-progress--stop">
+                            ${step.complete ? IconCheckmarkSm : ""}
+                        </a>
+                        ${i > 0 ? '<div class="s-progress--bar s-progress--bar__left"></div>' : ""}
+
+                        ${i < steppedItems.length - 1 ? '<div class="s-progress--bar s-progress--bar__right"></div>' : ""}
+                        <a class="s-progress--label">${step.label}</a>
+                    </div>
+                `;
+                }).join("");
+        default:
+            return `<div class="s-progress--bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="75" aria-label="progress" style="width: 75%"></div>`;
+    }
+}
+describe("progress-bar", () => {
+    // Base
+    runComponentTests({
+        type: "visual",
+        baseClass: "s-progress",
+        variants: ["brand", "info"],
+        children: {
+            default: getChildren("")
+        },
+        template
+    });
+
+    // Badge
+    runComponentTests({
+        type: "visual",
+        baseClass: "s-progress",
+        variants: ["badge"],
+        modifiers: {
+            primary: ["gold", "silver", "bronze"]
+        },
+        children: {
+            default: getChildren("badge")
+        },
+        template,
+        options: {
+            ...defaultOptions,
+            includeNullVariant: false,
+            includeNullModifier: false
+        }
+    });
+
+    // Circular
+    runComponentTests({
+        type: "visual",
+        baseClass: "s-progress",
+        variants: ["circular"],
+        modifiers: {
+            global: ["fc-green-400", "fc-theme-primary"]
+        },
+        children: {
+            default: getChildren("circular")
+        },
+        template,
+        attributes: {
+            style: "--s-progress-value: .75"
+        },
+        options: {
+            ...defaultOptions,
+            includeNullVariant: false,
+            includeNullModifier: false
+        }
+    });
+
+    // Privilege
+    runComponentTests({
+        type: "visual",
+        baseClass: "s-progress",
+        variants: ["privilege"],
+        children: {
+            default: getChildren("privilege")
+        },
+        template,
+        options: {
+            ...defaultOptions,
+            includeNullVariant: false,
+        }
+    });
+
+    // Segmented
+    runComponentTests({
+        type: "visual",
+        baseClass: "s-progress",
+        variants: ["segmented"],
+        children: {
+            default: getChildren("segmented")
+        },
+        template,
+        options: {
+            ...defaultOptions,
+            includeNullVariant: false,
+        }
+    });
+
+    // Stepped
+    runComponentTests({
+        type: "visual",
+        baseClass: "s-progress",
+        variants: ["stepped"],
+        children: {
+            default: getChildren("stepped")
+        },
+        template: ({ component, testid }) => html`
+            <div class="d-block p8 ws5" data-testid="${testid}">${component}</div>
+        `,
+        options: {
+            ...defaultOptions,
+            includeNullVariant: false,
+        }
+    });
+});

--- a/screenshots/Chromium/baseline/s-progress-dark-badge-bronze.png
+++ b/screenshots/Chromium/baseline/s-progress-dark-badge-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:620796eb20e7a22ba0a0999262c75594c774c559bb9d8801a667ad1e1aa2ef61
+size 1820

--- a/screenshots/Chromium/baseline/s-progress-dark-badge-gold.png
+++ b/screenshots/Chromium/baseline/s-progress-dark-badge-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e2d177b97481cc10ecea7fed1f2c8d2c005dd133e7a87900ae7af772e8beb70
+size 1808

--- a/screenshots/Chromium/baseline/s-progress-dark-badge-silver.png
+++ b/screenshots/Chromium/baseline/s-progress-dark-badge-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a16f13b0de09a34be0586739f579e18696ea4cb0c176dcaf3310eb4ece7c42ca
+size 1810

--- a/screenshots/Chromium/baseline/s-progress-dark-brand.png
+++ b/screenshots/Chromium/baseline/s-progress-dark-brand.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:777ec7fae203d4afd3436d25e11648dc764d40d05d9bee7ac331e08cd1f29172
+size 281

--- a/screenshots/Chromium/baseline/s-progress-dark-circular-fc-green-400.png
+++ b/screenshots/Chromium/baseline/s-progress-dark-circular-fc-green-400.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c74f144fc479bdc76a2069abe6b8881e0e62eda572a95a035b7a57dcd1b8aa45
+size 1359

--- a/screenshots/Chromium/baseline/s-progress-dark-circular-fc-theme-primary.png
+++ b/screenshots/Chromium/baseline/s-progress-dark-circular-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1689b081e258ca648ecddd51db41c19b45d97398670a100daa0799ecaa935749
+size 1349

--- a/screenshots/Chromium/baseline/s-progress-dark-circular.png
+++ b/screenshots/Chromium/baseline/s-progress-dark-circular.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c672b2f2c441f87a550acf1cd213792e7042d6e34302e63e3d1bdc8c1ef9c637
+size 1286

--- a/screenshots/Chromium/baseline/s-progress-dark-info.png
+++ b/screenshots/Chromium/baseline/s-progress-dark-info.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:149ee96252d3bcfd7dcef47992f07a99293e9f5e028f325368ca1d37e71f0dad
+size 286

--- a/screenshots/Chromium/baseline/s-progress-dark-privilege.png
+++ b/screenshots/Chromium/baseline/s-progress-dark-privilege.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f11280fb494d0ac217ec83f4b8c928153a0339ca67849d856c7f400cc4ce5b70
+size 3169

--- a/screenshots/Chromium/baseline/s-progress-dark-segmented.png
+++ b/screenshots/Chromium/baseline/s-progress-dark-segmented.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2235d095e8c6519cb2a8d52027e29c9a4e23184766fd50fb0f2b33c0df28524
+size 304

--- a/screenshots/Chromium/baseline/s-progress-dark-stepped.png
+++ b/screenshots/Chromium/baseline/s-progress-dark-stepped.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:daa78114f07ce94fc0155074e76964eeafcaf33d32ae991c03cb67a469d6684b
+size 6776

--- a/screenshots/Chromium/baseline/s-progress-dark.png
+++ b/screenshots/Chromium/baseline/s-progress-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdaa6296d8dd21152239d0d4c044d256827595d8aa5b72197a4f27b8f0d4074d
+size 283

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-dark-badge-bronze.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-dark-badge-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ca2ae1d720aeb95d03eec4c87f501a1b3a40145900128b49bfcab518f0a7a09
+size 1815

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-dark-badge-gold.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-dark-badge-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:883951e1dc60ce291c51d5c57164cbcf9eef0c5f24fb132c7dbd6a1633e5c112
+size 1830

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-dark-badge-silver.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-dark-badge-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:750aa7121d03653c051a042fbac92d714921baf67a416beab4758d19122ef80e
+size 1813

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-dark-brand.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-dark-brand.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9f7b83a52dc7a428c56b8edaaeeebf7d320cc3428dace3a49f135de6ace4bf6
+size 277

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-dark-circular-fc-green-400.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-dark-circular-fc-green-400.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d4342fafabd447c0714aff5ec4462ee0aa7b1ec09524db65c1eee886493ad1f
+size 1362

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-dark-circular-fc-theme-primary.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-dark-circular-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f00ed2f352f37d1e04c8b8318a4140d1f9fb574727d54d0efd06651fab9f82eb
+size 1367

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-dark-circular.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-dark-circular.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65a4234e12595b9e00cab6879b418fa41b7756ad4e822925206d981d2ac773c8
+size 1255

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-dark-info.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-dark-info.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4af08d421b5423a04c5e4669748e526a3ce6947981287cf48d228c99e895dd3
+size 282

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-dark-privilege.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-dark-privilege.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d82cbdac14fe62123651c9f55e18215294dc4e9c542d1cfb5c5a836b59d6dd3d
+size 3072

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-dark-segmented.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-dark-segmented.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13cba05366fcfeefd7b7749395e17998fd6ba8c188f967173e02ab036a849c9b
+size 299

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-dark-stepped.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-dark-stepped.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f718ab060e8d874bdfd6d6d8a657a3d0bb8aa461a518bf9e729a4f556d9c110
+size 6703

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-dark.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2c7531bdbffde97b2f4ecdd22159cf8cfd077fc19a197ac051a4f33ac0bff4c
+size 281

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-light-badge-bronze.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-light-badge-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26eb07327f23653a398e471f60bd1ed8cdb7c867c68bf623ce29c4b994497741
+size 1819

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-light-badge-gold.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-light-badge-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8c22561ad7ec8a556c844d5b45e7fe71433763569960fd21eb9a6a1768fafe3
+size 1794

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-light-badge-silver.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-light-badge-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4487a6d8d6b7d382545f374eba0aaa4a78470aa4805af903eb5689559ea4552
+size 1766

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-light-brand.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-light-brand.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f88ec6e3e452518dbbeda6488d63b82d5c7374b14ce0f6c8b6bb15792b26065f
+size 280

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-light-circular-fc-green-400.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-light-circular-fc-green-400.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:307f7c3f77b1973b9071f0a4b4a1c18c249d93c6c47aa0c1ac654c3ade0d3fc3
+size 1348

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-light-circular-fc-theme-primary.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-light-circular-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36a4bb9ec348b2f0d634e4e8d5e6ec66ec5f41040b941f9180030d7525160bb1
+size 1257

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-light-circular.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-light-circular.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:478ffa984c55c6bc74c1f1e0e5c1b294bdb677c15707364b009e02aa5cd47553
+size 1286

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-light-info.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-light-info.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82d8a6d41d4bec80eaf83bda9062d917b84bc9b65243194b07bae6b27fc63470
+size 289

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-light-privilege.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-light-privilege.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23f0a205a2d1bc36bfabeada55f785defc263fad7d89dbbf8e215cdd121afe69
+size 2995

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-light-segmented.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-light-segmented.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:709ec8e82bc804c162eb31154e7a8ee02bb5a5c524c238423018b73fb7e7139f
+size 307

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-light-stepped.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-light-stepped.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0fb33984a7e007df8b71df8c9ff9e91ad80e62b6cbc22cb0c587c3b8bc6cf94
+size 6795

--- a/screenshots/Chromium/baseline/s-progress-highcontrast-light.png
+++ b/screenshots/Chromium/baseline/s-progress-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d4b0e757c2bf7bcd56b7e727d3823d75ce1a153fe6da6ef54df7239b64a99db
+size 292

--- a/screenshots/Chromium/baseline/s-progress-light-badge-bronze.png
+++ b/screenshots/Chromium/baseline/s-progress-light-badge-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbba0e31049ed89d9dbf9676ab2a98a5c404543b9d450800b40266091df59656
+size 1817

--- a/screenshots/Chromium/baseline/s-progress-light-badge-gold.png
+++ b/screenshots/Chromium/baseline/s-progress-light-badge-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42571be744423ae9fbb76c13312b081a6ab5bc253392d11341f69a9273b4715b
+size 1790

--- a/screenshots/Chromium/baseline/s-progress-light-badge-silver.png
+++ b/screenshots/Chromium/baseline/s-progress-light-badge-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4487a6d8d6b7d382545f374eba0aaa4a78470aa4805af903eb5689559ea4552
+size 1766

--- a/screenshots/Chromium/baseline/s-progress-light-brand.png
+++ b/screenshots/Chromium/baseline/s-progress-light-brand.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1560bc201381a70353bfdb59671be8bfdb014fa2c541f0b3ed911e3c9564cdf0
+size 285

--- a/screenshots/Chromium/baseline/s-progress-light-circular-fc-green-400.png
+++ b/screenshots/Chromium/baseline/s-progress-light-circular-fc-green-400.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1187626192cef6660d811f947135a7e01d2bba263761ca857ec1608fbacba897
+size 1343

--- a/screenshots/Chromium/baseline/s-progress-light-circular-fc-theme-primary.png
+++ b/screenshots/Chromium/baseline/s-progress-light-circular-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b35caa25f681dae6ebb55cfd73f727c515976f27599880c44cb03bf3e8ecb39
+size 1280

--- a/screenshots/Chromium/baseline/s-progress-light-circular.png
+++ b/screenshots/Chromium/baseline/s-progress-light-circular.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:478ffa984c55c6bc74c1f1e0e5c1b294bdb677c15707364b009e02aa5cd47553
+size 1286

--- a/screenshots/Chromium/baseline/s-progress-light-info.png
+++ b/screenshots/Chromium/baseline/s-progress-light-info.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37fb7b8582d4a03704a1563e538aeaa8bae023bf187139ca939c47db12276e62
+size 286

--- a/screenshots/Chromium/baseline/s-progress-light-privilege.png
+++ b/screenshots/Chromium/baseline/s-progress-light-privilege.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31aa5ce8655c104a4a8120c57f710bdc5d5ab5be34d2fbe8039cef0383b2bf02
+size 3173

--- a/screenshots/Chromium/baseline/s-progress-light-segmented.png
+++ b/screenshots/Chromium/baseline/s-progress-light-segmented.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf38bae3b4bfc67d5556c40bd1c05f37e2e02b57d909effe0317b95a6df59b33
+size 305

--- a/screenshots/Chromium/baseline/s-progress-light-stepped.png
+++ b/screenshots/Chromium/baseline/s-progress-light-stepped.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb528a0ee83b8619d99ceee83ba40c6b46fb1e23951fff75c4c812b6ff85a823
+size 6546

--- a/screenshots/Chromium/baseline/s-progress-light.png
+++ b/screenshots/Chromium/baseline/s-progress-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:746b2dad5ac83b98017351ecd85988b90507ad3fc956724d76168d88750a6319
+size 288

--- a/screenshots/Firefox/baseline/s-progress-dark-badge-bronze.png
+++ b/screenshots/Firefox/baseline/s-progress-dark-badge-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e7f56c39d39153a17c6f5dae63b1ff4cda81e0b585f2e5f937807d6529b45fa
+size 1868

--- a/screenshots/Firefox/baseline/s-progress-dark-badge-gold.png
+++ b/screenshots/Firefox/baseline/s-progress-dark-badge-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a1c1c0ad81c51480403d95f2656819ac1d80420b80fe32bbf9b1222e4649357
+size 1907

--- a/screenshots/Firefox/baseline/s-progress-dark-badge-silver.png
+++ b/screenshots/Firefox/baseline/s-progress-dark-badge-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ccd28446c42d999d43186fcc86cb058b027f3fcdee81c13975f48ef9965023a
+size 1861

--- a/screenshots/Firefox/baseline/s-progress-dark-brand.png
+++ b/screenshots/Firefox/baseline/s-progress-dark-brand.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdf3a97659bc1a14331d8f404935856cdf8476b5b5cac2448222ce347db02439
+size 352

--- a/screenshots/Firefox/baseline/s-progress-dark-circular-fc-green-400.png
+++ b/screenshots/Firefox/baseline/s-progress-dark-circular-fc-green-400.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0fd2c2e4a151fb592f3a72ee7407c2d05afd03fb5773a39eaf8e13927f224d3
+size 1563

--- a/screenshots/Firefox/baseline/s-progress-dark-circular-fc-theme-primary.png
+++ b/screenshots/Firefox/baseline/s-progress-dark-circular-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f9e3efe2e5f2c596dc5a5dd0373d85365ac2e8ef0786904de83c780edb80043
+size 1573

--- a/screenshots/Firefox/baseline/s-progress-dark-circular.png
+++ b/screenshots/Firefox/baseline/s-progress-dark-circular.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccf1c52b331225e534d9d3bebf08130dc0ff5515d22b116fc8b0cb3756bbfd42
+size 1543

--- a/screenshots/Firefox/baseline/s-progress-dark-info.png
+++ b/screenshots/Firefox/baseline/s-progress-dark-info.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cae8b14da3506f30a0d1b03b8ed32d5895bc61bc9487f9d26f1b255451a854f0
+size 351

--- a/screenshots/Firefox/baseline/s-progress-dark-privilege.png
+++ b/screenshots/Firefox/baseline/s-progress-dark-privilege.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74cd81784198a09f68937f1224f0c1e83503f8313d10846af47ed28cf54fdbcb
+size 3284

--- a/screenshots/Firefox/baseline/s-progress-dark-segmented.png
+++ b/screenshots/Firefox/baseline/s-progress-dark-segmented.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:501fb549f4ebc8a93b52acc9181d8fe31834ec08ad652e1264301aa61f4f4257
+size 364

--- a/screenshots/Firefox/baseline/s-progress-dark-stepped.png
+++ b/screenshots/Firefox/baseline/s-progress-dark-stepped.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0468f04cb37159fe280840343d6b5db3a4d3ce59a1bdb0f48caed08d697994a
+size 7451

--- a/screenshots/Firefox/baseline/s-progress-dark.png
+++ b/screenshots/Firefox/baseline/s-progress-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e74e3eca0cf34b9016473fa15931e7fe63d1bf9a58fa785f74b8d5d4764826b
+size 349

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-dark-badge-bronze.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-dark-badge-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcf3a6d61440e7dff2611271be78dfe51bc41e6978a5b68a747f36dd776f6d1a
+size 1871

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-dark-badge-gold.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-dark-badge-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e35b81c685589aeed2ffb7cad0134ccf3c1cbdfefe668cd5120d2f768dcb80fc
+size 1880

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-dark-badge-silver.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-dark-badge-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba7005632310a15f46e119ca0810a05628b41b410c93c1e41830bc593755259a
+size 1868

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-dark-brand.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-dark-brand.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4bb18900a8dfde3254e3b26779c70962d1c078a754c4ba40b4967e09c0490cdd
+size 364

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-dark-circular-fc-green-400.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-dark-circular-fc-green-400.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:896f79c4b18aa4e9025a8fdb2703cb3482ca4d9876c764f1e23e0fc1c905ed5b
+size 1576

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-dark-circular-fc-theme-primary.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-dark-circular-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2dc74a8fe5b027c4328944e3fec408426f411ee12a1aaae5d1b6024a2f620d81
+size 1581

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-dark-circular.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-dark-circular.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c3d18d8bcae240c60493953463c725cc90a4abd48a1a7ee0849cc663bb0510a
+size 1504

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-dark-info.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-dark-info.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e35ca6dfaaf7a0fdf27221e4195fc777156fd8a97ec9ede95f887ef20519f804
+size 353

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-dark-privilege.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-dark-privilege.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:651608856e59b2034e86c3003ca5174599b01ed75c87a352a7df0f760c48933e
+size 3170

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-dark-segmented.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-dark-segmented.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af83871a303ac505268e13bca53178ad885c6625f1a5ddecab1a47dc13bd8697
+size 389

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-dark-stepped.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-dark-stepped.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1423b1bc6fe6ee25dfb70261ebf0952a8d04ce1b61d6344ebbf19c04a7f7eb24
+size 7367

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-dark.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1049d59c7588f7257cdca0672dc782d5166d6cd2a8c93d43adc49ca60c4dc169
+size 366

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-light-badge-bronze.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-light-badge-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d441c058767106f3a34bed277eb765bf0dd4027ff58f9eedb3415682fa86564a
+size 1899

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-light-badge-gold.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-light-badge-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:608f04130cc7671328b1bb40f920b1aa363c24450a6c3b5e89a10b7a7b807908
+size 1887

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-light-badge-silver.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-light-badge-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a91fcc90d8a20f72c1e2999127cbe9ef69ebf01da7af537e0fa6b3ca720b8168
+size 1847

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-light-brand.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-light-brand.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4ece2ab28c1010bb4b2a484b569d2a4b73ed8c3a21ebaaf3c54dfafdc29a427
+size 366

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-light-circular-fc-green-400.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-light-circular-fc-green-400.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15a14a26d29a334be21cdc9ec4607f0ea0e9cb0d4df31d5f5ac9ebc24fd4d421
+size 1583

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-light-circular-fc-theme-primary.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-light-circular-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87adb427b7102f1a2a81f8afabf4f0097217050d3bf2a64c27928f320b93be24
+size 1543

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-light-circular.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-light-circular.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aae33568af8bea500e0b3b11b78004a0349b4e1948957ec8e927e91334cb4c1e
+size 1543

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-light-info.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-light-info.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da865574f99dda5b8da729c7a1c3149e42c2c536a22191eaebb0a7a0ca89fa44
+size 366

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-light-privilege.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-light-privilege.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a42d7bcd069d20f775c0d98503d54707a367bd5d12fcbe2c0d82c9196aa48e41
+size 3176

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-light-segmented.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-light-segmented.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6ddc724621f1df6b35280afa68d222202f9f5c3713b051f02e60de559037178
+size 398

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-light-stepped.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-light-stepped.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:773cb60736ad1fb7ee974d5974d29f25a47f0602cd13ebc4393d838986471a92
+size 7689

--- a/screenshots/Firefox/baseline/s-progress-highcontrast-light.png
+++ b/screenshots/Firefox/baseline/s-progress-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:185361bd41403a83a84daca8f511331b3b0e9c723857ef50db8e17508431af45
+size 372

--- a/screenshots/Firefox/baseline/s-progress-light-badge-bronze.png
+++ b/screenshots/Firefox/baseline/s-progress-light-badge-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d441c058767106f3a34bed277eb765bf0dd4027ff58f9eedb3415682fa86564a
+size 1899

--- a/screenshots/Firefox/baseline/s-progress-light-badge-gold.png
+++ b/screenshots/Firefox/baseline/s-progress-light-badge-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:608f04130cc7671328b1bb40f920b1aa363c24450a6c3b5e89a10b7a7b807908
+size 1887

--- a/screenshots/Firefox/baseline/s-progress-light-badge-silver.png
+++ b/screenshots/Firefox/baseline/s-progress-light-badge-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a91fcc90d8a20f72c1e2999127cbe9ef69ebf01da7af537e0fa6b3ca720b8168
+size 1847

--- a/screenshots/Firefox/baseline/s-progress-light-brand.png
+++ b/screenshots/Firefox/baseline/s-progress-light-brand.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a05ba00b830817acbc657fa9fba26a990ae89768bf7d402372e93a01c63b316e
+size 365

--- a/screenshots/Firefox/baseline/s-progress-light-circular-fc-green-400.png
+++ b/screenshots/Firefox/baseline/s-progress-light-circular-fc-green-400.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ead227a00be8940eea47825217e342bb8901a2bd7148add8d2931b79d9d9c549
+size 1566

--- a/screenshots/Firefox/baseline/s-progress-light-circular-fc-theme-primary.png
+++ b/screenshots/Firefox/baseline/s-progress-light-circular-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71bb7f3a714f0c8abc40628e3d008c0b85cba3ae32dd1983ec639c926072f25d
+size 1524

--- a/screenshots/Firefox/baseline/s-progress-light-circular.png
+++ b/screenshots/Firefox/baseline/s-progress-light-circular.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aae33568af8bea500e0b3b11b78004a0349b4e1948957ec8e927e91334cb4c1e
+size 1543

--- a/screenshots/Firefox/baseline/s-progress-light-info.png
+++ b/screenshots/Firefox/baseline/s-progress-light-info.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82135e876c9e012b200c2cc3caa043c6385b725ea2e710d5360c1f2516cc35c5
+size 362

--- a/screenshots/Firefox/baseline/s-progress-light-privilege.png
+++ b/screenshots/Firefox/baseline/s-progress-light-privilege.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1e7418272d1e336a6fb5b2977dce88df6c752cddab8fdc109c9ff8b0c1e6fb3
+size 3294

--- a/screenshots/Firefox/baseline/s-progress-light-segmented.png
+++ b/screenshots/Firefox/baseline/s-progress-light-segmented.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbb54530a2718593a32f44fa306f09adee1571aebedcdfece858d9c81fa35fdf
+size 401

--- a/screenshots/Firefox/baseline/s-progress-light-stepped.png
+++ b/screenshots/Firefox/baseline/s-progress-light-stepped.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfb3e75a90a74af46f04d6acfa1b6e5b975049546d31f4604402ede9ca4b0d9f
+size 7366

--- a/screenshots/Firefox/baseline/s-progress-light.png
+++ b/screenshots/Firefox/baseline/s-progress-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e7d211b51298045c85fa79a85fad8e34f8b38ddb7d7af81823e6337ee3895a9
+size 378

--- a/screenshots/Webkit/baseline/s-progress-dark-badge-bronze.png
+++ b/screenshots/Webkit/baseline/s-progress-dark-badge-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c7550e1379497d0fe0da4a6cb2f63e424dd9572ea54a81e7e5408c2c0ebf44c
+size 1570

--- a/screenshots/Webkit/baseline/s-progress-dark-badge-gold.png
+++ b/screenshots/Webkit/baseline/s-progress-dark-badge-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97e31eceb2190448cd25faf045a86b14cd16c77449fa3d90343d27597ea62659
+size 1554

--- a/screenshots/Webkit/baseline/s-progress-dark-badge-silver.png
+++ b/screenshots/Webkit/baseline/s-progress-dark-badge-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffae38a2f9ad77abc1dcb0a09b166f4fbb92c0267c355ea9b5ec745562dee3c1
+size 1527

--- a/screenshots/Webkit/baseline/s-progress-dark-brand.png
+++ b/screenshots/Webkit/baseline/s-progress-dark-brand.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d325fa6b54caa479dc8c14c4feaf6c69e367e8fba01f5fe4cf2e9283bf41865
+size 274

--- a/screenshots/Webkit/baseline/s-progress-dark-circular-fc-green-400.png
+++ b/screenshots/Webkit/baseline/s-progress-dark-circular-fc-green-400.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6948b7540e621d1bd85e4af1168350e63cf349294bebe74ed69fc95dac12bead
+size 1448

--- a/screenshots/Webkit/baseline/s-progress-dark-circular-fc-theme-primary.png
+++ b/screenshots/Webkit/baseline/s-progress-dark-circular-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4b7148da8a9ec80eaa2c501aff033acc9bc5465575afbda1787ac0afcf53929
+size 1458

--- a/screenshots/Webkit/baseline/s-progress-dark-circular.png
+++ b/screenshots/Webkit/baseline/s-progress-dark-circular.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:182557cfda1af4f203d30c2bbaf5d1f8497ab72d31a7528a2bc6e5367811e2ba
+size 1435

--- a/screenshots/Webkit/baseline/s-progress-dark-info.png
+++ b/screenshots/Webkit/baseline/s-progress-dark-info.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e230701626340b71a9bd01b7efc22a21bd5fb1f7cdd22973c83cdf8105ab0d94
+size 279

--- a/screenshots/Webkit/baseline/s-progress-dark-privilege.png
+++ b/screenshots/Webkit/baseline/s-progress-dark-privilege.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b500811909c788376ca2042c222d7482f7ebfe606ec446cf8c745a0967a94e66
+size 2808

--- a/screenshots/Webkit/baseline/s-progress-dark-segmented.png
+++ b/screenshots/Webkit/baseline/s-progress-dark-segmented.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1d28b64fe6aebc6107999c3a78f1f6bb88e96eabdf5c0fceeadab8ab6eaa990
+size 293

--- a/screenshots/Webkit/baseline/s-progress-dark-stepped.png
+++ b/screenshots/Webkit/baseline/s-progress-dark-stepped.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9470c836d443e35539662ceb1cce42efc974faa595fb5191261db66adb3dbeff
+size 5483

--- a/screenshots/Webkit/baseline/s-progress-dark.png
+++ b/screenshots/Webkit/baseline/s-progress-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6a1e67641f07b5859b47cf9f0e590dc6cc76b3c0f6a1e08be17b5810d882fe6
+size 274

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-dark-badge-bronze.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-dark-badge-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60e8ea72a8b6f88a7f2aca276e132a9f1ad36906538acb98760eb43cbafb7a0a
+size 1519

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-dark-badge-gold.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-dark-badge-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a0585364582e5e90da77c267223fc7b4da1d09632d3992a76a2cdd8db639cff
+size 1515

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-dark-badge-silver.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-dark-badge-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba5fe6570f7912346852b639ae37bdd8e675d096f81e457b4c4f25d0b1148992
+size 1495

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-dark-brand.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-dark-brand.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b59e913aeffa2d8e6459594593533dc7eef559ecdcc96eb8d64cde6b620bc878
+size 242

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-dark-circular-fc-green-400.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-dark-circular-fc-green-400.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aa5fee7e7e680ae5ece6273d3922a0fed8b021b0cdf93d523da726a6890213e
+size 1438

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-dark-circular-fc-theme-primary.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-dark-circular-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e43bde085fe5d73b8a6e5d267009404716ee7bea28496a2fdea5c77ef7d484bd
+size 1451

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-dark-circular.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-dark-circular.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15d162fdae6c0fd92d0772e32c0f3e570a2f6ce4bc3ae16e8dc56a08bcf615b9
+size 1276

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-dark-info.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-dark-info.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f8728915277ab151b453c2a6df82aa61a9b018f2f832f41e2c4a8ea340b1371
+size 249

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-dark-privilege.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-dark-privilege.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e89859373d4f02aa4a59d6db36ce16813b28a9f8be204f8be6ba910af1482654
+size 2665

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-dark-segmented.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-dark-segmented.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52c94636e4b0d2878658e72c968680e4b105797361114036c08fa316a63c4010
+size 258

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-dark-stepped.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-dark-stepped.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f15efacf6ae74d2f4d2e95e26f103083a7da00c42bcb3c4defb8ef48663ed971
+size 5318

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-dark.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5692e7c554585594e134a1be5343040c68b34fcd3b6bbf8684575f1ad054aaa9
+size 250

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-light-badge-bronze.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-light-badge-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:def9b264ea809e6cae7ac5c113dc8ec8584714c8e84d5657d0bd85eb33e1da3e
+size 1521

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-light-badge-gold.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-light-badge-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d352706ee962767c0e4faf9dd75968637005c4a05ed744696586782a741c2190
+size 1516

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-light-badge-silver.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-light-badge-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5278ed35acff7053d8e629c8397a478b2aee128f1e64608e517fc522b72bf2e8
+size 1480

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-light-brand.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-light-brand.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ecf4354f80e1c0bd1131fc15bfd77ff18f362e84b465b7bf7ccaf5c1eaa1cea
+size 269

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-light-circular-fc-green-400.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-light-circular-fc-green-400.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:647512b87b070b6c9cf778dc1f06bf134a4a3cbffd5cf59c4495bd7d001e71d5
+size 1428

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-light-circular-fc-theme-primary.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-light-circular-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9ccb5af9ac51741e520eaf9572aaf46302300cdc9466d80ffdf5e973e5110fc
+size 1324

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-light-circular.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-light-circular.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0dd78f3958ab2c1b2b0d0720f7f6fe47b9d7bbeffab61e530c00cfb75d14f6d
+size 1419

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-light-info.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-light-info.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd0ab951e69dd447e7dc5de23d21615ee743f366c4b7914e8e03902d85e0bcb7
+size 278

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-light-privilege.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-light-privilege.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c23307c408a6e3a685edf9640e8cb48bcdc57358b6568f57c309abde1acd317c
+size 2601

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-light-segmented.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-light-segmented.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b36930de69ab6bc68537a85b3c241c2a6e49b546b0ee3bea18dd3c924f384f9
+size 294

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-light-stepped.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-light-stepped.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58aed4873926c1184c7a1e62b8d3bd0438663498594ec6e55cb9de4d5f7f5708
+size 5453

--- a/screenshots/Webkit/baseline/s-progress-highcontrast-light.png
+++ b/screenshots/Webkit/baseline/s-progress-highcontrast-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81585e30fd3f18ba86ba56f8d83129190ce9d877d3b16f0b601329c82272515e
+size 280

--- a/screenshots/Webkit/baseline/s-progress-light-badge-bronze.png
+++ b/screenshots/Webkit/baseline/s-progress-light-badge-bronze.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:def9b264ea809e6cae7ac5c113dc8ec8584714c8e84d5657d0bd85eb33e1da3e
+size 1521

--- a/screenshots/Webkit/baseline/s-progress-light-badge-gold.png
+++ b/screenshots/Webkit/baseline/s-progress-light-badge-gold.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d352706ee962767c0e4faf9dd75968637005c4a05ed744696586782a741c2190
+size 1516

--- a/screenshots/Webkit/baseline/s-progress-light-badge-silver.png
+++ b/screenshots/Webkit/baseline/s-progress-light-badge-silver.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5278ed35acff7053d8e629c8397a478b2aee128f1e64608e517fc522b72bf2e8
+size 1480

--- a/screenshots/Webkit/baseline/s-progress-light-brand.png
+++ b/screenshots/Webkit/baseline/s-progress-light-brand.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed5babb6e34d976ea792a33e274b3599edbe8e4f2fe61b39f426b1988f6f3fc4
+size 274

--- a/screenshots/Webkit/baseline/s-progress-light-circular-fc-green-400.png
+++ b/screenshots/Webkit/baseline/s-progress-light-circular-fc-green-400.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10c215f26d7dac831dbeda6b80166e44763bbd7b6c909b20b870ecd9c6f51c61
+size 1425

--- a/screenshots/Webkit/baseline/s-progress-light-circular-fc-theme-primary.png
+++ b/screenshots/Webkit/baseline/s-progress-light-circular-fc-theme-primary.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:544f166c7a4eaf1ff6fc8ea0d3c8f178456311656aab6a75d3e059aed52f5874
+size 1370

--- a/screenshots/Webkit/baseline/s-progress-light-circular.png
+++ b/screenshots/Webkit/baseline/s-progress-light-circular.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0dd78f3958ab2c1b2b0d0720f7f6fe47b9d7bbeffab61e530c00cfb75d14f6d
+size 1419

--- a/screenshots/Webkit/baseline/s-progress-light-info.png
+++ b/screenshots/Webkit/baseline/s-progress-light-info.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:055afb0ff4c46364533877d225bd2fdc023eb167928f8083e94831485f0fa9b4
+size 272

--- a/screenshots/Webkit/baseline/s-progress-light-privilege.png
+++ b/screenshots/Webkit/baseline/s-progress-light-privilege.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4a5e0417a378ef2c3b2328046e612f3fde1b4006703ec9d578d0f6987ae7641
+size 2771

--- a/screenshots/Webkit/baseline/s-progress-light-segmented.png
+++ b/screenshots/Webkit/baseline/s-progress-light-segmented.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34e4efafd08fb8cd6ca2000fb145d20e1710489891d3f9732d7972550b53dfe1
+size 294

--- a/screenshots/Webkit/baseline/s-progress-light-stepped.png
+++ b/screenshots/Webkit/baseline/s-progress-light-stepped.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7beaec8124af015d988fe2b5f14176d47d2b2fe1109548f8de559138e6e2015
+size 5193

--- a/screenshots/Webkit/baseline/s-progress-light.png
+++ b/screenshots/Webkit/baseline/s-progress-light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad1a3da318b92c3bdd3f92ad2d6929c7e5b588b7f36941d1bae01b5b7d29281a
+size 279


### PR DESCRIPTION
This PR adds visual and accessibility tests for the `.s-progress-bar` component.

## TODO
- [x] Generate baseline images