### PR TITLE
fix(a11y): make focus ring meet 3:1 requirements

### DIFF
--- a/docs/_data/atomics.json
+++ b/docs/_data/atomics.json
@@ -26,7 +26,7 @@
     },
     {
       "class": "bs-ring",
-      "output": "box-shadow: 0 0 0 var(--su-static4) var(--focus-ring);",
+      "output": "box-shadow: var(--focus-ring-divider), 0 0 0 var(--_focus-ring-size, var(--su-static4)) var(--_focus-ring-color, var(--focus-ring));",
       "hover": true,
       "focus": true
     }

--- a/docs/_data/atomics.json
+++ b/docs/_data/atomics.json
@@ -29,6 +29,12 @@
       "output": "box-shadow: var(--focus-ring-divider), 0 0 0 var(--_focus-ring-size, var(--su-static4)) var(--_focus-ring-color, var(--focus-ring));",
       "hover": true,
       "focus": true
+    },
+    {
+      "class": "bs-ring-inset",
+      "output": "box-shadow: 0 0 0 var(--_focus-ring-size, var(--su-static4)) var(--_focus-ring-color, var(--focus-ring)), var(--focus-ring-divider-inset);",
+      "hover": true,
+      "focus": true
     }
   ],
   "box-sizing": [

--- a/docs/product/base/box-shadow.html
+++ b/docs/product/base/box-shadow.html
@@ -51,24 +51,15 @@ description: Box shadow atomic classes allow you to change an element’s box sh
 <div class="bs-lg">…</div>
 <div class="bs-xl">…</div>
 <div class="bs-ring">…</div>
+<div class="bs-ring-inset">…</div>
 {% endhighlight %}
         <div class="stacks-preview--example fs-caption ff-mono">
             <div class="d-grid grid__4 lg:grid__3 sm:grid__2 g16">
-                <div class="flex--item fd-column p12 bs-sm bar-sm h96">
-                    .bs-sm
-                </div>
-                <div class="flex--item fd-column p12 bs-md bar-sm h96">
-                    .bs-md
-                </div>
-                <div class="flex--item fd-column p12 bs-lg bar-sm h96">
-                    .bs-lg
-                </div>
-                <div class="flex--item fd-column p12 bs-xl bar-sm h96">
-                    .bs-xl
-                </div>
-                <div class="flex--item fd-column p12 bs-ring bar-sm h96">
-                    .bs-ring
-                </div>
+                {% for atomic in atomics.box-shadow %}
+                    <div class="fd-column p12 bar-sm h96 {{ atomic.class }}">
+                        .{{ atomic.class }}
+                    </div>
+                {% endfor %}
             </div>
         </div>
     </div>

--- a/docs/product/components/tags.html
+++ b/docs/product/components/tags.html
@@ -36,7 +36,7 @@ description: Tags are an interactive, community-generated keyword that allow com
 {% highlight html %}
 <div class="d-flex g4">
     <a class="s-tag" href="#">jquery</a>
-    <a class="s-tag" href="#">javascript <span class="s-tag--dismiss">@Svg.ClearSm</span></a>
+    <span class="s-tag" href="#">javascript <button class="s-tag--dismiss">@Svg.ClearSm</button></span>
     <a class="s-tag" href="#"><img class="s-tag--sponsor" src="https://i.stack.imgur.com/tKsDb.png" width="16" height="18" alt="Google Android"> android</a>
     <a class="s-tag is-selected" href="#">razor <span class="s-tag--dismiss">@Svg.ClearSm</span></a>
 </div>
@@ -44,9 +44,9 @@ description: Tags are an interactive, community-generated keyword that allow com
         <div class="stacks-preview--example">
             <div class="d-flex g4 fw-wrap">
                 <a class="s-tag" href="#">jquery</a>
-                <a class="s-tag" href="#">javascript <span class="s-tag--dismiss">{% icon "ClearSm" %}</span></a>
+                <span class="s-tag" href="#">javascript <button class="s-tag--dismiss">{% icon "ClearSm" %}</button></span>
                 <a class="s-tag" href="#"><img class="s-tag--sponsor" src="https://i.stack.imgur.com/tKsDb.png" width="16" height="18" alt="Google Android"> android</a>
-                <a class="s-tag is-selected" href="#">razor <span class="s-tag--dismiss">{% icon "ClearSm" %} </span></a>
+                <span class="s-tag is-selected" href="#">razor <button class="s-tag--dismiss">{% icon "ClearSm" %}</button></span>
             </div>
         </div>
     </div>
@@ -56,7 +56,7 @@ description: Tags are an interactive, community-generated keyword that allow com
 {% highlight html %}
 <div class="d-flex g4">
     <a class="s-tag s-tag__moderator" href="#">status-completed</a>
-    <a class="s-tag s-tag__moderator" href="#">status-bydesign <span class="s-tag--dismiss">@Svg.ClearSm</span></a>
+    <span class="s-tag s-tag__moderator" href="#">status-bydesign <button class="s-tag--dismiss">@Svg.ClearSm</button></span>
     <a class="s-tag s-tag__moderator" href="#">status-planned</a>
     <a class="s-tag s-tag__moderator is-selected" href="#">status-deferred</a>
 </div>
@@ -64,7 +64,7 @@ description: Tags are an interactive, community-generated keyword that allow com
         <div class="stacks-preview--example">
             <div class="d-flex g4 fw-wrap">
                 <a class="s-tag s-tag__moderator" href="#">status-completed</a>
-                <a class="s-tag s-tag__moderator" href="#">status-bydesign <span class="s-tag--dismiss">{% icon "ClearSm" %}</span></a>
+                <span class="s-tag s-tag__moderator" href="#">status-bydesign <button class="s-tag--dismiss">{% icon "ClearSm" %}</button></span>
                 <a class="s-tag s-tag__moderator" href="#">status-planned</a>
                 <a class="s-tag s-tag__moderator is-selected" href="#">status-deferred</a>
             </div>
@@ -76,7 +76,7 @@ description: Tags are an interactive, community-generated keyword that allow com
 {% highlight html %}
 <div class="d-flex g4">
     <a class="s-tag s-tag__required" href="#">discussion</a>
-    <a class="s-tag s-tag__required" href="#">feature-request <span class="s-tag--dismiss">@Svg.ClearSm</span></a>
+    <span class="s-tag s-tag__required" href="#">feature-request <button class="s-tag--dismiss">@Svg.ClearSm</button></span>
     <a class="s-tag s-tag__required" href="#">bug</a>
     <a class="s-tag s-tag__required is-selected" href="#">featured</a>
 </div>
@@ -84,7 +84,7 @@ description: Tags are an interactive, community-generated keyword that allow com
         <div class="stacks-preview--example">
             <div class="d-flex g4 fw-wrap">
                 <a class="s-tag s-tag__required" href="#">discussion</a>
-                <a class="s-tag s-tag__required" href="#">feature-request <span class="s-tag--dismiss">{% icon "ClearSm" %}</span></a>
+                <span class="s-tag s-tag__required" href="#">feature-request <button class="s-tag--dismiss">{% icon "ClearSm" %}</button></span>
                 <a class="s-tag s-tag__required" href="#">bug</a>
                 <a class="s-tag s-tag__required is-selected" href="#">featured</a>
             </div>
@@ -96,17 +96,17 @@ description: Tags are an interactive, community-generated keyword that allow com
 {% highlight html %}
 <div class="d-flex g4">
     <a class="s-tag s-tag__muted" href="#">asp-net</a>
-    <a class="s-tag s-tag__muted" href="#">netscape <span class="s-tag--dismiss">@Svg.ClearSm</span></a>
+    <span class="s-tag s-tag__muted" href="#">netscape <button class="s-tag--dismiss">@Svg.ClearSm</button></span>
     <a class="s-tag s-tag__muted" href="#"><img class="s-tag--sponsor" src="https://i.stack.imgur.com/gfrSH.png" width="18" height="16" alt="SQL Server"> sql-server</a>
-    <a class="s-tag s-tag__muted is-selected" href="#">razor <span class="s-tag--dismiss">@Svg.ClearSm</span></a>
+    <span class="s-tag s-tag__muted is-selected" href="#">razor <button class="s-tag--dismiss">@Svg.ClearSm</button></span>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="d-flex g4 fw-wrap">
                 <a class="s-tag s-tag__muted" href="#">asp-net</a>
-                <a class="s-tag s-tag__muted" href="#">netscape <span class="s-tag--dismiss">{% icon "ClearSm" %}</span></a>
+                <span class="s-tag s-tag__muted" href="#">netscape <button class="s-tag--dismiss">{% icon "ClearSm" %}</button></span>
                 <a class="s-tag s-tag__muted" href="#"><img class="s-tag--sponsor" src="https://i.stack.imgur.com/gfrSH.png" width="18" height="16" alt="SQL Server"> sql-server</a>
-                <a class="s-tag s-tag__muted is-selected" href="#">razor <span class="s-tag--dismiss">{% icon "ClearSm" %}</span></a>
+                <span class="s-tag s-tag__muted is-selected" href="#">razor <button class="s-tag--dismiss">{% icon "ClearSm" %}</button></span>
             </div>
         </div>
     </div>

--- a/docs/product/components/tags.html
+++ b/docs/product/components/tags.html
@@ -36,17 +36,17 @@ description: Tags are an interactive, community-generated keyword that allow com
 {% highlight html %}
 <div class="d-flex g4">
     <a class="s-tag" href="#">jquery</a>
-    <span class="s-tag" href="#">javascript <button class="s-tag--dismiss">@Svg.ClearSm</button></span>
+    <span class="s-tag">javascript <button class="s-tag--dismiss js-clear-tag">@Svg.ClearSm</button></span>
     <a class="s-tag" href="#"><img class="s-tag--sponsor" src="https://i.stack.imgur.com/tKsDb.png" width="16" height="18" alt="Google Android"> android</a>
-    <a class="s-tag is-selected" href="#">razor <span class="s-tag--dismiss">@Svg.ClearSm</span></a>
+    <span class="s-tag is-selected">razor <button class="s-tag--dismiss js-clear-tag">@Svg.ClearSm</button></span>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="d-flex g4 fw-wrap">
                 <a class="s-tag" href="#">jquery</a>
-                <span class="s-tag" href="#">javascript <button class="s-tag--dismiss">{% icon "ClearSm" %}</button></span>
+                <span class="s-tag">javascript <button class="s-tag--dismiss js-clear-tag">{% icon "ClearSm" %}</button></span>
                 <a class="s-tag" href="#"><img class="s-tag--sponsor" src="https://i.stack.imgur.com/tKsDb.png" width="16" height="18" alt="Google Android"> android</a>
-                <span class="s-tag is-selected" href="#">razor <button class="s-tag--dismiss">{% icon "ClearSm" %}</button></span>
+                <span class="s-tag is-selected">razor <button class="s-tag--dismiss js-clear-tag">{% icon "ClearSm" %}</button></span>
             </div>
         </div>
     </div>
@@ -56,7 +56,7 @@ description: Tags are an interactive, community-generated keyword that allow com
 {% highlight html %}
 <div class="d-flex g4">
     <a class="s-tag s-tag__moderator" href="#">status-completed</a>
-    <span class="s-tag s-tag__moderator" href="#">status-bydesign <button class="s-tag--dismiss">@Svg.ClearSm</button></span>
+    <span class="s-tag s-tag__moderator">status-bydesign <button class="s-tag--dismiss js-clear-tag">@Svg.ClearSm</button></span>
     <a class="s-tag s-tag__moderator" href="#">status-planned</a>
     <a class="s-tag s-tag__moderator is-selected" href="#">status-deferred</a>
 </div>
@@ -64,7 +64,7 @@ description: Tags are an interactive, community-generated keyword that allow com
         <div class="stacks-preview--example">
             <div class="d-flex g4 fw-wrap">
                 <a class="s-tag s-tag__moderator" href="#">status-completed</a>
-                <span class="s-tag s-tag__moderator" href="#">status-bydesign <button class="s-tag--dismiss">{% icon "ClearSm" %}</button></span>
+                <span class="s-tag s-tag__moderator">status-bydesign <button class="s-tag--dismiss js-clear-tag">{% icon "ClearSm" %}</button></span>
                 <a class="s-tag s-tag__moderator" href="#">status-planned</a>
                 <a class="s-tag s-tag__moderator is-selected" href="#">status-deferred</a>
             </div>
@@ -76,7 +76,7 @@ description: Tags are an interactive, community-generated keyword that allow com
 {% highlight html %}
 <div class="d-flex g4">
     <a class="s-tag s-tag__required" href="#">discussion</a>
-    <span class="s-tag s-tag__required" href="#">feature-request <button class="s-tag--dismiss">@Svg.ClearSm</button></span>
+    <span class="s-tag s-tag__required">feature-request <button class="s-tag--dismiss js-clear-tag">@Svg.ClearSm</button></span>
     <a class="s-tag s-tag__required" href="#">bug</a>
     <a class="s-tag s-tag__required is-selected" href="#">featured</a>
 </div>
@@ -84,7 +84,7 @@ description: Tags are an interactive, community-generated keyword that allow com
         <div class="stacks-preview--example">
             <div class="d-flex g4 fw-wrap">
                 <a class="s-tag s-tag__required" href="#">discussion</a>
-                <span class="s-tag s-tag__required" href="#">feature-request <button class="s-tag--dismiss">{% icon "ClearSm" %}</button></span>
+                <span class="s-tag s-tag__required">feature-request <button class="s-tag--dismiss js-clear-tag">{% icon "ClearSm" %}</button></span>
                 <a class="s-tag s-tag__required" href="#">bug</a>
                 <a class="s-tag s-tag__required is-selected" href="#">featured</a>
             </div>
@@ -96,17 +96,17 @@ description: Tags are an interactive, community-generated keyword that allow com
 {% highlight html %}
 <div class="d-flex g4">
     <a class="s-tag s-tag__muted" href="#">asp-net</a>
-    <span class="s-tag s-tag__muted" href="#">netscape <button class="s-tag--dismiss">@Svg.ClearSm</button></span>
+    <span class="s-tag s-tag__muted">netscape <button class="s-tag--dismiss js-clear-tag">@Svg.ClearSm</button></span>
     <a class="s-tag s-tag__muted" href="#"><img class="s-tag--sponsor" src="https://i.stack.imgur.com/gfrSH.png" width="18" height="16" alt="SQL Server"> sql-server</a>
-    <span class="s-tag s-tag__muted is-selected" href="#">razor <button class="s-tag--dismiss">@Svg.ClearSm</button></span>
+    <span class="s-tag s-tag__muted is-selected">razor <button class="s-tag--dismiss js-clear-tag">@Svg.ClearSm</button></span>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="d-flex g4 fw-wrap">
                 <a class="s-tag s-tag__muted" href="#">asp-net</a>
-                <span class="s-tag s-tag__muted" href="#">netscape <button class="s-tag--dismiss">{% icon "ClearSm" %}</button></span>
+                <span class="s-tag s-tag__muted">netscape <button class="s-tag--dismiss js-clear-tag">{% icon "ClearSm" %}</button></span>
                 <a class="s-tag s-tag__muted" href="#"><img class="s-tag--sponsor" src="https://i.stack.imgur.com/gfrSH.png" width="18" height="16" alt="SQL Server"> sql-server</a>
-                <span class="s-tag s-tag__muted is-selected" href="#">razor <button class="s-tag--dismiss">{% icon "ClearSm" %}</button></span>
+                <span class="s-tag s-tag__muted is-selected">razor <button class="s-tag--dismiss js-clear-tag">{% icon "ClearSm" %}</button></span>
             </div>
         </div>
     </div>

--- a/lib/atomic/misc.less
+++ b/lib/atomic/misc.less
@@ -293,7 +293,7 @@
 .bs-lg { box-shadow: var(--bs-lg) !important; }
 .h\:bs-lg:hover { .bs-lg; }
 .bs-xl { box-shadow: var(--bs-xl) !important; }
-.bs-ring { box-shadow: 0 0 0 var(--su-static4) var(--focus-ring); }
+.bs-ring { box-shadow: var(--focus-ring-divider), 0 0 0 var(--_focus-ring-size, var(--su-static4)) var(--_focus-ring-color, var(--focus-ring)); }
 .h\:bs-ring:hover { .bs-ring; }
 .f\:bs-ring {
     &:focus,

--- a/lib/atomic/misc.less
+++ b/lib/atomic/misc.less
@@ -293,12 +293,24 @@
 .bs-lg { box-shadow: var(--bs-lg) !important; }
 .h\:bs-lg:hover { .bs-lg; }
 .bs-xl { box-shadow: var(--bs-xl) !important; }
+
 .bs-ring { box-shadow: var(--focus-ring-divider), 0 0 0 var(--_focus-ring-size, var(--su-static4)) var(--_focus-ring-color, var(--focus-ring)); }
 .h\:bs-ring:hover { .bs-ring; }
 .f\:bs-ring {
     &:focus,
     &:focus-within {
         .bs-ring;
+    }
+}
+
+.bs-ring-inset {
+    box-shadow: inset 0 0 0 var(--_focus-ring-size, var(--su-static4)) var(--_focus-ring-color, var(--focus-ring)), var(--focus-ring-divider-inset);
+}
+.h\:bs-ring-inset:hover { .bs-ring-inset; }
+.f\:bs-ring-inset {
+    &:focus,
+    &:focus-within {
+        .bs-ring-inset;
     }
 }
 

--- a/lib/components/activity-indicator/activity-indicator.less
+++ b/lib/components/activity-indicator/activity-indicator.less
@@ -1,5 +1,4 @@
 .s-activity-indicator {
-    --_ai-focus-ring: var(--focus-ring);
     --_ai-bg: var(--theme-secondary-400);
     --_ai-fc: var(--white);
 
@@ -10,7 +9,6 @@
     // VARIANTS
     &&__danger {
         --_ai-bg: var(--red-400);
-        --_ai-focus-ring: var(--focus-ring-error);
 
         .highcontrast-mode({
             --_ai-bg: var(--red-500);
@@ -19,7 +17,6 @@
 
     &&__success {
         --_ai-bg: var(--green-400);
-        --_ai-focus-ring: var(--focus-ring-success);
 
         .highcontrast-mode({
             --_ai-bg: var(--green-500);
@@ -29,7 +26,6 @@
     &&__warning {
         --_ai-bg: var(--yellow-400);
         --_ai-fc: var(--_black-static);
-        --_ai-focus-ring: var(--focus-ring-warning);
 
         .highcontrast-mode({
             --_ai-bg: var(--yellow-500); // needs to be here to override default high contrast
@@ -37,8 +33,17 @@
         });
     }
 
+    &:before {
+        border: var(--su-static4) solid var(--_ai-bg);
+        border-radius: 1000px;
+        content: "";
+        inset: calc(var(--su-static4) * -1);
+        opacity: 0.15;
+        pointer-events: none;
+        position: absolute;
+    }
+
     background-color: var(--_ai-bg);
-    box-shadow: 0 0 0 var(--su-static4) var(--_ai-focus-ring);
     color: var(--_ai-fc);
 
     border-radius: 1000px;
@@ -49,5 +54,6 @@
     min-width: var(--su-static12);
     min-height: var(--su-static12);
     padding: var(--su2) var(--su4);
+    position: relative;
     text-transform: uppercase;
 }

--- a/lib/components/block-link/block-link.less
+++ b/lib/components/block-link/block-link.less
@@ -5,7 +5,7 @@ a.s-block-link,
     --_bl-fc: var(--black-500);
     --_bl-fc-hover: var(--black-600);
     --_bl-fc-visited: var(--_bl-fc);
-    --_focus-ring-color: var(--focus-ring-muted);
+    --_focus-ring-color: var(--focus-ring);
 
     // CONTEXTUAL STYLES
     .dark-mode({
@@ -32,7 +32,7 @@ a.s-block-link,
             }
 
             &:focus-visible {
-                box-shadow: inset var(--_li-block-bs-offset-x, 3px) 0 0 var(--_bl-bs-color), 0 0 0 var(--su-static4) var(--focus-ring-muted);
+                box-shadow: inset var(--_li-block-bs-offset-x, 3px) 0 0 var(--_bl-bs-color), 0 0 0 var(--su-static4) var(--focus-ring);
             }
 
             box-shadow: inset var(--_li-block-bs-offset-x, 3px) 0 0 var(--_bl-bs-color);

--- a/lib/components/block-link/block-link.less
+++ b/lib/components/block-link/block-link.less
@@ -5,7 +5,7 @@ a.s-block-link,
     --_bl-fc: var(--black-500);
     --_bl-fc-hover: var(--black-600);
     --_bl-fc-visited: var(--_bl-fc);
-    --_focus-ring-color: var(--focus-ring);
+    --_focus-ring-color: var(--focus-ring-muted);
 
     // CONTEXTUAL STYLES
     .dark-mode({
@@ -32,7 +32,7 @@ a.s-block-link,
             }
 
             &:focus-visible {
-                box-shadow: inset var(--_li-block-bs-offset-x, 3px) 0 0 var(--_bl-bs-color), 0 0 0 var(--su-static4) var(--focus-ring);
+                box-shadow: inset var(--_li-block-bs-offset-x, 3px) 0 0 var(--_bl-bs-color), 0 0 0 var(--su-static4) var(--focus-ring-muted);
             }
 
             box-shadow: inset var(--_li-block-bs-offset-x, 3px) 0 0 var(--_bl-bs-color);

--- a/lib/components/block-link/block-link.less
+++ b/lib/components/block-link/block-link.less
@@ -5,6 +5,7 @@ a.s-block-link,
     --_bl-fc: var(--black-500);
     --_bl-fc-hover: var(--black-600);
     --_bl-fc-visited: var(--_bl-fc);
+    --_focus-ring-color: var(--focus-ring-muted);
 
     // CONTEXTUAL STYLES
     .dark-mode({
@@ -63,7 +64,8 @@ a.s-block-link,
         color: var(--_bl-fc-visited);
     }
 
-    @focus-styles();
+    @focus-visible-styles();
+
     background-color: var(--_bl-bg); // [1]
     color: var(--_bl-fc);
 

--- a/lib/components/button/button.less
+++ b/lib/components/button/button.less
@@ -268,7 +268,7 @@
         --_bu-fc-active: var(--_bu-fc);
         --_bu-fc-hover: var(--black-500);
         --_bu-fc-selected: var(--black-500);
-        --_focus-ring-color: var(--focus-ring);
+        --_focus-ring-color: var(--focus-ring-muted);
         // The filled modifier on the muted button is deprecated and is to be
         // removed in Stacks Classic v2
         --_bu-filled-bc: transparent;
@@ -350,7 +350,7 @@
         --_bu-fc: var(--fc-medium);
         --_bu-fc-active: var(--fc-dark);
         --_bu-fc-hover: var(--black-600);
-        --_focus-ring-color: var(--focus-ring);
+        --_focus-ring-color: var(--focus-ring-muted);
     }
 
     &&__github {
@@ -360,7 +360,7 @@
         --_bu-fc: var(--white);
         --_bu-fc-active: var(--white);
         --_bu-fc-hover: var(--white);
-        --_focus-ring-color: var(--focus-ring);
+        --_focus-ring-color: var(--focus-ring-muted);
         --_bu-hc-bc: transparent;
     }
 

--- a/lib/components/button/button.less
+++ b/lib/components/button/button.less
@@ -5,7 +5,7 @@
     // --_bu-bg: inherit; // [1]
     --_bu-br: var(--br-md);
     --_bu-fc: var(--theme-button-color, var(--theme-secondary-400));
-    --_bu-focus-ring: 0 0 0 var(--su-static4) var(--focus-ring);
+    --_bu-focus-ring: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring);
     --_bu-fs: var(--fs-body1);
     --_bu-p: 0.8em;
     // STATE AND INTERACTION CUSTOM PROPERTIES
@@ -241,7 +241,7 @@
         --_bu-fc-active: var(--_bu-fc);
         --_bu-fc-hover: var(--red-500);
         --_bu-fc-selected: var(--red-600);
-        --_bu-focus-ring: 0 0 0 var(--su-static4) var(--focus-ring-error);
+        --_bu-focus-ring: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-error);
         --_bu-filled-bc: transparent;
         --_bu-filled-bc-selected: var(--_bu-filled-bc);
         --_bu-filled-bg: var(--red-400);
@@ -268,7 +268,7 @@
         --_bu-fc-active: var(--_bu-fc);
         --_bu-fc-hover: var(--black-500);
         --_bu-fc-selected: var(--black-500);
-        --_bu-focus-ring: 0 0 0 var(--su-static4) var(--focus-ring-muted);
+        --_bu-focus-ring: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-muted);
         // The filled modifier on the muted button is deprecated and is to be
         // removed in Stacks Classic v2
         --_bu-filled-bc: transparent;
@@ -350,7 +350,7 @@
         --_bu-fc: var(--fc-medium);
         --_bu-fc-active: var(--fc-dark);
         --_bu-fc-hover: var(--black-600);
-        --_bu-focus-ring: 0 0 0 var(--su-static4) var(--focus-ring-muted);
+        --_bu-focus-ring: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-muted);
     }
 
     &&__github {
@@ -360,7 +360,7 @@
         --_bu-fc: var(--white);
         --_bu-fc-active: var(--white);
         --_bu-fc-hover: var(--white);
-        --_bu-focus-ring: 0 0 0 var(--su-static4) var(--focus-ring-muted);
+        --_bu-focus-ring: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-muted);
         --_bu-hc-bc: transparent;
     }
 
@@ -427,7 +427,7 @@
 
     &:focus,
     &--radio:focus + & {
-        box-shadow: var(--_bu-focus-ring);
+        box-shadow: var(--focus-ring-divider), var(--_bu-focus-ring);
         outline: none;
     }
 

--- a/lib/components/button/button.less
+++ b/lib/components/button/button.less
@@ -268,7 +268,7 @@
         --_bu-fc-active: var(--_bu-fc);
         --_bu-fc-hover: var(--black-500);
         --_bu-fc-selected: var(--black-500);
-        --_focus-ring-color: var(--focus-ring-muted);
+        --_focus-ring-color: var(--focus-ring);
         // The filled modifier on the muted button is deprecated and is to be
         // removed in Stacks Classic v2
         --_bu-filled-bc: transparent;
@@ -350,7 +350,7 @@
         --_bu-fc: var(--fc-medium);
         --_bu-fc-active: var(--fc-dark);
         --_bu-fc-hover: var(--black-600);
-        --_focus-ring-color: var(--focus-ring-muted);
+        --_focus-ring-color: var(--focus-ring);
     }
 
     &&__github {
@@ -360,7 +360,7 @@
         --_bu-fc: var(--white);
         --_bu-fc-active: var(--white);
         --_bu-fc-hover: var(--white);
-        --_focus-ring-color: var(--focus-ring-muted);
+        --_focus-ring-color: var(--focus-ring);
         --_bu-hc-bc: transparent;
     }
 

--- a/lib/components/button/button.less
+++ b/lib/components/button/button.less
@@ -5,7 +5,6 @@
     // --_bu-bg: inherit; // [1]
     --_bu-br: var(--br-md);
     --_bu-fc: var(--theme-button-color, var(--theme-secondary-400));
-    --_bu-focus-ring: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring);
     --_bu-fs: var(--fs-body1);
     --_bu-p: 0.8em;
     // STATE AND INTERACTION CUSTOM PROPERTIES
@@ -132,6 +131,7 @@
     &&__unset {
         &:focus,
         &:focus-visible {
+            outline: initial;
             outline-style: auto;
         }
     }
@@ -139,7 +139,6 @@
     &&__link {
         --_bu-baw: 0;
         --_bu-br: 0;
-        --_bu-focus-ring: none;
         --_bu-p: 0;
 
         &,
@@ -149,6 +148,7 @@
         &[disabled],
         &[aria-disabled="true"] {
             --_bu-bg: none;
+            box-shadow: none;
         }
 
         &.s-btn__dropdown {
@@ -171,11 +171,11 @@
             --_bu-bg: none;
             --_bu-br: 0;
             --_bu-fc: unset;
-            --_bu-focus-ring: none;
             --_bu-p: 0;
 
             cursor: default;
             font: unset;
+            box-shadow: none;
             user-select: auto;
         }
 
@@ -241,7 +241,6 @@
         --_bu-fc-active: var(--_bu-fc);
         --_bu-fc-hover: var(--red-500);
         --_bu-fc-selected: var(--red-600);
-        --_bu-focus-ring: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-error);
         --_bu-filled-bc: transparent;
         --_bu-filled-bc-selected: var(--_bu-filled-bc);
         --_bu-filled-bg: var(--red-400);
@@ -258,6 +257,7 @@
         --_bu-outlined-fc-selected: var(--_bu-fc-selected);
         --_bu-number-fc: var(--white);
         --_bu-number-fc-filled: var(--black);
+        --_focus-ring-color: var(--focus-ring-error);
     }
 
     &&__muted {
@@ -268,7 +268,7 @@
         --_bu-fc-active: var(--_bu-fc);
         --_bu-fc-hover: var(--black-500);
         --_bu-fc-selected: var(--black-500);
-        --_bu-focus-ring: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-muted);
+        --_focus-ring-color: var(--focus-ring-muted);
         // The filled modifier on the muted button is deprecated and is to be
         // removed in Stacks Classic v2
         --_bu-filled-bc: transparent;
@@ -350,7 +350,7 @@
         --_bu-fc: var(--fc-medium);
         --_bu-fc-active: var(--fc-dark);
         --_bu-fc-hover: var(--black-600);
-        --_bu-focus-ring: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-muted);
+        --_focus-ring-color: var(--focus-ring-muted);
     }
 
     &&__github {
@@ -360,7 +360,7 @@
         --_bu-fc: var(--white);
         --_bu-fc-active: var(--white);
         --_bu-fc-hover: var(--white);
-        --_bu-focus-ring: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-muted);
+        --_focus-ring-color: var(--focus-ring-muted);
         --_bu-hc-bc: transparent;
     }
 
@@ -427,7 +427,7 @@
 
     &:focus,
     &--radio:focus + & {
-        box-shadow: var(--focus-ring-divider), var(--_bu-focus-ring);
+        box-shadow: var(--focus-ring-divider), 0 0 0 var(--_focus-ring-size, var(--su-static4)) var(--_focus-ring-color, var(--focus-ring));
         outline: none;
     }
 

--- a/lib/components/checkbox_radio/checkbox_radio.less
+++ b/lib/components/checkbox_radio/checkbox_radio.less
@@ -5,7 +5,6 @@
     --_ch-bc-focus: var(--theme-secondary-400);
     --_ch-bg: var(--white);
     --_ch-bg-image: unset;
-    --_ch-bs-focus: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring);
 
     // CONTEXTUAL STYLES
     fieldset[disabled] &,
@@ -29,9 +28,7 @@
     }
 
     // INTERACTION
-    &:focus {
-        box-shadow: var(--_ch-bs-focus);
-    }
+    @focus-styles();
 
     background-color: var(--_ch-bg);
     border: var(--_ch-baw) solid var(--_ch-bc);

--- a/lib/components/checkbox_radio/checkbox_radio.less
+++ b/lib/components/checkbox_radio/checkbox_radio.less
@@ -5,7 +5,7 @@
     --_ch-bc-focus: var(--theme-secondary-400);
     --_ch-bg: var(--white);
     --_ch-bg-image: unset;
-    --_ch-bs-focus: 0 0 0 var(--su-static4) var(--focus-ring);
+    --_ch-bs-focus: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring);
 
     // CONTEXTUAL STYLES
     fieldset[disabled] &,
@@ -63,9 +63,9 @@
 
     .highcontrast-dark-mode({
         &:checked, &:indeterminate {
-            --_ch-bc: var(--blue-500) !important;
+            --_ch-bc: var(--theme-secondary-500) !important;
             --_ch-bc-focus: var(--_ch-bc);
-            --_ch-bg: var(--blue-400);
+            --_ch-bg: var(--theme-secondary-400);
         }
     });
 

--- a/lib/components/input_textarea/input_textarea.less
+++ b/lib/components/input_textarea/input_textarea.less
@@ -4,7 +4,7 @@
     --_in-bc-focus: var(--theme-secondary-400);
     --_in-bg: var(--white);
     --_in-br: var(--br-md);
-    --_in-bs-focus: 0 0 0 var(--su-static4) var(--focus-ring);
+    --_in-bs-focus: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring);
     --_in-c: unset;
     --_in-fc: var(--fc-dark);
     --_in-fc-focus: var(--black);

--- a/lib/components/input_textarea/input_textarea.less
+++ b/lib/components/input_textarea/input_textarea.less
@@ -4,7 +4,6 @@
     --_in-bc-focus: var(--theme-secondary-400);
     --_in-bg: var(--white);
     --_in-br: var(--br-md);
-    --_in-bs-focus: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring);
     --_in-c: unset;
     --_in-fc: var(--fc-dark);
     --_in-fc-focus: var(--black);
@@ -106,11 +105,11 @@
     }
 
     // INTERACTION
+    @focus-styles();
+
     &:focus{
         border-color: var(--_in-bc-focus);
-        box-shadow: var(--_in-bs-focus);
         color: var(--_in-fc-focus);
-        outline: 0;
     }
 
     @scrollbar-styles();
@@ -140,7 +139,6 @@
         });
 
         border-color: var(--_in-bc-focus);
-        box-shadow: var(--_in-bs-focus);
         color: var(--_in-fc-focus);
         outline: 0;
     }

--- a/lib/components/navigation/navigation.less
+++ b/lib/components/navigation/navigation.less
@@ -15,6 +15,7 @@
     --_na-item-selected-fc: var(--white);
     --_na-item-selected-bg-hover: var(--theme-primary-500);
     --_na-title-mt: var(--su16);
+    --_focus-ring-color: var(--focus-ring-muted);
 
     // CONTEXTUAL STYLES
     .highcontrast-mode({
@@ -62,6 +63,7 @@
             --_na-item-fc: var(--_na-item-selected-fc);
             --_na-item-fc-hover: var(--_na-item-fc);
             --_na-item-bg-hover: var(--_na-item-selected-bg-hover);
+            --_focus-ring-color: var(--theme-primary-500);
 
             .highcontrast-mode({
                 text-decoration: none;
@@ -91,7 +93,7 @@
             color: var(--_na-item-fc-hover);
         }
 
-        @focus-styles();
+        @focus-visible-styles();
 
         background-color: var(--_na-item-bg);
         color: var(--_na-item-fc);

--- a/lib/components/navigation/navigation.less
+++ b/lib/components/navigation/navigation.less
@@ -15,7 +15,7 @@
     --_na-item-selected-fc: var(--white);
     --_na-item-selected-bg-hover: var(--theme-primary-500);
     --_na-title-mt: var(--su16);
-    --_focus-ring-color: var(--focus-ring);
+    --_focus-ring-color: var(--focus-ring-muted);
 
     // CONTEXTUAL STYLES
     .highcontrast-mode({

--- a/lib/components/navigation/navigation.less
+++ b/lib/components/navigation/navigation.less
@@ -15,7 +15,7 @@
     --_na-item-selected-fc: var(--white);
     --_na-item-selected-bg-hover: var(--theme-primary-500);
     --_na-title-mt: var(--su16);
-    --_focus-ring-color: var(--focus-ring-muted);
+    --_focus-ring-color: var(--focus-ring);
 
     // CONTEXTUAL STYLES
     .highcontrast-mode({

--- a/lib/components/pagination/pagination.less
+++ b/lib/components/pagination/pagination.less
@@ -6,6 +6,7 @@
         --_pa-item-bg-hover: var(--black-225);
         --_pa-item-bc-hover: var(--bc-darker);
         --_pa-item-fc-hover: var(--fc-dark);
+        --_focus-ring-color: var(--focus-ring-muted);
 
         // CONTEXTUAL STYLES
         .highcontrast-mode({ text-decoration: none; });
@@ -30,10 +31,7 @@
         }
 
         // INTERACTION
-        &:focus {
-            box-shadow: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-muted);
-            outline: none;
-        }
+        @focus-styles();
 
         &:hover {
             background-color: var(--_pa-item-bg-hover);

--- a/lib/components/pagination/pagination.less
+++ b/lib/components/pagination/pagination.less
@@ -6,7 +6,7 @@
         --_pa-item-bg-hover: var(--black-225);
         --_pa-item-bc-hover: var(--bc-darker);
         --_pa-item-fc-hover: var(--fc-dark);
-        --_focus-ring-color: var(--focus-ring);
+        --_focus-ring-color: var(--focus-ring-muted);
 
         // CONTEXTUAL STYLES
         .highcontrast-mode({ text-decoration: none; });

--- a/lib/components/pagination/pagination.less
+++ b/lib/components/pagination/pagination.less
@@ -30,6 +30,11 @@
         }
 
         // INTERACTION
+        &:focus {
+            box-shadow: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-muted);
+            outline: none;
+        }
+
         &:hover {
             background-color: var(--_pa-item-bg-hover);
             border-color: var(--_pa-item-bc-hover);

--- a/lib/components/pagination/pagination.less
+++ b/lib/components/pagination/pagination.less
@@ -6,7 +6,7 @@
         --_pa-item-bg-hover: var(--black-225);
         --_pa-item-bc-hover: var(--bc-darker);
         --_pa-item-fc-hover: var(--fc-dark);
-        --_focus-ring-color: var(--focus-ring-muted);
+        --_focus-ring-color: var(--focus-ring);
 
         // CONTEXTUAL STYLES
         .highcontrast-mode({ text-decoration: none; });

--- a/lib/components/progress-bar/progress-bar.less
+++ b/lib/components/progress-bar/progress-bar.less
@@ -169,8 +169,18 @@
                         }
 
                         &--stop {
+                            &:before {
+                                border: var(--su-static6) solid var(--focus-ring);
+                                border-radius: 1000px;
+                                content: "";
+                                inset: calc(var(--su-static6) * -1);
+                                opacity: 0.15;
+                                pointer-events: none;
+                                position: absolute;
+                            }
+
                             background: var(--theme-secondary-400);
-                            box-shadow: 0 0 0 var(--su-static6) var(--focus-ring);
+                            position: relative;
                         }
                     }
                 }

--- a/lib/components/select/select.less
+++ b/lib/components/select/select.less
@@ -3,7 +3,6 @@
     --_se-arrow-size: var(--su-static4); // Constant
     --_se-select-bc: var(--bc-darker);
     --_se-select-bc-focus: var(--theme-secondary-400);
-    --_se-select-bs-focus: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring);
     --_se-select-bg: var(--white);
     --_se-select-br: var(--br-md);
     --_se-select-fc: var(--black);
@@ -106,16 +105,15 @@
         }
 
         // INTERACTION
+        @focus-styles();
+
         &:focus {
             .highcontrast-mode({
                 --_se-select-bc-focus: var(--black);
             });
 
             border-color: var(--_se-select-bc-focus);
-            box-shadow: var(--_se-select-bs-focus);
-
             color: var(--black);
-            outline: 0;
         }
 
         background-color: var(--_se-select-bg);

--- a/lib/components/select/select.less
+++ b/lib/components/select/select.less
@@ -3,7 +3,7 @@
     --_se-arrow-size: var(--su-static4); // Constant
     --_se-select-bc: var(--bc-darker);
     --_se-select-bc-focus: var(--theme-secondary-400);
-    --_se-select-bs-focus: 0 0 0 var(--su-static4) var(--focus-ring);
+    --_se-select-bs-focus: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring);
     --_se-select-bg: var(--white);
     --_se-select-br: var(--br-md);
     --_se-select-fc: var(--black);

--- a/lib/components/tag/tag.less
+++ b/lib/components/tag/tag.less
@@ -13,7 +13,6 @@
     --_ta-fc-selected: var(--theme-tag-selected-color, var(--theme-secondary-600));
     // Other
     --_ta-br: var(--br-sm);
-    --_ta-bs-focus: var(--focus-ring);
     --_ta-fs: var(--fs-caption);
     --_ta-lh: 1.846153846;
     --_ta-pl: var(--_ta-px);
@@ -119,7 +118,7 @@
         --_ta-bc-selected: var(--orange-400);
         --_ta-bg-selected: var(--orange-300);
         --_ta-fc-selected: var(--orange-600); // Currently APCA Lc 49 😔
-        --_ta-bs-focus: var(--orange-500);
+        --_focus-ring-color: var(--orange-500);
     }
 
     &&__muted:not(&__moderator):not(&__required) {
@@ -132,7 +131,7 @@
         --_ta-bc-selected: transparent;
         --_ta-bg-selected: var(--black-225);
         --_ta-fc-selected: var(--black-600);
-        --_ta-bs-focus: var(--black-500);
+        --_focus-ring-color: var(--black-500);
 
         .highcontrast-mode({ --_ta-bc: currentColor; }); // Specificity has bit us, so we need this override
     }
@@ -159,6 +158,8 @@
 
     // CHILD ELEMENTS
     & &--dismiss { // Style adjustment to @Svg.ClearSm
+        all: unset;
+
         &:hover {
             .highcontrast-mode({
                 color: var(--white);
@@ -168,7 +169,10 @@
             color: var(--_ta-bg);
         }
 
+        @focus-styles();
+
         align-content: center;
+        align-items: center;
         align-self: center;
         background-color: transparent;
         border-radius: var(--br-sm);
@@ -211,10 +215,7 @@
         }
     }
 
-    &:focus {
-        box-shadow: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--_ta-bs-focus);
-        outline: none;
-    }
+    @focus-styles();
 
     background-color: var(--_ta-bg);
     border: var(--su-static1) solid var(--_ta-bc);

--- a/lib/components/tag/tag.less
+++ b/lib/components/tag/tag.less
@@ -13,6 +13,7 @@
     --_ta-fc-selected: var(--theme-tag-selected-color, var(--theme-secondary-600));
     // Other
     --_ta-br: var(--br-sm);
+    --_ta-bs-focus: var(--focus-ring);
     --_ta-fs: var(--fs-caption);
     --_ta-lh: 1.846153846;
     --_ta-pl: var(--_ta-px);
@@ -118,6 +119,7 @@
         --_ta-bc-selected: var(--orange-400);
         --_ta-bg-selected: var(--orange-300);
         --_ta-fc-selected: var(--orange-600); // Currently APCA Lc 49 😔
+        --_ta-bs-focus: var(--orange-500);
     }
 
     &&__muted:not(&__moderator):not(&__required) {
@@ -130,6 +132,7 @@
         --_ta-bc-selected: transparent;
         --_ta-bg-selected: var(--black-225);
         --_ta-fc-selected: var(--black-600);
+        --_ta-bs-focus: var(--black-500);
 
         .highcontrast-mode({ --_ta-bc: currentColor; }); // Specificity has bit us, so we need this override
     }
@@ -206,6 +209,11 @@
             border-color: var(--_ta-bc-hover);
             color: var(--_ta-fc-hover);
         }
+    }
+
+    &:focus {
+        box-shadow: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--_ta-bs-focus);
+        outline: none;
     }
 
     background-color: var(--_ta-bg);

--- a/lib/components/toggle-switch/toggle-switch.less
+++ b/lib/components/toggle-switch/toggle-switch.less
@@ -40,7 +40,7 @@
                     --_ts-bs: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-success);
 
                     &.s-toggle-switch--label-off {
-                        --_ts-bs: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-muted);
+                        --_ts-bs: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring);
                     }
                 }
             }
@@ -87,7 +87,7 @@
         }
 
         &:focus {
-            --_ts-bs: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-muted);
+            --_ts-bs: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring);
             outline: none;
         }
 

--- a/lib/components/toggle-switch/toggle-switch.less
+++ b/lib/components/toggle-switch/toggle-switch.less
@@ -4,7 +4,7 @@
     --_ts-bg: var(--black-350);
     --_ts-bg-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='@{ts-bg-image-fill}'/%3e%3c/svg%3e");
     --_ts-bg-ps: left center;
-    --_ts-bs-color: transparent;
+    --_ts-bs: none;
     --_ts-multiple-bg: unset;
     --_ts-multiple-fc: var(--black-400);
 
@@ -37,10 +37,10 @@
                 }
 
                 &:focus + label {
-                    --_ts-bs-color: var(--focus-ring-success);
+                    --_ts-bs: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-success);
 
                     &.s-toggle-switch--label-off {
-                        --_ts-bs-color: var(--focus-ring-muted);
+                        --_ts-bs: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-muted);
                     }
                 }
             }
@@ -53,7 +53,7 @@
 
         label {
             background-color: var(--_ts-multiple-bg);
-            box-shadow: 0 0 0 var(--su-static4) var(--_ts-bs-color);
+            box-shadow: var(--_ts-bs);
             color: var(--_ts-multiple-fc);
 
             border-radius: 1000px;
@@ -82,12 +82,12 @@
             --_ts-bg-ps: right center;
 
             &:focus {
-                --_ts-bs-color: var(--focus-ring-success);
+                --_ts-bs: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-success);
             }
         }
 
         &:focus {
-            --_ts-bs-color: var(--focus-ring-muted);
+            --_ts-bs: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-muted);
             outline: none;
         }
 
@@ -97,7 +97,7 @@
 
         background-color: var(--_ts-bg);
         background-position: var(--_ts-bg-ps);
-        box-shadow: 0 0 0 var(--su-static4) var(--_ts-bs-color);
+        box-shadow: var(--_ts-bs);
 
         appearance: none;
         background-image: var(--_ts-bg-image);

--- a/lib/components/toggle-switch/toggle-switch.less
+++ b/lib/components/toggle-switch/toggle-switch.less
@@ -40,7 +40,7 @@
                     --_ts-bs: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-success);
 
                     &.s-toggle-switch--label-off {
-                        --_ts-bs: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring);
+                        --_ts-bs: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-muted);
                     }
                 }
             }
@@ -87,7 +87,7 @@
         }
 
         &:focus {
-            --_ts-bs: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring);
+            --_ts-bs: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-muted);
             outline: none;
         }
 

--- a/lib/components/topbar/topbar.less
+++ b/lib/components/topbar/topbar.less
@@ -291,7 +291,7 @@
     
         // Show focus styles on keyboard focus.
         &:focus-visible {
-            box-shadow: inset 0 0 0 var(--_focus-ring-size, var(--su-static4)) var(--_focus-ring-color, var(--focus-ring)), inset 0 0 0 calc(var(--su-static4) + var(--su-static1)) var(--white);
+            box-shadow: inset 0 0 0 var(--_focus-ring-size, var(--su-static4)) var(--_focus-ring-color, var(--focus-ring)), var(--focus-ring-divider-inset);
             outline: none;
         }
 

--- a/lib/components/topbar/topbar.less
+++ b/lib/components/topbar/topbar.less
@@ -125,9 +125,6 @@
     }
 
     .s-navigation {
-        .s-navigation--item:focus-visible {
-            box-shadow: var(--theme-topbar-search-shadow-focus, 0 0 0 var(--su-static4) var(--focus-ring));
-        }
         .s-navigation--item:not(.is-selected) {
             color: var(--theme-topbar-item-color, var(--black-400));
         }
@@ -139,10 +136,6 @@
     }
     .s-popover .s-navigation {
         .s-navigation--item {
-            &:focus-visible {
-                box-shadow: var(0 0 0 var(--su-static4) var(--focus-ring));
-            }
-
             &:not(.is-selected) {
                 &:hover {
                     color: var(--black-600);
@@ -291,6 +284,17 @@
         white-space: nowrap;
         position: relative;
 
+        &:focus:not(:focus-visible) {
+            box-shadow: none;
+            outline: none;
+        }
+    
+        // Show focus styles on keyboard focus.
+        &:focus-visible {
+            box-shadow: inset 0 0 0 var(--_focus-ring-size, var(--su-static4)) var(--_focus-ring-color, var(--focus-ring)), inset 0 0 0 calc(var(--su-static4) + var(--su-static1)) var(--white);
+            outline: none;
+        }
+
         &:hover,
         &:focus,
         &.is-selected,
@@ -376,15 +380,9 @@
         .s-input {
             border-color: var(--theme-topbar-search-border, var(--black-300));
             background-color: var(--theme-topbar-search-background, var(--white));
-            box-shadow: var(--theme-topbar-search-shadow);
             color: var(--theme-topbar-search-color, var(--black-500));
             display: block;
             line-height: @inputLineHeights;
-
-            &:focus {
-                border-color: var(--theme-topbar-search-border-focus, var(--blue-400));
-                box-shadow: var(--theme-topbar-search-shadow-focus, 0 0 0 var(--su-static4) var(--focus-ring));
-            }
 
             &::placeholder {
                 color: var(--theme-topbar-search-placeholder, var(--black-400));
@@ -420,8 +418,6 @@
         color: var(--theme-topbar-select-color, var(--black-500));
 
         &:focus {
-            border-color: var(--theme-topbar-search-border-focus, var(--blue-400));
-            box-shadow: var(--theme-topbar-search-shadow-focus, 0 0 0 var(--su-static4) var(--focus-ring));
             z-index: var(--zi-selected);
         }
     }

--- a/lib/components/uploader/uploader.less
+++ b/lib/components/uploader/uploader.less
@@ -91,7 +91,7 @@
     & &--input {
         &:focus:focus-visible + .s-uploader--container {
             background-color: var(--_up-bg-focus);
-            box-shadow: 0 0 0 var(--su-static4) var(--_up-focus-ring-color);
+            box-shadow: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--_up-focus-ring-color);
         }
 
         cursor: pointer;

--- a/lib/exports/color-sets.less
+++ b/lib/exports/color-sets.less
@@ -434,6 +434,7 @@
 .set-focus() {
     default: var(--theme-secondary-500);
     divider: 0 0 0 var(--su-static1) var(--white);
+    divider-inset: inset 0 0 0 calc(var(--_focus-ring-size, var(--su-static4)) + var(--su-static1)) var(--white);
     success: var(--green-500);
     warning: var(--yellow-500);
     error: var(--red-500);

--- a/lib/exports/color-sets.less
+++ b/lib/exports/color-sets.less
@@ -438,7 +438,7 @@
     success: var(--green-500);
     warning: var(--yellow-500);
     error: var(--red-500);
-    muted: var(--black-400);
+    muted: var(--black-500);
 }
 
 // highlight

--- a/lib/exports/color-sets.less
+++ b/lib/exports/color-sets.less
@@ -437,7 +437,6 @@
     success: var(--green-500);
     warning: var(--yellow-500);
     error: var(--red-500);
-    muted: var(--black-400);
 }
 
 // highlight

--- a/lib/exports/color-sets.less
+++ b/lib/exports/color-sets.less
@@ -432,7 +432,7 @@
 
 // focus (sets represents both light and dark mode)
 .set-focus() {
-    default: var(--theme-secondary-500);
+    default: var(--theme-secondary-custom-500, var(--theme-primary-custom-500, var(--theme-secondary-500)));
     divider: 0 0 0 var(--su-static1) var(--white);
     divider-inset: inset 0 0 0 calc(var(--_focus-ring-size, var(--su-static4)) + var(--su-static1)) var(--white);
     success: var(--green-500);

--- a/lib/exports/color-sets.less
+++ b/lib/exports/color-sets.less
@@ -438,6 +438,7 @@
     success: var(--green-500);
     warning: var(--yellow-500);
     error: var(--red-500);
+    muted: var(--black-400);
 }
 
 // highlight

--- a/lib/exports/color-sets.less
+++ b/lib/exports/color-sets.less
@@ -432,25 +432,12 @@
 
 // focus (sets represents both light and dark mode)
 .set-focus() {
-    default: var(--theme-secondary-custom-focus-ring, hsla(206, 100%, 40%, 0.15));
-    success: hsla(140, 40%, 75%, 0.4);
-    warning: hsla(47, 79%, 58%, 0.4);
-    error: hsla(358, 62%, 47%, 0.15);
-    muted: hsla(210, 8%, 15%, 0.1);
-}
-.set-focus-dark() {
-    default: var(--theme-dark-secondary-custom-focus-ring, hsla(206, 100%, 40%, 0.25));
-    success: hsla(140, 40%, 75%, 0.4);
-    warning: hsla(47, 79%, 58%, 0.4);
-    error: hsla(358, 62%, 47%, 0.15);
-    muted: hsla(210, 8%, 15%, 0.1);
-}
-.set-focus-hc() {
-    default: hsla(206, 100%, 40%, 0.9);
-    success: hsla(140, 40%, 40%, 0.9);
-    warning: hsla(47, 76%, 46%, 0.9);
-    error: hsla(358, 62%, 47%, 0.9);
-    muted: hsla(210, 8%, 55%, 0.95);
+    default: var(--theme-secondary-500);
+    divider: 0 0 0 var(--su-static1) var(--white);
+    success: var(--green-500);
+    warning: var(--yellow-500);
+    error: var(--red-500);
+    muted: var(--black-400);
 }
 
 // highlight
@@ -615,7 +602,7 @@
 .sets-utility-dark() {
     bc: .set-bc();
     bs: .set-bs-dark();
-    focus-ring: .set-focus-dark();
+    focus-ring: .set-focus();
     highlight: .set-highlight-dark();
     scrollbar: .set-scrollbar-dark();
 }
@@ -623,7 +610,7 @@
 .sets-utility-hc() {
     bc: .set-bc-hc();
     bs: .set-bs-hc();
-    focus-ring: .set-focus-hc();
+    focus-ring: .set-focus();
     highlight: .set-highlight-hc();
     scrollbar: .set-scrollbar-hc();
 }
@@ -631,7 +618,7 @@
 .sets-utility-dark-hc() {
     bc: .set-bc-hc();
     bs: .set-bs-hc-dark();
-    focus-ring: .set-focus-hc();
+    focus-ring: .set-focus();
     highlight: .set-highlight-hc-dark();
     scrollbar: .set-scrollbar-hc-dark();
 }

--- a/lib/exports/constants-helpers.less
+++ b/lib/exports/constants-helpers.less
@@ -93,16 +93,23 @@ body {
 //  $   FOCUS STYLING
 //  ----------------------------------------------------------------------------
 @focus-styles: {
+    &:focus {
+        box-shadow: var(--focus-ring-divider), 0 0 0 var(--_focus-ring-size, var(--su-static4)) var(--_focus-ring-color, var(--focus-ring));
+        outline: none;
+    }
+}
+
+@focus-visible-styles: {
     // Hide focus styles if they're not needed, for example,
     // when an element receives focus via the mouse.
     &:focus:not(:focus-visible) {
-        outline: none;
         box-shadow: none;
+        outline: none;
     }
 
     // Show focus styles on keyboard focus.
     &:focus-visible {
+        box-shadow: var(--focus-ring-divider), 0 0 0 var(--_focus-ring-size, var(--su-static4)) var(--_focus-ring-color, var(--focus-ring));
         outline: none;
-        box-shadow: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-muted);
     }
 }

--- a/lib/exports/constants-helpers.less
+++ b/lib/exports/constants-helpers.less
@@ -103,6 +103,6 @@ body {
     // Show focus styles on keyboard focus.
     &:focus-visible {
         outline: none;
-        box-shadow: 0 0 0 var(--su-static4) var(--focus-ring-muted);
+        box-shadow: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-muted);
     }
 }

--- a/lib/input-utils.less
+++ b/lib/input-utils.less
@@ -17,19 +17,19 @@
 
     .has-error & {
         --_@{prefix}-bc: var(--red-400);
-        --_@{prefix}-bs-focus: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-error);
+        --_focus-ring-color: var(--focus-ring-error);
         @error();
     }
 
     .has-success & {
         --_@{prefix}-bc: var(--green-400);
-        --_@{prefix}-bs-focus: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-success);
+        --_focus-ring-color: var(--focus-ring-success);
         @success();
     }
 
     .has-warning & {
         --_@{prefix}-bc: var(--yellow-500);
-        --_@{prefix}-bs-focus: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-warning);
+        --_focus-ring-color: var(--focus-ring-warning);
         @warning();
     }
 }
@@ -41,4 +41,3 @@
 .has-warning {
     position: relative;
 }
-

--- a/lib/input-utils.less
+++ b/lib/input-utils.less
@@ -17,19 +17,19 @@
 
     .has-error & {
         --_@{prefix}-bc: var(--red-400);
-        --_@{prefix}-bs-focus: 0 0 0 var(--su-static4) var(--focus-ring-error);
+        --_@{prefix}-bs-focus: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-error);
         @error();
     }
 
     .has-success & {
         --_@{prefix}-bc: var(--green-400);
-        --_@{prefix}-bs-focus: 0 0 0 var(--su-static4) var(--focus-ring-success);
+        --_@{prefix}-bs-focus: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-success);
         @success();
     }
 
     .has-warning & {
         --_@{prefix}-bc: var(--yellow-500);
-        --_@{prefix}-bs-focus: 0 0 0 var(--su-static4) var(--focus-ring-warning);
+        --_@{prefix}-bs-focus: var(--focus-ring-divider), 0 0 0 var(--su-static4) var(--focus-ring-warning);
         @warning();
     }
 }


### PR DESCRIPTION
> **Note**
> Expect this PR to fail until I update the test snapshots (which I'll do when it's in a stable state)

This PR modifies the focus ring we use on focused elements to meet or exceed [WCAG 2.2 Success Criterion 2.4.11: Focus Appearance (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance-minimum)

# Outline of changes

## Update all focus state CSS vars to meet or exceed accessibility standard
[color-sets.less diff](https://github.com/StackExchange/Stacks/pull/1547/files#diff-ea72389fc03dddb312af7fc98958fa06757fdf175252829b9468c4a187e6f9a4)

A common approach to satisfying [WCAG 2.2 Success Criterion 2.4.11: Focus Appearance (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance-minimum) is to add a focus ring that includes a high contrast outline between the element and the focus ring. This is common among [Microsoft](https://react.fluentui.dev/?path=/docs/components-button-button--default), [Ant Design](https://ant.design/components/button), [Carbon](https://carbondesignsystem.com/components/button/usage/), and the  [U.S. Web Design System](https://designsystem.digital.gov/components/button/).

<details>
<summary>Screenshot of the U.S. Web Design System</summary>

![image](https://github.com/StackExchange/Stacks/assets/647177/91483d00-8545-4160-8f6e-e5f13ee111c4)

</details>

## Activity indicator, stepped progress bar

These components relied on `--focus-ring`. Since the style of `--focus-ring` is now much darker, it's being applied as a pseudo-element on `activity-indicator` and the `stepped` version of `progress` with a lower opacity to achieve the same effect as before.

## Provide themed fallback focus styles

Previously, focus states relied on `hsla(206,100%,40%,0.15)` or `--theme-secondary-custom-focus-ring`. If the custom property was not provided, it would result in the default value being used despite a primary theme value being available. 

<details>
<summary>Example of themed button with default focus ring style</summary>

![image](https://github.com/StackExchange/Stacks/assets/647177/7b43183f-8b05-47c1-bbc2-17c95219737f)

</details>

This PR allows focus ring to fall back from `theme-secondary-custom-500` to `theme-primary-custom-500` to theme-secondary-500`.

## Added focus styles to `pagination` and `tag` components

These elements were missing our custom focus states. This PR adds them.

## Added focus styles to `topbar` children

TBD

## `@focus-styles()` and `@focus-visible-styles()`
[constants-helpers.less diff](https://github.com/StackExchange/Stacks/pull/1547/files#diff-dd4021b008e0ec1764a2aa34ff408c687d5c12b6a5742bb120b4ca91ff161259)

Since the existing `@focus-styles()` function operated on `:focus-visible`, I renamed it to reflect that and free the name up. With `@focus-styles()` available, we can provide an abstraction for common focus styles that don't apply to `:focus-visible`. This means that many components that previously included custom `:focus` CSS can rely on `@focus-styles()`.

## Add `--_focus-ring-color`

Inputs (all of them including textareas, select element, etc) have validation states that restyle both the input and the focus ring. This PPCP is to be used to update the focus ring color in a given context.

## Add `.bs-ring-inset` with conditional prefixes

Since some elements live within a container that hides overflow, a normal box shadow cannot always be used to show a focus state. I've added this class to allow for an inset focus ring to be added to elements under those conditions.

<details>
<summary>Example of UI that would require an inset focus ring</summary>

![image](https://github.com/StackExchange/Stacks/assets/647177/53900b1f-8802-40d5-bc24-342a6055c511)

</details>

## Minor improvements and updates to doc

- Added `.bs-ring-inset` to box-shadow documentation
- Updated box-shadow documentation to render examples programmatically
- Changed tag documentation to use `span` when example includes a nested button
    - This was changed from the `.s-tag` being an anchor with a nested `span` for `.s-tag--dismiss`. Since `.s-tag--dismiss` is expected to always be interactive, it should be rendered as a `button` element, which cannot be placed within an anchor element.  From [W3C "`a` Additional constraints and admonitions"](https://w3c.github.io/html-reference/a.html#a-constraints):
        > The interactive element `a` must not appear as a descendant of the `button` element. 

# Success Criterion [2.4.11 Focus Appearance (Minimum)](https://www.w3.org/TR/WCAG22/#focus-appearance-minimum) (Level AA)
> When a [user interface component](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance-minimum#dfn-user-interface-component) has keyboard focus, the [focus indicator](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance-minimum#dfn-focus-indicator):
>
>   - [Encloses](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance-minimum#dfn-encloses) the visual presentation of the user interface component;
>   - Has a contrast ratio of at least 3:1 between its pixels in the focused and unfocused states;
>   - Has a contrast ratio of at least 3:1 against adjacent colors.
>
>    Exceptions:
>
>    - The focus indicator is determined by the user-agent and cannot be adjusted by the author, or
>    - The focus indicator and the indicator's background color are not modified by the author, or
>    - An area of the focus indicator meets all the following:
>        - At least as large as the area of a 1 [CSS pixel](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance-minimum#dfn-css-pixel) thick [perimeter](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance-minimum#dfn-perimeter) of the unfocused component, or is at least as large as a 4 CSS pixel thick line along the shortest side of the [minimum bounding box](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance-minimum#dfn-minimum-bounding-box) of the unfocused component, and
>        - has a contrast ratio of at least 3:1 against the same pixels in the unfocused state, and
>        - has a contrast ratio of at least 3:1 against adjacent non-focus-indicator colors, or is no thinner than 2 CSS pixels.
>
>    Where a user interface component has active sub-components, if a sub-component receives a focus indicator, these requirements can be applied to the sub-component instead.
>
>    Note: Examples of sub-components that may receive a focus indicator are menu items in an opened drop-down menu. However, it may also be possible to indicate user interaction for such sub-components by relying strictly on a visual indication of which item is selected. Where selectable sub-components have no differentiated focus indicator, the visual indicator for sub-component selection is measured against [1.4.11 Non-text Contrast](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html) requirements, not against this Criterion.
>
>    Note: Contrast calculations can be based on colors defined within the technology (such as HTML, CSS and SVG). Pixels modified by user agent resolution enhancements and anti-aliasing can be ignored.

### Questions

- ~~Should we retain the `muted` version of the focus ring or replace it with the default?~~ retain it as `black-500`
- ~~Which components need focus rings added?~~ `tag`, `pagination`, elements within `topbar`
- How should we go about testing focus states?

cc @CGuindon @andrewmeacham 