### PR TITLE
test(visual): add improved baseline images update workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,21 +98,19 @@ npm run test:unit:watch
 - `git lfs` ([installation docs](https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage))
 - `docker` ([installation docs](https://docs.docker.com/engine/install/))
 - `pwsh` ([Installation docs](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.3))
+- Run `git config diff.lfs.textconv cat` to make sure image diff works as expected ([More info](https://github.com/microsoft/vscode/issues/86611#issuecomment-875894108))
 
-This [Web Test Runner plugin](https://www.npmjs.com/package/@web/test-runner-visual-regression) is used to run visual regression tests. [DOM Testing Library](https://testing-library.com/docs/dom-testing-library/intro).
+This [Web Test Runner plugin](https://www.npmjs.com/package/@web/test-runner-visual-regression) is used to run visual regression tests.
 Visual regression tests end with this suffix `*.visual.test.ts`.
 
 Execute the visual regression tests suite by running:
 ```sh
 npm run test:visual
 ```
+After the first run, if there are failing snapshots, they end up overriding the baseline ones in the filesystem (e.g. `/screenshots/<browser>/baseline/<name>.png`). 
+We do this for easier comparison of the dif directly in vscode and to make sure only the failing snapshots get regenerated (see [this GH discussion](https://github.com/modernweb-dev/web/discussions/427#discussioncomment-3543771) that inspired the approach).
 
-Update the visual baseline via:
-```sh
-npm run test:visual:update
-```
-
-Failing tests (including diffs) can be found under `screenshots/[browser]/failed/` folders.
+We also recommend to install [this vscode extension](https://marketplace.visualstudio.com/items?itemName=RayWiis.png-image-diff) for getting better diffs.
 
 ### Less Tests
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
         "test:unit": "web-test-runner --group=unit",
         "test:unit:watch": "web-test-runner --group=unit --watch",
         "test:visual": "pwsh run-test-visual.ps1 npx web-test-runner --group=visual",
-        "test:visual:update": "pwsh run-test-visual.ps1 npx web-test-runner --group=visual --update-visual-baseline",
         "test:less": "vitest run .less.test.ts",
         "test:less:update": "npm run test:less -- -u",
         "prepublishOnly": "npm run build",

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -61,7 +61,10 @@ export default {
         commonjs(),
         esbuildPlugin({ ts: true }),
         visualRegressionPlugin({
-            update: process.argv.includes("--update-visual-baseline"),
+            // https://github.com/StackExchange/Stacks?tab=readme-ov-file#visual-regression-tests
+            getFailedName: ({ browser, name }) => {
+                return `${browser}/baseline/${name}.png`;
+            },
         }),
     ],
     filterBrowserLogs: ({ args }) =>


### PR DESCRIPTION
This PR change the way we upgrade our baseline images so that only the failing snapshots get regenerated.
It should also provide a better way to look at diff directly in vscode.

Run this command `git config diff.lfs.textconv cat` and install [this vscode extension](https://marketplace.visualstudio.com/items?itemName=RayWiis.png-image-diff) for optimal experience.

Chekout the [updated readme](https://github.com/StackExchange/Stacks/blob/b35aee76c1ececae3132aa2f6a157a4787add7e5/README.md#visual-regression-tests) for more info.