### PR TITLE
fix(pagination):improve focus style to meet WCAG 2.2 AA

### DIFF
--- a/docs/product/components/pagination.html
+++ b/docs/product/components/pagination.html
@@ -32,26 +32,68 @@ description: Pagination splits content into pages, as seen on questions, tags, u
     <div class="stacks-preview">
 {% highlight html %}
 <div class="s-pagination">
-    <span class="s-pagination--item is-selected" aria-current="page">1</span>
-    <a class="s-pagination--item" href="…">2</a>
-    <a class="s-pagination--item" href="…">3</a>
-    <a class="s-pagination--item" href="…">4</a>
-    <a class="s-pagination--item" href="…">5</a>
+    <a class="s-pagination--item is-selected" href="…" aria-current="page">
+        <span class="v-visible-sr">page</span>
+        1
+    </a>
+    <a class="s-pagination--item" href="…">
+        <span class="v-visible-sr">page</span>
+        2
+    </a>
+    <a class="s-pagination--item" href="…">
+        <span class="v-visible-sr">page</span>
+        3
+    </a>
+    <a class="s-pagination--item" href="…">
+        <span class="v-visible-sr">page</span>
+        4
+    </a>
+    <a class="s-pagination--item" href="…">
+        <span class="v-visible-sr">page</span>
+        5
+    </a>
     <span class="s-pagination--item s-pagination--item__clear">…</span>
-    <a class="s-pagination--item" href="…">1096917</a>
-    <a class="s-pagination--item" href="…">Next</a>
+    <a class="s-pagination--item" href="…">
+        <span class="v-visible-sr">page</span>
+        122386
+    </a>
+    <a class="s-pagination--item" href="…">
+        Next
+        <span class="v-visible-sr">page</span>
+    </a>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example overflow-x-auto">
             <div class="s-pagination">
-                <span class="s-pagination--item is-selected" aria-current="page">1</span>
-                <a class="s-pagination--item" href="#">2</a>
-                <a class="s-pagination--item" href="#">3</a>
-                <a class="s-pagination--item" href="#">4</a>
-                <a class="s-pagination--item" href="#">5</a>
+                <a class="s-pagination--item is-selected" href="#" aria-current="page">
+                    <span class="v-visible-sr">page</span>
+                    1
+                </a>
+                <a class="s-pagination--item" href="#">
+                    <span class="v-visible-sr">page</span>
+                    2
+                </a>
+                <a class="s-pagination--item" href="#">
+                    <span class="v-visible-sr">page</span>
+                    3
+                </a>
+                <a class="s-pagination--item" href="#">
+                    <span class="v-visible-sr">page</span>
+                    4
+                </a>
+                <a class="s-pagination--item" href="#">
+                    <span class="v-visible-sr">page</span>
+                    5
+                </a>
                 <span class="s-pagination--item s-pagination--item__clear">…</span>
-                <a class="s-pagination--item" href="#">1096917</a>
-                <a class="s-pagination--item" href="#">Next</a>
+                <a class="s-pagination--item" href="#">
+                    <span class="v-visible-sr">page</span>
+                    122386
+                </a>
+                <a class="s-pagination--item" href="#">
+                    Next
+                    <span class="v-visible-sr">page</span>
+                </a>
             </div>
         </div>
     </div>

--- a/lib/components/pagination/pagination.less
+++ b/lib/components/pagination/pagination.less
@@ -3,6 +3,8 @@
         --_pa-item-bg: transparent;
         --_pa-item-bc: var(--bc-darker);
         --_pa-item-fc: var(--fc-medium);
+        --_pa-item-bg-focus: var(--black-400);
+        --_pa-item-fc-focus: var(--white);
         --_pa-item-bg-hover: var(--black-225);
         --_pa-item-bc-hover: var(--bc-darker);
         --_pa-item-fc-hover: var(--fc-dark);
@@ -15,6 +17,7 @@
             --_pa-item-bg: var(--theme-primary);
             --_pa-item-bc: transparent;
             --_pa-item-fc: var(--white);
+            --_pa-item-bg-focus: var(--theme-primary-400);
         }
         &.s-pagination--item__clear {
             --_pa-item-bg: transparent;
@@ -34,6 +37,14 @@
             background-color: var(--_pa-item-bg-hover);
             border-color: var(--_pa-item-bc-hover);
             color: var(--_pa-item-fc-hover);
+        }
+
+        &:focus-visible {
+            background-color: var(--_pa-item-bg-focus);
+            border-color: var(--theme-secondary-400) !important;
+            box-shadow: inset 0 0 0 var(--su-static2) var(--theme-secondary-400), inset 0 0 0 var(--su-static4) var(--black-050);
+            color: var(--_pa-item-fc-focus);
+            outline: var(--su-static2) solid transparent;
         }
 
         background-color: var(--_pa-item-bg);


### PR DESCRIPTION
Addresses [STACKS-544](https://stackoverflow.atlassian.net/browse/STACKS-544)

### Technical notes
You'll notice that this PR achieves the focus style mainly with box-shadow:
```less
   box-shadow: inset 0 0 0 var(--su-static2) var(--theme-secondary-400), inset 0 0 0 var(--su-static4) var(--black-050);
    …
   outline: var(--su-static2) solid transparent;
```

This is because box-shadow tends to align more consistently. Additionally, a transparent outline is used to ensure that an outline doesn't render when expected but can still be rendered in forced-color modes (see https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/#gist105426765).