### PR TITLE
fix(block-link): improve focus style to meet WCAG 2.2 AA

### DIFF
--- a/lib/components/block-link/block-link.less
+++ b/lib/components/block-link/block-link.less
@@ -25,16 +25,9 @@ a.s-block-link,
     &&__left,
     &&__right {
         &.is-selected {
-            &:focus:not(:focus-visible),
-            &:focus-visible {
-                outline: none;
+            &:not(:focus-visible) {
+                box-shadow: inset var(--_li-block-bs-offset-x, 3px) 0 0 var(--_bl-bs-color);
             }
-
-            &:focus-visible {
-                box-shadow: inset var(--_li-block-bs-offset-x, 3px) 0 0 var(--_bl-bs-color), 0 0 0 var(--su-static4) var(--focus-ring-muted);
-            }
-
-            box-shadow: inset var(--_li-block-bs-offset-x, 3px) 0 0 var(--_bl-bs-color);
         }
     }
 
@@ -63,7 +56,11 @@ a.s-block-link,
         color: var(--_bl-fc-visited);
     }
 
-    @focus-styles();
+    &:focus-visible {
+        box-shadow: inset 0 0 0 var(--su-static2) var(--theme-secondary-400), inset 0 0 0 var(--su-static4) var(--black-050);
+       outline: var(--su-static2) solid transparent;
+    }
+
     background-color: var(--_bl-bg); // [1]
     color: var(--_bl-fc);
 

--- a/lib/components/block-link/block-link.less
+++ b/lib/components/block-link/block-link.less
@@ -57,7 +57,7 @@ a.s-block-link,
     }
 
     &:focus-visible {
-        box-shadow: inset 0 0 0 var(--su-static2) var(--theme-secondary-400), inset 0 0 0 var(--su-static4) var(--black-050);
+        box-shadow: inset 0 0 0 var(--su-static2) var(--theme-secondary-400), inset 0 0 0 var(--su-static4) var(--white);
        outline: var(--su-static2) solid transparent;
     }
 

--- a/lib/components/block-link/block-link.less
+++ b/lib/components/block-link/block-link.less
@@ -57,6 +57,7 @@ a.s-block-link,
     }
 
     &:focus-visible {
+        border-radius: var(--br-sm);
         box-shadow: inset 0 0 0 var(--su-static2) var(--theme-secondary-400), inset 0 0 0 var(--su-static4) var(--white);
        outline: var(--su-static2) solid transparent;
     }


### PR DESCRIPTION
Resolves [STACKS-545](https://stackoverflow.atlassian.net/browse/STACKS-545)

> **Note**
> The above linked ticket shows updates as they relate to the `s-menu` component. The focusable elements shown within the `s-menu` component are `s-block-link`s, so this PR updates the `s-block-link` focus style.