### PR TITLE
fix(focus): change focus ring from `black-050` to `white`

### DIFF
--- a/lib/components/button/button.less
+++ b/lib/components/button/button.less
@@ -409,7 +409,7 @@
     &:not(&__link):not(&__unset):focus-visible,
     &--radio:focus-visible + & {
         border-color: var(--theme-secondary-400) !important;
-        box-shadow: inset 0 0 0 var(--su-static2) var(--theme-secondary-400), inset 0 0 0 var(--su-static4) var(--black-050);
+        box-shadow: inset 0 0 0 var(--su-static2) var(--theme-secondary-400), inset 0 0 0 var(--su-static4) var(--white);
         outline: var(--su-static2) solid transparent;
     }
 

--- a/lib/components/pagination/pagination.less
+++ b/lib/components/pagination/pagination.less
@@ -42,7 +42,7 @@
         &:focus-visible {
             background-color: var(--_pa-item-bg-focus);
             border-color: var(--theme-secondary-400) !important;
-            box-shadow: inset 0 0 0 var(--su-static2) var(--theme-secondary-400), inset 0 0 0 var(--su-static4) var(--black-050);
+            box-shadow: inset 0 0 0 var(--su-static2) var(--theme-secondary-400), inset 0 0 0 var(--su-static4) var(--white);
             color: var(--_pa-item-fc-focus);
             outline: var(--su-static2) solid transparent;
         }

--- a/lib/components/tag/tag.less
+++ b/lib/components/tag/tag.less
@@ -158,7 +158,7 @@
     & &--dismiss,
     & button&--dismiss:not(.s-btn) { // Style adjustment to @Svg.ClearSm
         &:focus-visible {
-            box-shadow: 0 0 0 var(--su-static2) var(--black-050), 0 0 0 var(--su-static4) var(--theme-secondary-400);
+            box-shadow: 0 0 0 var(--su-static2) var(--white), 0 0 0 var(--su-static4) var(--theme-secondary-400);
             outline: var(--su-static2) solid transparent;
         }
 
@@ -213,7 +213,7 @@
 
     &:focus-visible {
         border-color: var(--white) !important;
-        box-shadow: 0 0 0 var(--su-static1) var(--black-050), 0 0 0 calc(var(--su-static4) - var(--su-static1)) var(--theme-secondary-400);
+        box-shadow: 0 0 0 var(--su-static1) var(--white), 0 0 0 calc(var(--su-static4) - var(--su-static1)) var(--theme-secondary-400);
         outline: var(--su-static2) solid transparent;
     }
 


### PR DESCRIPTION
Related https://github.com/StackExchange/Stacks/pull/1620#pullrequestreview-1851626479

---

@CGuindon This PR updates the focus ring color from `black-050` to `white` for button, pagination, and tag components so the focus ring matches the background of the page in all color modes. If this looks right, I'll update the values for the in-flight PR as well.