### PR TITLE
fix(topbar): improve focus style to meet WCAG 2.2 AA

### DIFF
--- a/lib/components/topbar/topbar.less
+++ b/lib/components/topbar/topbar.less
@@ -34,7 +34,7 @@
         // Topbar items
         --theme-topbar-item-color: var(--black-600);
         --theme-topbar-item-color-hover: var(--black-600);
-        --theme-topbar-item-background-hover: var(--black-200);
+        --theme-topbar-item-background-hover: var(--black-300);
         --theme-topbar-item-color-current: var(--black);
     });
 
@@ -68,7 +68,6 @@
         --_tb-focus-color-inner: .set-black()[600]; // set to match .s-topbar__dark --theme-topbar-background-color;
         --_tb-focus-color-outer: var(--theme-dark-secondary-custom-400, .theme-dark-default()[secondary]);
     }
-
 
     // focus styles
     a&--logo,

--- a/lib/components/topbar/topbar.less
+++ b/lib/components/topbar/topbar.less
@@ -5,6 +5,9 @@
 }
 
 .s-topbar {
+    --_tb-focus-color-inner: var(--white);
+    --_tb-focus-color-outer: var(--theme-secondary-400);
+
     min-width: auto;
     width: 100%;
     z-index: var(--zi-navigation-fixed);
@@ -23,7 +26,6 @@
         --theme-topbar-search-background: var(--theme-topbar-background-color, var(--white));
         --theme-topbar-search-placeholder: var(--theme-topbar-item-color, var(--black-400));
         --theme-topbar-search-border: var(--theme-topbar-item-color, var(--black-400));
-        --theme-topbar-search-border-focus: var(--theme-topbar-item-color, var(--black-400));
 
         // Search switcher
         --theme-topbar-select-color: var(--theme-topbar-item-color, var(--black-400));
@@ -32,11 +34,64 @@
         // Topbar items
         --theme-topbar-item-color: var(--black-600);
         --theme-topbar-item-color-hover: var(--black-600);
-        --theme-topbar-item-background-hover: var(--black-300);
+        --theme-topbar-item-background-hover: var(--black-200);
         --theme-topbar-item-color-current: var(--black);
     });
 
     .highcontrast-mode({ border-bottom: 1px solid currentColor; });
+
+    // Overrides for focus style colors in forced light variant
+    &&__light {
+        --_tb-focus-color-inner: .set-white()[default]; // forces white for inner focus ring color
+    }
+
+    .dark-mode({
+        &.s-topbar__light {
+            --_tb-focus-color-outer: var(--theme-dark-secondary-custom-200, .set-theme-secondary-default()[200]);
+        }
+    });
+
+    .highcontrast-dark-mode({
+        &.s-topbar__light {
+            --_tb-focus-color-outer: .set-theme-secondary-default()[200];
+        }
+    });
+
+    // Overrides for focus style colors in forced dark variant
+    .highcontrast-mode({
+        &.s-topbar__dark {
+            --_tb-focus-color-outer: .theme-dark-default()[secondary];
+        }
+    });
+
+    &&__dark {
+        --_tb-focus-color-inner: .set-black()[600]; // set to match .s-topbar__dark --theme-topbar-background-color;
+        --_tb-focus-color-outer: var(--theme-dark-secondary-custom-400, .theme-dark-default()[secondary]);
+    }
+
+
+    // focus styles
+    a&--logo,
+    & &--content &--item:not(&--item__unset),
+    &--notice,
+    .s-navigation .s-navigation--item {
+        &:focus-visible {
+            box-shadow: inset 0 0 0 var(--su-static2) var(--_tb-focus-color-outer), inset 0 0 0 var(--su-static4) var(--_tb-focus-color-inner);
+            outline: var(--su-static2) solid transparent;
+        }
+    }
+
+    // TODO investigate removing once .s-input and .s-select have updated focus styles
+    & .s-topbar--searchbar {
+        .s-topbar--searchbar--input-group .s-input,
+        .s-select > select {
+            &:focus-visible {
+                // border-color: var(--_tb-focus-color-outer) !important;
+                box-shadow: 0 0 0 var(--su-static2) var(--_tb-focus-color-inner), 0 0 0 var(--su-static4) var(--_tb-focus-color-outer) !important;
+                outline: var(--su-static2) solid transparent !important;
+            }
+        }
+    }
 
     // Wraps the content so the topbar stretches 100% w/ content at some value below that
     .s-topbar--container {
@@ -54,14 +109,17 @@
         display: flex;
         align-items: center;
         background-color: transparent;
+        border-radius: var(--br-sm);
     }
 
-    a.s-topbar--logo:hover {
-        background-color: var(--theme-topbar-item-background-hover, var(--black-200));
-    }
+    a.s-topbar--logo {
+        &:hover {
+            background-color: var(--theme-topbar-item-background-hover, var(--black-200));
+        }
 
-    a.s-topbar--logo.is-selected {
-        background-color: var(--theme-topbar-item-background-hover, var(--black-200));
+        &.is-selected {
+            background-color: var(--theme-topbar-item-background-hover, var(--black-200));
+        }
     }
 
     .s-topbar--menu-btn {
@@ -125,9 +183,6 @@
     }
 
     .s-navigation {
-        .s-navigation--item:focus-visible {
-            box-shadow: var(--theme-topbar-search-shadow-focus, 0 0 0 var(--su-static4) var(--focus-ring));
-        }
         .s-navigation--item:not(.is-selected) {
             color: var(--theme-topbar-item-color, var(--black-400));
         }
@@ -139,10 +194,6 @@
     }
     .s-popover .s-navigation {
         .s-navigation--item {
-            &:focus-visible {
-                box-shadow: var(0 0 0 var(--su-static4) var(--focus-ring));
-            }
-
             &:not(.is-selected) {
                 &:hover {
                     color: var(--black-600);
@@ -170,8 +221,6 @@
     --theme-topbar-search-background: var(--_white-static);
     --theme-topbar-search-placeholder: .set-black()[400];
     --theme-topbar-search-border: .set-black()[300];
-    --theme-topbar-search-border-focus: .set-blue()[400];
-    --theme-topbar-search-shadow-focus: 0 0 0 var(--su-static4) var(--focus-ring);
 
     // Search switcher
     --theme-topbar-select-color: .set-black()[500];
@@ -222,8 +271,6 @@
     --theme-topbar-search-background: lighten(@topbar-actual-background, @topbar-search-lightness-increase);
     --theme-topbar-search-placeholder: lighten(@topbar-actual-background, 60% + @topbar-search-lightness-increase);
     --theme-topbar-search-border: lighten(@topbar-actual-background, 20% + @topbar-search-lightness-increase);
-    --theme-topbar-search-border-focus: lighten(@topbar-actual-background, 45% + @topbar-search-lightness-increase);
-    --theme-topbar-search-shadow-focus: 0 0 0 var(--su-static4) fade(.set-white()[default], 30%);
 
     // Search switcher
     --theme-topbar-select-color: lighten(@topbar-actual-background, 60% + @topbar-search-lightness-increase);
@@ -290,16 +337,14 @@
         text-decoration: none;
         white-space: nowrap;
         position: relative;
+        border-radius: var(--br-sm);
 
         &:hover,
-        &:focus,
         &.is-selected,
-        &.is-selected:hover,
-        &.is-selected:focus {
+        &.is-selected:hover {
             color: var(--theme-topbar-item-color-hover, var(--black-600));
             background-color: var(--theme-topbar-item-background-hover, var(--black-200));
             text-decoration: none;
-            outline: none;
 
             .s-activity-indicator {
                 top: calc(50% - calc(var(--su16) + var(--su2))); // 50% - 18px
@@ -343,16 +388,14 @@
 
     .topbar-notice-styles(transparent, transparent, var(--theme-topbar-item-color, var(--black-400)));
 
-    &:hover,
-    &:focus {
+    &:hover {
         .topbar-notice-styles(var(--theme-topbar-item-background-hover, var(--black-200)), var(--theme-topbar-item-background-hover, var(--black-200)), var(--theme-topbar-item-color-hover, var(--black-600)));
     }
 
     &.is-unread {
         .topbar-notice-styles(var(--theme-primary), var(--theme-primary), var(--white));
 
-        &:hover,
-        &:focus {
+        &:hover {
             .topbar-notice-styles(var(--theme-primary-500), var(--theme-primary-500), var(--white));
         }
     }
@@ -374,17 +417,15 @@
         flex-grow: 1;
 
         .s-input {
-            border-color: var(--theme-topbar-search-border, var(--black-300));
+            &:not(:focus-visible) {
+                box-shadow: var(--theme-topbar-search-shadow);
+            }
+
             background-color: var(--theme-topbar-search-background, var(--white));
-            box-shadow: var(--theme-topbar-search-shadow);
+            border-color: var(--theme-topbar-search-border, var(--black-300));
             color: var(--theme-topbar-search-color, var(--black-500));
             display: block;
             line-height: @inputLineHeights;
-
-            &:focus {
-                border-color: var(--theme-topbar-search-border-focus, var(--blue-400));
-                box-shadow: var(--theme-topbar-search-shadow-focus, 0 0 0 var(--su-static4) var(--focus-ring));
-            }
 
             &::placeholder {
                 color: var(--theme-topbar-search-placeholder, var(--black-400));
@@ -411,19 +452,18 @@
     }
 
     .s-select > select {
+        border-color: var(--theme-topbar-search-border, var(--black-300));
+
+        &:focus-visible {
+            z-index: var(--zi-selected);
+        }
+
         .brr0;
         height: 100%;
         line-height: @inputLineHeights;
-
-        border-color: var(--theme-topbar-search-border, var(--black-300));
         background-color: var(--theme-topbar-select-background, var(--black-200));
         color: var(--theme-topbar-select-color, var(--black-500));
 
-        &:focus {
-            border-color: var(--theme-topbar-search-border-focus, var(--blue-400));
-            box-shadow: var(--theme-topbar-search-shadow-focus, 0 0 0 var(--su-static4) var(--focus-ring));
-            z-index: var(--zi-selected);
-        }
     }
 
     // Drop the left border of the search input when it is next to the select

--- a/lib/components/topbar/topbar.less
+++ b/lib/components/topbar/topbar.less
@@ -81,14 +81,12 @@
     }
 
     // TODO investigate removing once .s-input and .s-select have updated focus styles
-    & .s-topbar--searchbar {
-        .s-topbar--searchbar--input-group .s-input,
-        .s-select > select {
-            &:focus-visible {
-                // border-color: var(--_tb-focus-color-outer) !important;
-                box-shadow: 0 0 0 var(--su-static2) var(--_tb-focus-color-inner), 0 0 0 var(--su-static4) var(--_tb-focus-color-outer) !important;
-                outline: var(--su-static2) solid transparent !important;
-            }
+    & .s-topbar--searchbar .s-topbar--searchbar--input-group .s-input,
+    & .s-topbar--searchbar .s-select > select {
+        &:focus-visible {
+            // border-color: var(--_tb-focus-color-outer) !important;
+            box-shadow: 0 0 0 var(--su-static2) var(--_tb-focus-color-inner), 0 0 0 var(--su-static4) var(--_tb-focus-color-outer) !important;
+            outline: var(--su-static2) solid transparent !important;
         }
     }
 


### PR DESCRIPTION
Addresses https://stackoverflow.atlassian.net/browse/STACKS-549

This PR updates focus styles for all elements _generally_ included within the topbar component.

[Deploy preview](https://deploy-preview-1628--stacks.netlify.app/product/components/topbar/)

## Notes on visual changes

### `.s-topbar--item`, `.s-topbar--logo`

**From [STACKS-549](https://stackoverflow.atlassian.net/browse/STACKS-549)**:

> Rounded corners will match the original non-focused component.
> <img src="https://github.com/StackExchange/Stacks/assets/647177/b9ab9ce5-fadb-4301-82ad-f8dc0b8fef13" width="200" />

To match the mockup, I added a border radius of `var(--br-sm)` of items (and of the logo for consistency). @CGuindon let me know if this is ok or if it needs modification.

| | focused | hovered | focused + hovered |
|-|---------|---------|-------------------|
| item | ![image](https://github.com/StackExchange/Stacks/assets/647177/51e3f319-a2fb-4558-9a4f-4afe4dcd8aee) | ![image](https://github.com/StackExchange/Stacks/assets/647177/9a1884b4-e00c-4653-bdc8-641adb484e1a) | ![image](https://github.com/StackExchange/Stacks/assets/647177/0326c613-f45b-499c-8e12-0a6782943563) |
| logo | ![image](https://github.com/StackExchange/Stacks/assets/647177/0502eaf0-4f81-42d1-a76b-9869b350d1a4) | ![image](https://github.com/StackExchange/Stacks/assets/647177/c3e7f877-8f5f-4c58-8c16-94a6f06ab23c) | ![image](https://github.com/StackExchange/Stacks/assets/647177/8e3b79c6-e853-4118-a0d7-b843535260d4) |

### Search

The old focus styles looked out of place and it was easy enough to add a matching focus ring to the search input and select element. @CGuindon is this alright or should I revert/modify?

| | focused |
|-|---------|
| select | ![image](https://github.com/StackExchange/Stacks/assets/647177/a710cc75-bf2c-4acb-b30b-e1e6ad1e8df2) |
| input | ![image](https://github.com/StackExchange/Stacks/assets/647177/6d409c20-2019-4816-a103-b07f65f58895) |

#### Ring placement

For the search input and select elements, I opted to render the focus ring _outside_ the element. This stands in contrast with other topbar elements, which all have the focus ring rendered inside the element. I did this because these elements rely on the border being visible to read as an input/select. When I tried adding the ring inside the element, the focus state was kinda tough to distinguish from the unfocused state, especially in high contrast mode.

| | light mode | light HC mode |
|-|---------|-|
| select | ![image](https://github.com/StackExchange/Stacks/assets/647177/f1297065-43ff-46bf-be38-37ad9e9901df) | ![image](https://github.com/StackExchange/Stacks/assets/647177/c6fce120-50a1-4a11-b5e0-fb5ade0d53a8) |
| input | ![image](https://github.com/StackExchange/Stacks/assets/647177/e99654e7-8cd6-4781-87f7-c7069be11339) | ![image](https://github.com/StackExchange/Stacks/assets/647177/3bbbce83-b0dd-4a58-a524-5bc653000c53) |

## Notes on technical changes

### Code structure

Since this component doesn't yet adhere to our PPCP structure, I decided it was best to keep all of the focus code grouped for easy parsing (and easy porting when we make the switch to PPCP).
