### PR TITLE
fix(form-elements): improve focus style to meet WCAG 2.2 AA

### DIFF
--- a/lib/components/block-link/block-link.less
+++ b/lib/components/block-link/block-link.less
@@ -58,8 +58,7 @@ a.s-block-link,
 
     &:focus-visible {
         border-radius: var(--br-sm);
-        box-shadow: inset 0 0 0 var(--su-static2) var(--theme-secondary-400), inset 0 0 0 var(--su-static4) var(--white);
-       outline: var(--su-static2) solid transparent;
+        .focus-styles(true);
     }
 
     background-color: var(--_bl-bg); // [1]

--- a/lib/components/button/button.less
+++ b/lib/components/button/button.less
@@ -409,8 +409,7 @@
     &:not(&__link):not(&__unset):focus-visible,
     &--radio:focus-visible + & {
         border-color: var(--theme-secondary-400) !important;
-        box-shadow: inset 0 0 0 var(--su-static2) var(--theme-secondary-400), inset 0 0 0 var(--su-static4) var(--white);
-        outline: var(--su-static2) solid transparent;
+        .focus-styles(true, true);
     }
 
     &:not(&__link):not(&__unset)&:not(&__facebook):not(&__github):not(&__google):not(.is-selected):focus-visible,

--- a/lib/components/checkbox_radio/checkbox_radio.less
+++ b/lib/components/checkbox_radio/checkbox_radio.less
@@ -2,7 +2,6 @@
 .s-radio {
     --_ch-baw: var(--su-static1);
     --_ch-bc: var(--bc-dark);
-    --_ch-bc-focus: var(--theme-secondary-400);
     --_ch-bg: var(--white);
     --_ch-bg-image: unset;
 
@@ -63,7 +62,6 @@
     .highcontrast-dark-mode({
         &:checked, &:indeterminate {
             --_ch-bc: var(--blue-500) !important;
-            --_ch-bc-focus: var(--_ch-bc);
             --_ch-bg: var(--blue-400);
         }
     });
@@ -72,10 +70,6 @@
     &:checked, &:indeterminate {
         --_ch-bc: var(--theme-secondary-400) !important;
         --_ch-bg: var(--theme-secondary-400);
-
-        &:focus {
-            --_ch-bc-focus: var(--theme-secondary-400);
-        }
     }
 
     &:checked {
@@ -84,11 +78,6 @@
 
     &:indeterminate {
         --_ch-bg-image: url("data:image/svg+xml;,%3Csvg width='11' height='11' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2 4.5 h7 v2 h-7 z' fill='@{ch-bg-image-fill}'/%3E%3C/svg%3E");
-    }
-
-    // INTERACTION
-    &:focus {
-        border-color: var(--_ch-bc-focus);
     }
 
     background-image: var(--_ch-bg-image);

--- a/lib/components/checkbox_radio/checkbox_radio.less
+++ b/lib/components/checkbox_radio/checkbox_radio.less
@@ -5,7 +5,6 @@
     --_ch-bc-focus: var(--theme-secondary-400);
     --_ch-bg: var(--white);
     --_ch-bg-image: unset;
-    --_ch-bs-focus: 0 0 0 var(--su-static4) var(--focus-ring);
 
     // CONTEXTUAL STYLES
     fieldset[disabled] &,
@@ -30,7 +29,7 @@
 
     // INTERACTION
     &:focus {
-        box-shadow: var(--_ch-bs-focus);
+        .focus-styles();
     }
 
     background-color: var(--_ch-bg);

--- a/lib/components/input_textarea/input_textarea.less
+++ b/lib/components/input_textarea/input_textarea.less
@@ -108,9 +108,10 @@
     // INTERACTION
     &:focus{
         border-color: var(--_in-bc-focus);
-        box-shadow: var(--_in-bs-focus);
         color: var(--_in-fc-focus);
-        outline: 0;
+
+        box-shadow: 0 0 0 var(--su-static2) var(--white), 0 0 0 var(--su-static4) var(--theme-secondary-400) !important;
+        outline: var(--su-static2) solid transparent !important;
     }
 
     @scrollbar-styles();

--- a/lib/components/input_textarea/input_textarea.less
+++ b/lib/components/input_textarea/input_textarea.less
@@ -1,12 +1,10 @@
 .s-input,
 .s-textarea {
     --_in-bc: var(--bc-darker);
-    --_in-bc-focus: var(--theme-secondary-400);
     --_in-bg: var(--white);
     --_in-br: var(--br-md);
     --_in-c: unset;
     --_in-fc: var(--fc-dark);
-    --_in-fc-focus: var(--black);
     --_in-fs: var(--fs-body1);
     --_in-o: unset;
     --_in-px: 0.7em;
@@ -51,7 +49,6 @@
         --_in-bg: var(--black-150);
         --_in-bc: var(--bc-light);
         --_in-fc: var(--black-300);
-        --_in-fc-focus: var(--_in-fc);
     }
 
     .validation-states(
@@ -106,9 +103,6 @@
 
     // INTERACTION
     &:focus {
-        border-color: var(--_in-bc-focus);
-        color: var(--_in-fc-focus);
-
         .focus-styles();
     }
 
@@ -132,15 +126,6 @@
     .input-states({
         padding-right: var(--su32);
     });
-
-    &:focus-within {
-        .highcontrast-mode({
-            --_in-bc-focus: var(--black);
-        });
-
-        border-color: var(--_in-bc-focus);
-        color: var(--_in-fc-focus);
-    }
 
     &&__md {
         --_in-py: 0.5em;

--- a/lib/components/input_textarea/input_textarea.less
+++ b/lib/components/input_textarea/input_textarea.less
@@ -4,7 +4,6 @@
     --_in-bc-focus: var(--theme-secondary-400);
     --_in-bg: var(--white);
     --_in-br: var(--br-md);
-    --_in-bs-focus: 0 0 0 var(--su-static4) var(--focus-ring);
     --_in-c: unset;
     --_in-fc: var(--fc-dark);
     --_in-fc-focus: var(--black);
@@ -106,12 +105,11 @@
     }
 
     // INTERACTION
-    &:focus{
+    &:focus {
         border-color: var(--_in-bc-focus);
         color: var(--_in-fc-focus);
 
-        box-shadow: 0 0 0 var(--su-static2) var(--white), 0 0 0 var(--su-static4) var(--theme-secondary-400) !important;
-        outline: var(--su-static2) solid transparent !important;
+        .focus-styles();
     }
 
     @scrollbar-styles();
@@ -141,9 +139,7 @@
         });
 
         border-color: var(--_in-bc-focus);
-        box-shadow: var(--_in-bs-focus);
         color: var(--_in-fc-focus);
-        outline: 0;
     }
 
     &&__md {

--- a/lib/components/navigation/navigation.less
+++ b/lib/components/navigation/navigation.less
@@ -92,8 +92,7 @@
         }
 
         &:focus-visible {
-            box-shadow: inset 0 0 0 var(--su-static2) var(--theme-secondary-400), inset 0 0 0 var(--su-static4) var(--white);
-           outline: var(--su-static2) solid transparent;
+            .focus-styles(true);
         }
 
         background-color: var(--_na-item-bg);

--- a/lib/components/pagination/pagination.less
+++ b/lib/components/pagination/pagination.less
@@ -41,10 +41,8 @@
 
         &:focus-visible {
             background-color: var(--_pa-item-bg-focus);
-            border-color: var(--theme-secondary-400) !important;
-            box-shadow: inset 0 0 0 var(--su-static2) var(--theme-secondary-400), inset 0 0 0 var(--su-static4) var(--white);
             color: var(--_pa-item-fc-focus);
-            outline: var(--su-static2) solid transparent;
+            .focus-styles(true, true);
         }
 
         background-color: var(--_pa-item-bg);

--- a/lib/components/select/select.less
+++ b/lib/components/select/select.less
@@ -3,7 +3,6 @@
     --_se-arrow-size: var(--su-static4); // Constant
     --_se-select-bc: var(--bc-darker);
     --_se-select-bc-focus: var(--theme-secondary-400);
-    --_se-select-bs-focus: 0 0 0 var(--su-static4) var(--focus-ring);
     --_se-select-bg: var(--white);
     --_se-select-br: var(--br-md);
     --_se-select-fc: var(--black);
@@ -112,10 +111,8 @@
             });
 
             border-color: var(--_se-select-bc-focus);
-            box-shadow: var(--_se-select-bs-focus);
-
             color: var(--black);
-            outline: 0;
+            .focus-styles();
         }
 
         background-color: var(--_se-select-bg);

--- a/lib/components/select/select.less
+++ b/lib/components/select/select.less
@@ -2,7 +2,6 @@
     --_se-arrow-bc: currentColor transparent;
     --_se-arrow-size: var(--su-static4); // Constant
     --_se-select-bc: var(--bc-darker);
-    --_se-select-bc-focus: var(--theme-secondary-400);
     --_se-select-bg: var(--white);
     --_se-select-br: var(--br-md);
     --_se-select-fc: var(--black);
@@ -99,18 +98,8 @@
             cursor: not-allowed;
         }
 
-        // CHILD ELEMENTS
-        &::-moz-focus-inner {
-            outline: none !important;
-        }
-
         // INTERACTION
         &:focus {
-            .highcontrast-mode({
-                --_se-select-bc-focus: var(--black);
-            });
-
-            border-color: var(--_se-select-bc-focus);
             color: var(--black);
             .focus-styles();
         }

--- a/lib/components/tag/tag.less
+++ b/lib/components/tag/tag.less
@@ -158,8 +158,7 @@
     & &--dismiss,
     & button&--dismiss:not(.s-btn) { // Style adjustment to @Svg.ClearSm
         &:focus-visible {
-            box-shadow: 0 0 0 var(--su-static2) var(--white), 0 0 0 var(--su-static4) var(--theme-secondary-400);
-            outline: var(--su-static2) solid transparent;
+            .focus-styles();
         }
 
         &:hover {
@@ -212,9 +211,7 @@
     }
 
     &:focus-visible {
-        border-color: var(--white) !important;
-        box-shadow: 0 0 0 var(--su-static1) var(--white), 0 0 0 calc(var(--su-static4) - var(--su-static1)) var(--theme-secondary-400);
-        outline: var(--su-static2) solid transparent;
+        .focus-styles(false, true);
     }
 
     background-color: var(--_ta-bg);

--- a/lib/components/toggle-switch/toggle-switch.less
+++ b/lib/components/toggle-switch/toggle-switch.less
@@ -38,8 +38,7 @@
             }
 
             &:focus-visible + label {
-                box-shadow: inset 0 0 0 var(--su-static2) var(--theme-secondary-400), inset 0 0 0 var(--su-static4) var(--white);
-                outline: var(--su-static2) solid transparent;
+                .focus-styles(true);
             }
 
             left: -999em;
@@ -79,8 +78,7 @@
         }
 
         &:focus-visible {
-            box-shadow: 0 0 0 var(--su-static2) var(--white), 0 0 0 var(--su-static4) var(--theme-secondary-400);
-            outline: var(--su-static2) solid transparent;
+            .focus-styles();
         }
 
         &[disabled] {

--- a/lib/components/topbar/topbar.less
+++ b/lib/components/topbar/topbar.less
@@ -5,9 +5,6 @@
 }
 
 .s-topbar {
-    --_tb-focus-color-inner: var(--white);
-    --_tb-focus-color-outer: var(--theme-secondary-400);
-
     min-width: auto;
     width: 100%;
     z-index: var(--zi-navigation-fixed);
@@ -42,50 +39,39 @@
 
     // Overrides for focus style colors in forced light variant
     &&__light {
-        --_tb-focus-color-inner: .set-white()[default]; // forces white for inner focus ring color
+        --focus-neutral: .set-white()[default]; // forces white for inner focus ring color
     }
 
     .dark-mode({
         &.s-topbar__light {
-            --_tb-focus-color-outer: var(--theme-dark-secondary-custom-200, .set-theme-secondary-default()[200]);
+            --focus-theme: var(--theme-dark-secondary-custom-200, .set-theme-secondary-default()[200]);
         }
     });
 
     .highcontrast-dark-mode({
         &.s-topbar__light {
-            --_tb-focus-color-outer: .set-theme-secondary-default()[200];
+            --focus-theme: .set-theme-secondary-default()[200];
         }
     });
 
     // Overrides for focus style colors in forced dark variant
     .highcontrast-mode({
         &.s-topbar__dark {
-            --_tb-focus-color-outer: .theme-dark-default()[secondary];
+            --focus-theme: .theme-dark-default()[secondary];
         }
     });
 
     &&__dark {
-        --_tb-focus-color-inner: .set-black()[600]; // set to match .s-topbar__dark --theme-topbar-background-color;
-        --_tb-focus-color-outer: var(--theme-dark-secondary-custom-400, .theme-dark-default()[secondary]);
+        --focus-neutral: .set-black()[600]; // set to match .s-topbar__dark --theme-topbar-background-color;
+        --focus-theme: var(--theme-dark-secondary-custom-400, .theme-dark-default()[secondary]);
     }
 
     // focus styles
     a&--logo,
     & &--content &--item:not(&--item__unset),
-    &--notice,
-    .s-navigation .s-navigation--item {
+    &--notice {
         &:focus-visible {
-            box-shadow: inset 0 0 0 var(--su-static2) var(--_tb-focus-color-outer), inset 0 0 0 var(--su-static4) var(--_tb-focus-color-inner);
-            outline: var(--su-static2) solid transparent;
-        }
-    }
-
-    // TODO investigate removing once .s-input and .s-select have updated focus styles
-    & .s-topbar--searchbar .s-topbar--searchbar--input-group .s-input,
-    & .s-topbar--searchbar .s-select > select {
-        &:focus {
-            box-shadow: 0 0 0 var(--su-static2) var(--_tb-focus-color-inner), 0 0 0 var(--su-static4) var(--_tb-focus-color-outer) !important;
-            outline: var(--su-static2) solid transparent !important;
+            .focus-styles(true);
         }
     }
 

--- a/lib/components/topbar/topbar.less
+++ b/lib/components/topbar/topbar.less
@@ -83,8 +83,7 @@
     // TODO investigate removing once .s-input and .s-select have updated focus styles
     & .s-topbar--searchbar .s-topbar--searchbar--input-group .s-input,
     & .s-topbar--searchbar .s-select > select {
-        &:focus-visible {
-            // border-color: var(--_tb-focus-color-outer) !important;
+        &:focus {
             box-shadow: 0 0 0 var(--su-static2) var(--_tb-focus-color-inner), 0 0 0 var(--su-static4) var(--_tb-focus-color-outer) !important;
             outline: var(--su-static2) solid transparent !important;
         }

--- a/lib/components/uploader/uploader.less
+++ b/lib/components/uploader/uploader.less
@@ -91,7 +91,7 @@
     & &--input {
         &:focus:focus-visible + .s-uploader--container {
             background-color: var(--_up-bg-focus);
-            box-shadow: 0 0 0 var(--su-static4) var(--_up-focus-ring-color);
+            .focus-styles();
         }
 
         cursor: pointer;

--- a/lib/exports/__snapshots__/color-mixins.less.test.ts.snap
+++ b/lib/exports/__snapshots__/color-mixins.less.test.ts.snap
@@ -359,6 +359,8 @@ body .themed {
     --translucent-warning: hsla(47, 79%, 58%, 0.4);
     --translucent-error: hsla(358, 62%, 47%, 0.15);
     --translucent-muted: hsla(210, 8%, 15%, 0.1);
+    --focus-neutral: var(--white);
+    --focus-theme: var(--theme-secondary-400);
     --focus-ring: var(--theme-secondary-custom-focus-ring, hsla(206, 100%, 40%, 0.15));
     --focus-ring-success: hsla(140, 40%, 75%, 0.4);
     --focus-ring-warning: hsla(47, 79%, 58%, 0.4);

--- a/lib/exports/__snapshots__/color.less.test.ts.snap
+++ b/lib/exports/__snapshots__/color.less.test.ts.snap
@@ -147,6 +147,8 @@ body:not(.theme-highcontrast).theme-system .theme-light__forced .themed {
     --translucent-warning: hsla(47, 79%, 58%, 0.4);
     --translucent-error: hsla(358, 62%, 47%, 0.15);
     --translucent-muted: hsla(210, 8%, 15%, 0.1);
+    --focus-neutral: var(--white);
+    --focus-theme: var(--theme-secondary-400);
     --focus-ring: var(--theme-secondary-custom-focus-ring, hsla(206, 100%, 40%, 0.15));
     --focus-ring-success: hsla(140, 40%, 75%, 0.4);
     --focus-ring-warning: hsla(47, 79%, 58%, 0.4);
@@ -280,6 +282,8 @@ body:not(.theme-highcontrast):not(.theme-dark) .theme-dark__forced .themed {
     --translucent-warning: hsla(47, 79%, 58%, 0.4);
     --translucent-error: hsla(358, 62%, 47%, 0.15);
     --translucent-muted: hsla(210, 8%, 15%, 0.1);
+    --focus-neutral: var(--white);
+    --focus-theme: var(--theme-secondary-400);
     --focus-ring: var(--theme-dark-secondary-custom-focus-ring, hsla(206, 100%, 40%, 0.25));
     --focus-ring-success: hsla(140, 40%, 75%, 0.4);
     --focus-ring-warning: hsla(47, 79%, 58%, 0.4);
@@ -411,6 +415,8 @@ body:not(.theme-highcontrast):not(.theme-dark) .theme-dark__forced .themed {
         --translucent-warning: hsla(47, 79%, 58%, 0.4);
         --translucent-error: hsla(358, 62%, 47%, 0.15);
         --translucent-muted: hsla(210, 8%, 15%, 0.1);
+        --focus-neutral: var(--white);
+        --focus-theme: var(--theme-secondary-400);
         --focus-ring: var(--theme-dark-secondary-custom-focus-ring, hsla(206, 100%, 40%, 0.25));
         --focus-ring-success: hsla(140, 40%, 75%, 0.4);
         --focus-ring-warning: hsla(47, 79%, 58%, 0.4);
@@ -542,6 +548,8 @@ body.theme-highcontrast.theme-system .theme-light__forced {
     --translucent-warning: hsla(47, 76%, 46%, 0.9);
     --translucent-error: hsla(358, 62%, 47%, 0.9);
     --translucent-muted: hsla(210, 8%, 55%, 0.95);
+    --focus-neutral: var(--white);
+    --focus-theme: var(--theme-secondary-400);
     --focus-ring: hsla(206, 100%, 40%, 0.9);
     --focus-ring-success: hsla(140, 40%, 40%, 0.9);
     --focus-ring-warning: hsla(47, 76%, 46%, 0.9);
@@ -655,6 +663,8 @@ body.theme-highcontrast:not(.theme-dark) .theme-dark__forced {
     --translucent-warning: hsla(47, 76%, 46%, 0.9);
     --translucent-error: hsla(358, 62%, 47%, 0.9);
     --translucent-muted: hsla(210, 8%, 55%, 0.95);
+    --focus-neutral: var(--white);
+    --focus-theme: var(--theme-secondary-400);
     --focus-ring: hsla(206, 100%, 40%, 0.9);
     --focus-ring-success: hsla(140, 40%, 40%, 0.9);
     --focus-ring-warning: hsla(47, 76%, 46%, 0.9);
@@ -768,6 +778,8 @@ body.theme-highcontrast:not(.theme-dark) .theme-dark__forced {
         --translucent-warning: hsla(47, 76%, 46%, 0.9);
         --translucent-error: hsla(358, 62%, 47%, 0.9);
         --translucent-muted: hsla(210, 8%, 55%, 0.95);
+        --focus-neutral: var(--white);
+        --focus-theme: var(--theme-secondary-400);
         --focus-ring: hsla(206, 100%, 40%, 0.9);
         --focus-ring-success: hsla(140, 40%, 40%, 0.9);
         --focus-ring-warning: hsla(47, 76%, 46%, 0.9);

--- a/lib/exports/color-sets.less
+++ b/lib/exports/color-sets.less
@@ -453,22 +453,28 @@
     muted: hsla(210, 8%, 55%, 0.95);
 }
 
-// focus (sets represents both light and dark mode)
+// focus colors used for accessible focus styles
 .set-focus() {
+    neutral: var(--white);
+    theme: var(--theme-secondary-400);
+}
+
+// focus ring (sets represents both light and dark mode)
+.set-focus-ring() {
     default: var(--theme-secondary-custom-focus-ring, hsla(206, 100%, 40%, 0.15));
     success: hsla(140, 40%, 75%, 0.4);
     warning: hsla(47, 79%, 58%, 0.4);
     error: hsla(358, 62%, 47%, 0.15);
     muted: hsla(210, 8%, 15%, 0.1);
 }
-.set-focus-dark() {
+.set-focus-ring-dark() {
     default: var(--theme-dark-secondary-custom-focus-ring, hsla(206, 100%, 40%, 0.25));
     success: hsla(140, 40%, 75%, 0.4);
     warning: hsla(47, 79%, 58%, 0.4);
     error: hsla(358, 62%, 47%, 0.15);
     muted: hsla(210, 8%, 15%, 0.1);
 }
-.set-focus-hc() {
+.set-focus-ring-hc() {
     default: hsla(206, 100%, 40%, 0.9);
     success: hsla(140, 40%, 40%, 0.9);
     warning: hsla(47, 76%, 46%, 0.9);
@@ -631,7 +637,8 @@
     bc: .set-bc();
     bs: .set-bs();
     translucent: .set-translucent();
-    focus-ring: .set-focus();
+    focus: .set-focus();
+    focus-ring: .set-focus-ring();
     highlight: .set-highlight();
     scrollbar: .set-scrollbar();
 }
@@ -640,7 +647,8 @@
     bc: .set-bc();
     bs: .set-bs-dark();
     translucent: .set-translucent-dark();
-    focus-ring: .set-focus-dark();
+    focus: .set-focus();
+    focus-ring: .set-focus-ring-dark();
     highlight: .set-highlight-dark();
     scrollbar: .set-scrollbar-dark();
 }
@@ -649,7 +657,8 @@
     bc: .set-bc-hc();
     bs: .set-bs-hc();
     translucent: .set-translucent-hc();
-    focus-ring: .set-focus-hc();
+    focus: .set-focus();
+    focus-ring: .set-focus-ring-hc();
     highlight: .set-highlight-hc();
     scrollbar: .set-scrollbar-hc();
 }
@@ -658,7 +667,8 @@
     bc: .set-bc-hc();
     bs: .set-bs-hc-dark();
     translucent: .set-translucent-hc();
-    focus-ring: .set-focus-hc();
+    focus: .set-focus();
+    focus-ring: .set-focus-ring-hc();
     highlight: .set-highlight-hc-dark();
     scrollbar: .set-scrollbar-hc-dark();
 }

--- a/lib/exports/mixins.less
+++ b/lib/exports/mixins.less
@@ -120,23 +120,22 @@
  * @border: boolean - whether the element's border color change to match the focus style.
  */
 .focus-styles(@inset: false, @border: false) {
-    & when (@inset = false) {
-        & when (@border = false) {
-            box-shadow: 0 0 0 var(--su-static2) var(--focus-neutral), 0 0 0 var(--su-static4) var(--focus-theme);
-        }
-        & when (@border = true) {
-            border-color: var(--focus-neutral) !important;
-            box-shadow: 0 0 0 var(--su-static1) var(--focus-neutral), 0 0 0 calc(var(--su-static4) - var(--su-static1)) var(--focus-theme);
-        }
+    & when not (@inset) and not (@border) {
+        box-shadow: 0 0 0 var(--su-static2) var(--focus-neutral), 0 0 0 var(--su-static4) var(--focus-theme);
     }
-    & when (@inset = true) {
-        & when (@border = false) {
-            box-shadow: inset 0 0 0 var(--su-static2) var(--focus-theme), inset 0 0 0 var(--su-static4) var(--focus-neutral);
-        }
-        & when (@border = true) {
-            border-color: var(--focus-theme) !important;
-            box-shadow: inset 0 0 0 var(--su-static1) var(--focus-theme), inset 0 0 0 calc(var(--su-static4) - var(--su-static1)) var(--focus-neutral);
-        }
+
+    & when not (@inset) and (@border) {
+        border-color: var(--focus-neutral) !important;
+        box-shadow: 0 0 0 var(--su-static1) var(--focus-neutral), 0 0 0 calc(var(--su-static4) - var(--su-static1)) var(--focus-theme);
+    }
+
+    & when (@inset) and not (@border) {
+        box-shadow: inset 0 0 0 var(--su-static2) var(--focus-theme), inset 0 0 0 var(--su-static4) var(--focus-neutral);
+    }
+
+    & when (@inset) and (@border) {
+        border-color: var(--focus-theme) !important;
+        box-shadow: inset 0 0 0 var(--su-static1) var(--focus-theme), inset 0 0 0 calc(var(--su-static4) - var(--su-static1)) var(--focus-neutral);
     }
 
     // We include a 2px transparent outline to ensure Windows High Contrast Forced Color Mode

--- a/lib/exports/mixins.less
+++ b/lib/exports/mixins.less
@@ -110,6 +110,40 @@
 }
 
 
+/**
+ * Focus styles for the given context.
+ *
+ * Usage example:
+ * .focus-styles(true, true);
+ *
+ * @inset: boolean - whether the focus style be placed inside the element.
+ * @border: boolean - whether the element's border color change to match the focus style.
+ */
+.focus-styles(@inset: false, @border: false) {
+    & when (@inset = false) {
+        & when (@border = false) {
+            box-shadow: 0 0 0 var(--su-static2) var(--focus-neutral), 0 0 0 var(--su-static4) var(--focus-theme);
+        }
+        & when (@border = true) {
+            border-color: var(--focus-neutral) !important;
+            box-shadow: 0 0 0 var(--su-static1) var(--focus-neutral), 0 0 0 calc(var(--su-static4) - var(--su-static1)) var(--focus-theme);
+        }
+    }
+    & when (@inset = true) {
+        & when (@border = false) {
+            box-shadow: inset 0 0 0 var(--su-static2) var(--focus-theme), inset 0 0 0 var(--su-static4) var(--focus-neutral);
+        }
+        & when (@border = true) {
+            border-color: var(--focus-theme) !important;
+            box-shadow: inset 0 0 0 var(--su-static1) var(--focus-theme), inset 0 0 0 calc(var(--su-static4) - var(--su-static1)) var(--focus-neutral);
+        }
+    }
+
+    // We include a 2px transparent outline to ensure Windows High Contrast Forced Color Mode
+    // includes outlines as expected See https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/
+    outline: var(--su-static2) solid transparent !important;
+}
+
 //  =============================================================================
 //  --  COLORS
 //      The following mixins let us do color math on the browser. They take a

--- a/lib/input-utils.less
+++ b/lib/input-utils.less
@@ -17,19 +17,16 @@
 
     .has-error & {
         --_@{prefix}-bc: var(--red-400);
-        --_@{prefix}-bs-focus: 0 0 0 var(--su-static4) var(--focus-ring-error);
         @error();
     }
 
     .has-success & {
         --_@{prefix}-bc: var(--green-400);
-        --_@{prefix}-bs-focus: 0 0 0 var(--su-static4) var(--focus-ring-success);
         @success();
     }
 
     .has-warning & {
         --_@{prefix}-bc: var(--yellow-500);
-        --_@{prefix}-bs-focus: 0 0 0 var(--su-static4) var(--focus-ring-warning);
         @warning();
     }
 }


### PR DESCRIPTION
[STACKS-553](https://stackoverflow.atlassian.net/browse/STACKS-553)

This PR update the focus styles for any input/textarea-based elements including:

- `s-input`
- `s-textarea`
- `s-checkbox`
- `s-radio`
- `s-select`
- `s-uploader`

### `.focus-styles()` mixin

I took this opportunity to add the `--focus-neutral` and `--focus-theme` color custom properties and generalize some common focus styles with the `.focus-styles()` mixin. This will allow us to set focus styles for a given component using just the mixin and modify the colors of the focus styles contextually when needed (particularly useful for the `.s-topbar__light` and `.s-topbar__dark` variants).

> **Note**
> This PR incidentally addresses a minor bug in the `s-btn` and `s-pagination` components. Previously, the themed focus ring rendered as 3px and this PR updates that so it renders 2px as expected. 