### PR TITLE
fix(test): ensure `includeNullModifier` value is honored

### DIFF
--- a/lib/test/test-utils.ts
+++ b/lib/test/test-utils.ts
@@ -229,17 +229,6 @@ const generatePrimitiveVariations = ({
                     secondaryModifiers.forEach((secondaryModifier) => {
                         globalModifiers.forEach((globalModifier) => {
                             allVariants.forEach((variant) => {
-                                console.log("globalModifier", buildTestid([
-                                    testidBase,
-                                    variant,
-                                    [
-                                        primaryModifier,
-                                        secondaryModifier,
-                                        globalModifier,
-                                    ]
-                                        .filter(Boolean)
-                                        .join("-"),
-                                ]));
                                 primitiveVariations.push({
                                     classes: buildClasses({
                                         baseClass,

--- a/lib/test/test-utils.ts
+++ b/lib/test/test-utils.ts
@@ -215,16 +215,31 @@ const generatePrimitiveVariations = ({
                         : modifiers.primary
                     : [""];
                 const secondaryModifiers = modifiers?.secondary
-                    ? ["", ...(<[]>modifiers.secondary)]
+                    ? opts.includeNullModifier
+                        ? ["", ...(<[]>modifiers.secondary)]
+                        : modifiers.secondary
                     : [""];
                 const globalModifiers = modifiers?.global
-                    ? ["", ...(<[]>modifiers.global)]
+                    ? opts.includeNullModifier
+                        ? ["", ...(<[]>modifiers.global)]
+                        : modifiers.global
                     : [""];
 
                 primaryModifiers.forEach((primaryModifier) => {
                     secondaryModifiers.forEach((secondaryModifier) => {
                         globalModifiers.forEach((globalModifier) => {
                             allVariants.forEach((variant) => {
+                                console.log("globalModifier", buildTestid([
+                                    testidBase,
+                                    variant,
+                                    [
+                                        primaryModifier,
+                                        secondaryModifier,
+                                        globalModifier,
+                                    ]
+                                        .filter(Boolean)
+                                        .join("-"),
+                                ]));
                                 primitiveVariations.push({
                                     classes: buildClasses({
                                         baseClass,


### PR DESCRIPTION
After having visual failures of _[test(select): add a11y, visual tests #1498](https://github.com/StackExchange/Stacks/pull/1498)_ after it had been updated with the latest test changes in develop, I realized something was not working as expected.

Turns out that we're not fully honoring the `includeNullModifier` option for secondary and global modifiers (this bug predates the recent test changes). This PR fixes that bug.