### PR TITLE
fix(button): ensure visited link button renders legibly

### DIFF
--- a/docs/product/components/button-groups.html
+++ b/docs/product/components/button-groups.html
@@ -61,27 +61,27 @@ description: Button groups are a collection of buttons. This component is used i
     <div class="stacks-preview">
 {% highlight html %}
 <div class="s-btn-group">
-    <button class="s-btn s-btn__muted s-btn__outlined" role="button">Newest</button>
-    <button class="s-btn s-btn__muted s-btn__outlined" role="button">Frequent</button>
+    <button class="s-btn s-btn__muted s-btn__outlined" type="button">Newest</button>
+    <button class="s-btn s-btn__muted s-btn__outlined" type="button">Frequent</button>
     <form>
-        <button class="s-btn s-btn__muted s-btn__outlined is-selected" role="button" aria-current="true">Votes</button>
+        <button class="s-btn s-btn__muted s-btn__outlined is-selected" type="button" aria-current="true">Votes</button>
     </form>
-    <button class="s-btn s-btn__muted s-btn__outlined" role="button">Active</button>
+    <button class="s-btn s-btn__muted s-btn__outlined" type="button">Active</button>
     <form>
-        <button class="s-btn s-btn__muted s-btn__outlined" role="button">Unanswered</button>
+        <button class="s-btn s-btn__muted s-btn__outlined" type="button">Unanswered</button>
     </form>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="s-btn-group">
-                <button class="s-btn s-btn__muted s-btn__outlined" role="button">Newest</button>
-                <button class="s-btn s-btn__muted s-btn__outlined" role="button">Frequent</button>
+                <button class="s-btn s-btn__muted s-btn__outlined" type="button">Newest</button>
+                <button class="s-btn s-btn__muted s-btn__outlined" type="button">Frequent</button>
                 <form>
-                    <button class="s-btn s-btn__muted s-btn__outlined is-selected" role="button" aria-current="true">Votes</button>
+                    <button class="s-btn s-btn__muted s-btn__outlined is-selected" type="button" aria-current="true">Votes</button>
                 </form>
-                <button class="s-btn s-btn__muted s-btn__outlined" role="button">Active</button>
+                <button class="s-btn s-btn__muted s-btn__outlined" type="button">Active</button>
                 <form>
-                    <button class="s-btn s-btn__muted s-btn__outlined" role="button">Unanswered</button>
+                    <button class="s-btn s-btn__muted s-btn__outlined" type="button">Unanswered</button>
                 </form>
             </div>
         </div>
@@ -96,19 +96,19 @@ description: Button groups are a collection of buttons. This component is used i
     <div class="stacks-preview">
 {% highlight html %}
 <div class="s-btn-group">
-    <button class="s-btn s-btn__muted s-btn__outlined" role="button">
+    <button class="s-btn s-btn__muted s-btn__outlined" type="button">
         Active
         <span class="s-btn--badge">
             <span class="s-btn--number">197</span>
         </span>
     </button>
-    <button class="s-btn s-btn__muted s-btn__outlined" role="button">
+    <button class="s-btn s-btn__muted s-btn__outlined" type="button">
         Inactive
         <span class="s-btn--badge">
             <span class="s-btn--number">37</span>
         </span>
     </button>
-    <button class="s-btn s-btn__muted s-btn__outlined is-selected" role="button" aria-current="true">
+    <button class="s-btn s-btn__muted s-btn__outlined is-selected" type="button" aria-current="true">
         All
         <span class="s-btn--badge">
             <span class="s-btn--number">234</span>
@@ -118,19 +118,19 @@ description: Button groups are a collection of buttons. This component is used i
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="s-btn-group js-btn-group">
-                <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" role="button">
+                <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item" type="button">
                     Active
                     <span class="s-btn--badge">
                         <span class="s-btn--number">197</span>
                     </span>
                 </button>
-                <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item  s-btn__dropdown" role="button">
+                <button class="s-btn s-btn__muted s-btn__outlined js-btn-group-item  s-btn__dropdown" type="button">
                     Inactive
                     <span class="s-btn--badge">
                         <span class="s-btn--number">37</span>
                     </span>
                 </button>
-                <button class="s-btn s-btn__muted s-btn__outlined is-selected js-btn-group-item" role="button" aria-current="true">
+                <button class="s-btn s-btn__muted s-btn__outlined is-selected js-btn-group-item" type="button" aria-current="true">
                     All
                     <span class="s-btn--badge">
                         <span class="s-btn--number">234</span>

--- a/docs/product/components/button-groups.html
+++ b/docs/product/components/button-groups.html
@@ -63,26 +63,18 @@ description: Button groups are a collection of buttons. This component is used i
 <div class="s-btn-group">
     <button class="s-btn s-btn__muted s-btn__outlined" type="button">Newest</button>
     <button class="s-btn s-btn__muted s-btn__outlined" type="button">Frequent</button>
-    <form>
-        <button class="s-btn s-btn__muted s-btn__outlined is-selected" type="button" aria-current="true">Votes</button>
-    </form>
+    <button class="s-btn s-btn__muted s-btn__outlined is-selected" type="button" aria-current="true">Votes</button>
     <button class="s-btn s-btn__muted s-btn__outlined" type="button">Active</button>
-    <form>
-        <button class="s-btn s-btn__muted s-btn__outlined" type="button">Unanswered</button>
-    </form>
+    <button class="s-btn s-btn__muted s-btn__outlined" type="button">Unanswered</button>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="s-btn-group">
                 <button class="s-btn s-btn__muted s-btn__outlined" type="button">Newest</button>
                 <button class="s-btn s-btn__muted s-btn__outlined" type="button">Frequent</button>
-                <form>
-                    <button class="s-btn s-btn__muted s-btn__outlined is-selected" type="button" aria-current="true">Votes</button>
-                </form>
+                <button class="s-btn s-btn__muted s-btn__outlined is-selected" type="button" aria-current="true">Votes</button>
                 <button class="s-btn s-btn__muted s-btn__outlined" type="button">Active</button>
-                <form>
-                    <button class="s-btn s-btn__muted s-btn__outlined" type="button">Unanswered</button>
-                </form>
+                <button class="s-btn s-btn__muted s-btn__outlined" type="button">Unanswered</button>
             </div>
         </div>
     </div>

--- a/docs/product/components/button-groups.html
+++ b/docs/product/components/button-groups.html
@@ -182,6 +182,30 @@ description: Button groups are a collection of buttons. This component is used i
     </div>
 </section>
 
+<section class="stacks-section">
+    {% header "h2", "Links" %}
+    <p class="stacks-copy">
+        In some cases items in the button groups let users navigate between related sections of content, displaying one section at a time.
+        In those cases an <code class="stacks-code">a</code> tag should be prefferred over the <code class="stacks-code">button</code>.
+    </p>
+    <div class="stacks-preview">
+{% highlight html %}
+<div class="s-btn-group">
+    <a href="#" class="s-btn s-btn__muted s-btn__outlined is-selected" aria-current="true">Newest</a>
+    <a href="#" class="s-btn s-btn__muted s-btn__outlined">Frequent</a>
+    <a href="#" class="s-btn s-btn__muted s-btn__outlined">Unanswered</a>
+</div>
+{% endhighlight %}
+        <div class="stacks-preview--example">
+            <div class="s-btn-group">
+                <a href="#links" class="s-btn s-btn__muted s-btn__outlined is-selected" aria-current="true">Newest</a>
+                <a href="#links" class="s-btn s-btn__muted s-btn__outlined">Frequent</a>
+                <a href="#links" class="s-btn s-btn__muted s-btn__outlined">Unanswered</a>
+            </div>
+        </div>
+    </div>
+</section>
+
 <script>
     document.querySelectorAll('.js-btn-group-item').forEach(buttonGroup => {
         buttonGroup.addEventListener('click', e => {

--- a/lib/components/button/button.less
+++ b/lib/components/button/button.less
@@ -412,7 +412,7 @@
         .focus-styles(true, true);
     }
 
-    &:not(&__link):not(&__unset)&:not(&__facebook):not(&__github):not(&__google):not(.is-selected):focus-visible,
+    &:not(&__link):not(&__unset):not(&__facebook):not(&__github):not(&__google):not(.is-selected):focus-visible,
     &--radio:focus-visible + & {
         &,
         &.s-btn__filled {
@@ -425,15 +425,28 @@
         }
     }
 
-    &:not(&__link):not(&__unset)&:not(&__facebook):not(&__github):not(&__google):not(.is-selected) {
+    &:not(&__link):not(&__unset):not(&__facebook):not(&__github):not(&__google):not(.is-selected) {
         &:hover {
             &.s-btn__filled {
                 background-color: var(--_bu-filled-bg-hover);
                 border-color: var(--_bu-filled-bc-hover);
                 color: var(--_bu-filled-fc-hover);
             }
+
             &:not(.s-btn__outlined) {
                 border-color: var(--_bu-bc-hover);
+            }
+
+            &:visited:not(:hover):not(:focus) {
+                &.s-btn__filled {
+                    background-color: var(--_bu-filled-bg);
+                    border-color: var(--_bu-filled-bc);
+                    color: var(--_bu-filled-fc);
+                }
+
+                background-color: var(--_bu-bg);
+                border-color: var(--_bu-bc);
+                color: var(--_bu-fc);
             }
 
             background-color: var(--_bu-bg-hover);
@@ -451,19 +464,6 @@
             border-color: var(--_bu-bc-active);
             color: var(--_bu-fc-active);
         }
-    }
-
-
-    &:visited:not(:hover):not(:focus) {
-        &.s-btn__filled {
-            background-color: var(--_bu-filled-bg);
-            border-color: var(--_bu-filled-bc);
-            color: var(--_bu-filled-fc);
-        }
-
-        background-color: var(--_bu-bg);
-        border-color: var(--_bu-bc);
-        color: var(--_bu-fc);
     }
 
     background-color: var(--_bu-bg, inherit); // [1]


### PR DESCRIPTION
In the course of reviewing https://github.com/StackEng/StackOverflow/pull/18700#issuecomment-1936535576, a bug was discovered where a visited link with `.s-btn` would be illegible in HC mode. This was due to a selector being mis-scoped in  https://github.com/StackExchange/Stacks/pull/1613. This PR resolves that mistake.

> Questions page sort button text color doesn't change when selected/visited in HC mode
![questions_sort](https://github.com/StackEng/StackOverflow/assets/95162865/95c2936f-b038-414d-b5bb-c356e9e46f4a)

**Sidenote:** @giamir This is a situation where visual regression tests for interaction states may have caught the bug before it was shipped. A nice real-world case that proves the value of interaction state visual regression test.