### PR TITLE
test(spacing): add less tests

### DIFF
--- a/lib/atomic/__snapshots__/spacing.less.test.ts.snap
+++ b/lib/atomic/__snapshots__/spacing.less.test.ts.snap
@@ -1,0 +1,1882 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`atomic: misc > should output all atomic css classes 1`] = `
+"body {
+    --su-base: 1;
+    --su-static1: 1px;
+    --su-static2: 2px;
+    --su-static4: 4px;
+    --su-static6: 6px;
+    --su-static8: 8px;
+    --su-static12: 12px;
+    --su-static16: 16px;
+    --su-static24: 24px;
+    --su-static32: 32px;
+    --su-static48: 48px;
+    --su-static64: 64px;
+    --su-static96: 96px;
+    --su-static128: 128px;
+    --su1: clamp(var(--su-static1), calc(var(--su-static1) * var(--su-base)), calc(var(--su-static1) * var(--su-base)));
+    --su2: calc(var(--su-static2) * var(--su-base));
+    --su4: calc(var(--su-static4) * var(--su-base));
+    --su6: calc(var(--su-static6) * var(--su-base));
+    --su8: calc(var(--su-static8) * var(--su-base));
+    --su12: calc(var(--su-static12) * var(--su-base));
+    --su16: calc(var(--su-static16) * var(--su-base));
+    --su24: calc(var(--su-static24) * var(--su-base));
+    --su32: calc(var(--su-static32) * var(--su-base));
+    --su48: calc(var(--su-static48) * var(--su-base));
+    --su64: calc(var(--su-static64) * var(--su-base));
+    --su96: calc(var(--su-static96) * var(--su-base));
+    --su128: calc(var(--su-static128) * var(--su-base));
+}
+
+.m0 {
+    margin: 0 !important;
+}
+
+.mt0 {
+    margin-top: 0 !important;
+}
+
+.mr0 {
+    margin-right: 0 !important;
+}
+
+.mb0 {
+    margin-bottom: 0 !important;
+}
+
+.ml0 {
+    margin-left: 0 !important;
+}
+
+.mx0 {
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+}
+
+.my0 {
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+}
+
+.m-auto {
+    margin: auto !important;
+}
+
+.mt-auto {
+    margin-top: auto !important;
+}
+
+.mr-auto {
+    margin-right: auto !important;
+}
+
+.mb-auto {
+    margin-bottom: auto !important;
+}
+
+.ml-auto {
+    margin-left: auto !important;
+}
+
+.mx-auto {
+    margin-left: auto !important;
+    margin-right: auto !important;
+}
+
+.my-auto {
+    margin-top: auto !important;
+    margin-bottom: auto !important;
+}
+
+.m1 {
+    margin: var(--su1) !important;
+}
+
+.m2 {
+    margin: var(--su2) !important;
+}
+
+.m4 {
+    margin: var(--su4) !important;
+}
+
+.m6 {
+    margin: var(--su6) !important;
+}
+
+.m8 {
+    margin: var(--su8) !important;
+}
+
+.m12 {
+    margin: var(--su12) !important;
+}
+
+.m16 {
+    margin: var(--su16) !important;
+}
+
+.m24 {
+    margin: var(--su24) !important;
+}
+
+.m32 {
+    margin: var(--su32) !important;
+}
+
+.m48 {
+    margin: var(--su48) !important;
+}
+
+.m64 {
+    margin: var(--su64) !important;
+}
+
+.m96 {
+    margin: var(--su96) !important;
+}
+
+.m128 {
+    margin: var(--su128) !important;
+}
+
+.m0 {
+    margin: 0 !important;
+}
+
+.mn1 {
+    margin: calc(var(--su1) * -1) !important;
+}
+
+.mn2 {
+    margin: calc(var(--su2) * -1) !important;
+}
+
+.mn4 {
+    margin: calc(var(--su4) * -1) !important;
+}
+
+.mn6 {
+    margin: calc(var(--su6) * -1) !important;
+}
+
+.mn8 {
+    margin: calc(var(--su8) * -1) !important;
+}
+
+.mn12 {
+    margin: calc(var(--su12) * -1) !important;
+}
+
+.mn16 {
+    margin: calc(var(--su16) * -1) !important;
+}
+
+.mn24 {
+    margin: calc(var(--su24) * -1) !important;
+}
+
+.mn32 {
+    margin: calc(var(--su32) * -1) !important;
+}
+
+.mn48 {
+    margin: calc(var(--su48) * -1) !important;
+}
+
+.mn64 {
+    margin: calc(var(--su64) * -1) !important;
+}
+
+.mn96 {
+    margin: calc(var(--su96) * -1) !important;
+}
+
+.mn128 {
+    margin: calc(var(--su128) * -1) !important;
+}
+
+.mt1 {
+    margin-top: var(--su1) !important;
+}
+
+.mt2 {
+    margin-top: var(--su2) !important;
+}
+
+.mt4 {
+    margin-top: var(--su4) !important;
+}
+
+.mt6 {
+    margin-top: var(--su6) !important;
+}
+
+.mt8 {
+    margin-top: var(--su8) !important;
+}
+
+.mt12 {
+    margin-top: var(--su12) !important;
+}
+
+.mt16 {
+    margin-top: var(--su16) !important;
+}
+
+.mt24 {
+    margin-top: var(--su24) !important;
+}
+
+.mt32 {
+    margin-top: var(--su32) !important;
+}
+
+.mt48 {
+    margin-top: var(--su48) !important;
+}
+
+.mt64 {
+    margin-top: var(--su64) !important;
+}
+
+.mt96 {
+    margin-top: var(--su96) !important;
+}
+
+.mt128 {
+    margin-top: var(--su128) !important;
+}
+
+.mt0 {
+    margin-top: 0 !important;
+}
+
+.mtn1 {
+    margin-top: calc(var(--su1) * -1) !important;
+}
+
+.mtn2 {
+    margin-top: calc(var(--su2) * -1) !important;
+}
+
+.mtn4 {
+    margin-top: calc(var(--su4) * -1) !important;
+}
+
+.mtn6 {
+    margin-top: calc(var(--su6) * -1) !important;
+}
+
+.mtn8 {
+    margin-top: calc(var(--su8) * -1) !important;
+}
+
+.mtn12 {
+    margin-top: calc(var(--su12) * -1) !important;
+}
+
+.mtn16 {
+    margin-top: calc(var(--su16) * -1) !important;
+}
+
+.mtn24 {
+    margin-top: calc(var(--su24) * -1) !important;
+}
+
+.mtn32 {
+    margin-top: calc(var(--su32) * -1) !important;
+}
+
+.mtn48 {
+    margin-top: calc(var(--su48) * -1) !important;
+}
+
+.mtn64 {
+    margin-top: calc(var(--su64) * -1) !important;
+}
+
+.mtn96 {
+    margin-top: calc(var(--su96) * -1) !important;
+}
+
+.mtn128 {
+    margin-top: calc(var(--su128) * -1) !important;
+}
+
+.mr1 {
+    margin-right: var(--su1) !important;
+}
+
+.mr2 {
+    margin-right: var(--su2) !important;
+}
+
+.mr4 {
+    margin-right: var(--su4) !important;
+}
+
+.mr6 {
+    margin-right: var(--su6) !important;
+}
+
+.mr8 {
+    margin-right: var(--su8) !important;
+}
+
+.mr12 {
+    margin-right: var(--su12) !important;
+}
+
+.mr16 {
+    margin-right: var(--su16) !important;
+}
+
+.mr24 {
+    margin-right: var(--su24) !important;
+}
+
+.mr32 {
+    margin-right: var(--su32) !important;
+}
+
+.mr48 {
+    margin-right: var(--su48) !important;
+}
+
+.mr64 {
+    margin-right: var(--su64) !important;
+}
+
+.mr96 {
+    margin-right: var(--su96) !important;
+}
+
+.mr128 {
+    margin-right: var(--su128) !important;
+}
+
+.mr0 {
+    margin-right: 0 !important;
+}
+
+.mrn1 {
+    margin-right: calc(var(--su1) * -1) !important;
+}
+
+.mrn2 {
+    margin-right: calc(var(--su2) * -1) !important;
+}
+
+.mrn4 {
+    margin-right: calc(var(--su4) * -1) !important;
+}
+
+.mrn6 {
+    margin-right: calc(var(--su6) * -1) !important;
+}
+
+.mrn8 {
+    margin-right: calc(var(--su8) * -1) !important;
+}
+
+.mrn12 {
+    margin-right: calc(var(--su12) * -1) !important;
+}
+
+.mrn16 {
+    margin-right: calc(var(--su16) * -1) !important;
+}
+
+.mrn24 {
+    margin-right: calc(var(--su24) * -1) !important;
+}
+
+.mrn32 {
+    margin-right: calc(var(--su32) * -1) !important;
+}
+
+.mrn48 {
+    margin-right: calc(var(--su48) * -1) !important;
+}
+
+.mrn64 {
+    margin-right: calc(var(--su64) * -1) !important;
+}
+
+.mrn96 {
+    margin-right: calc(var(--su96) * -1) !important;
+}
+
+.mrn128 {
+    margin-right: calc(var(--su128) * -1) !important;
+}
+
+.mb1 {
+    margin-bottom: var(--su1) !important;
+}
+
+.mb2 {
+    margin-bottom: var(--su2) !important;
+}
+
+.mb4 {
+    margin-bottom: var(--su4) !important;
+}
+
+.mb6 {
+    margin-bottom: var(--su6) !important;
+}
+
+.mb8 {
+    margin-bottom: var(--su8) !important;
+}
+
+.mb12 {
+    margin-bottom: var(--su12) !important;
+}
+
+.mb16 {
+    margin-bottom: var(--su16) !important;
+}
+
+.mb24 {
+    margin-bottom: var(--su24) !important;
+}
+
+.mb32 {
+    margin-bottom: var(--su32) !important;
+}
+
+.mb48 {
+    margin-bottom: var(--su48) !important;
+}
+
+.mb64 {
+    margin-bottom: var(--su64) !important;
+}
+
+.mb96 {
+    margin-bottom: var(--su96) !important;
+}
+
+.mb128 {
+    margin-bottom: var(--su128) !important;
+}
+
+.mb0 {
+    margin-bottom: 0 !important;
+}
+
+.mbn1 {
+    margin-bottom: calc(var(--su1) * -1) !important;
+}
+
+.mbn2 {
+    margin-bottom: calc(var(--su2) * -1) !important;
+}
+
+.mbn4 {
+    margin-bottom: calc(var(--su4) * -1) !important;
+}
+
+.mbn6 {
+    margin-bottom: calc(var(--su6) * -1) !important;
+}
+
+.mbn8 {
+    margin-bottom: calc(var(--su8) * -1) !important;
+}
+
+.mbn12 {
+    margin-bottom: calc(var(--su12) * -1) !important;
+}
+
+.mbn16 {
+    margin-bottom: calc(var(--su16) * -1) !important;
+}
+
+.mbn24 {
+    margin-bottom: calc(var(--su24) * -1) !important;
+}
+
+.mbn32 {
+    margin-bottom: calc(var(--su32) * -1) !important;
+}
+
+.mbn48 {
+    margin-bottom: calc(var(--su48) * -1) !important;
+}
+
+.mbn64 {
+    margin-bottom: calc(var(--su64) * -1) !important;
+}
+
+.mbn96 {
+    margin-bottom: calc(var(--su96) * -1) !important;
+}
+
+.mbn128 {
+    margin-bottom: calc(var(--su128) * -1) !important;
+}
+
+.ml1 {
+    margin-left: var(--su1) !important;
+}
+
+.ml2 {
+    margin-left: var(--su2) !important;
+}
+
+.ml4 {
+    margin-left: var(--su4) !important;
+}
+
+.ml6 {
+    margin-left: var(--su6) !important;
+}
+
+.ml8 {
+    margin-left: var(--su8) !important;
+}
+
+.ml12 {
+    margin-left: var(--su12) !important;
+}
+
+.ml16 {
+    margin-left: var(--su16) !important;
+}
+
+.ml24 {
+    margin-left: var(--su24) !important;
+}
+
+.ml32 {
+    margin-left: var(--su32) !important;
+}
+
+.ml48 {
+    margin-left: var(--su48) !important;
+}
+
+.ml64 {
+    margin-left: var(--su64) !important;
+}
+
+.ml96 {
+    margin-left: var(--su96) !important;
+}
+
+.ml128 {
+    margin-left: var(--su128) !important;
+}
+
+.ml0 {
+    margin-left: 0 !important;
+}
+
+.mln1 {
+    margin-left: calc(var(--su1) * -1) !important;
+}
+
+.mln2 {
+    margin-left: calc(var(--su2) * -1) !important;
+}
+
+.mln4 {
+    margin-left: calc(var(--su4) * -1) !important;
+}
+
+.mln6 {
+    margin-left: calc(var(--su6) * -1) !important;
+}
+
+.mln8 {
+    margin-left: calc(var(--su8) * -1) !important;
+}
+
+.mln12 {
+    margin-left: calc(var(--su12) * -1) !important;
+}
+
+.mln16 {
+    margin-left: calc(var(--su16) * -1) !important;
+}
+
+.mln24 {
+    margin-left: calc(var(--su24) * -1) !important;
+}
+
+.mln32 {
+    margin-left: calc(var(--su32) * -1) !important;
+}
+
+.mln48 {
+    margin-left: calc(var(--su48) * -1) !important;
+}
+
+.mln64 {
+    margin-left: calc(var(--su64) * -1) !important;
+}
+
+.mln96 {
+    margin-left: calc(var(--su96) * -1) !important;
+}
+
+.mln128 {
+    margin-left: calc(var(--su128) * -1) !important;
+}
+
+.mx1 {
+    margin-left: var(--su1) !important;
+    margin-right: var(--su1) !important;
+}
+
+.mx2 {
+    margin-left: var(--su2) !important;
+    margin-right: var(--su2) !important;
+}
+
+.mx4 {
+    margin-left: var(--su4) !important;
+    margin-right: var(--su4) !important;
+}
+
+.mx6 {
+    margin-left: var(--su6) !important;
+    margin-right: var(--su6) !important;
+}
+
+.mx8 {
+    margin-left: var(--su8) !important;
+    margin-right: var(--su8) !important;
+}
+
+.mx12 {
+    margin-left: var(--su12) !important;
+    margin-right: var(--su12) !important;
+}
+
+.mx16 {
+    margin-left: var(--su16) !important;
+    margin-right: var(--su16) !important;
+}
+
+.mx24 {
+    margin-left: var(--su24) !important;
+    margin-right: var(--su24) !important;
+}
+
+.mx32 {
+    margin-left: var(--su32) !important;
+    margin-right: var(--su32) !important;
+}
+
+.mx48 {
+    margin-left: var(--su48) !important;
+    margin-right: var(--su48) !important;
+}
+
+.mx64 {
+    margin-left: var(--su64) !important;
+    margin-right: var(--su64) !important;
+}
+
+.mx96 {
+    margin-left: var(--su96) !important;
+    margin-right: var(--su96) !important;
+}
+
+.mx128 {
+    margin-left: var(--su128) !important;
+    margin-right: var(--su128) !important;
+}
+
+.mxn1 {
+    margin-left: calc(var(--su1) * -1) !important;
+    margin-right: calc(var(--su1) * -1) !important;
+}
+
+.mxn2 {
+    margin-left: calc(var(--su2) * -1) !important;
+    margin-right: calc(var(--su2) * -1) !important;
+}
+
+.mxn4 {
+    margin-left: calc(var(--su4) * -1) !important;
+    margin-right: calc(var(--su4) * -1) !important;
+}
+
+.mxn6 {
+    margin-left: calc(var(--su6) * -1) !important;
+    margin-right: calc(var(--su6) * -1) !important;
+}
+
+.mxn8 {
+    margin-left: calc(var(--su8) * -1) !important;
+    margin-right: calc(var(--su8) * -1) !important;
+}
+
+.mxn12 {
+    margin-left: calc(var(--su12) * -1) !important;
+    margin-right: calc(var(--su12) * -1) !important;
+}
+
+.mxn16 {
+    margin-left: calc(var(--su16) * -1) !important;
+    margin-right: calc(var(--su16) * -1) !important;
+}
+
+.mxn24 {
+    margin-left: calc(var(--su24) * -1) !important;
+    margin-right: calc(var(--su24) * -1) !important;
+}
+
+.mxn32 {
+    margin-left: calc(var(--su32) * -1) !important;
+    margin-right: calc(var(--su32) * -1) !important;
+}
+
+.mxn48 {
+    margin-left: calc(var(--su48) * -1) !important;
+    margin-right: calc(var(--su48) * -1) !important;
+}
+
+.mxn64 {
+    margin-left: calc(var(--su64) * -1) !important;
+    margin-right: calc(var(--su64) * -1) !important;
+}
+
+.mxn96 {
+    margin-left: calc(var(--su96) * -1) !important;
+    margin-right: calc(var(--su96) * -1) !important;
+}
+
+.mxn128 {
+    margin-left: calc(var(--su128) * -1) !important;
+    margin-right: calc(var(--su128) * -1) !important;
+}
+
+.my1 {
+    margin-top: var(--su1) !important;
+    margin-bottom: var(--su1) !important;
+}
+
+.my2 {
+    margin-top: var(--su2) !important;
+    margin-bottom: var(--su2) !important;
+}
+
+.my4 {
+    margin-top: var(--su4) !important;
+    margin-bottom: var(--su4) !important;
+}
+
+.my6 {
+    margin-top: var(--su6) !important;
+    margin-bottom: var(--su6) !important;
+}
+
+.my8 {
+    margin-top: var(--su8) !important;
+    margin-bottom: var(--su8) !important;
+}
+
+.my12 {
+    margin-top: var(--su12) !important;
+    margin-bottom: var(--su12) !important;
+}
+
+.my16 {
+    margin-top: var(--su16) !important;
+    margin-bottom: var(--su16) !important;
+}
+
+.my24 {
+    margin-top: var(--su24) !important;
+    margin-bottom: var(--su24) !important;
+}
+
+.my32 {
+    margin-top: var(--su32) !important;
+    margin-bottom: var(--su32) !important;
+}
+
+.my48 {
+    margin-top: var(--su48) !important;
+    margin-bottom: var(--su48) !important;
+}
+
+.my64 {
+    margin-top: var(--su64) !important;
+    margin-bottom: var(--su64) !important;
+}
+
+.my96 {
+    margin-top: var(--su96) !important;
+    margin-bottom: var(--su96) !important;
+}
+
+.my128 {
+    margin-top: var(--su128) !important;
+    margin-bottom: var(--su128) !important;
+}
+
+.myn1 {
+    margin-top: calc(var(--su1) * -1) !important;
+    margin-bottom: calc(var(--su1) * -1) !important;
+}
+
+.myn2 {
+    margin-top: calc(var(--su2) * -1) !important;
+    margin-bottom: calc(var(--su2) * -1) !important;
+}
+
+.myn4 {
+    margin-top: calc(var(--su4) * -1) !important;
+    margin-bottom: calc(var(--su4) * -1) !important;
+}
+
+.myn6 {
+    margin-top: calc(var(--su6) * -1) !important;
+    margin-bottom: calc(var(--su6) * -1) !important;
+}
+
+.myn8 {
+    margin-top: calc(var(--su8) * -1) !important;
+    margin-bottom: calc(var(--su8) * -1) !important;
+}
+
+.myn12 {
+    margin-top: calc(var(--su12) * -1) !important;
+    margin-bottom: calc(var(--su12) * -1) !important;
+}
+
+.myn16 {
+    margin-top: calc(var(--su16) * -1) !important;
+    margin-bottom: calc(var(--su16) * -1) !important;
+}
+
+.myn24 {
+    margin-top: calc(var(--su24) * -1) !important;
+    margin-bottom: calc(var(--su24) * -1) !important;
+}
+
+.myn32 {
+    margin-top: calc(var(--su32) * -1) !important;
+    margin-bottom: calc(var(--su32) * -1) !important;
+}
+
+.myn48 {
+    margin-top: calc(var(--su48) * -1) !important;
+    margin-bottom: calc(var(--su48) * -1) !important;
+}
+
+.myn64 {
+    margin-top: calc(var(--su64) * -1) !important;
+    margin-bottom: calc(var(--su64) * -1) !important;
+}
+
+.myn96 {
+    margin-top: calc(var(--su96) * -1) !important;
+    margin-bottom: calc(var(--su96) * -1) !important;
+}
+
+.myn128 {
+    margin-top: calc(var(--su128) * -1) !important;
+    margin-bottom: calc(var(--su128) * -1) !important;
+}
+
+.p0 {
+    padding: 0 !important;
+}
+
+.pt0 {
+    padding-top: 0 !important;
+}
+
+.pr0 {
+    padding-right: 0 !important;
+}
+
+.pb0 {
+    padding-bottom: 0 !important;
+}
+
+.pl0 {
+    padding-left: 0 !important;
+}
+
+.px0 {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+}
+
+.py0 {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+}
+
+.p1 {
+    padding: var(--su1) !important;
+}
+
+.p2 {
+    padding: var(--su2) !important;
+}
+
+.p4 {
+    padding: var(--su4) !important;
+}
+
+.p6 {
+    padding: var(--su6) !important;
+}
+
+.p8 {
+    padding: var(--su8) !important;
+}
+
+.p12 {
+    padding: var(--su12) !important;
+}
+
+.p16 {
+    padding: var(--su16) !important;
+}
+
+.p24 {
+    padding: var(--su24) !important;
+}
+
+.p32 {
+    padding: var(--su32) !important;
+}
+
+.p48 {
+    padding: var(--su48) !important;
+}
+
+.p64 {
+    padding: var(--su64) !important;
+}
+
+.p96 {
+    padding: var(--su96) !important;
+}
+
+.p128 {
+    padding: var(--su128) !important;
+}
+
+.p0 {
+    padding: 0 !important;
+}
+
+.pt1 {
+    padding-top: var(--su1) !important;
+}
+
+.pt2 {
+    padding-top: var(--su2) !important;
+}
+
+.pt4 {
+    padding-top: var(--su4) !important;
+}
+
+.pt6 {
+    padding-top: var(--su6) !important;
+}
+
+.pt8 {
+    padding-top: var(--su8) !important;
+}
+
+.pt12 {
+    padding-top: var(--su12) !important;
+}
+
+.pt16 {
+    padding-top: var(--su16) !important;
+}
+
+.pt24 {
+    padding-top: var(--su24) !important;
+}
+
+.pt32 {
+    padding-top: var(--su32) !important;
+}
+
+.pt48 {
+    padding-top: var(--su48) !important;
+}
+
+.pt64 {
+    padding-top: var(--su64) !important;
+}
+
+.pt96 {
+    padding-top: var(--su96) !important;
+}
+
+.pt128 {
+    padding-top: var(--su128) !important;
+}
+
+.pt0 {
+    padding-top: 0 !important;
+}
+
+.pr1 {
+    padding-right: var(--su1) !important;
+}
+
+.pr2 {
+    padding-right: var(--su2) !important;
+}
+
+.pr4 {
+    padding-right: var(--su4) !important;
+}
+
+.pr6 {
+    padding-right: var(--su6) !important;
+}
+
+.pr8 {
+    padding-right: var(--su8) !important;
+}
+
+.pr12 {
+    padding-right: var(--su12) !important;
+}
+
+.pr16 {
+    padding-right: var(--su16) !important;
+}
+
+.pr24 {
+    padding-right: var(--su24) !important;
+}
+
+.pr32 {
+    padding-right: var(--su32) !important;
+}
+
+.pr48 {
+    padding-right: var(--su48) !important;
+}
+
+.pr64 {
+    padding-right: var(--su64) !important;
+}
+
+.pr96 {
+    padding-right: var(--su96) !important;
+}
+
+.pr128 {
+    padding-right: var(--su128) !important;
+}
+
+.pb1 {
+    padding-bottom: var(--su1) !important;
+}
+
+.pb2 {
+    padding-bottom: var(--su2) !important;
+}
+
+.pb4 {
+    padding-bottom: var(--su4) !important;
+}
+
+.pb6 {
+    padding-bottom: var(--su6) !important;
+}
+
+.pb8 {
+    padding-bottom: var(--su8) !important;
+}
+
+.pb12 {
+    padding-bottom: var(--su12) !important;
+}
+
+.pb16 {
+    padding-bottom: var(--su16) !important;
+}
+
+.pb24 {
+    padding-bottom: var(--su24) !important;
+}
+
+.pb32 {
+    padding-bottom: var(--su32) !important;
+}
+
+.pb48 {
+    padding-bottom: var(--su48) !important;
+}
+
+.pb64 {
+    padding-bottom: var(--su64) !important;
+}
+
+.pb96 {
+    padding-bottom: var(--su96) !important;
+}
+
+.pb128 {
+    padding-bottom: var(--su128) !important;
+}
+
+.pr0 {
+    padding-right: 0 !important;
+}
+
+.pl1 {
+    padding-left: var(--su1) !important;
+}
+
+.pl2 {
+    padding-left: var(--su2) !important;
+}
+
+.pl4 {
+    padding-left: var(--su4) !important;
+}
+
+.pl6 {
+    padding-left: var(--su6) !important;
+}
+
+.pl8 {
+    padding-left: var(--su8) !important;
+}
+
+.pl12 {
+    padding-left: var(--su12) !important;
+}
+
+.pl16 {
+    padding-left: var(--su16) !important;
+}
+
+.pl24 {
+    padding-left: var(--su24) !important;
+}
+
+.pl32 {
+    padding-left: var(--su32) !important;
+}
+
+.pl48 {
+    padding-left: var(--su48) !important;
+}
+
+.pl64 {
+    padding-left: var(--su64) !important;
+}
+
+.pl96 {
+    padding-left: var(--su96) !important;
+}
+
+.pl128 {
+    padding-left: var(--su128) !important;
+}
+
+.pl0 {
+    padding-left: 0 !important;
+}
+
+.px1 {
+    padding-left: var(--su1) !important;
+    padding-right: var(--su1) !important;
+}
+
+.px2 {
+    padding-left: var(--su2) !important;
+    padding-right: var(--su2) !important;
+}
+
+.px4 {
+    padding-left: var(--su4) !important;
+    padding-right: var(--su4) !important;
+}
+
+.px6 {
+    padding-left: var(--su6) !important;
+    padding-right: var(--su6) !important;
+}
+
+.px8 {
+    padding-left: var(--su8) !important;
+    padding-right: var(--su8) !important;
+}
+
+.px12 {
+    padding-left: var(--su12) !important;
+    padding-right: var(--su12) !important;
+}
+
+.px16 {
+    padding-left: var(--su16) !important;
+    padding-right: var(--su16) !important;
+}
+
+.px24 {
+    padding-left: var(--su24) !important;
+    padding-right: var(--su24) !important;
+}
+
+.px32 {
+    padding-left: var(--su32) !important;
+    padding-right: var(--su32) !important;
+}
+
+.px48 {
+    padding-left: var(--su48) !important;
+    padding-right: var(--su48) !important;
+}
+
+.px64 {
+    padding-left: var(--su64) !important;
+    padding-right: var(--su64) !important;
+}
+
+.px96 {
+    padding-left: var(--su96) !important;
+    padding-right: var(--su96) !important;
+}
+
+.px128 {
+    padding-left: var(--su128) !important;
+    padding-right: var(--su128) !important;
+}
+
+.py1 {
+    padding-top: var(--su1) !important;
+    padding-bottom: var(--su1) !important;
+}
+
+.py2 {
+    padding-top: var(--su2) !important;
+    padding-bottom: var(--su2) !important;
+}
+
+.py4 {
+    padding-top: var(--su4) !important;
+    padding-bottom: var(--su4) !important;
+}
+
+.py6 {
+    padding-top: var(--su6) !important;
+    padding-bottom: var(--su6) !important;
+}
+
+.py8 {
+    padding-top: var(--su8) !important;
+    padding-bottom: var(--su8) !important;
+}
+
+.py12 {
+    padding-top: var(--su12) !important;
+    padding-bottom: var(--su12) !important;
+}
+
+.py16 {
+    padding-top: var(--su16) !important;
+    padding-bottom: var(--su16) !important;
+}
+
+.py24 {
+    padding-top: var(--su24) !important;
+    padding-bottom: var(--su24) !important;
+}
+
+.py32 {
+    padding-top: var(--su32) !important;
+    padding-bottom: var(--su32) !important;
+}
+
+.py48 {
+    padding-top: var(--su48) !important;
+    padding-bottom: var(--su48) !important;
+}
+
+.py64 {
+    padding-top: var(--su64) !important;
+    padding-bottom: var(--su64) !important;
+}
+
+.py96 {
+    padding-top: var(--su96) !important;
+    padding-bottom: var(--su96) !important;
+}
+
+.py128 {
+    padding-top: var(--su128) !important;
+    padding-bottom: var(--su128) !important;
+}
+
+.t1 {
+    top: var(--su1) !important;
+}
+
+.t2 {
+    top: var(--su2) !important;
+}
+
+.t4 {
+    top: var(--su4) !important;
+}
+
+.t6 {
+    top: var(--su6) !important;
+}
+
+.t8 {
+    top: var(--su8) !important;
+}
+
+.t12 {
+    top: var(--su12) !important;
+}
+
+.t16 {
+    top: var(--su16) !important;
+}
+
+.t24 {
+    top: var(--su24) !important;
+}
+
+.t32 {
+    top: var(--su32) !important;
+}
+
+.t48 {
+    top: var(--su48) !important;
+}
+
+.t64 {
+    top: var(--su64) !important;
+}
+
+.t96 {
+    top: var(--su96) !important;
+}
+
+.t128 {
+    top: var(--su128) !important;
+}
+
+.t0 {
+    top: 0 !important;
+}
+
+.t50 {
+    top: 50% !important;
+}
+
+.tn50 {
+    top: -50% !important;
+}
+
+.t100 {
+    top: 100% !important;
+}
+
+.tn100 {
+    top: -100% !important;
+}
+
+.tn1 {
+    top: calc(var(--su1) * -1) !important;
+}
+
+.tn2 {
+    top: calc(var(--su2) * -1) !important;
+}
+
+.tn4 {
+    top: calc(var(--su4) * -1) !important;
+}
+
+.tn6 {
+    top: calc(var(--su6) * -1) !important;
+}
+
+.tn8 {
+    top: calc(var(--su8) * -1) !important;
+}
+
+.tn12 {
+    top: calc(var(--su12) * -1) !important;
+}
+
+.tn16 {
+    top: calc(var(--su16) * -1) !important;
+}
+
+.tn24 {
+    top: calc(var(--su24) * -1) !important;
+}
+
+.tn32 {
+    top: calc(var(--su32) * -1) !important;
+}
+
+.tn48 {
+    top: calc(var(--su48) * -1) !important;
+}
+
+.tn64 {
+    top: calc(var(--su64) * -1) !important;
+}
+
+.tn96 {
+    top: calc(var(--su96) * -1) !important;
+}
+
+.tn128 {
+    top: calc(var(--su128) * -1) !important;
+}
+
+.r1 {
+    right: var(--su1) !important;
+}
+
+.r2 {
+    right: var(--su2) !important;
+}
+
+.r4 {
+    right: var(--su4) !important;
+}
+
+.r6 {
+    right: var(--su6) !important;
+}
+
+.r8 {
+    right: var(--su8) !important;
+}
+
+.r12 {
+    right: var(--su12) !important;
+}
+
+.r16 {
+    right: var(--su16) !important;
+}
+
+.r24 {
+    right: var(--su24) !important;
+}
+
+.r32 {
+    right: var(--su32) !important;
+}
+
+.r48 {
+    right: var(--su48) !important;
+}
+
+.r64 {
+    right: var(--su64) !important;
+}
+
+.r96 {
+    right: var(--su96) !important;
+}
+
+.r128 {
+    right: var(--su128) !important;
+}
+
+.r0 {
+    right: 0 !important;
+}
+
+.r50 {
+    right: 50% !important;
+}
+
+.rn50 {
+    right: -50% !important;
+}
+
+.r100 {
+    right: 100% !important;
+}
+
+.rn100 {
+    right: -100% !important;
+}
+
+.rn1 {
+    right: calc(var(--su1) * -1) !important;
+}
+
+.rn2 {
+    right: calc(var(--su2) * -1) !important;
+}
+
+.rn4 {
+    right: calc(var(--su4) * -1) !important;
+}
+
+.rn6 {
+    right: calc(var(--su6) * -1) !important;
+}
+
+.rn8 {
+    right: calc(var(--su8) * -1) !important;
+}
+
+.rn12 {
+    right: calc(var(--su12) * -1) !important;
+}
+
+.rn16 {
+    right: calc(var(--su16) * -1) !important;
+}
+
+.rn24 {
+    right: calc(var(--su24) * -1) !important;
+}
+
+.rn32 {
+    right: calc(var(--su32) * -1) !important;
+}
+
+.rn48 {
+    right: calc(var(--su48) * -1) !important;
+}
+
+.rn64 {
+    right: calc(var(--su64) * -1) !important;
+}
+
+.rn96 {
+    right: calc(var(--su96) * -1) !important;
+}
+
+.rn128 {
+    right: calc(var(--su128) * -1) !important;
+}
+
+.b1 {
+    bottom: var(--su1) !important;
+}
+
+.b2 {
+    bottom: var(--su2) !important;
+}
+
+.b4 {
+    bottom: var(--su4) !important;
+}
+
+.b6 {
+    bottom: var(--su6) !important;
+}
+
+.b8 {
+    bottom: var(--su8) !important;
+}
+
+.b12 {
+    bottom: var(--su12) !important;
+}
+
+.b16 {
+    bottom: var(--su16) !important;
+}
+
+.b24 {
+    bottom: var(--su24) !important;
+}
+
+.b32 {
+    bottom: var(--su32) !important;
+}
+
+.b48 {
+    bottom: var(--su48) !important;
+}
+
+.b64 {
+    bottom: var(--su64) !important;
+}
+
+.b96 {
+    bottom: var(--su96) !important;
+}
+
+.b128 {
+    bottom: var(--su128) !important;
+}
+
+.b0 {
+    bottom: 0 !important;
+}
+
+.b50 {
+    bottom: 50% !important;
+}
+
+.bn50 {
+    bottom: -50% !important;
+}
+
+.b100 {
+    bottom: 100% !important;
+}
+
+.bn100 {
+    bottom: -100% !important;
+}
+
+.bn1 {
+    bottom: calc(var(--su1) * -1) !important;
+}
+
+.bn2 {
+    bottom: calc(var(--su2) * -1) !important;
+}
+
+.bn4 {
+    bottom: calc(var(--su4) * -1) !important;
+}
+
+.bn6 {
+    bottom: calc(var(--su6) * -1) !important;
+}
+
+.bn8 {
+    bottom: calc(var(--su8) * -1) !important;
+}
+
+.bn12 {
+    bottom: calc(var(--su12) * -1) !important;
+}
+
+.bn16 {
+    bottom: calc(var(--su16) * -1) !important;
+}
+
+.bn24 {
+    bottom: calc(var(--su24) * -1) !important;
+}
+
+.bn32 {
+    bottom: calc(var(--su32) * -1) !important;
+}
+
+.bn48 {
+    bottom: calc(var(--su48) * -1) !important;
+}
+
+.bn64 {
+    bottom: calc(var(--su64) * -1) !important;
+}
+
+.bn96 {
+    bottom: calc(var(--su96) * -1) !important;
+}
+
+.bn128 {
+    bottom: calc(var(--su128) * -1) !important;
+}
+
+.l1 {
+    left: var(--su1) !important;
+}
+
+.l2 {
+    left: var(--su2) !important;
+}
+
+.l4 {
+    left: var(--su4) !important;
+}
+
+.l6 {
+    left: var(--su6) !important;
+}
+
+.l8 {
+    left: var(--su8) !important;
+}
+
+.l12 {
+    left: var(--su12) !important;
+}
+
+.l16 {
+    left: var(--su16) !important;
+}
+
+.l24 {
+    left: var(--su24) !important;
+}
+
+.l32 {
+    left: var(--su32) !important;
+}
+
+.l48 {
+    left: var(--su48) !important;
+}
+
+.l64 {
+    left: var(--su64) !important;
+}
+
+.l96 {
+    left: var(--su96) !important;
+}
+
+.l128 {
+    left: var(--su128) !important;
+}
+
+.l0 {
+    left: 0 !important;
+}
+
+.l50 {
+    left: 50% !important;
+}
+
+.ln50 {
+    left: -50% !important;
+}
+
+.l100 {
+    left: 100% !important;
+}
+
+.ln100 {
+    left: -100% !important;
+}
+
+.ln1 {
+    left: calc(var(--su1) * -1) !important;
+}
+
+.ln2 {
+    left: calc(var(--su2) * -1) !important;
+}
+
+.ln4 {
+    left: calc(var(--su4) * -1) !important;
+}
+
+.ln6 {
+    left: calc(var(--su6) * -1) !important;
+}
+
+.ln8 {
+    left: calc(var(--su8) * -1) !important;
+}
+
+.ln12 {
+    left: calc(var(--su12) * -1) !important;
+}
+
+.ln16 {
+    left: calc(var(--su16) * -1) !important;
+}
+
+.ln24 {
+    left: calc(var(--su24) * -1) !important;
+}
+
+.ln32 {
+    left: calc(var(--su32) * -1) !important;
+}
+
+.ln48 {
+    left: calc(var(--su48) * -1) !important;
+}
+
+.ln64 {
+    left: calc(var(--su64) * -1) !important;
+}
+
+.ln96 {
+    left: calc(var(--su96) * -1) !important;
+}
+
+.ln128 {
+    left: calc(var(--su128) * -1) !important;
+}
+
+.i1 {
+    inset: var(--su1) !important;
+}
+
+.i2 {
+    inset: var(--su2) !important;
+}
+
+.i4 {
+    inset: var(--su4) !important;
+}
+
+.i6 {
+    inset: var(--su6) !important;
+}
+
+.i8 {
+    inset: var(--su8) !important;
+}
+
+.i12 {
+    inset: var(--su12) !important;
+}
+
+.i16 {
+    inset: var(--su16) !important;
+}
+
+.i24 {
+    inset: var(--su24) !important;
+}
+
+.i32 {
+    inset: var(--su32) !important;
+}
+
+.i48 {
+    inset: var(--su48) !important;
+}
+
+.i64 {
+    inset: var(--su64) !important;
+}
+
+.i96 {
+    inset: var(--su96) !important;
+}
+
+.i128 {
+    inset: var(--su128) !important;
+}
+
+.i0 {
+    inset: 0 !important;
+}
+"
+`;

--- a/lib/atomic/spacing.less
+++ b/lib/atomic/spacing.less
@@ -1,3 +1,5 @@
+@import (reference) "../base/internal.less";
+
 //
 //  STACK OVERFLOW
 //  SPACING

--- a/lib/atomic/spacing.less.test.ts
+++ b/lib/atomic/spacing.less.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { renderLess } from "../test/less-test-utils";
+
+describe("atomic: misc", () => {
+    it("should output all atomic css classes", async () => {
+        const css = await renderLess(`
+            @import "./lib/atomic/spacing.less";
+        `);
+
+        expect(css).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
This PR adds tests for the atomic spacing less output.

---

Addresses https://github.com/StackExchange/Stacks/pull/1654/files#r1497120416

> @dancormier just glancing at this PR. What would you think about adding the less snapshot test directly in develop to start with to then have here a better diff of what have actually changed with your refactor?
