### PR TITLE
test(button): abstract test args to setup file

### DIFF
--- a/lib/components/button/button.a11y.test.ts
+++ b/lib/components/button/button.a11y.test.ts
@@ -10,7 +10,7 @@ describe("button", () => {
         ],
         skippedTestids: [
             // TODO resolve btn badge contrast issues
-            // matches tests with a badge in light, dark, and highcontrast-light modes
+            // matches tests with a badge in light and dark modes
             /s-btn-(light|dark).*?badge/,
             // matches tests with a badge in highcontrast-light modes, excluding filled, danger, github, facebook, sm, or xs
             /s-btn-highcontrast-light-(?!.*(filled|danger|github|facebook|sm|xs)).*?badge/,

--- a/lib/components/button/button.a11y.test.ts
+++ b/lib/components/button/button.a11y.test.ts
@@ -1,25 +1,21 @@
+import testArgs from "./button.test.setup";
 import { runA11yTests } from "../../test/a11y-test-utils";
 import "../../index";
 
 describe("button", () => {
     runA11yTests({
-        baseClass: "s-btn",
-        variants: ["danger", "muted"],
-        modifiers: {
-            primary: ["filled", "outlined"],
-            secondary: [...["xs", "sm", "md"], ...["dropdown", "icon"]],
-            global: ["is-loading"],
-            standalone: [
-                ...["link", "unset"],
-                ...["facebook", "github", "google"],
-            ],
-        },
-        attributes: {
-            type: "button",
-        },
-        children: {
-            default: "Ask question",
-        },
-        tag: "button",
+        ...testArgs,
+        excludedTestids: [
+            /^s-btn-(?=.*unset).*badge$/, // s-btn with badge and unset variant not supported
+        ],
+        skippedTestids: [
+            // TODO resolve btn badge contrast issues
+            // matches tests with a badge in light, dark, and highcontrast-light modes
+            /s-btn-(light|dark).*?badge/,
+            // matches tests with a badge in highcontrast-light modes, excluding filled, danger, github, facebook, sm, or xs
+            /s-btn-highcontrast-light-(?!.*(filled|danger|github|facebook|sm|xs)).*?badge/,
+            // matches tests with a badge in highcontrast-light modes, are muted and/or outlined, and are sm or xs
+            /s-btn-highcontrast-light-(?:muted-outlined-|muted-|outlined-)?(?:sm|xs).*?badge/,
+        ],
     });
 });

--- a/lib/components/button/button.test.setup.ts
+++ b/lib/components/button/button.test.setup.ts
@@ -21,10 +21,7 @@ const testArgs: TestVariationArgs = {
         primary: ["filled", "outlined"],
         secondary: [...["xs", "sm", "md"], ...["dropdown", "icon"]],
         global: ["is-loading"],
-        standalone: [
-            ...["link", "unset"],
-            ...["facebook", "github", "google"],
-        ],
+        standalone: [...["link", "unset"], ...["facebook", "github", "google"]],
     },
     attributes: {
         type: "button",

--- a/lib/components/button/button.test.setup.ts
+++ b/lib/components/button/button.test.setup.ts
@@ -1,0 +1,39 @@
+import type { TestVariationArgs } from "../../test/test-utils";
+import "../../index";
+
+const getChild = (child?: string): string => {
+    switch (child) {
+        case "badge":
+            return `Ask question
+                <span class="s-btn--badge">
+                    <span class="s-btn--number">198</span>
+                </span>`;
+        default:
+            return "Ask question";
+    }
+};
+
+// TODO test disabled states, interaction pseudo-classes
+const testArgs: TestVariationArgs = {
+    baseClass: "s-btn",
+    variants: ["danger", "muted"],
+    modifiers: {
+        primary: ["filled", "outlined"],
+        secondary: [...["xs", "sm", "md"], ...["dropdown", "icon"]],
+        global: ["is-loading"],
+        standalone: [
+            ...["link", "unset"],
+            ...["facebook", "github", "google"],
+        ],
+    },
+    attributes: {
+        type: "button",
+    },
+    children: {
+        default: getChild(),
+        badge: getChild("badge"),
+    },
+    tag: "button",
+};
+
+export default testArgs;

--- a/lib/components/button/button.visual.test.ts
+++ b/lib/components/button/button.visual.test.ts
@@ -1,41 +1,11 @@
-import { html } from "@open-wc/testing";
+import testArgs from "./button.test.setup";
 import { runVisualTests } from "../../test/visual-test-utils";
 import "../../index";
-
-const getChild = (child?: string): string => {
-    switch (child) {
-        case "badge":
-            return `Ask question
-                <span class="s-btn--badge">
-                    <span class="s-btn--number">198</span>
-                </span>`;
-        default:
-            return "Ask question";
-    }
-};
+import { html } from "@open-wc/testing";
 
 describe("button", () => {
-    // TODO test disabled states, interaction pseudo-classes
     runVisualTests({
-        baseClass: "s-btn",
-        variants: ["danger", "muted"],
-        modifiers: {
-            primary: ["filled", "outlined"],
-            secondary: [...["xs", "sm", "md"], ...["dropdown", "icon"]],
-            global: ["is-loading"],
-            standalone: [
-                ...["link", "unset"],
-                ...["facebook", "github", "google"],
-            ],
-        },
-        attributes: {
-            type: "button",
-        },
-        children: {
-            default: getChild(),
-            badge: getChild("badge"),
-        },
-        tag: "button",
+        ...testArgs,
         template: ({ component, testid }) => html`
             <div
                 class="bg-black-225 d-inline-flex ai-center jc-center hs1 ws2 p8"
@@ -43,6 +13,6 @@ describe("button", () => {
             >
                 ${component}
             </div>
-        `,
+        `
     });
 });

--- a/lib/components/button/button.visual.test.ts
+++ b/lib/components/button/button.visual.test.ts
@@ -13,6 +13,6 @@ describe("button", () => {
             >
                 ${component}
             </div>
-        `
+        `,
     });
 });

--- a/lib/tsconfig.build.json
+++ b/lib/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
     "extends": "./tsconfig.json",
-    "exclude": ["test/**/*.ts", "**/*.test.ts"]
+    "exclude": ["test/**/*.ts", "**/*.test.ts", "**/*.setup.ts"]
 }


### PR DESCRIPTION
This PR moves much of the button test arguments to `button.test.setup.ts`. This PR also introduces a11y testing for buttons that contain badges. 

> [!NOTE]
> This PR is inspired by failures noticed in button group test runs (see [failing test run](https://github.com/StackExchange/Stacks/actions/runs/8101019402/job/22140253902?pr=1346), [PR](https://github.com/StackExchange/Stacks/pull/1346))

---

The accessibility failures found in the a11y test have been captured in Jira:
- light/dark modes: https://stackoverflow.atlassian.net/browse/A11Y-32
- light high contrast mode: https://stackoverflow.atlassian.net/browse/A11Y-33