### PR TITLE
fix(button): ensure button gains bg color when focused

### DIFF
--- a/lib/components/button/button.less
+++ b/lib/components/button/button.less
@@ -411,8 +411,6 @@
     &:not(&--radio:checked + label):not(&__link):not(&__unset):not(&__facebook):not(&__github):not(&__google):not(.is-selected) {
         &:focus-visible {
             &.s-btn__filled {
-                &:not(:hover) .s-btn--number {
-        &:focus-visible,
         &.focus-inset-bordered {
             &:not(:hover) .s-btn--number {
                 color: var(--_bu-number-fc-focus, var(--_bu-number-fc-filled));

--- a/lib/components/button/button.less
+++ b/lib/components/button/button.less
@@ -410,8 +410,6 @@
 
     &:not(&--radio:checked + label):not(&__link):not(&__unset):not(&__facebook):not(&__github):not(&__google):not(.is-selected) {
         &:focus-visible {
-            &.s-btn__filled {
-        &.focus-inset-bordered {
             &:not(:hover) .s-btn--number {
                 color: var(--_bu-number-fc-focus, var(--_bu-number-fc-filled));
             }

--- a/lib/components/button/button.less
+++ b/lib/components/button/button.less
@@ -412,12 +412,14 @@
         &:focus-visible {
             &.s-btn__filled {
                 &:not(:hover) .s-btn--number {
-                    color: var(--_bu-number-fc-focus, var(--_bu-number-fc-filled));
-                }
-
-                background-color: var(--_bu-bg-focus, var(--_bu-filled-bg));
-                color: var(--_bu-fc-focus, var(--_bu-filled-fc));
+        &:focus-visible,
+        &.focus-inset-bordered {
+            &:not(:hover) .s-btn--number {
+                color: var(--_bu-number-fc-focus, var(--_bu-number-fc-filled));
             }
+
+            background-color: var(--_bu-bg-focus, var(--_bu-filled-bg));
+            color: var(--_bu-fc-focus, var(--_bu-filled-fc));
         }
 
         &:hover {


### PR DESCRIPTION
This PR ensures that the button gains a background color when focused as expected.

[🔗 Button component in deploy preview](https://deploy-preview-1671--stacks.netlify.app/product/components/buttons/)

---

In the process of building the accessibility docs page, I noticed that button variants with no modifiers were not showing the intended background color when focused:

### Expectation

![image](https://github.com/StackExchange/Stacks/assets/647177/d1879278-14fb-4f2d-a2c5-3bf55170ef62)
![image](https://github.com/StackExchange/Stacks/assets/647177/92b09435-5722-4835-809b-157a6160ca77)
![image](https://github.com/StackExchange/Stacks/assets/647177/e5fecbb0-c61d-43e8-afd9-3c16331e852c)

### Reality

![image](https://github.com/StackExchange/Stacks/assets/647177/b46b132f-87ae-4b44-b2d1-665be040ceaf)
![image](https://github.com/StackExchange/Stacks/assets/647177/c5565c4a-7910-4f3e-83a5-a9976d9a6f3e)
![image](https://github.com/StackExchange/Stacks/assets/647177/35c9af77-97d6-431c-85e1-3bb2b460f1aa)