### PR TITLE
bug(focus): apply per-component focus styles on focus classes

### DIFF
--- a/lib/components/block-link/block-link.less
+++ b/lib/components/block-link/block-link.less
@@ -25,7 +25,7 @@ a.s-block-link,
     &&__left,
     &&__right {
         &.is-selected {
-            &:not(:focus-visible) {
+            &:not(:focus-visible):not(.focus-inset) {
                 box-shadow: inset var(--_li-block-bs-offset-x, 3px) 0 0 var(--_bl-bs-color);
             }
         }
@@ -57,9 +57,13 @@ a.s-block-link,
     }
 
     &:focus-visible {
-        border-radius: var(--br-sm);
         .focus-styles(true);
     }
+
+    &:focus-visible,
+    &.focus-inset {
+        border-radius: var(--br-sm);
+    }    
 
     background-color: var(--_bl-bg); // [1]
     color: var(--_bl-fc);

--- a/lib/components/button/button.less
+++ b/lib/components/button/button.less
@@ -409,7 +409,8 @@
     }
 
     &:not(&--radio:checked + label):not(&__link):not(&__unset):not(&__facebook):not(&__github):not(&__google):not(.is-selected) {
-        &:focus-visible {
+        &:focus-visible,
+        &.focus-inset-bordered {
             &:not(:hover) .s-btn--number {
                 color: var(--_bu-number-fc-focus, var(--_bu-number-fc-filled));
             }

--- a/lib/components/notice/notice.less
+++ b/lib/components/notice/notice.less
@@ -168,7 +168,8 @@
         }
 
         &:focus-visible,
-        &:hover {
+        &:hover,
+        &.focus-inset-bordered {
             background-color: var(--_no-btn-bg-focus, inherit) !important;
         }
 

--- a/lib/components/pagination/pagination.less
+++ b/lib/components/pagination/pagination.less
@@ -40,9 +40,13 @@
         }
 
         &:focus-visible {
+            .focus-styles(true, true);
+        }
+
+        &:focus-visible,
+        &.focus-inset-bordered {
             background-color: var(--_pa-item-bg-focus);
             color: var(--_pa-item-fc-focus);
-            .focus-styles(true, true);
         }
 
         background-color: var(--_pa-item-bg);

--- a/lib/components/post-summary/post-summary.less
+++ b/lib/components/post-summary/post-summary.less
@@ -67,7 +67,8 @@
                 &,
                 &:active,
                 &:hover,
-                &:focus {
+                &:focus,
+                .focus-bordered {
                     .highcontrast-mode({
                         border-color: currentColor;
                     });

--- a/lib/components/select/select.less
+++ b/lib/components/select/select.less
@@ -100,8 +100,12 @@
 
         // INTERACTION
         &:focus {
-            color: var(--black);
             .focus-styles();
+        }
+
+        &:focus,
+        &.focus {
+            color: var(--black);
         }
 
         background-color: var(--_se-select-bg);

--- a/lib/components/topbar/topbar.less
+++ b/lib/components/topbar/topbar.less
@@ -334,7 +334,7 @@
                     font-style: normal;
                 }
 
-                &:not(:focus-visible) {
+                &:not(:focus-visible):not(.focus) {
                     box-shadow: var(--theme-topbar-search-shadow);
                 }
 
@@ -355,7 +355,8 @@
 
         .s-select {
             > select {
-                &:focus-visible {
+                &:focus-visible,
+                &.focus {
                     z-index: var(--zi-selected);
                 }
 

--- a/lib/components/uploader/uploader.less
+++ b/lib/components/uploader/uploader.less
@@ -90,8 +90,12 @@
 
     & &--input {
         &:focus:focus-visible + .s-uploader--container {
-            background-color: var(--_up-bg-focus);
             .focus-styles();
+        }
+
+        &:focus:focus-visible + .s-uploader--container,
+        .s-uploader--container.focus {
+            background-color: var(--_up-bg-focus);
         }
 
         cursor: pointer;


### PR DESCRIPTION
This PR applies custom focus styles set on specific components to their relevant atomic focus class. This ensures that when an atomic focus class is added to one of these components (or their children when applicable), they gain the correct styles.

### Example (Muted button)

Not the `.focus-inset-bordered` on the markup below. It should render the button as if it is focused. In the "before" example, you'll see that the button did not receive the background color and font color you'd expect to see with this class added and when this button is focused.

```html
<button class="s-btn s-btn__dropdown s-btn__icon s-btn__muted focus-inset-bordered" role="presentation">
    <svg …> …</svg>
    Button
<button>
```

#### Before

![image](https://github.com/StackExchange/Stacks/assets/647177/3d88ffa9-d42e-4940-ae09-b6be3bc089bb)

#### After

![image](https://github.com/StackExchange/Stacks/assets/647177/63d4e051-cc25-4a2f-ac17-feff6613bab2)


