### PR TITLE
fix(topbar): ensure search renders correctly at small widths

### DIFF
--- a/lib/components/topbar/topbar.less
+++ b/lib/components/topbar/topbar.less
@@ -90,23 +90,11 @@
     });
 
     #stacks-internals #screen-sm({
-        & &--searchbar {
-            --_tb-searchbar-d: none;
-            --_tb-searchbar-p: var(--su8) var(--su12);
-            --_tb-searchbar-open-d: flex;
-            --_tb-searchbar-open-mxw: none;
-
-            .s-select {
-                width: 25% !important;
-            }
-
-            background: var(--theme-topbar-item-background-hover, var(--black-200));
-            left: 0;
-            max-width: 100%;
-            position: absolute;
-            right: 0;
-            top: 100%;
-        }
+        --_tb-searchbar-d: none;
+        --_tb-searchbar-p: var(--su8) var(--su12);
+        --_tb-searchbar-open-d: flex;
+        --_tb-searchbar-open-mxw: none;
+        --_tb-searchbar-select-w: 25%;
     });
 
     // VARIANTS
@@ -327,6 +315,15 @@
     }
 
     & &--searchbar {
+        #stacks-internals #screen-sm({
+            background: var(--theme-topbar-item-background-hover, var(--black-200));
+            left: 0;
+            max-width: 100%;
+            position: absolute;
+            right: 0;
+            top: 100%;
+        });
+
         .s-topbar--searchbar--input-group {
             .s-input {
                 &::placeholder {
@@ -354,6 +351,10 @@
         }
 
         .s-select {
+            #stacks-internals #screen-sm({
+                width: 25% !important;
+            });
+
             > select {
                 &:focus-visible,
                 &.focus {

--- a/lib/components/topbar/topbar.less
+++ b/lib/components/topbar/topbar.less
@@ -387,8 +387,10 @@
         }
 
         &.s-topbar--searchbar__open {
-            display: var(--_tb-searchbar-open-d);
-            max-width: var(--_tb-searchbar-open-mxw);
+            #stacks-internals #screen-sm({
+                display: var(--_tb-searchbar-open-d);
+                max-width: var(--_tb-searchbar-open-mxw);
+            });
         }
 
         display: var(--_tb-searchbar-d);


### PR DESCRIPTION
Addresses https://meta.stackexchange.com/questions/398680/too-small-search-bar 
See also https://stackexchange.slack.com/archives/C27RWNQN9/p1711421438736069?thread_ts=1711408665.906589&cid=C27RWNQN9

**Note**: Core currently has a hotfix that should be removed once it consumes a Stacks Classic version that includes this fix.

---

## The issue

This PR fixes responsive topbar styles, specifically styles on the searchbar. In Core, responsive topbar styles were rendering as:

```css
@media (max-width: 640px) {
  html.html__responsive:not(.html__unpinned-leftnav) .s-topbar html.html__responsive:not(.html__unpinned-leftnav) .s-topbar--searchbar {
    --_tb-searchbar-d: none;
    --_tb-searchbar-p: var(--su8) var(--su12);
    --_tb-searchbar-open-d: flex;
    --_tb-searchbar-open-mxw: none;
    background: var(--theme-topbar-item-background-hover, var(--black-200));
    left: 0;
    max-width: 100%;
    position: absolute;
    right: 0;
    top: 100%;
  }
  html.html__responsive:not(.html__unpinned-leftnav) .s-topbar html.html__responsive:not(.html__unpinned-leftnav) .s-topbar--searchbar .s-select {
    width: 25% !important;
  }
}
@media (max-width: 640px) {
  html.html__responsive.html__unpinned-leftnav .s-topbar html.html__responsive.html__unpinned-leftnav .s-topbar--searchbar {
    --_tb-searchbar-d: none;
    --_tb-searchbar-p: var(--su8) var(--su12);
    --_tb-searchbar-open-d: flex;
    --_tb-searchbar-open-mxw: none;
    background: var(--theme-topbar-item-background-hover, var(--black-200));
    left: 0;
    max-width: 100%;
    position: absolute;
    right: 0;
    top: 100%;
  }
  html.html__responsive.html__unpinned-leftnav .s-topbar html.html__responsive.html__unpinned-leftnav .s-topbar--searchbar .s-select {
    width: 25% !important;
  }
}
```

Note the extra `html.html__responsive.html__unpinned-leftnav`. I believe this is related to the [@force-selector](https://github.com/StackExchange/Stacks/blob/dcormier/fix-topbar-responsive-search-styles/lib/base/internal.less#L113-L125) code in the responsive less functions, but I haven't totally deciphered _why_ the CSS renders differently in consumers. I'll make a ticket to understand and (possibly) refactor our responsive helpers so they're easier to use and understand.

## The fix

A stable solution seems to be to remove any nested selectors in the responsive functions, instead opting to include the responsive functions within the nested selectors themselves. I've tested this in Core and it resolves the issue.

FYI you should see no visible change in the Stacks docs.

---

## To test

### In Stacks

1. Go to the Stacks docs Topbar page.
2. Resize your browser window so it's smaller than 640px width
    - See the search input be replaced with a button containing the search icon
3. Click the button with the search icon
    - See the search input show below the topbar
4. Resize your browser window so it's _larger_ than 640px width
    - See the search button hide and the search input show in the topbar again

### In Core

> [!NOTE]
> You should be able to use [npm link](https://docs.npmjs.com/cli/v10/commands/npm-link) to check instead of the instructions below.

1. Copy the entire contents of the Stacks `topbar.less` file
2. Replace the contents of `StackOverflow/node_modules/@stackoverflow/stacks/lib/components/topbar/topbar.less` with the copied code
4. Run `npm run build` in the `StackOverflow` directory
5. View the topbar in your local Core instance, repeating steps 2-4 in the "_In Stacks_" section above

---

@CGuindon for visibility.