### PR TITLE
Refactor skip link to nest it within .s-topbar

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,5 +1,5 @@
-<a href="#content" class="s-topbar--skip-link">Skip to main content</a>
 <header class="s-topbar stacks-topbar ps-fixed js-stacks-topbar print:d-none">
+    <a href="#content" class="s-topbar--skip-link">Skip to main content</a>
     <div class="s-topbar--container px8">
         <a href="#" class="s-topbar--menu-btn d-none md:d-flex js-hamburger-btn"><span></span></a>
         <a class="s-topbar--logo" href="{{ "/" | url }}">

--- a/docs/_includes/layouts/page.html
+++ b/docs/_includes/layouts/page.html
@@ -9,7 +9,7 @@
     <div class="d-flex mx-auto w100 wmx12">
         {% include 'navigation.html' %}
 
-        <main id="content" class="d-flex fl-grow1 ps-relative pt96 pb24 pl48 md:pl24 sm:pl16 sm:pr16">
+        <main id="content" class="d-flex fl-grow1 ps-relative t64 py24 pl48 md:pl24 sm:pl16 sm:pr16">
             {% if hide-menu != true %}
                 <div class="flex--item order-last ml32 sm:d-none print:d-none" style="width: 14rem;">
                     <div class="ps-fixed t64 b0 py12 overflow-y-auto" style="width: 14rem;">

--- a/docs/_includes/topbar.html
+++ b/docs/_includes/topbar.html
@@ -1,5 +1,5 @@
-<a href="#content" class="s-topbar--skip-link">Skip to main content</a>
 <header class="s-topbar {{ additionalClass }} z-base js-topbar-example">
+    <a href="#content" class="s-topbar--skip-link">Skip to main content</a>
     <div class="s-topbar--container {{ containerClass }}">
         {% if showMenu %}
             <a href="#" class="s-topbar--menu-btn" aria-label="menu"><span></span></a>

--- a/docs/product/components/topbar.html
+++ b/docs/product/components/topbar.html
@@ -90,21 +90,23 @@ description: The topbar component is a navigation bar that is placed at the top 
     <div class="stacks-preview">
 {% highlight html %}
 <header class="s-topbar">
-    <a href="…" class="s-topbar--logo">…</a>
+    <div class="s-topbar--container">
+        <a href="…" class="s-topbar--logo">…</a>
 
-    <form id="search" class="s-topbar--searchbar" autocomplete="off">
-        <div class="s-select">
-            <select aria-label="Search scope">…</select>
-        </div>
-        <div class="s-topbar--searchbar--input-group">
-            <input type="text" placeholder="Search…" value="" autocomplete="off" class="s-input s-input__search" />
-            @Svg.Search.With("s-input-icon s-input-icon__search")
-        </div>
-    </form>
+        <form id="search" class="s-topbar--searchbar" autocomplete="off">
+            <div class="s-select">
+                <select aria-label="Search scope">…</select>
+            </div>
+            <div class="s-topbar--searchbar--input-group">
+                <input type="text" placeholder="Search…" value="" autocomplete="off" class="s-input s-input__search" />
+                @Svg.Search.With("s-input-icon s-input-icon__search")
+            </div>
+        </form>
 
-    <nav class="s-topbar--navigation" aria-label="primary navigation">
-        <ol class="s-topbar--content">…</ol>
-    </nav>
+        <nav class="s-topbar--navigation" aria-label="primary navigation">
+            <ol class="s-topbar--content">…</ol>
+        </nav>
+    </div>
 </header>
 {% endhighlight %}
         <div class="stacks-preview--example bg-black-100">
@@ -126,31 +128,33 @@ description: The topbar component is a navigation bar that is placed at the top 
     <div class="stacks-preview">
 {% highlight html %}
 <header class="s-topbar">
-    <a href="…" class="s-topbar--menu-btn">…</a>
-    <a href="…" class="s-topbar--logo">…</a>
+    <div class="s-topbar--container">
+        <a href="…" class="s-topbar--menu-btn">…</a>
+        <a href="…" class="s-topbar--logo">…</a>
 
-    <a href="#" class="s-topbar--notice is-unread">
-        New
-    </a>
+        <a href="#" class="s-topbar--notice is-unread">
+            New
+        </a>
 
-    <nav aria-label="More from Stack Overflow">
-        <ol class="s-navigation">
-            <li><a href="…" class="s-navigation--item">About</a></li>
-            <li><a href="…" class="s-navigation--item is-selected">Products</a></li>
-            <li><a href="…" class="s-navigation--item">For Teams</a></li>
-        </ol>
-    </nav>
+        <nav aria-label="More from Stack Overflow">
+            <ol class="s-navigation">
+                <li><a href="…" class="s-navigation--item">About</a></li>
+                <li><a href="…" class="s-navigation--item is-selected">Products</a></li>
+                <li><a href="…" class="s-navigation--item">For Teams</a></li>
+            </ol>
+        </nav>
 
-    <nav class="s-topbar--navigation" aria-label="Log in or sign up">
-        <ol class="s-topbar--content">
-            <li>
-                <a href="…" class="s-topbar--item s-topbar--item__unset s-btn s-btn__filled">Log in</a>
-            </li>
-            <li>
-                <a href="…" class="s-topbar--item s-topbar--item__unset ml4 s-btn s-btn__primary">Sign up</a>
-            </li>
-        </ol>
-    </nav>
+        <nav class="s-topbar--navigation" aria-label="Log in or sign up">
+            <ol class="s-topbar--content">
+                <li>
+                    <a href="…" class="s-topbar--item s-topbar--item__unset s-btn s-btn__filled">Log in</a>
+                </li>
+                <li>
+                    <a href="…" class="s-topbar--item s-topbar--item__unset ml4 s-btn s-btn__primary">Sign up</a>
+                </li>
+            </ol>
+        </nav>
+    </div>
 </header>
 {% endhighlight %}
         <div class="stacks-preview--example bg-black-100">

--- a/lib/components/topbar/topbar.less
+++ b/lib/components/topbar/topbar.less
@@ -407,7 +407,7 @@
         background-color: var(--theme-secondary-100);
         border-bottom: var(--_tb-bt);
         display: block;
-        outline: var(--su-static2) solid transparent;
+        outline: none;
         padding: var(--su12);
         text-align: center;
     }

--- a/lib/components/topbar/topbar.less
+++ b/lib/components/topbar/topbar.less
@@ -1,4 +1,5 @@
 .s-topbar {
+    --_tb-bt: var(--theme-topbar-accent-border, 3px solid var(--theme-primary));
     // CHILD COMPONENT CUSTOM PROPERTIES
     // Item
     --_tb-item-bg: unset;
@@ -121,6 +122,16 @@
     }
 
     // CHILD ELEMENTS
+    &:before {
+        border-top: var(--_tb-bt);
+        content: '';
+        display: block;
+    }
+
+    &:has(> &--skip-link:focus):before {
+        display: none; // Hide `:before` element if .s-topbar--skip-link is focused
+    }
+
     & a&--logo {
         &:focus-visible {
             .focus-styles(true);
@@ -135,7 +146,7 @@
     & &--container {
         align-items: center;
         display: flex;
-        height: 100%;
+        height: var(--theme-topbar-height, calc(var(--su-static48) + var(--su-static8)));
         margin: 0 auto;
         max-width: 100%;
         width: var(--s-full);
@@ -398,6 +409,20 @@
         padding: var(--_tb-searchbar-p);
     }
 
+    & &--skip-link {
+        &:not(:focus) {
+            &:extend(.v-visible-sr);
+        }
+
+        background-color: var(--theme-secondary-100);
+        border-bottom: var(--_tb-bt);
+        display: block;
+        outline: none;
+        padding: var(--su12);
+        text-align: center;
+    }
+
+
     .s-navigation {
         .s-navigation--item {
             &:not(.is-selected) {
@@ -428,9 +453,6 @@
     align-items: center;
     background-color: var(--theme-topbar-background-color, var(--white));
     border-bottom: var(--theme-topbar-bottom-border, var(--su-static1) solid var(--black-225));
-    border-top: var(--theme-topbar-accent-border, 3px solid var(--theme-primary));
-    display: flex;
-    height: var(--theme-topbar-height, calc(var(--su-static48) + var(--su-static8)));
     min-width: auto;
     position: relative;
     width: 100%;
@@ -503,23 +525,4 @@
     --theme-topbar-item-color-current: var(--_black-static);
 
     --scrollbar: hsla(0, 0%, 0%, 0.2);
-}
-
-.s-topbar--skip-link {
-    &:extend(.v-visible-sr);
-    display: block;
-    text-align: center;
-    background-color: var(--theme-secondary-100);
-    z-index: var(--zi-navigation-fixed);
-    outline: none;
-
-    &:focus {
-        position: sticky;
-        height: auto;
-        width: 100%;
-        padding: var(--su12);
-        inset: 0;
-        clip: auto;
-        clip-path: none;
-    }
 }

--- a/lib/components/topbar/topbar.less
+++ b/lib/components/topbar/topbar.less
@@ -122,16 +122,6 @@
     }
 
     // CHILD ELEMENTS
-    &:before {
-        border-top: var(--_tb-bt);
-        content: '';
-        display: block;
-    }
-
-    &:has(> &--skip-link:focus):before {
-        display: none; // Hide `:before` element if .s-topbar--skip-link is focused
-    }
-
     & a&--logo {
         &:focus-visible {
             .focus-styles(true);
@@ -449,10 +439,15 @@
         }
     }
 
+    &:has(> &--skip-link:focus) {
+        border-top: none; // Hide the border-top when the skip link is focused
+    }
+
     // STATIC COMPONENT STYLES
     align-items: center;
     background-color: var(--theme-topbar-background-color, var(--white));
     border-bottom: var(--theme-topbar-bottom-border, var(--su-static1) solid var(--black-225));
+    border-top: var(--_tb-bt);
     min-width: auto;
     position: relative;
     width: 100%;

--- a/lib/components/topbar/topbar.less
+++ b/lib/components/topbar/topbar.less
@@ -407,7 +407,7 @@
         background-color: var(--theme-secondary-100);
         border-bottom: var(--_tb-bt);
         display: block;
-        outline: none;
+        outline: var(--su-static2) solid transparent;
         padding: var(--su12);
         text-align: center;
     }


### PR DESCRIPTION
This PR is an attempt to add the `.s-topbar--skip-link` component as a child of `.s-topbar` while retaining the style shown in https://github.com/StackExchange/Stacks/pull/1692.

@giamir I've added notes in a review of this code that should provide some context. I'm happy to discuss this PR with you whenever you'd like.