### PR TITLE
fix(a11y): update code highlight colors to meet contrast requirement

### DIFF
--- a/lib/components/code-block/code-block.a11y.test.ts
+++ b/lib/components/code-block/code-block.a11y.test.ts
@@ -16,12 +16,6 @@ describe("code block", () => {
             attributes: {
                 tabindex: "0",
             },
-            // TODO revisit these skipped test ids
-            skippedTestids: [
-                /s-code-block-language-(html|css|javascript)-dark/,
-                /s-code-block-language-html-highcontrast-(light|dark)/,
-                "s-code-block-language-javascript-highcontrast-light",
-            ],
         });
     });
 });

--- a/lib/exports/__snapshots__/color.less.test.ts.snap
+++ b/lib/exports/__snapshots__/color.less.test.ts.snap
@@ -296,10 +296,10 @@ body:not(.theme-highcontrast):not(.theme-dark) .theme-dark__forced .themed {
     --highlight-comment: hsl(0, 0%, 60%);
     --highlight-deletion: var(--red-500);
     --highlight-keyword: var(--blue-400);
-    --highlight-literal: hsl(27, 85%, 61.5%);
-    --highlight-namespace: hsl(27, 85%, 61.5%);
+    --highlight-literal: hsl(27, 95%, 65%);
+    --highlight-namespace: hsl(27, 95%, 65%);
     --highlight-punctuation: hsl(0, 0%, 80%);
-    --highlight-symbol: hsl(306, 43%, 69%);
+    --highlight-symbol: hsl(306, 50%, 75%);
     --highlight-variable: hsl(65.5, 39%, 57.5%);
     --scrollbar: hsla(0, 0%, 100%, 0.2);
     --theme-primary: var(--theme-dark-primary-custom, var(--orange-400));
@@ -429,10 +429,10 @@ body:not(.theme-highcontrast):not(.theme-dark) .theme-dark__forced .themed {
         --highlight-comment: hsl(0, 0%, 60%);
         --highlight-deletion: var(--red-500);
         --highlight-keyword: var(--blue-400);
-        --highlight-literal: hsl(27, 85%, 61.5%);
-        --highlight-namespace: hsl(27, 85%, 61.5%);
+        --highlight-literal: hsl(27, 95%, 65%);
+        --highlight-namespace: hsl(27, 95%, 65%);
         --highlight-punctuation: hsl(0, 0%, 80%);
-        --highlight-symbol: hsl(306, 43%, 69%);
+        --highlight-symbol: hsl(306, 50%, 75%);
         --highlight-variable: hsl(65.5, 39%, 57.5%);
         --scrollbar: hsla(0, 0%, 100%, 0.2);
         --theme-primary: var(--theme-dark-primary-custom, var(--orange-400));
@@ -566,7 +566,7 @@ body.theme-highcontrast.theme-system .theme-light__forced {
     --highlight-namespace: hsl(16, 94%, 31%);
     --highlight-punctuation: var(--black-500);
     --highlight-symbol: hsl(309, 45%, 31%);
-    --highlight-variable: hsl(88, 100%, 19%);
+    --highlight-variable: hsl(88, 100%, 18%);
     --scrollbar: var(--black);
     --theme-primary: var(--orange-400);
     --theme-primary-100: var(--orange-100);

--- a/lib/exports/color-sets.less
+++ b/lib/exports/color-sets.less
@@ -524,7 +524,7 @@
     namespace: hsl(16, 94%, 31%);
     punctuation: var(--black-500);
     symbol: hsl(309, 45%, 31%);
-    variable: hsl(88, 100%, 19%);
+    variable: hsl(88, 100%, 18%);
 }
 .set-highlight-hc-dark() {
     addition: var(--green-500);

--- a/lib/exports/color-sets.less
+++ b/lib/exports/color-sets.less
@@ -506,10 +506,10 @@
     comment: hsl(0, 0%, 60%);
     deletion: var(--red-500);
     keyword:var(--blue-400);
-    literal: hsl(27, 85%, 61.5%);
-    namespace: hsl(27, 85%, 61.5%);
+    literal: var(--orange-400);
+    namespace: var(--orange-400);
     punctuation: hsl(0, 0%, 80%);
-    symbol: hsl(306, 43%, 69%);
+    symbol: hsl(306, 50%, 75%);
     variable: hsl(65.5, 39%, 57.5%);
 }
 .set-highlight-hc() {

--- a/lib/exports/color-sets.less
+++ b/lib/exports/color-sets.less
@@ -506,8 +506,8 @@
     comment: hsl(0, 0%, 60%);
     deletion: var(--red-500);
     keyword:var(--blue-400);
-    literal: var(--orange-400);
-    namespace: var(--orange-400);
+    literal: hsl(27, 95%, 65%);
+    namespace: hsl(27, 95%, 65%);
     punctuation: hsl(0, 0%, 80%);
     symbol: hsl(306, 50%, 75%);
     variable: hsl(65.5, 39%, 57.5%);


### PR DESCRIPTION
Addresses:
- [x] https://stackoverflow.atlassian.net/browse/A11Y-10
- [x] https://stackoverflow.atlassian.net/browse/A11Y-11
- [x] https://stackoverflow.atlassian.net/browse/A11Y-12

---

This PR resolves outstanding contrast issues with code highlight colors. The changes should be subtle enough as to barely be noticeable. 

> [!NOTE]
> We could attempt to change many of these colors to use core Stacks colors, but I figure it's best to keep it simple for now in order to resolve A11Y issues and decide later if we want to make more sweeping changes here.

## Color variable changes

| variable name | mode | old color | old contrast |  new color | new contrast |
|-|-|-|-|-|-|
|`--highlight-literal`|dark|`hsl(27, 85%, 61.5%)` | Lc 55 |`hsl(27, 95%, 65%)` | Lc 60|
|`--highlight-namespace`|dark|`hsl(27, 85%, 61.5%)` | Lc 55 |`hsl(27, 95%, 65%)` | Lc 60|
|`--highlight-symbol`|dark|`hsl(306, 43%, 69%)` | Lc 51 |`hsl(306, 50%, 75%)` | Lc 60|
|`--highlight-variable`|light HC|`hsl(88, 100%, 19%)` | 6.8:1 |`hsl(88, 100%, 18%)` | 7.3:1|

<details>
<summary>Screenshot comparison (dark mode)</summary>

**Note**: The difference is in the orange (e.g.: `0.6em 0.7em`) and purple (e.g.: `border-radius`) text.

### Before

![image](https://github.com/StackExchange/Stacks/assets/647177/051c0699-e39b-4d1d-b496-e4f5a89b876e)

### After

![image](https://github.com/StackExchange/Stacks/assets/647177/28b85a56-11a5-4cb9-af49-ad7a564caeee)

</details>

<details>
<summary>Screenshot comparison (light HC mode)</summary>

**Note**: The difference is in the green (e.g.: `apples`) text.

### Before

![image](https://github.com/StackExchange/Stacks/assets/647177/ecb7c7e2-f0ec-4da4-876b-9e7b8aab984e)

### After

![image](https://github.com/StackExchange/Stacks/assets/647177/c7cab8aa-cce5-4c8c-8ae5-541a2f42b264)

</details>

## To test

- Go to https://deploy-preview-1724--stacks.netlify.app/product/components/code-blocks/
- Switch to dark mode
   - Look at the code blocks. They should look nearly identical to [how they look in prod](https://stackoverflow.design/product/components/code-blocks).
- Repeat, but for light HC mode
