### PR TITLE
docs(a11y): fix tertiary nav heading color contrast

### DIFF
--- a/docs/_includes/layouts/page.html
+++ b/docs/_includes/layouts/page.html
@@ -13,7 +13,7 @@
             {% if hide-menu != true %}
                 <div class="flex--item order-last ml32 sm:d-none print:d-none" style="width: 14rem;">
                     <div class="ps-fixed t64 b0 py12 overflow-y-auto" style="width: 14rem;">
-                        <h5 class="mt16 mb8 fw-bold tt-uppercase fs-fine fc-theme-primary mnl1">Sections</h5>
+                        <h5 class="mt16 mb8 fw-bold tt-uppercase fs-fine fc-black-400 mnl1">Sections</h5>
                         {{ content | toc }}
                     </div>
                 </div>


### PR DESCRIPTION
This is a minor accessibility fix for our Stacks docs to change the tertiary nav (right side) heading color from `fc-theme-primary` to `black-400`.

See https://stackexchange.slack.com/archives/C27RWNQN9/p1716992049112259?thread_ts=1716979306.515569&cid=C27RWNQN9