### PR TITLE
docs(a11y): document usage of ARIA landmarks across our products

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -8,14 +8,16 @@
         </a>
 
         {% if site-navigation %}
-            <ul class="s-navigation ml8 fw-nowrap sm:d-none">
-                {% assign slug = page.url | replace:'/',' ' | truncatewords: 2 | remove:'...' %}
+            <nav aria-label="Global" class="sm:d-none">
+                <ul class="s-navigation ml8 fw-nowrap sm:d-none">
+                    {% assign slug = page.url | replace:'/',' ' | truncatewords: 2 | remove:'...' %}
 
-                {% for section in site-navigation.sections %}
-                    {% assign url = section.url | replace:'/',' ' | truncatewords: 2 | remove:'...' %}
-                    <li><a class="s-navigation--item{% if url == slug %} is-selected{% endif %}" href="{{ section.url }}">{{ section.title }}</a></li>
-                {% endfor %}
-            </ul>
+                    {% for section in site-navigation.sections %}
+                        {% assign url = section.url | replace:'/',' ' | truncatewords: 2 | remove:'...' %}
+                        <li><a class="s-navigation--item{% if url == slug %} is-selected{% endif %}" href="{{ section.url }}" {% if url == slug %} aria-current="page"{% endif %}>{{ section.title }}</a></li>
+                    {% endfor %}
+                </ul>
+            </nav>
         {% endif %}
 
         <ol class="s-topbar--content sm:ml0 overflow-hidden">
@@ -36,7 +38,7 @@
             </li>
         </ol>
 
-        <div class="s-topbar--searchbar w100 wmx3 sm:wmx-initial js-search">
+        <div class="s-topbar--searchbar w100 wmx3 sm:wmx-initial js-search" role="search">
             <div class="s-topbar--searchbar--input-group">
                 <input id="searchbox" type="text" placeholder="Search Stacks…" value="" autocomplete="off" class="s-input s-input__search" />
                 {% icon "Search", "s-input-icon s-input-icon__search" %}

--- a/docs/_includes/layouts/home.html
+++ b/docs/_includes/layouts/home.html
@@ -4,7 +4,7 @@
 
 <body class="d-flex fd-column bg-black-100 theme-system">
     {% include 'theme.html' %}
-    <div class="d-flex fl-grow1 bg-theme-primary-400 fd-column ps-relative ai-center px64 sm:pl24 sm:pr24">
+    <header class="d-flex fl-grow1 bg-theme-primary-400 fd-column ps-relative ai-center px64 sm:pl24 sm:pr24">
         <svg class="stacks-intro-field theme-light__forced" width="716" height="519" viewBox="0 0 716 519">
             <defs>
                 <linearGradient id="a" x1="427.325" y1="187.632" x2="458.682" y2="132.104" gradientUnits="userSpaceOnUse">
@@ -149,7 +149,7 @@
                     <svg aria-hidden="true" class="svg-icon iconCodepen" width="24" height="24" viewBox="0 0 18 18"><path d="M12.67 8.17l-2.98-2v-3.2l5.38 3.6-2.4 1.6zM13.9 9l1.73-1.15v2.3L13.9 9zm-4.2 2.82l2.98-2 2.4 1.62-5.38 3.59v-3.2zm-4.36-2l2.98 2v3.2l-5.38-3.58 2.4-1.61zM4.1 9l-1.73 1.15v-2.3L4.1 9zm4.2-2.82l-2.98 2-2.4-1.62L8.3 2.97v3.2zm.7 4.45L6.57 9 9 7.37 11.43 9 9 10.63zm7.99-4.19l-.01-.05-.01-.04-.02-.05-.02-.03a.6.6 0 0 0-.02-.05l-.02-.03a.69.69 0 0 0-.15-.17L16.7 6h-.02L9.4 1.11a.69.69 0 0 0-.77 0L1.3 5.99h-.02c0 .02-.02.02-.03.03a.81.81 0 0 0-.12.13.69.69 0 0 0-.03.04l-.02.03-.02.05-.02.03-.02.05v.04L1 6.44v.03a.7.7 0 0 0-.01.1v4.87a.7.7 0 0 0 0 .09l.01.03.01.05.01.04.02.05.02.03a.51.51 0 0 0 .07.12.53.53 0 0 0 .08.1c.02 0 .03.02.04.03l.03.02h.02l7.3 4.88a.69.69 0 0 0 .77 0l7.31-4.87h.02c0-.02.02-.02.03-.03a.72.72 0 0 0 .04-.04l.02-.02a.62.62 0 0 0 .13-.19l.02-.03a.6.6 0 0 0 .02-.05v-.04l.02-.05v-.03a.7.7 0 0 0 .01-.1V6.57a.7.7 0 0 0 0-.09l-.01-.03z"/></svg>
                 </a>
 
-                <div class="flex--item ps-relative w100 wmx3 js-search">
+                <div class="flex--item ps-relative w100 wmx3 js-search" role="search">
                     <input id="searchbox" class="s-input s-input__search bar-md ba bc-theme-primary-500 js-stacks-search-bar" type="text" placeholder="Search Stacks…">
                     {% icon "Search", "s-input-icon s-input-icon__search" %}
                 </div>
@@ -192,9 +192,9 @@
                 <p class="m0 fs-subheading"><em>Stacks</em> provides everything you need to quickly design, build, and ship coherent experiences across all of Stack Overflow—from the brand and product itself, down to how we send emails and write copy.</p>
             </div>
         </div>
-    </div>
+    </header>
     <div class="flex--item bg-black-100 p64 sm:pt24 sm:pl24 sm:pr24 sm:pb24">
-        <div class="d-grid grid__4 lg:grid__2 sm:grid__1 g16 w100 wmx12 mx-auto">
+        <nav class="d-grid grid__4 lg:grid__2 sm:grid__1 g16 w100 wmx12 mx-auto" aria-label="Global">
             <a class="d-flex s-card p16 bs-sm bar-md h:bs-md sm:ai-center" href="{{ "/product/develop/using-stacks" | url }}">
                 <div class="flex--item fc-theme-primary-400 mr16">
                     {% spot "Puzzle" %}
@@ -235,7 +235,7 @@
                     <div class="fc-medium">Visual patterns and guidelines for Stack Overflow’s brand.</div>
                 </div>
             </a>
-        </div>
+        </nav>
     </div>
     {% include 'scripts.html' %}
 </body>

--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -3,7 +3,7 @@
         <div class="d-none sm:d-block">
             <div class="d-flex fd-column ai-center">
                 {% if site-navigation %}
-                    <nav class="s-navigation s-navigation__wrap mx8 mb12 jc-center" aria-label="Global navigation">
+                    <nav class="s-navigation s-navigation__wrap mx8 mb12 jc-center" aria-label="Global">
                         {% assign slug = page.url | replace:'/',' ' | truncatewords: 2 | remove:'...' %}
 
                         {% for section in site-navigation.sections %}
@@ -22,14 +22,14 @@
 
                 {% if url == slug %}
                     {% if section.sections %}
-                        <nav id="nav" class="s-navigation s-navigation__vertical mt16" aria-label="Navigation">
+                        <nav id="nav" class="s-navigation s-navigation__vertical mt16" aria-label="Main">
                             {% for section in section.sections %}
                                 <div class="s-navigation--title">
                                     {{ section.title }}
                                 </div>
                                 {% if section.links %}
                                     {% for link in section.links %}
-                                        <a class="s-navigation--item {% if page.url == link.url %}is-selected{% endif %}" href="{{ link.url | url }}">
+                                        <a class="s-navigation--item {% if page.url == link.url %}is-selected{% endif %}" href="{{ link.url | url }}" {% if page.url == link.url %}aria-current="page"{% endif %}>
                                             {{ link.title }}
                                         </a>
                                     {% endfor %}

--- a/docs/_includes/topbar.html
+++ b/docs/_includes/topbar.html
@@ -47,7 +47,7 @@
         {% endunless %}
 
         {% unless hideSearch %}
-            <form class="s-topbar--searchbar" autocomplete="off">
+            <form class="s-topbar--searchbar" autocomplete="off" role="search">
                 {% unless hideSelect %}
                     <div class="s-select">
                         <select aria-label="Search scope">

--- a/docs/product/components/topbar.html
+++ b/docs/product/components/topbar.html
@@ -115,7 +115,7 @@ description: The topbar component is a navigation bar that is placed at the top 
     <div class="s-topbar--container">
         <a href="…" class="s-topbar--logo">…</a>
 
-        <form id="search" class="s-topbar--searchbar" autocomplete="off">
+        <form id="search" class="s-topbar--searchbar" autocomplete="off" role="search">
             <div class="s-select">
                 <select aria-label="Search scope">…</select>
             </div>

--- a/docs/product/foundation/accessibility.html
+++ b/docs/product/foundation/accessibility.html
@@ -332,3 +332,19 @@ description: A non-comprehensive guide to accessibility best practices when usin
         There are some exceptions to this rule. Some elements such as tables and videos may require horizontal scrolling on small viewports. In these cases, it's acceptable to require scrolling in two dimensions. See the <a class="s-link" href="https://www.w3.org/WAI/WCAG22/Understanding/reflow.html#content-exceptions-for-reflow">WCAG 2.2 documentation on Reflow</a> for detailed guidance.
     </p>
 </section>
+
+<section class="stacks-section">
+    {% header "h2", "Landmarks" %}
+
+    <p class="stacks-copy">
+        <a class="s-link" href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role">ARIA landmarks</a> should be used across Stack Overflow product pages to provide clear navigation structures for users relying on assistive technologies.
+        Landmarks are inserted into the page explictly using the <code class="stacks-code">role</code> attribute on an element (e.g. <code class="stacks-code">role="search"</code>, etc...) or by leveraging semantic HTML (e.g. an <code class="stacks-code">header</code> element is given automatically the <code class="stacks-code">banner</code> landmark).<br />
+        Using semantic HTML elements should be preferred over using the <code class="stacks-code">role</code> attribute whenever possible.
+    </p>
+    <p class="stacks-copy">For a comprehensive guide on using ARIA landmark roles refer to:</p>
+    <ul class="stacks-list">
+       <li><a class="s-link" href="https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA11">WCAG ARIA11 Technique</a></li>
+       <li><a class="s-link" href="https://developer.mozilla.org/en-US/blog/aria-accessibility-html-landmark-roles">Using HTML landmark roles to improve accessibility</a></li>
+       <li><a class="s-link" href="https://matatk.agrip.org.uk/landmarks">Landmarks Browser Extension</a></li>
+    </ul>
+</section>


### PR DESCRIPTION
[STACKS-614](https://stackoverflow.atlassian.net/browse/STACKS-614)

This PR documents the usage of ARIA landmarks in our [accessibility page](https://deploy-preview-1752--stacks.netlify.app/product/foundation/accessibility/#landmarks).

Furthermore it adjusts landmarks issues across our docs. 

## How to test

- Download the [Landmarks Browser Extension](https://matatk.agrip.org.uk/landmarks)
- Navigate to any page
- Observe we now have 6 landmarks (`banner`, including `global navigation` and `search` - `main navigation` - `main`, including `table of contents navigation`). Screen readers and keyboard-only users can easily jump between landmark sections.

_Sidenote: This PR is also adding the `aria-current="page"` to the selected item in the global and main navigations._