### PR TITLE
fix(popover): prevent content child from clipping elements

### DIFF
--- a/docs/product/components/popovers.html
+++ b/docs/product/components/popovers.html
@@ -170,12 +170,18 @@ description: Popovers are small content containers that provide a contextual ove
                 <div id="popover-example-1" class="s-popover ws2" role="menu">
                     <div class="s-popover--arrow"></div>
                     <div class="s-popover--content">
-                        <div class="tt-uppercase fs-fine fc-light">
-                            Saved filters
-                        </div>
-                        <div class="fc-black-350 fs-caption ta-center p16">
-                            Save custom sorting & filtering for easy access.
-                        </div>
+                        <form class="d-flex fd-column g8" role="presentation">
+                            <div class="d-flex gy4 fd-column">
+                                <label class="s-label" for="example-item1">Username</label>
+                                <input class="s-input" id="example-item1" type="text" />
+                            </div>
+                            <div class="d-flex gy4 fd-column">
+                                <label class="s-label" for="example-item2">Password</label>
+                                <input class="s-input" id="example-item2" type="password" />
+                            </div>
+                            <button type="submit" class="s-btn s-btn__filled w100">Sign in</button>
+                            <a href="#" class="s-btn s-btn__outlined w100">Create an account</a>
+                        </form>
                     </div>
                 </div>
                 <button class="flex--item s-btn s-btn__filled s-btn__dropdown"

--- a/lib/components/popover/popover.less
+++ b/lib/components/popover/popover.less
@@ -137,6 +137,8 @@
     & &--content {
         max-height: var(--_po-content-mxh);
         overflow-y: auto;
+        margin: calc(var(--su12) * -1);
+        padding: var(--su12);
     }
 
     background-color: var(--_po-bg);


### PR DESCRIPTION
[STACKS-635](https://stackoverflow.atlassian.net/browse/STACKS-635)

---

This PR ensures that anything extending (12px or less) from the `s-popover--content` element will still be visible. The largest impact will be on focused inputs within a popover.

### Before

![image](https://github.com/StackExchange/Stacks/assets/647177/f52f8897-23f2-4996-9abc-f1ddcd2a8d5b)


### After

![image](https://github.com/StackExchange/Stacks/assets/647177/1e841775-950c-4d09-afe9-66cbf563d13e)


