### PR TITLE
fix(link): prevent visited styles from applying to .post-tag

### DIFF
--- a/lib/components/link/link.less
+++ b/lib/components/link/link.less
@@ -4,7 +4,8 @@ a {
     &:visited {
         // We're target these specific selectors to avoid affecting the visited state of stacks components
         // not specified here. See for https://github.com/StackExchange/Stacks/pull/1740#discussion_r1698389312
-        &:not([class*="s-"]),
+        // TODO remove .post-tag reference once core no longer requires them
+        &:not([class*="s-"]):not(.post-tag),
         &.s-link,
         &.s-sidebarwidget--action,
         &.s-user-card--link {


### PR DESCRIPTION
Addresses issue reported in [Core integration PR](https://github.com/StackEng/StackOverflow/pull/20322#pullrequestreview-2225519712)