### PR TITLE
Improve readonly input APCA Lc values for a11y

### DIFF
--- a/lib/components/input_textarea/input_textarea.a11y.test.ts
+++ b/lib/components/input_textarea/input_textarea.a11y.test.ts
@@ -78,9 +78,7 @@ const otherModifiers = ["creditcard", "search"];
                               ...attributes,
                           },
                 children,
-                template,
-                // TODO revisit these skipped test ids
-                skippedTestids: [/readonly/],
+                template
             });
         });
 

--- a/lib/components/input_textarea/input_textarea.a11y.test.ts
+++ b/lib/components/input_textarea/input_textarea.a11y.test.ts
@@ -78,7 +78,7 @@ const otherModifiers = ["creditcard", "search"];
                               ...attributes,
                           },
                 children,
-                template
+                template,
             });
         });
 

--- a/lib/components/input_textarea/input_textarea.less
+++ b/lib/components/input_textarea/input_textarea.less
@@ -48,7 +48,7 @@
 
         --_in-bg: var(--black-150);
         --_in-bc: var(--bc-light);
-        --_in-fc: var(--black-300);
+        --_in-fc: var(--black-400);
     }
 
     .validation-states(

--- a/lib/components/input_textarea/input_textarea.less
+++ b/lib/components/input_textarea/input_textarea.less
@@ -43,7 +43,7 @@
     &[readonly],
     .is-readonly & {
         .highcontrast-mode({
-            --_in-fc: var(--fc-light);
+            --_in-fc: var(--fc-medium);
         });
 
         --_in-bg: var(--black-150);

--- a/screenshots/Chromium/baseline/s-input-readonly-dark.png
+++ b/screenshots/Chromium/baseline/s-input-readonly-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c9cb985d65bc23f88d5f984835e65ae43ade5e3ff98c538929dbccab81dbeda
-size 1966
+oid sha256:6d3f0022aa2070b2813db900a2ea3a4f6853f62d683b9913024113c29feadc89
+size 2177

--- a/screenshots/Chromium/baseline/s-input-readonly-light.png
+++ b/screenshots/Chromium/baseline/s-input-readonly-light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:47617c629ae03fd24decbe89285188847ab0e555adb5b4f96cb6c7a81e828afc
-size 1803
+oid sha256:be60f93bcb105d4bf13e346d59b10757fbec041fc5e87da19010a7354fb3dbbd
+size 2128

--- a/screenshots/Chromium/baseline/s-input-state-is-readonly-dark.png
+++ b/screenshots/Chromium/baseline/s-input-state-is-readonly-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c9cb985d65bc23f88d5f984835e65ae43ade5e3ff98c538929dbccab81dbeda
-size 1966
+oid sha256:6d3f0022aa2070b2813db900a2ea3a4f6853f62d683b9913024113c29feadc89
+size 2177

--- a/screenshots/Chromium/baseline/s-input-state-is-readonly-light.png
+++ b/screenshots/Chromium/baseline/s-input-state-is-readonly-light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:47617c629ae03fd24decbe89285188847ab0e555adb5b4f96cb6c7a81e828afc
-size 1803
+oid sha256:be60f93bcb105d4bf13e346d59b10757fbec041fc5e87da19010a7354fb3dbbd
+size 2128

--- a/screenshots/Chromium/baseline/s-textarea-readonly-dark.png
+++ b/screenshots/Chromium/baseline/s-textarea-readonly-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d8733e90f774b48b1653544556626f9609a0b47d144a242d81d67d982e7e3a00
-size 2283
+oid sha256:c61bc7b9dcb93dc9cb5fe5ad997e54b145bb8e37f47417254ee4eb9c9bf40efa
+size 2507

--- a/screenshots/Chromium/baseline/s-textarea-readonly-light.png
+++ b/screenshots/Chromium/baseline/s-textarea-readonly-light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:779f9af91cc3925557aac1d6d7396fe29a0500e8f6f97ced1ca0c42a174285c9
-size 2184
+oid sha256:c74fc106b84b728fdc5efab35288242ce8315b95230fe46f9c90dd81c51335a0
+size 2466

--- a/screenshots/Chromium/baseline/s-textarea-state-is-readonly-dark.png
+++ b/screenshots/Chromium/baseline/s-textarea-state-is-readonly-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d8733e90f774b48b1653544556626f9609a0b47d144a242d81d67d982e7e3a00
-size 2283
+oid sha256:c61bc7b9dcb93dc9cb5fe5ad997e54b145bb8e37f47417254ee4eb9c9bf40efa
+size 2507

--- a/screenshots/Chromium/baseline/s-textarea-state-is-readonly-light.png
+++ b/screenshots/Chromium/baseline/s-textarea-state-is-readonly-light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:779f9af91cc3925557aac1d6d7396fe29a0500e8f6f97ced1ca0c42a174285c9
-size 2184
+oid sha256:c74fc106b84b728fdc5efab35288242ce8315b95230fe46f9c90dd81c51335a0
+size 2466

--- a/screenshots/Firefox/baseline/s-input-readonly-dark.png
+++ b/screenshots/Firefox/baseline/s-input-readonly-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:88dad7367923fc01a5bbc5d44749ff1c2d2d20c3ab144a5b1d44eac708aa0c96
-size 2347
+oid sha256:3ef7a5be762e579a99bd31cf2d05693f1a851ff7e28ac5ed27b38d27b9d6d9e0
+size 2549

--- a/screenshots/Firefox/baseline/s-input-readonly-light.png
+++ b/screenshots/Firefox/baseline/s-input-readonly-light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:250718b84de9b07c70f02461d1cbe16193d34594850258a24a5c86352c52ce84
-size 2248
+oid sha256:7b0f76ecaba349ea044c6093a015d2f48de111915ac0278515d2ba3e8c3432bb
+size 2530

--- a/screenshots/Firefox/baseline/s-input-state-is-readonly-dark.png
+++ b/screenshots/Firefox/baseline/s-input-state-is-readonly-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:88dad7367923fc01a5bbc5d44749ff1c2d2d20c3ab144a5b1d44eac708aa0c96
-size 2347
+oid sha256:3ef7a5be762e579a99bd31cf2d05693f1a851ff7e28ac5ed27b38d27b9d6d9e0
+size 2549

--- a/screenshots/Firefox/baseline/s-input-state-is-readonly-light.png
+++ b/screenshots/Firefox/baseline/s-input-state-is-readonly-light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:250718b84de9b07c70f02461d1cbe16193d34594850258a24a5c86352c52ce84
-size 2248
+oid sha256:7b0f76ecaba349ea044c6093a015d2f48de111915ac0278515d2ba3e8c3432bb
+size 2530

--- a/screenshots/Firefox/baseline/s-textarea-readonly-dark.png
+++ b/screenshots/Firefox/baseline/s-textarea-readonly-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:24a03e0a86fc7ea4776696020c77175c3fd22df8864d3c71e18bad9c28516705
-size 2773
+oid sha256:b34e2c49a9bdb4b921cbbd25776691ef5c8a180415f34aabe050025d9901973a
+size 3007

--- a/screenshots/Firefox/baseline/s-textarea-readonly-light.png
+++ b/screenshots/Firefox/baseline/s-textarea-readonly-light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd266e8a5fd2fe6c00d82079421defa5cc818a1bf4f0879f28294f1a92acb5a9
-size 2657
+oid sha256:ef84e1f1cfee887e50999cd96278cc7d05d2789f2a1b88d854a04fc017547caf
+size 2979

--- a/screenshots/Firefox/baseline/s-textarea-state-is-readonly-dark.png
+++ b/screenshots/Firefox/baseline/s-textarea-state-is-readonly-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:24a03e0a86fc7ea4776696020c77175c3fd22df8864d3c71e18bad9c28516705
-size 2773
+oid sha256:b34e2c49a9bdb4b921cbbd25776691ef5c8a180415f34aabe050025d9901973a
+size 3007

--- a/screenshots/Firefox/baseline/s-textarea-state-is-readonly-light.png
+++ b/screenshots/Firefox/baseline/s-textarea-state-is-readonly-light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd266e8a5fd2fe6c00d82079421defa5cc818a1bf4f0879f28294f1a92acb5a9
-size 2657
+oid sha256:ef84e1f1cfee887e50999cd96278cc7d05d2789f2a1b88d854a04fc017547caf
+size 2979

--- a/screenshots/Webkit/baseline/s-input-readonly-dark.png
+++ b/screenshots/Webkit/baseline/s-input-readonly-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fc501200d28dd1c5f01ebbbb0203d1ec8593800205989af9e0eda83eddb91dcc
-size 1670
+oid sha256:25e87f390fc332c0a924fd7d5490d9ce5286f19f614c8b1920955dc35432eba6
+size 1854

--- a/screenshots/Webkit/baseline/s-input-readonly-light.png
+++ b/screenshots/Webkit/baseline/s-input-readonly-light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:648a2f03dc68321deb6d539fcc55f62ec5b5ba2bd06df06465da79f256183a58
-size 1597
+oid sha256:b2e7cff5bf8e0723998333d3e4c04ac3ff92952ece38e78f7dc7a7c2ff5adbb4
+size 1808

--- a/screenshots/Webkit/baseline/s-input-state-is-readonly-dark.png
+++ b/screenshots/Webkit/baseline/s-input-state-is-readonly-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fc501200d28dd1c5f01ebbbb0203d1ec8593800205989af9e0eda83eddb91dcc
-size 1670
+oid sha256:25e87f390fc332c0a924fd7d5490d9ce5286f19f614c8b1920955dc35432eba6
+size 1854

--- a/screenshots/Webkit/baseline/s-input-state-is-readonly-light.png
+++ b/screenshots/Webkit/baseline/s-input-state-is-readonly-light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:648a2f03dc68321deb6d539fcc55f62ec5b5ba2bd06df06465da79f256183a58
-size 1597
+oid sha256:b2e7cff5bf8e0723998333d3e4c04ac3ff92952ece38e78f7dc7a7c2ff5adbb4
+size 1808

--- a/screenshots/Webkit/baseline/s-textarea-readonly-dark.png
+++ b/screenshots/Webkit/baseline/s-textarea-readonly-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:745ebf4efc3f9f221ffad3096785b24899503d4e143de242e2cfad28b1315303
-size 1849
+oid sha256:a1019e569553069180e79d2d8e9f12c683427757e709f32dee1ee50ff8cb1dba
+size 2035

--- a/screenshots/Webkit/baseline/s-textarea-readonly-light.png
+++ b/screenshots/Webkit/baseline/s-textarea-readonly-light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f0bd5239d5067f746dc89694fed61956ca92dad241fad2fae1ba9642a253218f
-size 1769
+oid sha256:c8471509338715f5c96b83ee7c96ecef5e6650b669282d412c1348f807f993de
+size 1997

--- a/screenshots/Webkit/baseline/s-textarea-state-is-readonly-dark.png
+++ b/screenshots/Webkit/baseline/s-textarea-state-is-readonly-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:745ebf4efc3f9f221ffad3096785b24899503d4e143de242e2cfad28b1315303
-size 1849
+oid sha256:a1019e569553069180e79d2d8e9f12c683427757e709f32dee1ee50ff8cb1dba
+size 2035

--- a/screenshots/Webkit/baseline/s-textarea-state-is-readonly-light.png
+++ b/screenshots/Webkit/baseline/s-textarea-state-is-readonly-light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f0bd5239d5067f746dc89694fed61956ca92dad241fad2fae1ba9642a253218f
-size 1769
+oid sha256:c8471509338715f5c96b83ee7c96ecef5e6650b669282d412c1348f807f993de
+size 1997


### PR DESCRIPTION
# Summary

This PR modifies the font color for readonly inputs to improve their contrast, matching the recommendations by APCA for accessibility friendly contrast values.

Here are before and after screenshots of the readonly input in various color modes:

### Before & After for Light Mode:
![readonly-input-old-style-light](https://github.com/user-attachments/assets/b7388467-25f1-4328-af62-8583d4df9703)
![readonly-input-new-style-light](https://github.com/user-attachments/assets/4f5a9e91-8d58-4d8a-b458-1cfeb59d6ae2)



### Before & After for Dark Mode:
![readonly-input-old-style-dark](https://github.com/user-attachments/assets/a778bea9-d04b-4c42-91d0-d20364c38efe)
![readonly-input-new-style-dark](https://github.com/user-attachments/assets/fcd60394-4044-450a-8afc-cd4f1dc39695)

### Before & After For Light Mode High Contrast:
![readonly-input-old-style-light-highcontrast](https://github.com/user-attachments/assets/ebdbaa28-b0ea-440b-9f73-28b4732c41ef)
![readonly-input-new-style-light-highcontrast](https://github.com/user-attachments/assets/1b84c8bb-5a88-4c1f-958a-7d5f372e6023)


### Before & After For Dark Mode High Contrast:
![readonly-input-old-style-dark-highcontrast](https://github.com/user-attachments/assets/707cc9f9-96dd-49a7-82f8-3de467c6bd41)
After for Dark Mode High Contrast:
![readonly-input-new-style-dark-highcontrast](https://github.com/user-attachments/assets/33597172-c34a-45a4-9f99-afc46d6522fa)

