### PR TITLE
docs(spot illustrations): update spot prototype usage instructions

### DIFF
--- a/docs/product/foundation/spots.html
+++ b/docs/product/foundation/spots.html
@@ -21,7 +21,7 @@ description: Spot illustrations are the slightly grown up version of icons with 
 {% spot "Wave" %}
 
 <!-- JavaScript Helper -->
-<svg data-spot="Wave"></svg>
+<svg data-spot="SpotWave"></svg>
 {% endhighlight %}
         <div class="stacks-preview--example">
             {% spot "Wave" %}
@@ -40,7 +40,7 @@ description: Spot illustrations are the slightly grown up version of icons with 
 {% spot "Wave", "fc-orange-400 float-right js-dropdown-target" %}
 
 <!-- JavaScript Helper -->
-<svg data-spot="Wave" class="fc-orange-400 float-right js-dropdown-target"></svg>
+<svg data-spot="SpotWave" class="fc-orange-400 float-right js-dropdown-target"></svg>
 {% endhighlight %}
         <div class="stacks-preview--example overflow-hidden">
             {% spot "Wave", "fc-orange-400 float-right js-dropdown-target" %}


### PR DESCRIPTION
Follow up to #1116, particularly @b-kelly ["technically" comment](https://github.com/StackExchange/Stacks/pull/1116#pullrequestreview-1117541396)

Using the Prototype syntax, Spot data attributes now need to be prefixed with "Spot":

```diff
- <svg data-spot="Wave"></svg>
+ <svg data-spot="SpotWave"></svg>
```

