### PR TITLE
fix(btn): don't render visited colors on outlined btn

### DIFF
--- a/lib/components/button/button.less
+++ b/lib/components/button/button.less
@@ -419,9 +419,11 @@
                     color: var(--_bu-filled-fc);
                 }
 
-                background-color: var(--_bu-bg);
-                border-color: var(--_bu-bc);
-                color: var(--_bu-fc);
+                &:not(.s-btn__outlined) {
+                    background-color: var(--_bu-bg);
+                    border-color: var(--_bu-bc);
+                    color: var(--_bu-fc);
+                }
             }
 
             background-color: var(--_bu-bg-hover);


### PR DESCRIPTION
Quick bug fix for unexpected border color being applied to `.s-btn.s-btn__outlined:hover:visited`. When an outlined button is being hovered and is visited, it shows a black border when it should show a theme color border. This happens in Chrome but not Firefox and seems to be an issue with how a given browser honors the cascade.

From [slack thread](https://stackexchange.slack.com/archives/C27RWNQN9/p1729694733912009):

> ![image](https://github.com/user-attachments/assets/56721621-f60d-46c0-8f12-1782473e3f7a)