### PR TITLE
fix(table): apply font color to anchors in headings

### DIFF
--- a/docs/product/components/tables.html
+++ b/docs/product/components/tables.html
@@ -675,10 +675,10 @@ description: Tables are used to list all information from a data set. The base s
                     <thead>
                         <tr>
                             <th scope="col" class="is-sorted">
-                                <a href="#">Listing {% icon "ArrowDownSm" %}</a>
+                                <a href="#sortable-tables">Listing {% icon "ArrowDownSm" %}</a>
                             </th>
                             <th scope="col">
-                                <a href="#">Status {% icon "ArrowUpDownSm" %}</a>
+                                <a href="#sortable-tables">Status {% icon "ArrowUpDownSm" %}</a>
                             </th>
                             <th scope="col">
                                 <button type="button">Owner {% icon "ArrowUpDownSm" %}</button>

--- a/docs/product/components/tables.html
+++ b/docs/product/components/tables.html
@@ -642,11 +642,25 @@ description: Tables are used to list all information from a data set. The base s
     <table class="s-table s-table__sortable">
         <thead>
             <tr>
-                <th scope="col" class="is-sorted">Listing @Svg.ArrowDownSm</th>
-                <th scope="col">Status @Svg.ArrowUpDownSm</th>
-                <th scope="col">Owner @Svg.ArrowUpDownSm</th>
-                <th scope="col" class="ta-right">Views @Svg.ArrowUpDownSm</th>
-                <th scope="col" class="ta-right">Applies @Svg.ArrowUpDownSm</th>
+                <th scope="col" class="is-sorted">
+                    <button type="button">Listing @Svg.ArrowDownSm</button>
+                </th>
+                <th scope="col">
+                    <button type="button">Status @Svg.ArrowUpDownSm</button>
+
+                </th>
+                <th scope="col">
+                    <button type="button">Owner @Svg.ArrowUpDownSm</button>
+
+                </th>
+                <th scope="col" class="ta-right">
+                    <button type="button">Views @Svg.ArrowUpDownSm</button>
+
+                </th>
+                <th scope="col" class="ta-right">
+                    <button type="button">Applies @Svg.ArrowUpDownSm</button>
+
+                </th>
             </tr>
         </thead>
         <tbody>
@@ -661,24 +675,19 @@ description: Tables are used to list all information from a data set. The base s
                     <thead>
                         <tr>
                             <th scope="col" class="is-sorted">
-                                Listing
-                                {% icon "ArrowDownSm" %}
+                                <a href="#">Listing {% icon "ArrowDownSm" %}</a>
                             </th>
                             <th scope="col">
-                                Status
-                                {% icon "ArrowUpDownSm" %}
+                                <a href="#">Status {% icon "ArrowUpDownSm" %}</a>
                             </th>
                             <th scope="col">
-                                Owner
-                                {% icon "ArrowUpDownSm" %}
+                                <button type="button">Owner {% icon "ArrowUpDownSm" %}</button>
                             </th>
                             <th scope="col" class="ta-right">
-                                Views
-                                {% icon "ArrowUpDownSm" %}
+                                <button type="button">Views {% icon "ArrowUpDownSm" %}</button>
                             </th>
                             <th scope="col" class="ta-right">
-                                Applies
-                                {% icon "ArrowUpDownSm" %}
+                                <button type="button">Applies {% icon "ArrowUpDownSm" %}</button>
                             </th>
                         </tr>
                     </thead>

--- a/lib/components/table/table.less
+++ b/lib/components/table/table.less
@@ -124,7 +124,9 @@
         thead th {
             a,
             button { //  If an anchor is used, it should appear like a normal header
-                color: inherit;
+                // `!important` is used to ensure the appropriate color is on visited links. See STACKS-658.
+                // https://stackoverflow.atlassian.net/browse/STACKS-658
+                color: inherit !important;
             }
 
             button {


### PR DESCRIPTION
[STACKS-658](https://stackoverflow.atlassian.net/browse/STACKS-658)

---

This PR resolves an issue where default anchor visited styles were being applied to anchors within sortable table headers.

Specifically, this PR:

- adds `!important` to `color: inherit` on `a, button` within sortable table headers
- modifies the table docs code example to include `button`s within each header
- modifies the table docs rendered example to include `a`s and `button`s within each header

### Screenshots

<details>
<summary>Before</summary>

![image](https://github.com/user-attachments/assets/b27539bb-581d-4baa-b9de-73d25347e75a)

</details>

<details>
<summary>After</summary>

![image](https://github.com/user-attachments/assets/5d5d4ba8-5b6d-4c40-95e6-e2e5bef1c406)

</details>

## How to test

- Visit the [table documentation page](https://deploy-preview-1869--stacks.netlify.app/product/components/tables/)
- Scroll to the "Sortable Tables" section
- Click on one of the first two headers (`Listing` or `Status`) to navigate to `#sortable-tables`
- Notice that the first two headers color stay the same
  - Previous, those headers would gain the purple visited link color