### PR TITLE
Fix hover style of filled buttons that are anchors

### DIFF
--- a/lib/components/button/button.less
+++ b/lib/components/button/button.less
@@ -440,7 +440,7 @@
                 border-color: var(--_bu-bc-hover);
             }
 
-            &:visited:not(:active):not(:focus) {
+            &:visited:not(:hover):not(:focus) {
                 &.s-btn__filled {
                     background-color: var(--_bu-filled-bg);
                     border-color: var(--_bu-filled-bc);


### PR DESCRIPTION
This partially reverts a change in 4db47a6a4eb016b406c9a2971e734f61a569e68f. Here is an example reproduction:
```
<a href="" class="s-btn s-btn__filled">Example</a>
```

Since 2.5.5, hover styles on that example have not worked correctly. This is because 2.5.5 changed a selector to `.s-button`..`&:hover`..`&:visited:not(:active):not(:focus)`. This style applies to hovered and visited buttons. When it is applied, it sets the background colour to `var(--_bu-filled-bg);`, which is the standard background colour. Separately, the button hover selector has also matched this button and set the background colour to `var(--_bu-filled-bg-hover);`, but this selector is further up the file, so it has less priority. The hover style is being overwritten by this visited style.

I've fixed hovered visited link-buttons by undoing that change, since it doesn't seem to be related to the rest of 4db47a6a4eb016b406c9a2971e734f61a569e68f.

I've confirmed that this change fixes the example, and I haven't seen any negative side-effects in my use case. 😊