### PR TITLE
fix(anchors): ensure anchor styles take priority over `<a>` styles

### DIFF
--- a/lib/components/anchor/anchor.less
+++ b/lib/components/anchor/anchor.less
@@ -41,6 +41,13 @@
     }
 
     &&__inherit {
+        a:not(.s-link):not(.s-btn),
+        .s-btn.s-btn__link {
+            // This ensures inherited colors are applied instead of generic link colors targeting `a`
+            // See lib/components/link/link.less
+            color: var(--_an-a-fc) !important;
+        }
+
         --_an-a-fc: inherit;
         --_an-a-fc-hover: inherit;
         --_an-a-fc-visited: inherit;

--- a/lib/components/link/link.less
+++ b/lib/components/link/link.less
@@ -12,7 +12,7 @@ a {
         // Otherwise, use the default link colors.
         &:active,
         &:hover {
-            color: var(--_an-a-fc-hover, --_li-fc-hover);
+            color: var(--_an-a-fc-hover, var(--_li-fc-hover));
         }    
 
         &:visited {
@@ -20,7 +20,7 @@ a {
         }
 
         &:hover:visited {
-            color: var(--_an-a-fc-hover-visited, --_li-fc-hover-visited);
+            color: var(--_an-a-fc-hover-visited, var(--_li-fc-hover-visited));
         }
     }
 }

--- a/lib/components/link/link.less
+++ b/lib/components/link/link.less
@@ -1,19 +1,26 @@
 // TODO we *really* shouldn't be apply styles directly onto `<a>` like this, but
 // it's tech debt that'll take some doing in consumer's code to pay down.
 a {
-    &:visited {
-        // We're target these specific selectors to avoid affecting the visited state of stacks components
-        // not specified here. See for https://github.com/StackExchange/Stacks/pull/1740#discussion_r1698389312
-        // TODO remove .post-tag, .badge, .badge-tag reference once core no longer requires them
-        &:not([class*="s-"]):not(.post-tag):not(.badge):not(.badge-tag),
-        &.s-link,
-        &.s-sidebarwidget--action,
-        &.s-user-card--link {
-            &:hover {
-                color: var(--_li-fc-hover-visited);
-            }
+    // We're target these specific selectors to avoid affecting the visited state of stacks components
+    // not specified here. See for https://github.com/StackExchange/Stacks/pull/1740#discussion_r1698389312
+    // TODO remove .post-tag, .badge, .badge-tag reference once core no longer requires them
+    &:not([class*="s-"]):not(.post-tag):not(.badge):not(.badge-tag),
+    &.s-link,
+    &.s-sidebarwidget--action,
+    &.s-user-card--link {
+        // Use --_an-a-* (.s-anchors a) custom properties when they're defined.
+        // Otherwise, use the default link colors.
+        &:active,
+        &:hover {
+            color: var(--_an-a-fc-hover, --_li-fc-hover);
+        }    
 
-            color: var(--_li-fc-visited);
+        &:visited {
+            color: var(--_an-a-fc-visited, var(--_li-fc-visited));
+        }
+
+        &:hover:visited {
+            color: var(--_an-a-fc-hover-visited, --_li-fc-hover-visited);
         }
     }
 }
@@ -103,12 +110,6 @@ a,
         pointer-events: none;
     }
 
-    // INTERACTION
-    &:active,
-    &:hover {
-        --_li-fc: var(--_li-fc-hover);
-    }
-
     color: var(--_li-fc);
     cursor: pointer;
     text-decoration: none;
@@ -132,5 +133,11 @@ a,
 
     p & {
         text-decoration: underline;
+    }
+
+    // INTERACTION
+    &:active,
+    &:hover {
+        --_li-fc: var(--_li-fc-hover);
     }
 }


### PR DESCRIPTION
This PR resolves an issue where styles that should be applied to `.s-anchors a:visited` were being superseded by styles on `a` (see [link.less](https://github.com/StackExchange/Stacks/blob/develop/lib/components/link/link.less#L3-L19)). The issue reports issues specifically with `.s-anchors__inherit` but some investigation revealed that styles were not being applied as expected with _all_ `.s-anchor` variants.

## Screenshots

> [!NOTE]
> All screenshots are within containers with the classes `.s-notice.s-anchors.s-anchors__underline`.

<details>
<summary>Before</summary>

### .s-anchors__inherit
![image](https://github.com/user-attachments/assets/936f80c5-9fa4-4422-9094-a1fcad439d45)

### .s-anchors__danger
![image](https://github.com/user-attachments/assets/5c475ce4-47d0-4981-8a4e-026b6e7c4a7b)

</details>

<details>
<summary>After</summary>

### .s-anchors__inherit
![image](https://github.com/user-attachments/assets/99811c3c-2876-4b8a-ace6-d3c1ca118212)

### .s-anchors__danger
![image](https://github.com/user-attachments/assets/7a679d82-e65c-4c78-8914-0bea0c147c67)

</details>

## Note on tests

This PR does not include any modification of tests despite fixing a styling bug. We currently do not have a way to test links with pseudo classes (in this case, `:visited`) applied.

## How to test

- Ensure the [Stacks docs](https://stackoverflow.design/product/develop/using-stacks/) have been visited in your current browser
- Spin up the docs locally (`npm run start`)
- Open any Stacks docs page (such as [links.html](https://github.com/StackExchange/Stacks/blob/develop/docs/product/components/links.html))
- Insert the below HTML and save the change

```html
    <div class="s-notice s-notice__important s-anchors s-anchors__inherit s-anchors__underlined">
        <a href="https://stackoverflow.design/product/develop/using-stacks/">Link within `.s-notice.s-anchors.s-anchors__inherit`</a>
        <br/>
        <button class="s-btn s-notice--btn js-notice-seen">.s-btn.s-notice--btn</button>
        <br/>
        <a href="https://stackoverflow.design/product/develop/using-stacks/">.s-btn.s-notice--btn visited</a>
        <br/>
        <a href="#unvisited">.s-btn.s-notice--btn unvisited</button>
    </div>
```
- Visit the page you edited
- Observe the links within the added s-notice element inherit the link styles
- (Bonus): Change `.s-anchors__inherit` on the s-notice element to any other anchors variant and observe that links render as expected

---

[STACKS-708](https://stackoverflow.atlassian.net/browse/STACKS-708)