### PR TITLE
chore(input): update cursor styles

### DIFF
--- a/.changeset/open-eels-run.md
+++ b/.changeset/open-eels-run.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks": patch
+---
+
+Update cursor styles for disabled, readonly inputs

--- a/docs/product/components/inputs.html
+++ b/docs/product/components/inputs.html
@@ -19,7 +19,7 @@ description: Input elements are used to gather information from users.
 </div>
 
 <!-- Disabled -->
-<div class="d-flex gy4 fd-column">
+<div class="d-flex gy4 fd-column is-disabled">
     <label class="s-label" for="example-item2">Display name</label>
     <div class="d-flex ps-relative">
         <input class="s-input" id="example-item2" type="text" placeholder="Enter your input here" disabled />
@@ -43,7 +43,7 @@ description: Input elements are used to gather information from users.
                     <p class="s-description mtn2 mb0">This will be shown only to employers and other Team members.</p>
                     <input class="s-input" id="example-item1" type="text" placeholder="Enter your input here" />
                 </div>
-                <div class="d-flex gy4 fd-column">
+                <div class="d-flex gy4 fd-column is-disabled">
                     <label class="s-label" for="example-item2">Display name</label>
                     <div class="d-flex ps-relative">
                         <input class="s-input" id="example-item2" type="text" placeholder="Enter your input here" disabled />

--- a/lib/components/input_textarea/input_textarea.less
+++ b/lib/components/input_textarea/input_textarea.less
@@ -29,14 +29,8 @@
 
     // MODIFIERS
     fieldset[disabled] &,
-    &[disabled],
-    &[readonly],
-    .is-readonly & {
-        --_in-c: not-allowed;
-    }
-
-    fieldset[disabled] &,
     &[disabled] {
+        --_in-c: not-allowed;
         --_in-o: var(--_o-disabled-static);
     }
 
@@ -48,6 +42,7 @@
 
         --_in-bg: var(--black-150);
         --_in-bc: var(--bc-light);
+        --_in-c: default;
         --_in-fc: var(--black-400);
     }
 

--- a/lib/components/label/label.less
+++ b/lib/components/label/label.less
@@ -1,9 +1,10 @@
 .s-label {
+    --_la-c: unset;
     --_la-fs: var(--fs-body2);
 
     // CONTEXTUAL STYLES
     &[for] {
-        cursor: pointer;
+        --_la-c: pointer;
     }
 
     fieldset[disabled] &,
@@ -12,12 +13,16 @@
             opacity: unset;
         }
 
-        cursor: not-allowed;
+        &,
+        &[for] {
+            --_la-c: not-allowed;
+        }
+
         opacity: var(--_o-disabled-static);
     }
 
     .is-readonly & {
-        cursor: not-allowed;
+        --_la-c: default;
     }
 
     // MODIFIERS
@@ -88,6 +93,7 @@
         padding: 0;
     }
 
+    cursor: var(--_la-c);
     font-size: var(--_la-fs);
 
     color: var(--fc-medium);


### PR DESCRIPTION
[STACKS-751](https://stackoverflow.atlassian.net/browse/STACKS-751)

## Description
This PR updates cursor styles on disabled fields. See [MDN's page on cursor styles](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#values) for examples of each cursor's appearance.

## Screenshots

### Default (`cursor: unset`)
![20250502-115934](https://github.com/user-attachments/assets/fdf29fac-ae5f-4709-b587-e2ed3d204c1b)

### Disabled (`cursor: not-allowed`)
![20250502-120046](https://github.com/user-attachments/assets/518dac6d-921a-48f2-837e-772b9fc146c2)

### Read-only (`cursor: default`)
![20250502-115830-1](https://github.com/user-attachments/assets/bf99e973-48eb-4352-9629-55f8782a034e)

This PR also includes a minor update to the `Inputs` docs page to include `.is-disabled` on the `input` and `label` container. I've done this to parallel the `.is-readonly` wrapper shown.

## To test
1. Visit the [Inputs docs page "Base style" section](https://deploy-preview-1913--stacks.netlify.app/product/components/inputs/#base-style)
2. Hover your cursor over each input/label pair
3. Observe that the cursor show matches the screenshots above