### PR TITLE
docs(notice): add suggestion to apply s-anchors

### DIFF
--- a/docs/product/components/notices.html
+++ b/docs/product/components/notices.html
@@ -239,13 +239,19 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
         </table>
     </div>
 
+    {% tip, "", "mb24" %}
+        <p><strong>Note:</strong> We recommend including <code class="stacks-code">.s-anchors.s-anchors__inherit.s-anchors__underlined</code> classes for appropriate child link styling for notices containing links.</p>
+    {% endtip %}
+
     {% header "h3", "Filled" %}
     <p class="stacks-copy">Default style used to separate notices from the main content</p>
     <div class="stacks-preview">
 {% highlight html %}
 <div class="s-notice" role="status">…</div>
 <div class="s-notice s-notice__info" role="status">…</div>
-<div class="s-notice s-notice__success" role="status">…</div>
+<div class="s-notice s-notice__success s-anchors s-anchors__inherit s-anchors__underlined" role="status">
+    … <a href="…">…</a>
+</div>
 <div class="s-notice s-notice__warning" role="status">…</div>
 <div class="s-notice s-notice__danger" role="status">…</div>
 {% endhighlight %}
@@ -258,10 +264,10 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
                         {% assign variantClass = "" %}
                     {% endif %}
 
-                    <div class="s-notice{{variantClass}}" role="presentation">
+                    <div class="s-notice{{variantClass}} s-anchors s-anchors__inherit s-anchors__underlined" role="presentation">
                         <p class="m0">
                             {{variantCapitalized}} filled message style
-                            <code>and some code</code> notice. <a class="s-link s-link__inherit s-link__underlined" href="#">Link</a>
+                            <code>and some code</code> notice. <a href="#">Link</a>
                         </p>
                     </div>
                 {% endfor %}
@@ -275,7 +281,9 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
 {% highlight html %}
 <div class="s-notice s-notice__important" role="alert">…</div>
 <div class="s-notice s-notice__info s-notice__important" role="alert">…</div>
-<div class="s-notice s-notice__success s-notice__important" role="alert">… <a class="s-link s-link__inherit s-link__underlined" href="…">…</a></div>
+<div class="s-notice s-notice__success s-notice__important s-anchors s-anchors__inherit s-anchors__underlined" role="alert">
+    … <a href="…">…</a>
+</div>
 <div class="s-notice s-notice__warning s-notice__important" role="alert">…</div>
 <div class="s-notice s-notice__danger s-notice__important" role="alert">…</div>
 {% endhighlight %}
@@ -288,10 +296,10 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
                         {% assign variantClass = "" %}
                     {% endif %}
 
-                    <div class="s-notice{{variantClass}} s-notice__important" role="presentation">
+                    <div class="s-notice{{variantClass}} s-notice__important s-anchors s-anchors__inherit s-anchors__underlined" role="presentation">
                         <p class="m0">
                             {{variantCapitalized}} important message style
-                            <code>and some code</code> notice. <a class="s-link s-link__inherit s-link__underlined" href="#">Link</a>
+                            <code>and some code</code> notice. <a href="#">Link</a>
                         </p>
                     </div>
                 {% endfor %}

--- a/docs/product/components/notices.html
+++ b/docs/product/components/notices.html
@@ -239,9 +239,6 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
         </table>
     </div>
 
-    {% tip, "", "mb24" %}
-        <p><strong>Note:</strong> We recommend including <code class="stacks-code">.s-anchors.s-anchors__inherit.s-anchors__underlined</code> classes for appropriate child link styling for notices containing links.</p>
-    {% endtip %}
 
     {% header "h3", "Filled" %}
     <p class="stacks-copy">Default style used to separate notices from the main content</p>
@@ -303,6 +300,37 @@ description: Notices deliver <strong>System</strong> and <strong>Engagement</str
                         </p>
                     </div>
                 {% endfor %}
+            </div>
+        </div>
+    </div>
+
+        {% header "h3", "Styling child links" %}
+    <p class="stacks-copy">We recommend using <a href="{{ "/product/components/links/#descendent-anchors" | url }}"><b>descendent anchor</b> classes</a>, typically <code class="stacks-code">.s-anchors.s-anchors__inherit.s-anchors__underlined</code> for notices containing links generated from markdown when you cannot manually generate the inner html.</p>
+    <div class="stacks-preview">
+{% highlight html %}
+<div class="s-notice s-notice__info" role="presentation">
+    Notice with <a href="#" class="s-link">default link style</a>
+</div>  
+<div class="s-notice s-notice__info s-anchors s-anchors__inherit s-anchors__underlined" role="presentation">
+    Notice with <a href="#">custom link style</a>
+</div>
+{% endhighlight %}
+        <div class="stacks-preview--example">
+            <div class="d-flex fd-column g8">
+
+                <div class="s-notice s-notice__info" role="presentation">
+                    <p class="m0">
+                        Notice with <a href="#" class="s-link">default link style</a>
+                    </p>
+                </div>   
+                
+                <div class="s-notice s-notice__info s-anchors s-anchors__inherit s-anchors__underlined" role="presentation">
+                    <p class="m0">
+                        Notice with 
+                        <code>.s-anchors</code> <code>.s-anchors__inherit</code> <code>.s-anchors__underlined</code> and <a href="#">custom link style</a>
+                    </p>
+                </div>   
+
             </div>
         </div>
     </div>


### PR DESCRIPTION
This PR updates the notice docs to suggest using `.s-anchor` classes to style child links.

See also: [🔒 Slack discussion](https://stackexchange.slack.com/archives/C27RWNQN9/p1752247460586519)

### How to test
- View the [notice docs](https://deploy-preview-1950--stacks.netlify.app/product/components/notices/#classes)
- Verify that the tip suggesting `.s-anchors` on notices is appropriate
- Verify that example code snippets are appropriate