### PR TITLE
chore(modal): remove unneeded will-change CSS property

### DIFF
--- a/.changeset/petite-beans-start.md
+++ b/.changeset/petite-beans-start.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks": patch
+---
+
+Remove unneeded will-change CSS property on modal

--- a/lib/components/modal/modal.less
+++ b/lib/components/modal/modal.less
@@ -82,7 +82,6 @@
         transform: translate3d(0, 30%, 0) scale3d(0.6, 0.6, 0.6);
         transition: opacity 200ms var(--te-smooth) 0s, z-index 0s 100ms, visibility 0s 100ms, transform 100ms var(--te-smooth) 0s, transform 100ms var(--te-smooth) 0s; // Transition out
         visibility: hidden;
-        will-change: visibility, z-index, opacity, transform; // Not supported by Edge
         z-index: var(--zi-hide); // Make sure it's also below everything so we can't interact with it.
     }
 
@@ -113,6 +112,5 @@
     position: fixed;
     transition: opacity 100ms var(--te-smooth) 0s, z-index 0s 100ms, visibility 0s 100ms; // Transition out
     visibility: hidden;
-    will-change: visibility, z-index, opacity; // Not supported in Edge
     z-index: var(--zi-hide); // Make sure it's also below everything so we can't interact with it.
 }

--- a/lib/components/modal/modal.less
+++ b/lib/components/modal/modal.less
@@ -82,6 +82,7 @@
         transform: translate3d(0, 30%, 0) scale3d(0.6, 0.6, 0.6);
         transition: opacity 200ms var(--te-smooth) 0s, z-index 0s 100ms, visibility 0s 100ms, transform 100ms var(--te-smooth) 0s, transform 100ms var(--te-smooth) 0s; // Transition out
         visibility: hidden;
+        will-change: visibility, z-index, opacity, transform; // Not supported by Edge
         z-index: var(--zi-hide); // Make sure it's also below everything so we can't interact with it.
     }
 
@@ -112,5 +113,6 @@
     position: fixed;
     transition: opacity 100ms var(--te-smooth) 0s, z-index 0s 100ms, visibility 0s 100ms; // Transition out
     visibility: hidden;
+    will-change: visibility, z-index, opacity; // Not supported in Edge
     z-index: var(--zi-hide); // Make sure it's also below everything so we can't interact with it.
 }


### PR DESCRIPTION
We've had the `will-change` CSS property on our modals for some ~7 years. Seems it's not necessary and possibly detrimental to performance (see [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change)).

This PR moves that CSS property. See also [this Meta post](https://meta.stackexchange.com/questions/411541/stop-using-will-change-in-s-modal-or-give-me-back-my-ram).