### PR TITLE
chore(build): don't publish changeset for private package stacks-docs

### DIFF
--- a/.changeset/six-buckets-grab.md
+++ b/.changeset/six-buckets-grab.md
@@ -1,6 +1,5 @@
 ---
 "@stackoverflow/stacks": patch
-"@stackoverflow/stacks-docs": patch
 ---
 
 chore(docs): add readme for each workspace


### PR DESCRIPTION
# Summary

I mistakenly included `@stackoverflow/stacks-docs` in the changeset file somehow which made `changeset` very unhappy: https://github.com/StackExchange/Stacks/actions/runs/17678874074/job/50247863445

This PR fixes my mistake.