### PR TITLE
chore(deps): integrate stacks icons v7-beta and rename v6 legacy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
                 "@rollup/plugin-commonjs": "^26.0.1",
                 "@rollup/plugin-replace": "^6.0.2",
                 "@stackoverflow/prettier-config": "^1.0.0",
-                "@stackoverflow/stacks": "^2.8.4",
-                "@stackoverflow/stacks-icons": "^6.6.1",
+                "@stackoverflow/stacks-icons": "^7.0.0-beta.1",
+                "@stackoverflow/stacks-icons-legacy": "npm:@stackoverflow/stacks-icons@^6.6.1",
                 "@storybook/addon-docs": "^9.1.5",
                 "@storybook/addon-links": "^9.1.3",
                 "@storybook/addon-svelte-csf": "^5.0.8",
@@ -308,9 +308,9 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -318,13 +318,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-            "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+            "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.28.4"
+                "@babel/types": "^7.28.5"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -344,41 +344,57 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-            "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+            "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1"
+                "@babel/helper-validator-identifier": "^7.28.5"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@cacheable/memoize": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@cacheable/memoize/-/memoize-2.0.2.tgz",
-            "integrity": "sha512-wPrr7FUiq3Qt4yQyda2/NcOLTJCFcQSU3Am2adP+WLy+sz93/fKTokVTHmtz+rjp4PD7ee0AEOeRVNN6IvIfsg==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@cacheable/memoize/-/memoize-2.0.3.tgz",
+            "integrity": "sha512-hl9wfQgpiydhQEIv7fkjEzTGE+tcosCXLKFDO707wYJ/78FVOlowb36djex5GdbSyeHnG62pomYLMuV/OT8Pbw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@cacheable/utils": "^2.0.2"
+                "@cacheable/utils": "^2.0.3"
             }
         },
         "node_modules/@cacheable/memory": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.2.tgz",
-            "integrity": "sha512-sJTITLfeCI1rg7P3ssaGmQryq235EGT8dXGcx6oZwX5NRnKq9IE6lddlllcOl+oXW+yaeTRddCjo0xrfU6ZySA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.3.tgz",
+            "integrity": "sha512-R3UKy/CKOyb1LZG/VRCTMcpiMDyLH7SH3JrraRdK6kf3GweWCOU3sgvE13W3TiDRbxnDKylzKJvhUAvWl9LQOA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@cacheable/memoize": "^2.0.1",
-                "@cacheable/utils": "^2.0.2",
+                "@cacheable/memoize": "^2.0.3",
+                "@cacheable/utils": "^2.0.3",
                 "@keyv/bigmap": "^1.0.2",
                 "hookified": "^1.12.1",
-                "keyv": "^5.5.2"
+                "keyv": "^5.5.3"
+            }
+        },
+        "node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.1.0.tgz",
+            "integrity": "sha512-MX7XIUNwVRK+hjZcAbNJ0Z8DREo+Weu9vinBOjGU1thEi9F6vPhICzBbk4CCf3eEefKRz7n6TfZXwUFZTSgj8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hookified": "^1.12.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "keyv": "^5.5.3"
             }
         },
         "node_modules/@cacheable/memory/node_modules/keyv": {
@@ -392,11 +408,24 @@
             }
         },
         "node_modules/@cacheable/utils": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.0.2.tgz",
-            "integrity": "sha512-JTFM3raFhVv8LH95T7YnZbf2YoE9wEtkPPStuRF9a6ExZ103hFvs+QyCuYJ6r0hA9wRtbzgZtwUCoDWxssZd4Q==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.1.0.tgz",
+            "integrity": "sha512-ZdxfOiaarMqMj+H7qwlt5EBKWaeGihSYVHdQv5lUsbn8MJJOTW82OIwirQ39U5tMZkNvy3bQE+ryzC+xTAb9/g==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "keyv": "^5.5.3"
+            }
+        },
+        "node_modules/@cacheable/utils/node_modules/keyv": {
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.3.tgz",
+            "integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@keyv/serialize": "^1.1.1"
+            }
         },
         "node_modules/@changesets/apply-release-plan": {
             "version": "7.0.13",
@@ -832,9 +861,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
-            "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.11.tgz",
+            "integrity": "sha512-Xt1dOL13m8u0WE8iplx9Ibbm+hFAO0GsU2P34UNoDGvZYkY8ifSiy6Zuc1lYxfG7svWE2fzqCUmFp5HCn51gJg==",
             "cpu": [
                 "ppc64"
             ],
@@ -849,9 +878,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
-            "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.11.tgz",
+            "integrity": "sha512-uoa7dU+Dt3HYsethkJ1k6Z9YdcHjTrSb5NUy66ZfZaSV8hEYGD5ZHbEMXnqLFlbBflLsl89Zke7CAdDJ4JI+Gg==",
             "cpu": [
                 "arm"
             ],
@@ -866,9 +895,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
-            "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.11.tgz",
+            "integrity": "sha512-9slpyFBc4FPPz48+f6jyiXOx/Y4v34TUeDDXJpZqAWQn/08lKGeD8aDp9TMn9jDz2CiEuHwfhRmGBvpnd/PWIQ==",
             "cpu": [
                 "arm64"
             ],
@@ -883,9 +912,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
-            "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.11.tgz",
+            "integrity": "sha512-Sgiab4xBjPU1QoPEIqS3Xx+R2lezu0LKIEcYe6pftr56PqPygbB7+szVnzoShbx64MUupqoE0KyRlN7gezbl8g==",
             "cpu": [
                 "x64"
             ],
@@ -900,9 +929,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
-            "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.11.tgz",
+            "integrity": "sha512-VekY0PBCukppoQrycFxUqkCojnTQhdec0vevUL/EDOCnXd9LKWqD/bHwMPzigIJXPhC59Vd1WFIL57SKs2mg4w==",
             "cpu": [
                 "arm64"
             ],
@@ -917,9 +946,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
-            "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.11.tgz",
+            "integrity": "sha512-+hfp3yfBalNEpTGp9loYgbknjR695HkqtY3d3/JjSRUyPg/xd6q+mQqIb5qdywnDxRZykIHs3axEqU6l1+oWEQ==",
             "cpu": [
                 "x64"
             ],
@@ -934,9 +963,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
-            "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.11.tgz",
+            "integrity": "sha512-CmKjrnayyTJF2eVuO//uSjl/K3KsMIeYeyN7FyDBjsR3lnSJHaXlVoAK8DZa7lXWChbuOk7NjAc7ygAwrnPBhA==",
             "cpu": [
                 "arm64"
             ],
@@ -951,9 +980,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
-            "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.11.tgz",
+            "integrity": "sha512-Dyq+5oscTJvMaYPvW3x3FLpi2+gSZTCE/1ffdwuM6G1ARang/mb3jvjxs0mw6n3Lsw84ocfo9CrNMqc5lTfGOw==",
             "cpu": [
                 "x64"
             ],
@@ -968,9 +997,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
-            "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.11.tgz",
+            "integrity": "sha512-TBMv6B4kCfrGJ8cUPo7vd6NECZH/8hPpBHHlYI3qzoYFvWu2AdTvZNuU/7hsbKWqu/COU7NIK12dHAAqBLLXgw==",
             "cpu": [
                 "arm"
             ],
@@ -985,9 +1014,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
-            "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.11.tgz",
+            "integrity": "sha512-Qr8AzcplUhGvdyUF08A1kHU3Vr2O88xxP0Tm8GcdVOUm25XYcMPp2YqSVHbLuXzYQMf9Bh/iKx7YPqECs6ffLA==",
             "cpu": [
                 "arm64"
             ],
@@ -1002,9 +1031,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
-            "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.11.tgz",
+            "integrity": "sha512-TmnJg8BMGPehs5JKrCLqyWTVAvielc615jbkOirATQvWWB1NMXY77oLMzsUjRLa0+ngecEmDGqt5jiDC6bfvOw==",
             "cpu": [
                 "ia32"
             ],
@@ -1019,9 +1048,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
-            "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.11.tgz",
+            "integrity": "sha512-DIGXL2+gvDaXlaq8xruNXUJdT5tF+SBbJQKbWy/0J7OhU8gOHOzKmGIlfTTl6nHaCOoipxQbuJi7O++ldrxgMw==",
             "cpu": [
                 "loong64"
             ],
@@ -1036,9 +1065,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
-            "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.11.tgz",
+            "integrity": "sha512-Osx1nALUJu4pU43o9OyjSCXokFkFbyzjXb6VhGIJZQ5JZi8ylCQ9/LFagolPsHtgw6himDSyb5ETSfmp4rpiKQ==",
             "cpu": [
                 "mips64el"
             ],
@@ -1053,9 +1082,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
-            "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.11.tgz",
+            "integrity": "sha512-nbLFgsQQEsBa8XSgSTSlrnBSrpoWh7ioFDUmwo158gIm5NNP+17IYmNWzaIzWmgCxq56vfr34xGkOcZ7jX6CPw==",
             "cpu": [
                 "ppc64"
             ],
@@ -1070,9 +1099,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
-            "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.11.tgz",
+            "integrity": "sha512-HfyAmqZi9uBAbgKYP1yGuI7tSREXwIb438q0nqvlpxAOs3XnZ8RsisRfmVsgV486NdjD7Mw2UrFSw51lzUk1ww==",
             "cpu": [
                 "riscv64"
             ],
@@ -1087,9 +1116,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
-            "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.11.tgz",
+            "integrity": "sha512-HjLqVgSSYnVXRisyfmzsH6mXqyvj0SA7pG5g+9W7ESgwA70AXYNpfKBqh1KbTxmQVaYxpzA/SvlB9oclGPbApw==",
             "cpu": [
                 "s390x"
             ],
@@ -1104,9 +1133,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
-            "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.11.tgz",
+            "integrity": "sha512-HSFAT4+WYjIhrHxKBwGmOOSpphjYkcswF449j6EjsjbinTZbp8PJtjsVK1XFJStdzXdy/jaddAep2FGY+wyFAQ==",
             "cpu": [
                 "x64"
             ],
@@ -1121,9 +1150,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
-            "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.11.tgz",
+            "integrity": "sha512-hr9Oxj1Fa4r04dNpWr3P8QKVVsjQhqrMSUzZzf+LZcYjZNqhA3IAfPQdEh1FLVUJSiu6sgAwp3OmwBfbFgG2Xg==",
             "cpu": [
                 "arm64"
             ],
@@ -1138,9 +1167,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
-            "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.11.tgz",
+            "integrity": "sha512-u7tKA+qbzBydyj0vgpu+5h5AeudxOAGncb8N6C9Kh1N4n7wU1Xw1JDApsRjpShRpXRQlJLb9wY28ELpwdPcZ7A==",
             "cpu": [
                 "x64"
             ],
@@ -1155,9 +1184,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
-            "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.11.tgz",
+            "integrity": "sha512-Qq6YHhayieor3DxFOoYM1q0q1uMFYb7cSpLD2qzDSvK1NAvqFi8Xgivv0cFC6J+hWVw2teCYltyy9/m/14ryHg==",
             "cpu": [
                 "arm64"
             ],
@@ -1172,9 +1201,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
-            "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.11.tgz",
+            "integrity": "sha512-CN+7c++kkbrckTOz5hrehxWN7uIhFFlmS/hqziSFVWpAzpWrQoAG4chH+nN3Be+Kzv/uuo7zhX716x3Sn2Jduw==",
             "cpu": [
                 "x64"
             ],
@@ -1189,9 +1218,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
-            "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.11.tgz",
+            "integrity": "sha512-rOREuNIQgaiR+9QuNkbkxubbp8MSO9rONmwP5nKncnWJ9v5jQ4JxFnLu4zDSRPf3x4u+2VN4pM4RdyIzDty/wQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1206,9 +1235,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
-            "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.11.tgz",
+            "integrity": "sha512-nq2xdYaWxyg9DcIyXkZhcYulC6pQ2FuCgem3LI92IwMgIZ69KHeY8T4Y88pcwoLIjbed8n36CyKoYRDygNSGhA==",
             "cpu": [
                 "x64"
             ],
@@ -1223,9 +1252,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
-            "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.11.tgz",
+            "integrity": "sha512-3XxECOWJq1qMZ3MN8srCJ/QfoLpL+VaxD/WfNRm1O3B4+AZ/BnLVgFbUV3eiRYDMXetciH16dwPbbHqwe1uU0Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1240,9 +1269,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
-            "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.11.tgz",
+            "integrity": "sha512-3ukss6gb9XZ8TlRyJlgLn17ecsK4NSQTmdIXRASVsiS2sQ6zPPZklNJT5GR5tE/MUarymmy8kCEf5xPCNCqVOA==",
             "cpu": [
                 "ia32"
             ],
@@ -1257,9 +1286,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
-            "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.11.tgz",
+            "integrity": "sha512-D7Hpz6A2L4hzsRpPaCYkQnGOotdUpDzSGRIv9I+1ITdHROSFUWW95ZPZWQmGka1Fg7W3zFJowyn9WGwMJ0+KPA==",
             "cpu": [
                 "x64"
             ],
@@ -1306,9 +1335,9 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.12.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-            "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+            "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1316,13 +1345,13 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.21.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-            "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+            "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/object-schema": "^2.1.6",
+                "@eslint/object-schema": "^2.1.7",
                 "debug": "^4.3.1",
                 "minimatch": "^3.1.2"
             },
@@ -1355,19 +1384,22 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
-            "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.1.tgz",
+            "integrity": "sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.16.0"
+            },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
-            "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
+            "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -1439,9 +1471,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.36.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
-            "integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
+            "version": "9.38.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.38.0.tgz",
+            "integrity": "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1452,9 +1484,9 @@
             }
         },
         "node_modules/@eslint/object-schema": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-            "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+            "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -1462,13 +1494,13 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
-            "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.0.tgz",
+            "integrity": "sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.15.2",
+                "@eslint/core": "^0.16.0",
                 "levn": "^0.4.1"
             },
             "engines": {
@@ -1733,19 +1765,6 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
-        "node_modules/@keyv/bigmap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.0.2.tgz",
-            "integrity": "sha512-KR03xkEZlAZNF4IxXgVXb+uNIVNvwdh8UwI0cnc7WI6a+aQcDp8GL80qVfeB4E5NpsKJzou5jU0r6yLSSbMOtA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "hookified": "^1.12.1"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
         "node_modules/@keyv/serialize": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
@@ -1754,24 +1773,24 @@
             "license": "MIT"
         },
         "node_modules/@lezer/common": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
-            "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.3.0.tgz",
+            "integrity": "sha512-L9X8uHCYU310o99L3/MpJKYxPzXPOS7S0NmBaM7UO/x2Kb2WbmMLSkfvdr1KxRIFYOpbY0Jhn7CfLSUDzL8arQ==",
             "license": "MIT"
         },
         "node_modules/@lezer/highlight": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
-            "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+            "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
             "license": "MIT",
             "dependencies": {
-                "@lezer/common": "^1.0.0"
+                "@lezer/common": "^1.3.0"
             }
         },
         "node_modules/@lezer/markdown": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.4.3.tgz",
-            "integrity": "sha512-kfw+2uMrQ/wy/+ONfrH83OkdFNM0ye5Xq96cLlaCy7h5UT9FO54DU4oRoIc0CSBh5NWmWuiIJA7NGLMJbQ+Oxg==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.5.1.tgz",
+            "integrity": "sha512-F3ZFnIfNAOy/jPSk6Q0e3bs7e9grfK/n5zerkKoc5COH6Guy3Zb0vrJwXzdck79K16goBhYBRAvhf+ksqe0cMg==",
             "license": "MIT",
             "dependencies": {
                 "@lezer/common": "^1.0.0",
@@ -2331,9 +2350,9 @@
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "2.10.10",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.10.tgz",
-            "integrity": "sha512-3ZG500+ZeLql8rE0hjfhkycJjDj0pI/btEh3L9IkWUYcOrgP0xCNRq3HbtbqOPbvDhFaAWD88pDFtlLv8ns8gA==",
+            "version": "2.10.12",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.12.tgz",
+            "integrity": "sha512-mP9iLFZwH+FapKJLeA7/fLqOlSUwYpMwjR1P5J23qd4e7qGJwecJccJqHYrjw33jmIZYV4dtiTHPD/J+1e7cEw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -2341,8 +2360,8 @@
                 "extract-zip": "^2.0.1",
                 "progress": "^2.0.3",
                 "proxy-agent": "^6.5.0",
-                "semver": "^7.7.2",
-                "tar-fs": "^3.1.0",
+                "semver": "^7.7.3",
+                "tar-fs": "^3.1.1",
                 "yargs": "^17.7.2"
             },
             "bin": {
@@ -2462,9 +2481,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.3.tgz",
-            "integrity": "sha512-h6cqHGZ6VdnwliFG1NXvMPTy/9PS3h8oLh7ImwR+kl+oYnQizgjxsONmmPSb2C66RksfkfIxEVtDSEcJiO0tqw==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.5.tgz",
+            "integrity": "sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==",
             "cpu": [
                 "arm"
             ],
@@ -2476,9 +2495,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.3.tgz",
-            "integrity": "sha512-wd+u7SLT/u6knklV/ifG7gr5Qy4GUbH2hMWcDauPFJzmCZUAJ8L2bTkVXC2niOIxp8lk3iH/QX8kSrUxVZrOVw==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.5.tgz",
+            "integrity": "sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==",
             "cpu": [
                 "arm64"
             ],
@@ -2490,9 +2509,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.3.tgz",
-            "integrity": "sha512-lj9ViATR1SsqycwFkJCtYfQTheBdvlWJqzqxwc9f2qrcVrQaF/gCuBRTiTolkRWS6KvNxSk4KHZWG7tDktLgjg==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.5.tgz",
+            "integrity": "sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==",
             "cpu": [
                 "arm64"
             ],
@@ -2504,9 +2523,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.3.tgz",
-            "integrity": "sha512-+Dyo7O1KUmIsbzx1l+4V4tvEVnVQqMOIYtrxK7ncLSknl1xnMHLgn7gddJVrYPNZfEB8CIi3hK8gq8bDhb3h5A==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.5.tgz",
+            "integrity": "sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==",
             "cpu": [
                 "x64"
             ],
@@ -2518,9 +2537,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.3.tgz",
-            "integrity": "sha512-u9Xg2FavYbD30g3DSfNhxgNrxhi6xVG4Y6i9Ur1C7xUuGDW3banRbXj+qgnIrwRN4KeJ396jchwy9bCIzbyBEQ==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.5.tgz",
+            "integrity": "sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==",
             "cpu": [
                 "arm64"
             ],
@@ -2532,9 +2551,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.3.tgz",
-            "integrity": "sha512-5M8kyi/OX96wtD5qJR89a/3x5x8x5inXBZO04JWhkQb2JWavOWfjgkdvUqibGJeNNaz1/Z1PPza5/tAPXICI6A==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.5.tgz",
+            "integrity": "sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==",
             "cpu": [
                 "x64"
             ],
@@ -2546,9 +2565,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.3.tgz",
-            "integrity": "sha512-IoerZJ4l1wRMopEHRKOO16e04iXRDyZFZnNZKrWeNquh5d6bucjezgd+OxG03mOMTnS1x7hilzb3uURPkJ0OfA==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.5.tgz",
+            "integrity": "sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==",
             "cpu": [
                 "arm"
             ],
@@ -2560,9 +2579,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.3.tgz",
-            "integrity": "sha512-ZYdtqgHTDfvrJHSh3W22TvjWxwOgc3ThK/XjgcNGP2DIwFIPeAPNsQxrJO5XqleSlgDux2VAoWQ5iJrtaC1TbA==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.5.tgz",
+            "integrity": "sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==",
             "cpu": [
                 "arm"
             ],
@@ -2574,9 +2593,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.3.tgz",
-            "integrity": "sha512-NcViG7A0YtuFDA6xWSgmFb6iPFzHlf5vcqb2p0lGEbT+gjrEEz8nC/EeDHvx6mnGXnGCC1SeVV+8u+smj0CeGQ==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.5.tgz",
+            "integrity": "sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==",
             "cpu": [
                 "arm64"
             ],
@@ -2588,9 +2607,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.3.tgz",
-            "integrity": "sha512-d3pY7LWno6SYNXRm6Ebsq0DJGoiLXTb83AIPCXl9fmtIQs/rXoS8SJxxUNtFbJ5MiOvs+7y34np77+9l4nfFMw==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.5.tgz",
+            "integrity": "sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==",
             "cpu": [
                 "arm64"
             ],
@@ -2602,9 +2621,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.3.tgz",
-            "integrity": "sha512-3y5GA0JkBuirLqmjwAKwB0keDlI6JfGYduMlJD/Rl7fvb4Ni8iKdQs1eiunMZJhwDWdCvrcqXRY++VEBbvk6Eg==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.5.tgz",
+            "integrity": "sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==",
             "cpu": [
                 "loong64"
             ],
@@ -2616,9 +2635,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.3.tgz",
-            "integrity": "sha512-AUUH65a0p3Q0Yfm5oD2KVgzTKgwPyp9DSXc3UA7DtxhEb/WSPfbG4wqXeSN62OG5gSo18em4xv6dbfcUGXcagw==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.5.tgz",
+            "integrity": "sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==",
             "cpu": [
                 "ppc64"
             ],
@@ -2630,9 +2649,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.3.tgz",
-            "integrity": "sha512-1makPhFFVBqZE+XFg3Dkq+IkQ7JvmUrwwqaYBL2CE+ZpxPaqkGaiWFEWVGyvTwZace6WLJHwjVh/+CXbKDGPmg==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.5.tgz",
+            "integrity": "sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==",
             "cpu": [
                 "riscv64"
             ],
@@ -2644,9 +2663,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.3.tgz",
-            "integrity": "sha512-OOFJa28dxfl8kLOPMUOQBCO6z3X2SAfzIE276fwT52uXDWUS178KWq0pL7d6p1kz7pkzA0yQwtqL0dEPoVcRWg==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.5.tgz",
+            "integrity": "sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==",
             "cpu": [
                 "riscv64"
             ],
@@ -2658,9 +2677,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.3.tgz",
-            "integrity": "sha512-jMdsML2VI5l+V7cKfZx3ak+SLlJ8fKvLJ0Eoa4b9/vCUrzXKgoKxvHqvJ/mkWhFiyp88nCkM5S2v6nIwRtPcgg==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.5.tgz",
+            "integrity": "sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==",
             "cpu": [
                 "s390x"
             ],
@@ -2672,9 +2691,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.3.tgz",
-            "integrity": "sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz",
+            "integrity": "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==",
             "cpu": [
                 "x64"
             ],
@@ -2686,9 +2705,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.3.tgz",
-            "integrity": "sha512-BCFkJjgk+WFzP+tcSMXq77ymAPIxsX9lFJWs+2JzuZTLtksJ2o5hvgTdIcZ5+oKzUDMwI0PfWzRBYAydAHF2Mw==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.5.tgz",
+            "integrity": "sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==",
             "cpu": [
                 "x64"
             ],
@@ -2700,9 +2719,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.3.tgz",
-            "integrity": "sha512-KTD/EqjZF3yvRaWUJdD1cW+IQBk4fbQaHYJUmP8N4XoKFZilVL8cobFSTDnjTtxWJQ3JYaMgF4nObY/+nYkumA==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.5.tgz",
+            "integrity": "sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==",
             "cpu": [
                 "arm64"
             ],
@@ -2714,9 +2733,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.3.tgz",
-            "integrity": "sha512-+zteHZdoUYLkyYKObGHieibUFLbttX2r+58l27XZauq0tcWYYuKUwY2wjeCN9oK1Um2YgH2ibd6cnX/wFD7DuA==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.5.tgz",
+            "integrity": "sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==",
             "cpu": [
                 "arm64"
             ],
@@ -2728,9 +2747,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.3.tgz",
-            "integrity": "sha512-of1iHkTQSo3kr6dTIRX6t81uj/c/b15HXVsPcEElN5sS859qHrOepM5p9G41Hah+CTqSh2r8Bm56dL2z9UQQ7g==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.5.tgz",
+            "integrity": "sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==",
             "cpu": [
                 "ia32"
             ],
@@ -2742,9 +2761,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.3.tgz",
-            "integrity": "sha512-s0hybmlHb56mWVZQj8ra9048/WZTPLILKxcvcq+8awSZmyiSUZjjem1AhU3Tf4ZKpYhK4mg36HtHDOe8QJS5PQ==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.5.tgz",
+            "integrity": "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==",
             "cpu": [
                 "x64"
             ],
@@ -2756,9 +2775,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.3.tgz",
-            "integrity": "sha512-zGIbEVVXVtauFgl3MRwGWEN36P5ZGenHRMgNw88X5wEhEBpq0XrMEZwOn07+ICrwM17XO5xfMZqh0OldCH5VTA==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.5.tgz",
+            "integrity": "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==",
             "cpu": [
                 "x64"
             ],
@@ -2862,9 +2881,9 @@
             "link": true
         },
         "node_modules/@stackoverflow/stacks-editor": {
-            "version": "0.15.3",
-            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-editor/-/stacks-editor-0.15.3.tgz",
-            "integrity": "sha512-PrxD0h5NK0Q9fjFmBATeec2rrw0lcEHUP8Ic00q3MjnAf/FKZhS3cT4D3bOgCkaQXPby74YF6VYMq/Y5vB0Mxg==",
+            "version": "1.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-editor/-/stacks-editor-1.0.0-beta.3.tgz",
+            "integrity": "sha512-oPzE4umLPGT8EA/L7W+/L/cUuPDTx/xL/gjOp5qWMJUnwvxtah0SxqQHlfMOqGYhnZt2hnQWAp5SZLiJYW0FSQ==",
             "license": "MIT",
             "dependencies": {
                 "@lezer/highlight": "^1.2.0",
@@ -2888,14 +2907,27 @@
                 "prosemirror-view": "^1.37.1"
             },
             "peerDependencies": {
-                "@stackoverflow/stacks": "^2.3.0",
+                "@stackoverflow/stacks": "^3.0.0-beta.0",
                 "highlight.js": "^11.6.0"
             }
         },
+        "node_modules/@stackoverflow/stacks-editor/node_modules/@stackoverflow/stacks-icons": {
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-6.7.0.tgz",
+            "integrity": "sha512-/VT9+1fvHkTuNTLXxa3U9FhwZ3UOXbWYNQ46zqAvhPZd2k+AnDKBlNZ1rsn8ozRMKtoWI7tC8jN1gXqQghDIRQ==",
+            "license": "MIT"
+        },
         "node_modules/@stackoverflow/stacks-icons": {
-            "version": "6.6.2",
-            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-6.6.2.tgz",
-            "integrity": "sha512-ktovt9XAt46Unt5xw/loPTJtbmEhsxiSRqUHgIBajU/S5xxxGY9RnWDLZU9iTyk6sZuedceAhlS7HmxzacSy0g==",
+            "version": "7.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-7.0.0-beta.1.tgz",
+            "integrity": "sha512-9tudeowtDiIt+B++dA3HukOa6kLQ70uvhvn32sjPDk78dLFH4n/gLZwLsnpKLIr7wXOHmj9vZQILrdavoWWTfQ==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@stackoverflow/stacks-icons-legacy": {
+            "name": "@stackoverflow/stacks-icons",
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-6.7.0.tgz",
+            "integrity": "sha512-/VT9+1fvHkTuNTLXxa3U9FhwZ3UOXbWYNQ46zqAvhPZd2k+AnDKBlNZ1rsn8ozRMKtoWI7tC8jN1gXqQghDIRQ==",
             "license": "MIT"
         },
         "node_modules/@stackoverflow/stacks-svelte": {
@@ -2903,16 +2935,16 @@
             "link": true
         },
         "node_modules/@storybook/addon-docs": {
-            "version": "9.1.8",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.8.tgz",
-            "integrity": "sha512-GVrNVEdNRRo6r1hawfgyy6x+HJqPx1oOHm0U0wz0SGAxgS/Xh6SQVZL+RDoh7NpXkNi1GbezVlT931UsHQTyvQ==",
+            "version": "9.1.15",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.15.tgz",
+            "integrity": "sha512-thbBQKzN0ycSEQjtIeXJT4i6+4kWoNIWYo4x2GQ3jtqHsT8T4FZW1n/xK1ysZbB4eCwG2hOn44BRTu8p4S7UoQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@mdx-js/react": "^3.0.0",
-                "@storybook/csf-plugin": "9.1.8",
+                "@storybook/csf-plugin": "9.1.15",
                 "@storybook/icons": "^1.4.0",
-                "@storybook/react-dom-shim": "9.1.8",
+                "@storybook/react-dom-shim": "9.1.15",
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
                 "ts-dedent": "^2.0.0"
@@ -2922,13 +2954,13 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^9.1.8"
+                "storybook": "^9.1.15"
             }
         },
         "node_modules/@storybook/addon-links": {
-            "version": "9.1.8",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.8.tgz",
-            "integrity": "sha512-+XJiYO3Cu79nTMnkybA4ORjSbQfKvVyVer1TC6cDJC7AGVe0FpdgGu2ZWIn3edUmQHLPwovd6B+5pU4VH5tgPQ==",
+            "version": "9.1.15",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.15.tgz",
+            "integrity": "sha512-pPrE2rbLzZewsvEN5pbJ4xfc05RADP7MMkaqySNWwcNQwLx0GLvk3ZL+bA/wG73aaPH+w3Gc7gy2En8q5m+DBQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2940,7 +2972,7 @@
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-                "storybook": "^9.1.8"
+                "storybook": "^9.1.15"
             },
             "peerDependenciesMeta": {
                 "react": {
@@ -2949,9 +2981,9 @@
             }
         },
         "node_modules/@storybook/addon-svelte-csf": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-svelte-csf/-/addon-svelte-csf-5.0.8.tgz",
-            "integrity": "sha512-RJZdlImptVUfidsdZWovdnhPqU7bmvp47rtVV9a71ZaC2gV+XAi4sim0+FWxmyY1DWo3tUQtu82B0xo42lT0XQ==",
+            "version": "5.0.10",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-svelte-csf/-/addon-svelte-csf-5.0.10.tgz",
+            "integrity": "sha512-poSvTS7VdaQ42ZoqW5e4+2Hv1iLO0mekH9fwn/QuBNse48R4WlTyR8XFbHRTfatl9gdc9ZYC4uWzazrmV6zGIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2990,7 +3022,17 @@
                 "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
             }
         },
-        "node_modules/@storybook/builder-vite/node_modules/@storybook/csf-plugin": {
+        "node_modules/@storybook/csf": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.13.tgz",
+            "integrity": "sha512-7xOOwCLGB3ebM87eemep89MYRFTko+D8qE7EdAAq74lgdqRR5cOUtYWJLjO2dLtP94nqoOdHJo6MdLLKzg412Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^2.19.0"
+            }
+        },
+        "node_modules/@storybook/csf-plugin": {
             "version": "9.1.15",
             "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.15.tgz",
             "integrity": "sha512-UThWh7V3+zd+71XdIsNFkrNslkjyaD/HQPnjWGWBCU4ZWNWRSPd3r0r02nH0zzo+NBi0V4vzNDg/PmfD51iaOg==",
@@ -3005,33 +3047,6 @@
             },
             "peerDependencies": {
                 "storybook": "^9.1.15"
-            }
-        },
-        "node_modules/@storybook/csf": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.13.tgz",
-            "integrity": "sha512-7xOOwCLGB3ebM87eemep89MYRFTko+D8qE7EdAAq74lgdqRR5cOUtYWJLjO2dLtP94nqoOdHJo6MdLLKzg412Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "type-fest": "^2.19.0"
-            }
-        },
-        "node_modules/@storybook/csf-plugin": {
-            "version": "9.1.8",
-            "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.8.tgz",
-            "integrity": "sha512-KnrXPz87bn+8ZGkzFEBc7TT5HkWpR1Xz7ojxPclSvkKxTfzazuaw0JlOQMzJoI1+wHXDAIw/4MIsO8HEiaWyfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "unplugin": "^1.3.1"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/storybook"
-            },
-            "peerDependencies": {
-                "storybook": "^9.1.8"
             }
         },
         "node_modules/@storybook/global": {
@@ -3056,9 +3071,9 @@
             }
         },
         "node_modules/@storybook/react-dom-shim": {
-            "version": "9.1.8",
-            "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.8.tgz",
-            "integrity": "sha512-OepccjVZh/KQugTH8/RL2CIyf1g5Lwc5ESC8x8BH3iuYc82WMQBwMJzRI5EofQdirau63NGrqkWCgQASoVreEA==",
+            "version": "9.1.15",
+            "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.15.tgz",
+            "integrity": "sha512-l6smvNwxh6kp2U/BupzQ4/NSraTWysZcAe2x+GO5CiIIB8Jbi41XLu5XIHI/GQRnNqpXXE3uMImiHGOORmHEXA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -3068,7 +3083,7 @@
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
                 "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-                "storybook": "^9.1.8"
+                "storybook": "^9.1.15"
             }
         },
         "node_modules/@storybook/svelte": {
@@ -3243,9 +3258,9 @@
             }
         },
         "node_modules/@testing-library/jest-dom": {
-            "version": "6.8.0",
-            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
-            "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
+            "version": "6.9.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+            "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3466,9 +3481,9 @@
             "license": "MIT"
         },
         "node_modules/@types/cookies": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.1.tgz",
-            "integrity": "sha512-E/DPgzifH4sM1UMadJMWd6mO2jOd4g1Ejwzx8/uRCDpJis1IrlyQEcGAYEomtAqRYmD5ORbNXMeI9U0RiVGZbg==",
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.2.tgz",
+            "integrity": "sha512-1AvkDdZM2dbyFybL4fxpuNCaWyv//0AwsuUk2DWeXyM1/5ZKm6W3z6mQi24RZ4l2ucY+bkSHzbDVpySqPGuV8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3528,9 +3543,9 @@
             "license": "MIT"
         },
         "node_modules/@types/express": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
-            "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.4.tgz",
+            "integrity": "sha512-g64dbryHk7loCIrsa0R3shBnEu5p6LPJ09bu9NG58+jz+cRUjFrc3Bz0kNQ7j9bXeCsrRDvNET1G54P/GJkAyA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3540,9 +3555,9 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz",
-            "integrity": "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.0.tgz",
+            "integrity": "sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3625,9 +3640,9 @@
             }
         },
         "node_modules/@types/koa-compose": {
-            "version": "3.2.8",
-            "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.8.tgz",
-            "integrity": "sha512-4Olc63RY+MKvxMwVknCUDhRQX1pFQoBZ/lXcRLP69PQkEpze/0cr8LNqJQe5NFb/b19DWi2a5bTi2VAlQzhJuA==",
+            "version": "3.2.9",
+            "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.9.tgz",
+            "integrity": "sha512-BroAZ9FTvPiCy0Pi8tjD1OfJ7bgU1gQf0eR6e1Vm+JJATy9eKOG3hQMFtMciMawiSOVnLMdmUOC46s7HBhSTsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3695,13 +3710,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.6.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.0.tgz",
-            "integrity": "sha512-F1CBxgqwOMc4GKJ7eY22hWhBVQuMYTtqI8L0FcszYcpYX0fzfDGpez22Xau8Mgm7O9fI+zA/TYIdq3tGWfweBA==",
+            "version": "24.9.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
+            "integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.13.0"
+                "undici-types": "~7.16.0"
             }
         },
         "node_modules/@types/parse5": {
@@ -3746,9 +3761,9 @@
             "license": "MIT"
         },
         "node_modules/@types/react": {
-            "version": "19.1.15",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.15.tgz",
-            "integrity": "sha512-+kLxJpaJzXybyDyFXYADyP1cznTO8HSuBpenGlnKOAkH4hyNINiywvXS/tGJhsrGGP/gM185RA3xpjY0Yg4erA==",
+            "version": "19.2.2",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
+            "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -3764,26 +3779,36 @@
             "license": "MIT"
         },
         "node_modules/@types/send": {
-            "version": "0.17.5",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
-            "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/mime": "^1",
                 "@types/node": "*"
             }
         },
         "node_modules/@types/serve-static": {
-            "version": "1.15.8",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
-            "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+            "version": "1.15.10",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+            "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/http-errors": "*",
                 "@types/node": "*",
-                "@types/send": "*"
+                "@types/send": "<1"
+            }
+        },
+        "node_modules/@types/serve-static/node_modules/@types/send": {
+            "version": "0.17.6",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+            "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mime": "^1",
+                "@types/node": "*"
             }
         },
         "node_modules/@types/sinon": {
@@ -3808,9 +3833,9 @@
             }
         },
         "node_modules/@types/sinonjs__fake-timers": {
-            "version": "8.1.5",
-            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
-            "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+            "version": "15.0.0",
+            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.0.tgz",
+            "integrity": "sha512-lqKG4X0fO3aJF7Bz590vuCkFt/inbDyL7FXaVjPEYO+LogMZ2fwSDUiP7bJvdYHaCgCQGNOPxquzSrrnVH3fGw==",
             "dev": true,
             "license": "MIT"
         },
@@ -3843,17 +3868,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.46.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.1.tgz",
-            "integrity": "sha512-rUsLh8PXmBjdiPY+Emjz9NX2yHvhS11v0SR6xNJkm5GM1MO9ea/1GoDKlHHZGrOJclL/cZ2i/vRUYVtjRhrHVQ==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.2.tgz",
+            "integrity": "sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.46.1",
-                "@typescript-eslint/type-utils": "8.46.1",
-                "@typescript-eslint/utils": "8.46.1",
-                "@typescript-eslint/visitor-keys": "8.46.1",
+                "@typescript-eslint/scope-manager": "8.46.2",
+                "@typescript-eslint/type-utils": "8.46.2",
+                "@typescript-eslint/utils": "8.46.2",
+                "@typescript-eslint/visitor-keys": "8.46.2",
                 "graphemer": "^1.4.0",
                 "ignore": "^7.0.0",
                 "natural-compare": "^1.4.0",
@@ -3867,7 +3892,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.46.1",
+                "@typescript-eslint/parser": "^8.46.2",
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
@@ -3883,16 +3908,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.46.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.1.tgz",
-            "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz",
+            "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.46.1",
-                "@typescript-eslint/types": "8.46.1",
-                "@typescript-eslint/typescript-estree": "8.46.1",
-                "@typescript-eslint/visitor-keys": "8.46.1",
+                "@typescript-eslint/scope-manager": "8.46.2",
+                "@typescript-eslint/types": "8.46.2",
+                "@typescript-eslint/typescript-estree": "8.46.2",
+                "@typescript-eslint/visitor-keys": "8.46.2",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -3908,14 +3933,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.46.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.1.tgz",
-            "integrity": "sha512-FOIaFVMHzRskXr5J4Jp8lFVV0gz5ngv3RHmn+E4HYxSJ3DgDzU7fVI1/M7Ijh1zf6S7HIoaIOtln1H5y8V+9Zg==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.2.tgz",
+            "integrity": "sha512-PULOLZ9iqwI7hXcmL4fVfIsBi6AN9YxRc0frbvmg8f+4hQAjQ5GYNKK0DIArNo+rOKmR/iBYwkpBmnIwin4wBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.46.1",
-                "@typescript-eslint/types": "^8.46.1",
+                "@typescript-eslint/tsconfig-utils": "^8.46.2",
+                "@typescript-eslint/types": "^8.46.2",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -3930,14 +3955,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.46.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.1.tgz",
-            "integrity": "sha512-weL9Gg3/5F0pVQKiF8eOXFZp8emqWzZsOJuWRUNtHT+UNV2xSJegmpCNQHy37aEQIbToTq7RHKhWvOsmbM680A==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.2.tgz",
+            "integrity": "sha512-LF4b/NmGvdWEHD2H4MsHD8ny6JpiVNDzrSZr3CsckEgCbAGZbYM4Cqxvi9L+WqDMT+51Ozy7lt2M+d0JLEuBqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.46.1",
-                "@typescript-eslint/visitor-keys": "8.46.1"
+                "@typescript-eslint/types": "8.46.2",
+                "@typescript-eslint/visitor-keys": "8.46.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3948,9 +3973,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.46.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.1.tgz",
-            "integrity": "sha512-X88+J/CwFvlJB+mK09VFqx5FE4H5cXD+H/Bdza2aEWkSb8hnWIQorNcscRl4IEo1Cz9VI/+/r/jnGWkbWPx54g==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.2.tgz",
+            "integrity": "sha512-a7QH6fw4S57+F5y2FIxxSDyi5M4UfGF+Jl1bCGd7+L4KsaUY80GsiF/t0UoRFDHAguKlBaACWJRmdrc6Xfkkag==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3965,15 +3990,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.46.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.1.tgz",
-            "integrity": "sha512-+BlmiHIiqufBxkVnOtFwjah/vrkF4MtKKvpXrKSPLCkCtAp8H01/VV43sfqA98Od7nJpDcFnkwgyfQbOG0AMvw==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.2.tgz",
+            "integrity": "sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.46.1",
-                "@typescript-eslint/typescript-estree": "8.46.1",
-                "@typescript-eslint/utils": "8.46.1",
+                "@typescript-eslint/types": "8.46.2",
+                "@typescript-eslint/typescript-estree": "8.46.2",
+                "@typescript-eslint/utils": "8.46.2",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.1.0"
             },
@@ -3990,9 +4015,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.46.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.1.tgz",
-            "integrity": "sha512-C+soprGBHwWBdkDpbaRC4paGBrkIXxVlNohadL5o0kfhsXqOC6GYH2S/Obmig+I0HTDl8wMaRySwrfrXVP8/pQ==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.2.tgz",
+            "integrity": "sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4004,16 +4029,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.46.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.1.tgz",
-            "integrity": "sha512-uIifjT4s8cQKFQ8ZBXXyoUODtRoAd7F7+G8MKmtzj17+1UbdzFl52AzRyZRyKqPHhgzvXunnSckVu36flGy8cg==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.2.tgz",
+            "integrity": "sha512-f7rW7LJ2b7Uh2EiQ+7sza6RDZnajbNbemn54Ob6fRwQbgcIn+GWfyuHDHRYgRoZu1P4AayVScrRW+YfbTvPQoQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.46.1",
-                "@typescript-eslint/tsconfig-utils": "8.46.1",
-                "@typescript-eslint/types": "8.46.1",
-                "@typescript-eslint/visitor-keys": "8.46.1",
+                "@typescript-eslint/project-service": "8.46.2",
+                "@typescript-eslint/tsconfig-utils": "8.46.2",
+                "@typescript-eslint/types": "8.46.2",
+                "@typescript-eslint/visitor-keys": "8.46.2",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -4033,16 +4058,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.46.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.1.tgz",
-            "integrity": "sha512-vkYUy6LdZS7q1v/Gxb2Zs7zziuXN0wxqsetJdeZdRe/f5dwJFglmuvZBfTUivCtjH725C1jWCDfpadadD95EDQ==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.2.tgz",
+            "integrity": "sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.7.0",
-                "@typescript-eslint/scope-manager": "8.46.1",
-                "@typescript-eslint/types": "8.46.1",
-                "@typescript-eslint/typescript-estree": "8.46.1"
+                "@typescript-eslint/scope-manager": "8.46.2",
+                "@typescript-eslint/types": "8.46.2",
+                "@typescript-eslint/typescript-estree": "8.46.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4057,13 +4082,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.46.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.1.tgz",
-            "integrity": "sha512-ptkmIf2iDkNUjdeu2bQqhFPV1m6qTnFFjg7PPDjxKWaMaP0Z6I9l30Jr3g5QqbZGdw8YdYvLp+XnqnWWZOg/NA==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.2.tgz",
+            "integrity": "sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.46.1",
+                "@typescript-eslint/types": "8.46.2",
                 "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
@@ -4092,13 +4117,14 @@
             }
         },
         "node_modules/@vitest/expect/node_modules/@types/chai": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-            "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/deep-eql": "*"
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
             }
         },
         "node_modules/@vitest/expect/node_modules/chai": {
@@ -5333,9 +5359,9 @@
             "license": "MIT"
         },
         "node_modules/axe-core": {
-            "version": "4.10.3",
-            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
-            "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.0.tgz",
+            "integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
             "dev": true,
             "license": "MPL-2.0",
             "engines": {
@@ -5374,16 +5400,24 @@
             "license": "MIT"
         },
         "node_modules/bare-events": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.7.0.tgz",
-            "integrity": "sha512-b3N5eTW1g7vXkw+0CXh/HazGTcO5KYuu/RCNaJbDMPI6LHDi+7qe8EmxKUVe1sUbY2KZOVZFyj62x0OEz9qyAA==",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.1.tgz",
+            "integrity": "sha512-oxSAxTS1hRfnyit2CL5QpAOS5ixfBjj6ex3yTNvXyY/kE719jQ/IjuESJBK2w5v4wwQRAHGseVJXx9QBYOtFGQ==",
             "dev": true,
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "bare-abort-controller": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-abort-controller": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/bare-fs": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.4.5.tgz",
-            "integrity": "sha512-TCtu93KGLu6/aiGWzMr12TmSRS6nKdfhAnzTQRbXoSWxkbb9eRd53jQ51jG7g1gYjjtto3hbBrrhzg6djcgiKg==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.0.tgz",
+            "integrity": "sha512-GljgCjeupKZJNetTqxKaQArLK10vpmK28or0+RwWjEl5Rk+/xG3wkpmkv+WrcBm3q1BwHKlnhXzR8O37kcvkXQ==",
             "dev": true,
             "license": "Apache-2.0",
             "optional": true,
@@ -5452,9 +5486,9 @@
             }
         },
         "node_modules/bare-url": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.2.2.tgz",
-            "integrity": "sha512-g+ueNGKkrjMazDG3elZO1pNs3HY5+mMmOet1jtKyhOaCnkLzitxf26z7hoAEkDNgdNmnc1KIlt/dw6Po6xZMpA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.1.tgz",
+            "integrity": "sha512-v2yl0TnaZTdEnelkKtXZGnotiV6qATBlnNuUMrHl6v9Lmmrh9mw9RYyImPU7/4RahumSwQS1k2oKXcRfXcbjJw==",
             "dev": true,
             "license": "Apache-2.0",
             "optional": true,
@@ -5463,9 +5497,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.8.9",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.9.tgz",
-            "integrity": "sha512-hY/u2lxLrbecMEWSB0IpGzGyDyeoMFQhCvZd2jGFSE5I17Fh01sYUBPCJtkWERw7zrac9+cIghxm/ytJa2X8iA==",
+            "version": "2.8.20",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.20.tgz",
+            "integrity": "sha512-JMWsdF+O8Orq3EMukbUN1QfbLK9mX2CkUmQBcW2T0s8OmdAUL5LLM/6wFwSrqXzlXB13yhyK9gTKS1rIizOduQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -5603,9 +5637,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.26.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz",
-            "integrity": "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==",
+            "version": "4.27.0",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
+            "integrity": "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==",
             "dev": true,
             "funding": [
                 {
@@ -5623,11 +5657,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.8.9",
-                "caniuse-lite": "^1.0.30001746",
-                "electron-to-chromium": "^1.5.227",
-                "node-releases": "^2.0.21",
-                "update-browserslist-db": "^1.1.3"
+                "baseline-browser-mapping": "^2.8.19",
+                "caniuse-lite": "^1.0.30001751",
+                "electron-to-chromium": "^1.5.238",
+                "node-releases": "^2.0.26",
+                "update-browserslist-db": "^1.1.4"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -5688,17 +5722,18 @@
             }
         },
         "node_modules/cacheable": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.0.2.tgz",
-            "integrity": "sha512-dWjhLx8RWnPsAWVKwW/wI6OJpQ/hSVb1qS0NUif8TR9vRiSwci7Gey8x04kRU9iAF+Rnbtex5Kjjfg/aB5w8Pg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.1.1.tgz",
+            "integrity": "sha512-LmF4AXiSNdiRbI2UjH8pAp9NIXxeQsTotpEaegPiDcnN0YPygDJDV3l/Urc0mL72JWdATEorKqIHEx55nDlONg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@cacheable/memoize": "^2.0.2",
-                "@cacheable/memory": "^2.0.2",
-                "@cacheable/utils": "^2.0.2",
-                "hookified": "^1.12.1",
-                "keyv": "^5.5.2"
+                "@cacheable/memoize": "^2.0.3",
+                "@cacheable/memory": "^2.0.3",
+                "@cacheable/utils": "^2.1.0",
+                "hookified": "^1.12.2",
+                "keyv": "^5.5.3",
+                "qified": "^0.5.0"
             }
         },
         "node_modules/cacheable/node_modules/keyv": {
@@ -5779,9 +5814,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001750",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001750.tgz",
-            "integrity": "sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ==",
+            "version": "1.0.30001751",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
+            "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
             "dev": true,
             "funding": [
                 {
@@ -6014,9 +6049,9 @@
             }
         },
         "node_modules/chromium-bidi": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-9.1.0.tgz",
-            "integrity": "sha512-rlUzQ4WzIAWdIbY/viPShhZU2n21CxDUgazXVbw4Hu1MwaeUSEksSeM6DqPgpRjCLXRk702AVRxJxoOz0dw4OA==",
+            "version": "10.5.1",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-10.5.1.tgz",
+            "integrity": "sha512-rlj6OyhKhVTnk4aENcUme3Jl9h+cq4oXu4AzBcvr8RMmT6BR4a3zSNT9dbIfXr9/BS6ibzRyDhowuw4n2GgzsQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -6967,9 +7002,9 @@
             }
         },
         "node_modules/devtools-protocol": {
-            "version": "0.0.1495869",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1495869.tgz",
-            "integrity": "sha512-i+bkd9UYFis40RcnkW7XrOprCujXRAHg62IVh/Ah3G8MmNXpCGt1m0dTFhSdx/AVs8XEMbdOGRwdkR1Bcta8AA==",
+            "version": "0.0.1508733",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1508733.tgz",
+            "integrity": "sha512-QJ1R5gtck6nDcdM+nlsaJXcelPEI7ZxSMw1ujHpO1c4+9l+Nue5qlebi9xO1Z2MGr92bFOQTW7/rrheh5hHxDg==",
             "dev": true,
             "license": "BSD-3-Clause"
         },
@@ -7146,9 +7181,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.227",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.227.tgz",
-            "integrity": "sha512-ITxuoPfJu3lsNWUi2lBM2PaBPYgH3uqmxut5vmBxgYvyI4AlJ6P3Cai1O76mOrkJCBzq0IxWg/NtqOrpu/0gKA==",
+            "version": "1.5.240",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.240.tgz",
+            "integrity": "sha512-OBwbZjWgrCOH+g6uJsA2/7Twpas2OlepS9uvByJjR2datRDuKGYeD+nP8lBBks2qnB7bGJNHDUx7c/YLaT3QMQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -7307,9 +7342,9 @@
             }
         },
         "node_modules/envinfo": {
-            "version": "7.15.0",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.15.0.tgz",
-            "integrity": "sha512-chR+t7exF6y59kelhXw5I3849nTy7KIRO+ePdLMhCD+JRP/JvmkenDWP7QSFGlsHX+kxGxdDutOPrmj5j1HR6g==",
+            "version": "7.19.0",
+            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.19.0.tgz",
+            "integrity": "sha512-DoSM9VyG6O3vqBf+p3Gjgr/Q52HYBBtO3v+4koAxt1MnWr+zEnxE+nke/yXS4lt2P4SYCHQ4V3f1i88LQVOpAw==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -7390,9 +7425,9 @@
             }
         },
         "node_modules/es-toolkit": {
-            "version": "1.39.10",
-            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
-            "integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==",
+            "version": "1.41.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.41.0.tgz",
+            "integrity": "sha512-bDd3oRmbVgqZCJS6WmeQieOrzpl3URcWBUVDXxOELlUW2FuW+0glPOz1n0KnRie+PdyvUZcXz2sOn00c6pPRIA==",
             "dev": true,
             "license": "MIT",
             "workspaces": [
@@ -7407,9 +7442,9 @@
             "license": "MIT"
         },
         "node_modules/esbuild": {
-            "version": "0.25.10",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
-            "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+            "version": "0.25.11",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.11.tgz",
+            "integrity": "sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -7420,32 +7455,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.25.10",
-                "@esbuild/android-arm": "0.25.10",
-                "@esbuild/android-arm64": "0.25.10",
-                "@esbuild/android-x64": "0.25.10",
-                "@esbuild/darwin-arm64": "0.25.10",
-                "@esbuild/darwin-x64": "0.25.10",
-                "@esbuild/freebsd-arm64": "0.25.10",
-                "@esbuild/freebsd-x64": "0.25.10",
-                "@esbuild/linux-arm": "0.25.10",
-                "@esbuild/linux-arm64": "0.25.10",
-                "@esbuild/linux-ia32": "0.25.10",
-                "@esbuild/linux-loong64": "0.25.10",
-                "@esbuild/linux-mips64el": "0.25.10",
-                "@esbuild/linux-ppc64": "0.25.10",
-                "@esbuild/linux-riscv64": "0.25.10",
-                "@esbuild/linux-s390x": "0.25.10",
-                "@esbuild/linux-x64": "0.25.10",
-                "@esbuild/netbsd-arm64": "0.25.10",
-                "@esbuild/netbsd-x64": "0.25.10",
-                "@esbuild/openbsd-arm64": "0.25.10",
-                "@esbuild/openbsd-x64": "0.25.10",
-                "@esbuild/openharmony-arm64": "0.25.10",
-                "@esbuild/sunos-x64": "0.25.10",
-                "@esbuild/win32-arm64": "0.25.10",
-                "@esbuild/win32-ia32": "0.25.10",
-                "@esbuild/win32-x64": "0.25.10"
+                "@esbuild/aix-ppc64": "0.25.11",
+                "@esbuild/android-arm": "0.25.11",
+                "@esbuild/android-arm64": "0.25.11",
+                "@esbuild/android-x64": "0.25.11",
+                "@esbuild/darwin-arm64": "0.25.11",
+                "@esbuild/darwin-x64": "0.25.11",
+                "@esbuild/freebsd-arm64": "0.25.11",
+                "@esbuild/freebsd-x64": "0.25.11",
+                "@esbuild/linux-arm": "0.25.11",
+                "@esbuild/linux-arm64": "0.25.11",
+                "@esbuild/linux-ia32": "0.25.11",
+                "@esbuild/linux-loong64": "0.25.11",
+                "@esbuild/linux-mips64el": "0.25.11",
+                "@esbuild/linux-ppc64": "0.25.11",
+                "@esbuild/linux-riscv64": "0.25.11",
+                "@esbuild/linux-s390x": "0.25.11",
+                "@esbuild/linux-x64": "0.25.11",
+                "@esbuild/netbsd-arm64": "0.25.11",
+                "@esbuild/netbsd-x64": "0.25.11",
+                "@esbuild/openbsd-arm64": "0.25.11",
+                "@esbuild/openbsd-x64": "0.25.11",
+                "@esbuild/openharmony-arm64": "0.25.11",
+                "@esbuild/sunos-x64": "0.25.11",
+                "@esbuild/win32-arm64": "0.25.11",
+                "@esbuild/win32-ia32": "0.25.11",
+                "@esbuild/win32-x64": "0.25.11"
             }
         },
         "node_modules/esbuild-register": {
@@ -7525,25 +7560,24 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.36.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
-            "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
+            "version": "9.38.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
+            "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.21.0",
-                "@eslint/config-helpers": "^0.3.1",
-                "@eslint/core": "^0.15.2",
+                "@eslint/config-array": "^0.21.1",
+                "@eslint/config-helpers": "^0.4.1",
+                "@eslint/core": "^0.16.0",
                 "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.36.0",
-                "@eslint/plugin-kit": "^0.3.5",
+                "@eslint/js": "9.38.0",
+                "@eslint/plugin-kit": "^0.4.0",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
                 "@types/estree": "^1.0.6",
-                "@types/json-schema": "^7.0.15",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.6",
@@ -8446,9 +8480,9 @@
             }
         },
         "node_modules/generator-function": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.0.tgz",
-            "integrity": "sha512-xPypGGincdfyl/AiSGa7GjXLkvld9V7GjZlowup9SHIJnQnHLFiLODCd/DqKOp0PBagbHJ68r1KJI9Mut7m4sA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+            "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8858,9 +8892,9 @@
             }
         },
         "node_modules/hookified": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.12.1.tgz",
-            "integrity": "sha512-xnKGl+iMIlhrZmGHB729MqlmPoWBznctSQTYCpFKqNsCgimJQmithcW0xSQMMFzYnV2iKUh25alswn6epgxS0Q==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.12.2.tgz",
+            "integrity": "sha512-aokUX1VdTpI0DUsndvW+OiwmBpKCu/NgRsSSkuSY0zq8PY6Q6a+lmOfAFDXAAOtBqJELvcWY9L1EVtzjbQcMdg==",
             "dev": true,
             "license": "MIT"
         },
@@ -9016,9 +9050,9 @@
             }
         },
         "node_modules/human-id": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.1.1.tgz",
-            "integrity": "sha512-3gKm/gCSUipeLsRYZbbdA1BD83lBoWUkZ7G9VFrhWPAU76KwYo5KR8V28bpoPm/ygy0x5/GCbpRQdY7VLYCoIg==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.1.2.tgz",
+            "integrity": "sha512-v/J+4Z/1eIJovEBdlV5TYj1IR+ZiohcYGRY+qN/oC9dAfKzVT023N/Bgw37hrKCoVRBvk3bqyzpr2PP5YeTMSg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -9104,9 +9138,9 @@
             "license": "MIT"
         },
         "node_modules/immutable": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
-            "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
+            "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
             "dev": true,
             "license": "MIT"
         },
@@ -9405,15 +9439,15 @@
             }
         },
         "node_modules/is-generator-function": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.1.tgz",
-            "integrity": "sha512-Gn8BWUdrTzf9XUJAvqIYP7QnSC3mKs8QjQdGdJ7HmBemzZo14wj/OVmmAwgxDX/7WhFEjboybL4VhXGIQYPlOA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+            "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bound": "^1.0.3",
+                "call-bound": "^1.0.4",
                 "generator-function": "^2.0.0",
-                "get-proto": "^1.0.0",
+                "get-proto": "^1.0.1",
                 "has-tostringtag": "^1.0.2",
                 "safe-regex-test": "^1.1.0"
             },
@@ -9715,9 +9749,9 @@
             }
         },
         "node_modules/jiti": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.0.tgz",
-            "integrity": "sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -9881,9 +9915,9 @@
             "license": "MIT"
         },
         "node_modules/koa": {
-            "version": "2.16.2",
-            "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.2.tgz",
-            "integrity": "sha512-+CCssgnrWKx9aI3OeZwroa/ckG4JICxvIFnSiOUyl2Uv+UTI+xIw0FfFrWS7cQFpoePpr9o8csss7KzsTzNL8Q==",
+            "version": "2.16.3",
+            "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.3.tgz",
+            "integrity": "sha512-zPPuIt+ku1iCpFBRwseMcPYQ1cJL8l60rSmKeOuGfOXyE6YnTBmf2aEFNL2HQGrD0cPcLO/t+v9RTgC+fwEh/g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10006,9 +10040,9 @@
             }
         },
         "node_modules/less": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/less/-/less-4.4.1.tgz",
-            "integrity": "sha512-X9HKyiXPi0f/ed0XhgUlBeFfxrlDP3xR4M7768Zl+WXLUViuL9AOPPJP4nCV0tgRWvTYvpNmN0SFhZOQzy16PA==",
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/less/-/less-4.4.2.tgz",
+            "integrity": "sha512-j1n1IuTX1VQjIy3tT7cyGbX7nvQOsFLoIqobZv4ttI5axP923gA44zUj6miiA6R5Aoms4sEGVIIcucXUbRI14g==",
             "dev": true,
             "license": "Apache-2.0",
             "peer": true,
@@ -10202,9 +10236,9 @@
             }
         },
         "node_modules/liquidjs": {
-            "version": "10.21.1",
-            "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.21.1.tgz",
-            "integrity": "sha512-NZXmCwv3RG5nire3fmIn9HsOyJX3vo+ptp0yaXUHAMzSNBhx74Hm+dAGJvscUA6lNqbLuYfXgNavRQ9UbUJhQQ==",
+            "version": "10.23.0",
+            "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.23.0.tgz",
+            "integrity": "sha512-Chm3luYvACZUj+Wlq7Nxwi0YvGXJv3vx+LPIGfa6n1FaUoMxe8T2M+5S1m2YkSToqJcsxZRK0VeCPZNrSa2yOw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10215,7 +10249,7 @@
                 "liquidjs": "bin/liquid.js"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             },
             "funding": {
                 "type": "opencollective",
@@ -10282,13 +10316,17 @@
             "license": "MIT"
         },
         "node_modules/loader-runner": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-            "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+            "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.11.5"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/loader-utils": {
@@ -10456,9 +10494,9 @@
             }
         },
         "node_modules/magic-string": {
-            "version": "0.30.19",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-            "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -10989,9 +11027,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.21",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
-            "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
+            "version": "2.0.26",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.26.tgz",
+            "integrity": "sha512-S2M9YimhSjBSvYnlr5/+umAnPHE++ODwt5e2Ij6FoX45HA/s4vHdkDx1eax2pAPeAOqu4s9b7ppahsyEFdVqQA==",
             "dev": true,
             "license": "MIT"
         },
@@ -12497,9 +12535,9 @@
             "license": "MIT"
         },
         "node_modules/posthtml": {
-            "version": "0.16.6",
-            "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
-            "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+            "version": "0.16.7",
+            "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.7.tgz",
+            "integrity": "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12781,9 +12819,9 @@
             }
         },
         "node_modules/prosemirror-inputrules": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.0.tgz",
-            "integrity": "sha512-K0xJRCmt+uSw7xesnHmcn72yBGTbY45vm8gXI4LZXbx2Z0jwh5aF9xrGQgrVPu0WbyFVFF3E/o9VhJYz6SQWnA==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+            "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
             "license": "MIT",
             "dependencies": {
                 "prosemirror-state": "^1.0.0",
@@ -12825,9 +12863,9 @@
             }
         },
         "node_modules/prosemirror-model": {
-            "version": "1.25.3",
-            "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.3.tgz",
-            "integrity": "sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==",
+            "version": "1.25.4",
+            "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+            "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
             "license": "MIT",
             "dependencies": {
                 "orderedmap": "^2.0.0"
@@ -12854,9 +12892,9 @@
             }
         },
         "node_modules/prosemirror-state": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
-            "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+            "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
             "license": "MIT",
             "dependencies": {
                 "prosemirror-model": "^1.0.0",
@@ -12884,9 +12922,9 @@
             }
         },
         "node_modules/prosemirror-view": {
-            "version": "1.41.2",
-            "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.2.tgz",
-            "integrity": "sha512-PGS/jETmh+Qjmre/6vcG7SNHAKiGc4vKOJmHMPRmvcUl7ISuVtrtHmH06UDUwaim4NDJfZfVMl7U7JkMMETa6g==",
+            "version": "1.41.3",
+            "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.3.tgz",
+            "integrity": "sha512-SqMiYMUQNNBP9kfPhLO8WXEk/fon47vc52FQsUiJzTBuyjKgEcoAwMyF04eQ4WZ2ArMn7+ReypYL60aKngbACQ==",
             "license": "MIT",
             "dependencies": {
                 "prosemirror-model": "^1.20.0",
@@ -12980,22 +13018,35 @@
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "24.22.3",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.22.3.tgz",
-            "integrity": "sha512-M/Jhg4PWRANSbL/C9im//Yb55wsWBS5wdp+h59iwM+EPicVQQCNs56iC5aEAO7avfDPRfxs4MM16wHjOYHNJEw==",
+            "version": "24.26.1",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.26.1.tgz",
+            "integrity": "sha512-YHZdo3chJ5b9pTYVnuDuoI3UX/tWJFJyRZvkLbThGy6XeHWC+0KI8iN0UMCkvde5l/YOk3huiVZ/PvwgSbwdrA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "2.10.10",
-                "chromium-bidi": "9.1.0",
+                "@puppeteer/browsers": "2.10.12",
+                "chromium-bidi": "10.5.1",
                 "debug": "^4.4.3",
-                "devtools-protocol": "0.0.1495869",
+                "devtools-protocol": "0.0.1508733",
                 "typed-query-selector": "^2.12.0",
-                "webdriver-bidi-protocol": "0.2.11",
+                "webdriver-bidi-protocol": "0.3.8",
                 "ws": "^8.18.3"
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/qified": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/qified/-/qified-0.5.1.tgz",
+            "integrity": "sha512-+BtFN3dCP+IaFA6IYNOu/f/uK1B8xD2QWyOeCse0rjtAebBmkzgd2d1OAXi3ikAzJMIBSdzZDNZ3wZKEUDQs5w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hookified": "^1.12.2"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/qs": {
@@ -13127,9 +13178,9 @@
             }
         },
         "node_modules/react": {
-            "version": "19.1.1",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
-            "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+            "version": "19.2.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+            "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13137,16 +13188,16 @@
             }
         },
         "node_modules/react-dom": {
-            "version": "19.1.1",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
-            "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+            "version": "19.2.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+            "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "scheduler": "^0.26.0"
+                "scheduler": "^0.27.0"
             },
             "peerDependencies": {
-                "react": "^19.1.1"
+                "react": "^19.2.0"
             }
         },
         "node_modules/react-is": {
@@ -13363,13 +13414,13 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.10",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-            "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+            "version": "1.22.11",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "is-core-module": "^2.16.0",
+                "is-core-module": "^2.16.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -13606,9 +13657,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.52.3",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.3.tgz",
-            "integrity": "sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==",
+            "version": "4.52.5",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
+            "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13622,28 +13673,28 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.52.3",
-                "@rollup/rollup-android-arm64": "4.52.3",
-                "@rollup/rollup-darwin-arm64": "4.52.3",
-                "@rollup/rollup-darwin-x64": "4.52.3",
-                "@rollup/rollup-freebsd-arm64": "4.52.3",
-                "@rollup/rollup-freebsd-x64": "4.52.3",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.52.3",
-                "@rollup/rollup-linux-arm-musleabihf": "4.52.3",
-                "@rollup/rollup-linux-arm64-gnu": "4.52.3",
-                "@rollup/rollup-linux-arm64-musl": "4.52.3",
-                "@rollup/rollup-linux-loong64-gnu": "4.52.3",
-                "@rollup/rollup-linux-ppc64-gnu": "4.52.3",
-                "@rollup/rollup-linux-riscv64-gnu": "4.52.3",
-                "@rollup/rollup-linux-riscv64-musl": "4.52.3",
-                "@rollup/rollup-linux-s390x-gnu": "4.52.3",
-                "@rollup/rollup-linux-x64-gnu": "4.52.3",
-                "@rollup/rollup-linux-x64-musl": "4.52.3",
-                "@rollup/rollup-openharmony-arm64": "4.52.3",
-                "@rollup/rollup-win32-arm64-msvc": "4.52.3",
-                "@rollup/rollup-win32-ia32-msvc": "4.52.3",
-                "@rollup/rollup-win32-x64-gnu": "4.52.3",
-                "@rollup/rollup-win32-x64-msvc": "4.52.3",
+                "@rollup/rollup-android-arm-eabi": "4.52.5",
+                "@rollup/rollup-android-arm64": "4.52.5",
+                "@rollup/rollup-darwin-arm64": "4.52.5",
+                "@rollup/rollup-darwin-x64": "4.52.5",
+                "@rollup/rollup-freebsd-arm64": "4.52.5",
+                "@rollup/rollup-freebsd-x64": "4.52.5",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.52.5",
+                "@rollup/rollup-linux-arm-musleabihf": "4.52.5",
+                "@rollup/rollup-linux-arm64-gnu": "4.52.5",
+                "@rollup/rollup-linux-arm64-musl": "4.52.5",
+                "@rollup/rollup-linux-loong64-gnu": "4.52.5",
+                "@rollup/rollup-linux-ppc64-gnu": "4.52.5",
+                "@rollup/rollup-linux-riscv64-gnu": "4.52.5",
+                "@rollup/rollup-linux-riscv64-musl": "4.52.5",
+                "@rollup/rollup-linux-s390x-gnu": "4.52.5",
+                "@rollup/rollup-linux-x64-gnu": "4.52.5",
+                "@rollup/rollup-linux-x64-musl": "4.52.5",
+                "@rollup/rollup-openharmony-arm64": "4.52.5",
+                "@rollup/rollup-win32-arm64-msvc": "4.52.5",
+                "@rollup/rollup-win32-ia32-msvc": "4.52.5",
+                "@rollup/rollup-win32-x64-gnu": "4.52.5",
+                "@rollup/rollup-win32-x64-msvc": "4.52.5",
                 "fsevents": "~2.3.2"
             }
         },
@@ -14608,9 +14659,9 @@
             "license": "ISC"
         },
         "node_modules/scheduler": {
-            "version": "0.26.0",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-            "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -14693,9 +14744,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+            "version": "7.7.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -15198,9 +15249,9 @@
             }
         },
         "node_modules/std-env": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
-            "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+            "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
             "dev": true,
             "license": "MIT"
         },
@@ -15463,9 +15514,9 @@
             }
         },
         "node_modules/stylelint": {
-            "version": "16.24.0",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.24.0.tgz",
-            "integrity": "sha512-7ksgz3zJaSbTUGr/ujMXvLVKdDhLbGl3R/3arNudH7z88+XZZGNLMTepsY28WlnvEFcuOmUe7fg40Q3lfhOfSQ==",
+            "version": "16.25.0",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.25.0.tgz",
+            "integrity": "sha512-Li0avYWV4nfv1zPbdnxLYBGq4z8DVZxbRgx4Kn6V+Uftz1rMoF1qiEI3oL4kgWqyYgCgs7gT5maHNZ82Gk03vQ==",
             "dev": true,
             "funding": [
                 {
@@ -15483,13 +15534,13 @@
                 "@csstools/css-tokenizer": "^3.0.4",
                 "@csstools/media-query-list-parser": "^4.0.3",
                 "@csstools/selector-specificity": "^5.0.0",
-                "@dual-bundle/import-meta-resolve": "^4.1.0",
+                "@dual-bundle/import-meta-resolve": "^4.2.1",
                 "balanced-match": "^2.0.0",
                 "colord": "^2.9.3",
                 "cosmiconfig": "^9.0.0",
                 "css-functions-list": "^3.2.3",
                 "css-tree": "^3.1.0",
-                "debug": "^4.4.1",
+                "debug": "^4.4.3",
                 "fast-glob": "^3.3.3",
                 "fastest-levenshtein": "^1.0.16",
                 "file-entry-cache": "^10.1.4",
@@ -15599,13 +15650,13 @@
             }
         },
         "node_modules/stylelint/node_modules/flat-cache": {
-            "version": "6.1.14",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.14.tgz",
-            "integrity": "sha512-ExZSCSV9e7v/Zt7RzCbX57lY2dnPdxzU/h3UE6WJ6NtEMfwBd8jmi1n4otDEUfz+T/R+zxrFDpICFdjhD3H/zw==",
+            "version": "6.1.18",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.18.tgz",
+            "integrity": "sha512-JUPnFgHMuAVmLmoH9/zoZ6RHOt5n9NlUw/sDXsTbROJ2SFoS2DS4s+swAV6UTeTbGH/CAsZIE6M8TaG/3jVxgQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "cacheable": "^2.0.1",
+                "cacheable": "^2.1.0",
                 "flatted": "^3.3.3",
                 "hookified": "^1.12.0"
             }
@@ -15679,9 +15730,9 @@
             }
         },
         "node_modules/svelte": {
-            "version": "5.39.11",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.39.11.tgz",
-            "integrity": "sha512-8MxWVm2+3YwrFbPaxOlT1bbMi6OTenrAgks6soZfiaS8Fptk4EVyRIFhJc3RpO264EeSNwgjWAdki0ufg4zkGw==",
+            "version": "5.42.2",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.42.2.tgz",
+            "integrity": "sha512-iSry5jsBHispVczyt9UrBX/1qu3HQ/UyKPAIjqlvlu3o/eUvc+kpyMyRS2O4HLLx4MvLurLGIUOyyP11pyD59g==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/remapping": "^2.3.4",
@@ -15910,9 +15961,9 @@
             }
         },
         "node_modules/svelte/node_modules/esrap": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.1.0.tgz",
-            "integrity": "sha512-yzmPNpl7TBbMRC5Lj2JlJZNPml0tzqoqP5B1JXycNUwtqma9AKCO0M2wHrdgsHcy1WRW7S9rJknAMtByg3usgA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.1.1.tgz",
+            "integrity": "sha512-ebTT9B6lOtZGMgJ3o5r12wBacHctG7oEWazIda8UlPfA3HD/Wrv8FdXoVo73vzdpwCxNyXjPauyN2bbJzMkB9A==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -15928,9 +15979,9 @@
             }
         },
         "node_modules/svelte2tsx": {
-            "version": "0.7.44",
-            "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.44.tgz",
-            "integrity": "sha512-opuH+bCboss0/ncxnfAO+qt0IAprxc8OqwuC7otafWeO5CHjJ6UAAwvQmu/+xjpCSarX8pQKydXQuoJmbCDcTg==",
+            "version": "0.7.45",
+            "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.45.tgz",
+            "integrity": "sha512-cSci+mYGygYBHIZLHlm/jYlEc1acjAHqaQaDFHdEBpUueM9kSTnPpvPtSl5VkJOU1qSJ7h1K+6F/LIUYiqC8VA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16502,16 +16553,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.46.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.1.tgz",
-            "integrity": "sha512-VHgijW803JafdSsDO8I761r3SHrgk4T00IdyQ+/UsthtgPRsBWQLqoSxOolxTpxRKi1kGXK0bSz4CoAc9ObqJA==",
+            "version": "8.46.2",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.2.tgz",
+            "integrity": "sha512-vbw8bOmiuYNdzzV3lsiWv6sRwjyuKJMQqWulBOU7M0RrxedXledX8G8kBbQeiOYDnTfiXz0Y4081E1QMNB6iQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.46.1",
-                "@typescript-eslint/parser": "8.46.1",
-                "@typescript-eslint/typescript-estree": "8.46.1",
-                "@typescript-eslint/utils": "8.46.1"
+                "@typescript-eslint/eslint-plugin": "8.46.2",
+                "@typescript-eslint/parser": "8.46.2",
+                "@typescript-eslint/typescript-estree": "8.46.2",
+                "@typescript-eslint/utils": "8.46.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -16579,9 +16630,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.13.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
-            "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
             "dev": true,
             "license": "MIT"
         },
@@ -16620,9 +16671,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
+            "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
             "dev": true,
             "funding": [
                 {
@@ -16914,13 +16965,14 @@
             }
         },
         "node_modules/vitest/node_modules/@types/chai": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-            "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/deep-eql": "*"
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
             }
         },
         "node_modules/vitest/node_modules/chai": {
@@ -16961,9 +17013,9 @@
             }
         },
         "node_modules/webdriver-bidi-protocol": {
-            "version": "0.2.11",
-            "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.2.11.tgz",
-            "integrity": "sha512-Y9E1/oi4XMxcR8AT0ZC4OvYntl34SPgwjmELH+owjBr0korAX4jKgZULBWILGCVGdVCQ0dodTToIETozhG8zvA==",
+            "version": "0.3.8",
+            "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.8.tgz",
+            "integrity": "sha512-21Yi2GhGntMc671vNBCjiAeEVknXjVRoyu+k+9xOMShu+ZQfpGQwnBqbNz/Sv4GXZ6JmutlPAi2nIJcrymAWuQ==",
             "dev": true,
             "license": "Apache-2.0"
         },
@@ -17236,9 +17288,9 @@
             }
         },
         "node_modules/wordwrapjs": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz",
-            "integrity": "sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+            "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -17533,9 +17585,10 @@
             "name": "@stackoverflow/stacks-docs",
             "dependencies": {
                 "@hotwired/stimulus": "^3.2.2",
-                "@stackoverflow/stacks": "3.0.0-beta.0",
-                "@stackoverflow/stacks-editor": "^0.15.2",
-                "@stackoverflow/stacks-icons": "*",
+                "@stackoverflow/stacks": "*",
+                "@stackoverflow/stacks-editor": "^1.0.0-beta.3",
+                "@stackoverflow/stacks-icons": "^7.0.0-beta.1",
+                "@stackoverflow/stacks-icons-legacy": "npm:@stackoverflow/stacks-icons@^6.6.1",
                 "docsearch.js": "^2.6.3",
                 "jquery": "^3.7.1",
                 "list.js": "^2.3.1"
@@ -17546,7 +17599,8 @@
             "version": "1.0.0-beta.1",
             "dependencies": {
                 "@floating-ui/core": "^1.7.3",
-                "@stackoverflow/stacks-icons": "^6.6.1",
+                "@stackoverflow/stacks-icons": "^7.0.0-beta.1",
+                "@stackoverflow/stacks-icons-legacy": "npm:@stackoverflow/stacks-icons@^6.6.1",
                 "svelte-floating-ui": "^1.6.2",
                 "svelte-sonner": "^1.0.5"
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
     "private": true,
-    "workspaces": ["packages/*"],
+    "workspaces": [
+        "packages/*"
+    ],
     "name": "stacks",
     "repository": {
         "type": "git",
@@ -9,7 +11,7 @@
     "license": "MIT",
     "scripts": {
         "build": "npm run build -workspaces -if-present",
-        "prepublishOnly": "npm run build -workspaces -if-present", 
+        "prepublishOnly": "npm run build -workspaces -if-present",
         "version": "changeset version && npm install --package-lock-only",
         "release": "npm run build && changeset publish",
         "format": "npm run format -workspaces -if-present",
@@ -28,8 +30,8 @@
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-replace": "^6.0.2",
         "@stackoverflow/prettier-config": "^1.0.0",
-        "@stackoverflow/stacks": "^2.8.4",
-        "@stackoverflow/stacks-icons": "^6.6.1",
+        "@stackoverflow/stacks-icons": "^7.0.0-beta.1",
+        "@stackoverflow/stacks-icons-legacy": "npm:@stackoverflow/stacks-icons@^6.6.1",
         "@storybook/addon-docs": "^9.1.5",
         "@storybook/addon-links": "^9.1.3",
         "@storybook/addon-svelte-csf": "^5.0.8",

--- a/packages/stacks-classic/lib/components/badge/badge.a11y.test.ts
+++ b/packages/stacks-classic/lib/components/badge/badge.a11y.test.ts
@@ -1,5 +1,5 @@
 import { runA11yTests } from "../../test/a11y-test-utils";
-import { IconEyeSm } from "@stackoverflow/stacks-icons/icons";
+import { IconEyeSm } from "@stackoverflow/stacks-icons-legacy/icons";
 import "../../index";
 
 const variants = {

--- a/packages/stacks-classic/lib/components/badge/badge.visual.test.ts
+++ b/packages/stacks-classic/lib/components/badge/badge.visual.test.ts
@@ -1,5 +1,5 @@
 import { runVisualTests } from "../../test/visual-test-utils";
-import { IconEyeSm } from "@stackoverflow/stacks-icons/icons";
+import { IconEyeSm } from "@stackoverflow/stacks-icons-legacy/icons";
 import "../../index";
 import { html } from "@open-wc/testing";
 

--- a/packages/stacks-classic/lib/components/empty-state/empty-state.a11y.test.ts
+++ b/packages/stacks-classic/lib/components/empty-state/empty-state.a11y.test.ts
@@ -1,5 +1,5 @@
 import { html } from "@open-wc/testing";
-import { SpotEmptyXL } from "@stackoverflow/stacks-icons";
+import { SpotEmptyXL } from "@stackoverflow/stacks-icons-legacy";
 import { runA11yTests } from "../../test/a11y-test-utils";
 import "../../index";
 

--- a/packages/stacks-classic/lib/components/empty-state/empty-state.visual.test.ts
+++ b/packages/stacks-classic/lib/components/empty-state/empty-state.visual.test.ts
@@ -1,5 +1,5 @@
 import { html } from "@open-wc/testing";
-import { SpotEmptyXL } from "@stackoverflow/stacks-icons";
+import { SpotEmptyXL } from "@stackoverflow/stacks-icons-legacy";
 import { runVisualTests } from "../../test/visual-test-utils";
 import "../../index";
 

--- a/packages/stacks-classic/lib/components/modal/modal.a11y.test.ts
+++ b/packages/stacks-classic/lib/components/modal/modal.a11y.test.ts
@@ -1,6 +1,6 @@
 import { html } from "@open-wc/testing";
 import { runA11yTests } from "../../test/a11y-test-utils";
-import { IconClearSm } from "@stackoverflow/stacks-icons/icons";
+import { IconClearSm } from "@stackoverflow/stacks-icons-legacy/icons";
 import "../../index";
 
 describe("modal", () => {

--- a/packages/stacks-classic/lib/components/modal/modal.visual.test.ts
+++ b/packages/stacks-classic/lib/components/modal/modal.visual.test.ts
@@ -1,6 +1,6 @@
 import { html } from "@open-wc/testing";
 import { runVisualTests } from "../../test/visual-test-utils";
-import { IconClearSm } from "@stackoverflow/stacks-icons/icons";
+import { IconClearSm } from "@stackoverflow/stacks-icons-legacy/icons";
 import "../../index";
 
 describe("modal", () => {

--- a/packages/stacks-classic/lib/components/post-summary/post-summary.test.setup.ts
+++ b/packages/stacks-classic/lib/components/post-summary/post-summary.test.setup.ts
@@ -8,7 +8,7 @@ import {
     IconPencilSm,
     IconTackSm,
     IconTrashSm,
-} from "@stackoverflow/stacks-icons/icons";
+} from "@stackoverflow/stacks-icons-legacy/icons";
 import type { TestVariationArgs } from "../../test/test-utils";
 import "../../index";
 

--- a/packages/stacks-classic/lib/components/progress-bar/progress-bar.a11y.test.ts
+++ b/packages/stacks-classic/lib/components/progress-bar/progress-bar.a11y.test.ts
@@ -2,7 +2,7 @@ import { html } from "@open-wc/testing";
 import {
     IconAchievementsSm,
     IconCheckmarkSm,
-} from "@stackoverflow/stacks-icons/icons";
+} from "@stackoverflow/stacks-icons-legacy/icons";
 import { runA11yTests } from "../../test/a11y-test-utils";
 import "../../index";
 

--- a/packages/stacks-classic/lib/components/progress-bar/progress-bar.visual.test.ts
+++ b/packages/stacks-classic/lib/components/progress-bar/progress-bar.visual.test.ts
@@ -2,7 +2,7 @@ import { html } from "@open-wc/testing";
 import {
     IconAchievementsSm,
     IconCheckmarkSm,
-} from "@stackoverflow/stacks-icons/icons";
+} from "@stackoverflow/stacks-icons-legacy/icons";
 import { runVisualTests } from "../../test/visual-test-utils";
 import "../../index";
 

--- a/packages/stacks-classic/lib/components/tag/tag.a11y.test.ts
+++ b/packages/stacks-classic/lib/components/tag/tag.a11y.test.ts
@@ -1,4 +1,4 @@
-import { IconClearSm } from "@stackoverflow/stacks-icons";
+import { IconClearSm } from "@stackoverflow/stacks-icons-legacy";
 import { runA11yTests } from "../../test/a11y-test-utils";
 import "../../index";
 

--- a/packages/stacks-classic/lib/components/tag/tag.visual.test.ts
+++ b/packages/stacks-classic/lib/components/tag/tag.visual.test.ts
@@ -1,5 +1,5 @@
 import { html } from "@open-wc/testing";
-import { IconClearSm } from "@stackoverflow/stacks-icons/icons";
+import { IconClearSm } from "@stackoverflow/stacks-icons-legacy/icons";
 import { runVisualTests } from "../../test/visual-test-utils";
 import "../../index";
 

--- a/packages/stacks-classic/lib/components/topbar/topbar.visual.test.ts
+++ b/packages/stacks-classic/lib/components/topbar/topbar.visual.test.ts
@@ -9,7 +9,7 @@ import {
     IconReviewQueue,
     IconSearch,
     IconStackExchange,
-} from "@stackoverflow/stacks-icons/icons";
+} from "@stackoverflow/stacks-icons-legacy/icons";
 import { html } from "@open-wc/testing";
 
 const base64Image =

--- a/packages/stacks-docs/package.json
+++ b/packages/stacks-docs/package.json
@@ -9,12 +9,13 @@
         "build": "webpack --mode=production && eleventy"
     },
     "dependencies": {
-        "@stackoverflow/stacks": "3.0.0-beta.0",
         "@hotwired/stimulus": "^3.2.2",
+        "@stackoverflow/stacks": "*",
+        "@stackoverflow/stacks-editor": "^1.0.0-beta.3",
+        "@stackoverflow/stacks-icons": "^7.0.0-beta.1",
+        "@stackoverflow/stacks-icons-legacy": "npm:@stackoverflow/stacks-icons@^6.6.1",
         "jquery": "^3.7.1",
         "list.js": "^2.3.1",
-        "docsearch.js": "^2.6.3",
-        "@stackoverflow/stacks-editor": "^0.15.2",
-        "@stackoverflow/stacks-icons": "*"
+        "docsearch.js": "^2.6.3"
     }
 }

--- a/packages/stacks-docs/plugins/banner-example.js
+++ b/packages/stacks-docs/plugins/banner-example.js
@@ -1,4 +1,4 @@
-const { Icons } = require("@stackoverflow/stacks-icons");
+const { Icons } = require("@stackoverflow/stacks-icons-legacy");
 
 module.exports = {
     configFunction(eleventyConfig) {

--- a/packages/stacks-docs/plugins/header.js
+++ b/packages/stacks-docs/plugins/header.js
@@ -1,5 +1,5 @@
 
-const { Icons } = require("@stackoverflow/stacks-icons");
+const { Icons } = require("@stackoverflow/stacks-icons-legacy");
 
 module.exports = {
   configFunction(eleventyConfig) {

--- a/packages/stacks-docs/plugins/icons.js
+++ b/packages/stacks-docs/plugins/icons.js
@@ -1,5 +1,9 @@
-const { Icons, Spots } = require("@stackoverflow/stacks-icons");
+const { Icons: LegacyIcons, Spots: LegacySpots } = require("@stackoverflow/stacks-icons-legacy");
+const { Icons: BetaIcons, Spots: BetaSpots } = require("@stackoverflow/stacks-icons");
 const fs = require("fs/promises");
+
+const Icons = { ...LegacyIcons, ...BetaIcons };
+const Spots = { ...LegacySpots, ...BetaSpots };
 
 function modifySvg(content, type, name, classes, dimension) {
   var defaultClasses = `svg-${type} ${type}${name}`;

--- a/packages/stacks-docs/plugins/tip.js
+++ b/packages/stacks-docs/plugins/tip.js
@@ -1,4 +1,4 @@
-const { Spots } = require("@stackoverflow/stacks-icons");
+const { Spots } = require("@stackoverflow/stacks-icons-legacy");
 
 module.exports = {
     configFunction(eleventyConfig) {

--- a/packages/stacks-docs/product/foundation/icons.html
+++ b/packages/stacks-docs/product/foundation/icons.html
@@ -2,7 +2,7 @@
 layout: page
 title: Icons
 razor: https://razor.stackoverflow.design/components/icon
-figma: https://svelte.stackoverflow.design/figma/icons
+figma: https://www.figma.com/design/Z5yoO4WH58QDHvmxwMWhr0
 description: Stacks provides a complete icon set, managed separately in the <a href="https://github.com/StackExchange/Stacks-Icons">Stacks-Icons</a> repository. There you’ll find deeper documentation on the various uses as well as the icons’ source in our design tool Figma.
 tags: foundation
 ---
@@ -11,79 +11,57 @@ tags: foundation
     {% header "h2", "Usage" %}
     <p class="stacks-copy">Stacks icons are designed to be directly injected into the markup as an <code class="stacks-code">svg</code> element. This allows us to color them on the fly using any of our atomic classes. We have different helpers in different environments.</p>
 
-    {% header "h3", "Production" %}
-    <p class="stacks-copy">If you’re in Stack Overflow’s production environment, we have a helper that can be called with <code class="stacks-code">@Svg.</code> and the icon name, eg. <code class="stacks-code">@Svg.Alert</code>. By default, any icon will inherit the text color of the parent element. Optionally, you can pass the class <code class="stacks-code">native</code> to the icon to render any native colors that are included eg. <code class="stacks-code">@Svg.Ballon.With("native")</code>. This same syntax allows you to pass additional arbitrary classes like atomic helpers, or <code class="stacks-code">js-</code> prefixed classes.</p>
-    <div class="stacks-preview">
-{% highlight java %}
-@Svg.Wave
-@Svg.Wave.With("native")
-@Svg.Wave.With("fc-black-350 float-right js-dropdown-target")
-{% endhighlight %}
-        <div class="stacks-preview--example">
-            <div class="d-flex g24 fw-wrap ff-mono">
-                <div class="flex--item">
-                    <div class="fc-medium mb12">Default</div>
-                    {% icon "Wave" %}
-                </div>
-                <div class="flex--item">
-                    <div class="fc-medium mb12">With native colors</div>
-                    {% icon "Wave", "native" %}
-                </div>
-                <div class="flex--item ml-auto">
-                    <div class="fc-medium mb12">With arbitrary classes</div>
-                    {% icon "Wave", "fc-black-350 float-right js-dropdown-target" %}
-                </div>
-            </div>
-        </div>
-    </div>
-
-    {% header "h3", "Prototypes" %}
-    <p class="stacks-copy">Our icon set also includes a JavaScript library for use in prototypes outside our production environment. This JavaScript is loaded in our Stacks playground in <a href="https://codepen.io/pen?template=wvmRgdp">Codepen</a>. When using <code>data-icon</code> attributes, you need to prefix the icon names with <code>Icon</code> (e.g. <code>IconWave</code>). If you’re building a prototype in your own environment, you’ll need to include Stacks as a dependency as well as the <a href="https://github.com/StackExchange/Stacks-Icons#using-the-front-end-helper-for-prototyping">icons library</a>.</p>
-    <div class="stacks-preview">
+    {% header "h3", "Svelte" %}
+    <p class="stacks-copy">If you are working in a Svelte project, you can use the <code class="stacks-code">Icon</code> component to render an icon.
+        This component will render the icon as an <code class="stacks-code">svg</code> element with the appropriate classes and attributes (<a href="https://svelte.stackoverflow.design/?path=/docs/components-icon--docs">docs</a>).
+    </p>
 {% highlight html %}
-<svg data-icon="IconWave"></svg>
-<svg data-icon="IconWave" class="native"></svg>
-<svg data-icon="IconWave" class="fc-black-350 float-right js-dropdown-target"></svg>
+<script lang="ts">
+    import { IconServiceCCPA } from "@stackoverflow/stacks-icons/icons";
+</script>
+
+<Icon src="IconServiceCCPA" />
+<Icon src="IconServiceCCPA" class="native" />
+<Icon src="IconServiceCCPA" class="fc-black-350 float-right" />
 {% endhighlight %}
-        <div class="stacks-preview--example">
-            <div class="d-flex g24 fw-wrap ff-mono">
-                <div class="flex--item">
-                    <div class="fc-medium mb12">Default</div>
-                    {% icon "Wave" %}
-                </div>
-                <div class="flex--item">
-                    <div class="fc-medium mb12">With native colors</div>
-                    {% icon "Wave", "native" %}
-                </div>
-                <div class="flex--item ml-auto">
-                    <div class="fc-medium mb12">With arbitrary classes</div>
-                    {% icon "Wave", "fc-black-350 float-right js-dropdown-target" %}
-                </div>
-            </div>
+<div class="stacks-preview--example">
+    <div class="d-flex g24 fw-wrap ff-mono">
+        <div class="flex--item">
+            <div class="fc-medium mb12">Default</div>
+            {% icon "ServiceCCPA" %}
+        </div>
+        <div class="flex--item">
+            <div class="fc-medium mb12">With native colors</div>
+            {% icon "ServiceCCPA", "native" %}
+        </div>
+        <div class="flex--item ml-auto">
+            <div class="fc-medium mb12">With arbitrary classes</div>
+            {% icon "ServiceCCPA", "fc-black-350 float-right" %}
         </div>
     </div>
+</div>
 
-    {% header "h3", "Documentation" %}
-    <p class="stacks-copy">For use within our documentation, we’ve also included a Liquid helper.</p>
+{% header "h3", "Dotnet" %}
+    <p class="stacks-copy">If you’re working in a dotnet project, we have a helper that can be called with <code class="stacks-code">@Svg.</code> and the icon name, eg. <code class="stacks-code">@Svg.Answer</code>. By default, any icon will inherit the text color of the parent element. Optionally, you can pass the class <code class="stacks-code">native</code> to the icon to render any native colors that are included eg. <code class="stacks-code">@Svg.ServiceCCPA.With("native")</code>. This same syntax allows you to pass additional arbitrary classes like atomic helpers, or <code class="stacks-code">js-</code> prefixed classes.</p>
     <div class="stacks-preview">
 {% highlight java %}
-{% icon "Wave" %}
-{% icon "Wave", "native" %}
-{% icon "Wave", "fc-black-350 float-right js-dropdown-target" %}
+@Svg.ServiceCCPA
+@Svg.ServiceCCPA.With("native")
+@Svg.ServiceCCPA.With("fc-black-350 float-right js-dropdown-target")
 {% endhighlight %}
         <div class="stacks-preview--example">
             <div class="d-flex g24 fw-wrap ff-mono">
                 <div class="flex--item">
                     <div class="fc-medium mb12">Default</div>
-                    {% icon "Wave" %}
+                    {% icon "ServiceCCPA" %}
                 </div>
                 <div class="flex--item">
                     <div class="fc-medium mb12">With native colors</div>
-                    {% icon "Wave", "native" %}
+                    {% icon "ServiceCCPA", "native" %}
                 </div>
                 <div class="flex--item ml-auto">
                     <div class="fc-medium mb12">With arbitrary classes</div>
-                    {% icon "Wave", "fc-black-350 float-right js-dropdown-target" %}
+                    {% icon "ServiceCCPA", "fc-black-350 float-right js-dropdown-target" %}
                 </div>
             </div>
         </div>
@@ -114,7 +92,7 @@ tags: foundation
                         {% icon iconName, "native js-svg" %}
                     </div>
                     <div class="d-flex ai-center jc-space-between p8">
-                        <code class="flex--item fs-caption py8 ff-mono ow-break-word js-name">@Svg.{{ iconName }}</code>
+                        <code class="flex--item fs-caption py8 ff-mono ow-break-word js-name">{{ iconName }}</code>
                         <a class="d-flex flex__center s-btn s-btn__muted fc-black-400 p2" href="#{{ iconName | downcase }}">
                             {% icon "Link" %}
                             <span class="v-visible-sr">{{ iconName }} icon</span>

--- a/packages/stacks-docs/product/foundation/spots.html
+++ b/packages/stacks-docs/product/foundation/spots.html
@@ -1,53 +1,11 @@
 ---
 layout: page
-title: Spot illustrations
+title: Spot illustrations (WIP)
 razor: https://razor.stackoverflow.design/components/spot
-figma: https://svelte.stackoverflow.design/figma/icons
+figma: https://www.figma.com/design/Z5yoO4WH58QDHvmxwMWhr0
 description: Spot illustrations are the slightly grown up version of icons with a little more detail. They’re most often used in empty states and new product announcements. They’re built externally on the <a href="https://github.com/StackExchange/Stacks-Icons">Icons</a> repository.
 tags: foundation
 ---
-
-<section class="stacks-section">
-    {% header "h2", "Using the spots helpers" %}
-    <p class="stacks-copy">Just like icons, spot illustrations are delivered as a Razor helper in Stack Overflow’s production environment, a custom liquid tag in our documentation’s Eleventy site generator, and a JavaScript helper for use in prototypes.</p>
-    <p class="stacks-copy">Helpers should be used for all spot illustrations in lieu of SVG sprite sheets or static raster image assets. This ensures a single source of truth for all spot illustrations.</p>
-
-    {% header "h3", "Basic" %}
-    <div class="stacks-preview">
-{% highlight html %}
-<!-- Razor -->
-@Svg.Spot.Wave
-
-<!-- Liquid -->
-{% spot "Wave" %}
-
-<!-- JavaScript Helper -->
-<svg data-spot="SpotWave"></svg>
-{% endhighlight %}
-        <div class="stacks-preview--example">
-            {% spot "Wave" %}
-        </div>
-    </div>
-
-    {% header "h3", "Arbitrary classes" %}
-    <p class="stacks-copy">Spot illustrations can be colored on the fly with support for arbitrary classes.</p>
-
-    <div class="stacks-preview">
-{% highlight html %}
-<!-- Razor -->
-@Svg.Spot.Wave.With("fc-orange-400 float-right js-dropdown-target")
-
-<!-- Liquid -->
-{% spot "Wave", "fc-orange-400 float-right js-dropdown-target" %}
-
-<!-- JavaScript Helper -->
-<svg data-spot="SpotWave" class="fc-orange-400 float-right js-dropdown-target"></svg>
-{% endhighlight %}
-        <div class="stacks-preview--example overflow-hidden">
-            {% spot "Wave", "fc-orange-400 float-right js-dropdown-target" %}
-        </div>
-    </div>
-</section>
 
 <section class="stacks-section mb32" id="js-sortable-list">
     {% header "h2", "Spot illustrations" %}
@@ -60,10 +18,10 @@ tags: foundation
             <div class="flex--item">
                 <div id="{{ spotName | downcase }}" class="d-flex fd-column p0 s-card h100 stacks-icon-container">
                     <div class="d-flex fl-grow1 flex__center stacks-icon-preview">
-                        {% spot spotName %}
+                        {% spot spotName, "native" %}
                     </div>
                     <div class="d-flex ai-center jc-space-between p8">
-                        <code class="flex--item fs-caption py8 ff-mono ow-break-word js-name">@Svg.Spot.{{ spotName }}</code>
+                        <code class="flex--item fs-caption py8 ff-mono ow-break-word js-name">{{ spotName }}</code>
                         <a class="d-flex flex__center s-btn s-btn__muted fc-black-400 p2" href="#{{ spotName | downcase }}">
                             {% icon "Link" %}
                             <span class="v-visible-sr">{{ spotName }} spot</span>

--- a/packages/stacks-svelte/package.json
+++ b/packages/stacks-svelte/package.json
@@ -32,7 +32,8 @@
     },
     "dependencies": {
         "@floating-ui/core": "^1.7.3",
-        "@stackoverflow/stacks-icons": "^6.6.1",
+        "@stackoverflow/stacks-icons": "^7.0.0-beta.1",
+        "@stackoverflow/stacks-icons-legacy": "npm:@stackoverflow/stacks-icons@^6.6.1",
         "svelte-floating-ui": "^1.6.2",
         "svelte-sonner": "^1.0.5"
     },

--- a/packages/stacks-svelte/src/components/Avatar/Avatar.svelte
+++ b/packages/stacks-svelte/src/components/Avatar/Avatar.svelte
@@ -4,7 +4,7 @@
 
 <script lang="ts">
     import Icon from "../Icon/Icon.svelte";
-    import { IconShieldXSm } from "@stackoverflow/stacks-icons/icons";
+    import { IconShieldXSm } from "@stackoverflow/stacks-icons-legacy/icons";
     import type { HTMLAnchorAttributes } from "svelte/elements";
 
     interface Props {

--- a/packages/stacks-svelte/src/components/Badge/Badge.stories.svelte
+++ b/packages/stacks-svelte/src/components/Badge/Badge.stories.svelte
@@ -10,7 +10,7 @@
         IconPencilSm,
         IconTackSm,
         IconTrashSm,
-    } from "@stackoverflow/stacks-icons/icons";
+    } from "@stackoverflow/stacks-icons-legacy/icons";
     import Badge, { type Award, type Size, type Variant } from "./Badge.svelte";
 
     const BadgeVariantGroups: {

--- a/packages/stacks-svelte/src/components/Badge/Badge.test.ts
+++ b/packages/stacks-svelte/src/components/Badge/Badge.test.ts
@@ -1,7 +1,7 @@
 import { createRawSnippet } from "svelte";
 import { expect } from "@open-wc/testing";
 import { render, screen } from "@testing-library/svelte";
-import { IconAlert } from "@stackoverflow/stacks-icons/icons";
+import { IconAlert } from "@stackoverflow/stacks-icons-legacy/icons";
 
 import Badge from "./Badge.svelte";
 

--- a/packages/stacks-svelte/src/components/Button/Button.stories.svelte
+++ b/packages/stacks-svelte/src/components/Button/Button.stories.svelte
@@ -3,7 +3,7 @@
     import Button from "./Button.svelte";
     import type { Brand, Size, Variant, Weight } from "./Button.svelte";
     import Icon from "../Icon/Icon.svelte";
-    import { IconTrash } from "@stackoverflow/stacks-icons/icons";
+    import { IconTrash } from "@stackoverflow/stacks-icons-legacy/icons";
 
     const ButtonBrands: Brand[] = ["", "facebook", "github", "google"];
     const ButtonSizes: Size[] = ["", "xs", "sm", "md"];

--- a/packages/stacks-svelte/src/components/Icon/Icon.stories.svelte
+++ b/packages/stacks-svelte/src/components/Icon/Icon.stories.svelte
@@ -20,12 +20,12 @@
     });
 </script>
 
-<Story name="Base" args={{ src: Icons.IconAnswer }} />
-<Story name="Title" args={{ src: Icons.IconAnswer, title: "Hello" }} />
-<Story name="Native" args={{ src: Icons.IconAnswer, native: true }} />
+<Story name="Base" args={{ src: Icons.IconServiceCCPA }} />
+<Story name="Title" args={{ src: Icons.IconServiceCCPA, title: "CCPA" }} />
+<Story name="Native" args={{ src: Icons.IconServiceCCPA, native: true }} />
 <Story
     name="Styles"
-    args={{ src: Icons.IconAnswer, class: "fc-theme-secondary-400" }}
+    args={{ src: Icons.IconServiceCCPA, class: "fc-theme-secondary-400" }}
 />
 
 <Story name="Showcase" asChild>

--- a/packages/stacks-svelte/src/components/Icon/Icon.stories.svelte
+++ b/packages/stacks-svelte/src/components/Icon/Icon.stories.svelte
@@ -20,12 +20,12 @@
     });
 </script>
 
-<Story name="Base" args={{ src: Icons.IconWave }} />
-<Story name="Title" args={{ src: Icons.IconWave, title: "Hello" }} />
-<Story name="Native" args={{ src: Icons.IconWave, native: true }} />
+<Story name="Base" args={{ src: Icons.IconAnswer }} />
+<Story name="Title" args={{ src: Icons.IconAnswer, title: "Hello" }} />
+<Story name="Native" args={{ src: Icons.IconAnswer, native: true }} />
 <Story
     name="Styles"
-    args={{ src: Icons.IconWave, class: "fc-theme-secondary-400" }}
+    args={{ src: Icons.IconAnswer, class: "fc-theme-secondary-400" }}
 />
 
 <Story name="Showcase" asChild>

--- a/packages/stacks-svelte/src/components/Modal/Modal.svelte
+++ b/packages/stacks-svelte/src/components/Modal/Modal.svelte
@@ -4,7 +4,7 @@
 
 <script lang="ts">
     import type { Snippet } from "svelte";
-    import { IconClear } from "@stackoverflow/stacks-icons/icons";
+    import { IconClear } from "@stackoverflow/stacks-icons-legacy/icons";
 
     import { Button, Icon } from "../../components";
     import { clickOutside, focusTrap } from "../../actions";

--- a/packages/stacks-svelte/src/components/Notice/Notice.stories.svelte
+++ b/packages/stacks-svelte/src/components/Notice/Notice.stories.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-    import { IconAlert } from "@stackoverflow/stacks-icons/icons";
+    import { IconAlert } from "@stackoverflow/stacks-icons-legacy/icons";
 
     import Notice, { type Variant } from "./Notice.svelte";
     import { defineMeta } from "@storybook/addon-svelte-csf";

--- a/packages/stacks-svelte/src/components/Notice/Notice.test.ts
+++ b/packages/stacks-svelte/src/components/Notice/Notice.test.ts
@@ -1,7 +1,7 @@
 import { createRawSnippet } from "svelte";
 import { expect } from "@open-wc/testing";
 import { render, screen } from "@testing-library/svelte";
-import { IconAlert } from "@stackoverflow/stacks-icons/icons";
+import { IconAlert } from "@stackoverflow/stacks-icons-legacy/icons";
 import { createSvelteComponentsSnippet } from "../../../test-utils";
 import sinon from "sinon";
 import userEvent from "@testing-library/user-event";

--- a/packages/stacks-svelte/src/components/Notice/NoticeAction.svelte
+++ b/packages/stacks-svelte/src/components/Notice/NoticeAction.svelte
@@ -2,7 +2,7 @@
     import type { Snippet } from "svelte";
     import Button from "../Button/Button.svelte";
     import Icon from "../Icon/Icon.svelte";
-    import { IconClear } from "@stackoverflow/stacks-icons/icons";
+    import { IconClear } from "@stackoverflow/stacks-icons-legacy/icons";
     import type { Props as ButtonProps } from "../Button/Button.svelte";
 
     interface Props {

--- a/packages/stacks-svelte/src/components/Popover/Popover.stories.svelte
+++ b/packages/stacks-svelte/src/components/Popover/Popover.stories.svelte
@@ -8,7 +8,7 @@
     import Button from "../Button/Button.svelte";
     import TextInput from "../TextInput/TextInput.svelte";
     import Icon from "../Icon/Icon.svelte";
-    import { IconAccessibility } from "@stackoverflow/stacks-icons/icons";
+    import { IconAccessibility } from "@stackoverflow/stacks-icons-legacy/icons";
 
     const PopoverPlacements: Placement[] = [
         "top",

--- a/packages/stacks-svelte/src/components/Popover/PopoverCloseButton.svelte
+++ b/packages/stacks-svelte/src/components/Popover/PopoverCloseButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import Icon from "../Icon/Icon.svelte";
-    import { IconClear } from "@stackoverflow/stacks-icons/icons";
+    import { IconClear } from "@stackoverflow/stacks-icons-legacy/icons";
     import { usePopoverContext } from "./Popover.svelte";
 
     interface Props {

--- a/packages/stacks-svelte/src/components/PostSummary/PostSummary.svelte
+++ b/packages/stacks-svelte/src/components/PostSummary/PostSummary.svelte
@@ -39,7 +39,7 @@
         IconCheckmarkSm,
         IconEllipsisVertical,
         IconShield,
-    } from "@stackoverflow/stacks-icons/icons";
+    } from "@stackoverflow/stacks-icons-legacy/icons";
 
     /**
      * The URL to navigate to when the post title is clicked

--- a/packages/stacks-svelte/src/components/PostSummary/PostSummaryAnswer.svelte
+++ b/packages/stacks-svelte/src/components/PostSummary/PostSummaryAnswer.svelte
@@ -5,7 +5,7 @@
 
 <script lang="ts">
     import PostSummaryStatsItem from "./PostSummaryStatsItem.svelte";
-    import { IconCheckmarkSm } from "@stackoverflow/stacks-icons/icons";
+    import { IconCheckmarkSm } from "@stackoverflow/stacks-icons-legacy/icons";
     import Badge from "../Badge/Badge.svelte";
     import Link from "../Link/Link.svelte";
     import UserCard from "../UserCard/UserCard.svelte";

--- a/packages/stacks-svelte/src/components/PostSummary/PostSummaryContentType.svelte
+++ b/packages/stacks-svelte/src/components/PostSummary/PostSummaryContentType.svelte
@@ -2,7 +2,7 @@
     import type { ContentTypeName } from "./PostSummary.svelte";
     import Icon from "../Icon/Icon.svelte";
     import Link from "../Link/Link.svelte";
-    import { IconDocumentAlt } from "@stackoverflow/stacks-icons/icons";
+    import { IconDocumentAlt } from "@stackoverflow/stacks-icons-legacy/icons";
 
     /**
      * The type of content to indicate

--- a/packages/stacks-svelte/src/components/PostSummary/PostSummaryStateBadge.svelte
+++ b/packages/stacks-svelte/src/components/PostSummary/PostSummaryStateBadge.svelte
@@ -9,7 +9,7 @@
         IconPencilSm,
         IconTackSm,
         IconTrashSm,
-    } from "@stackoverflow/stacks-icons/icons";
+    } from "@stackoverflow/stacks-icons-legacy/icons";
 
     type BadgeState = Exclude<State, undefined>;
 

--- a/packages/stacks-svelte/src/components/Select/Select.svelte
+++ b/packages/stacks-svelte/src/components/Select/Select.svelte
@@ -28,7 +28,7 @@
         IconAlert,
         IconAlertCircle,
         IconCheckmark,
-    } from "@stackoverflow/stacks-icons/icons";
+    } from "@stackoverflow/stacks-icons-legacy/icons";
     import { setContext } from "svelte";
     import type { Snippet } from "svelte";
     import type { HTMLSelectAttributes } from "svelte/elements";

--- a/packages/stacks-svelte/src/components/Tag/Tag.stories.svelte
+++ b/packages/stacks-svelte/src/components/Tag/Tag.stories.svelte
@@ -3,7 +3,10 @@
     import { createRawSnippet, type Snippet } from "svelte";
     import Tag, { type Size, type Variant } from "./Tag.svelte";
     import Icon from "../Icon/Icon.svelte";
-    import { IconMicrosoft, IconWave } from "@stackoverflow/stacks-icons/icons";
+    import {
+        IconMicrosoft,
+        IconWave,
+    } from "@stackoverflow/stacks-icons-legacy/icons";
 
     const TagSizes: Size[] = ["", "xs", "sm", "md", "lg"];
     const TagVariants: Variant[] = ["", "moderator", "required"];

--- a/packages/stacks-svelte/src/components/Tag/Tag.svelte
+++ b/packages/stacks-svelte/src/components/Tag/Tag.svelte
@@ -6,7 +6,7 @@
 <script lang="ts">
     import type { Snippet } from "svelte";
     import Icon from "../Icon/Icon.svelte";
-    import { IconClearSm } from "@stackoverflow/stacks-icons/icons";
+    import { IconClearSm } from "@stackoverflow/stacks-icons-legacy/icons";
     import type {
         HTMLAnchorAttributes,
         HTMLButtonAttributes,

--- a/packages/stacks-svelte/src/components/TextInput/TextInput.svelte
+++ b/packages/stacks-svelte/src/components/TextInput/TextInput.svelte
@@ -27,7 +27,7 @@
         IconCheckmark,
         IconCreditCard,
         IconSearch,
-    } from "@stackoverflow/stacks-icons/icons";
+    } from "@stackoverflow/stacks-icons-legacy/icons";
 
     /**
      * `id` attribute of the text input

--- a/packages/stacks-svelte/src/components/Toast/Toast.stories.svelte
+++ b/packages/stacks-svelte/src/components/Toast/Toast.stories.svelte
@@ -1,5 +1,8 @@
 <script lang="ts" module>
-    import { IconWave, IconAlert } from "@stackoverflow/stacks-icons/icons";
+    import {
+        IconWave,
+        IconAlert,
+    } from "@stackoverflow/stacks-icons-legacy/icons";
 
     import Toaster, { showToast, hideToast } from "./Toast.svelte";
     import { defineMeta } from "@storybook/addon-svelte-csf";

--- a/packages/stacks-svelte/src/components/Toast/Toast.test.ts
+++ b/packages/stacks-svelte/src/components/Toast/Toast.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@open-wc/testing";
 import { render, screen, waitFor } from "@testing-library/svelte";
-import { IconAlert } from "@stackoverflow/stacks-icons/icons";
+import { IconAlert } from "@stackoverflow/stacks-icons-legacy/icons";
 import userEvent from "@testing-library/user-event";
 import sinon from "sinon";
 import { createRawSnippet, mount, unmount } from "svelte";

--- a/packages/stacks-svelte/src/components/UserCard/UserCard.stories.svelte
+++ b/packages/stacks-svelte/src/components/UserCard/UserCard.stories.svelte
@@ -4,7 +4,7 @@
     import Tag from "../Tag/Tag.svelte";
     import UserCard, { type Size } from "./UserCard.svelte";
     import Icon from "../Icon/Icon.svelte";
-    import { IconStarVerifiedSm } from "@stackoverflow/stacks-icons/icons";
+    import { IconStarVerifiedSm } from "@stackoverflow/stacks-icons-legacy/icons";
 
     const createSnippet = (markup = "") =>
         createRawSnippet(() => ({

--- a/packages/stacks-svelte/src/components/UserCard/UserCard.svelte
+++ b/packages/stacks-svelte/src/components/UserCard/UserCard.svelte
@@ -7,7 +7,7 @@
     import type { Snippet } from "svelte";
     import Avatar, { type Size as AvatarSize } from "../Avatar/Avatar.svelte";
     import Icon from "../Icon/Icon.svelte";
-    import { IconPerson } from "@stackoverflow/stacks-icons/icons";
+    import { IconPerson } from "@stackoverflow/stacks-icons-legacy/icons";
 
     interface Props {
         /**

--- a/packages/stacks-svelte/src/stacks-icons-legacy.d.ts
+++ b/packages/stacks-svelte/src/stacks-icons-legacy.d.ts
@@ -1,0 +1,20 @@
+/**
+ * TODO: Remove this file once @stackoverflow/stacks-icons-legacy is no longer needed.
+ *
+ * This file provides TypeScript module declarations for the legacy icons package,
+ * which is an npm alias to @stackoverflow/stacks-icons@^6.6.1 in package.json.
+ * The alias is needed because some icons (like IconClear) don't exist in v7.0.0-beta.1.
+ *
+ * Once all components are migrated to use icons that exist in v7+, we can:
+ * 1. Remove the @stackoverflow/stacks-icons-legacy alias from package.json
+ * 2. Delete this file
+ * 3. Update all imports to use @stackoverflow/stacks-icons directly
+ */
+
+declare module "@stackoverflow/stacks-icons-legacy/icons" {
+    export * from "@stackoverflow/stacks-icons/icons";
+}
+
+declare module "@stackoverflow/stacks-icons-legacy/spots" {
+    export * from "@stackoverflow/stacks-icons/spots";
+}

--- a/packages/stacks-svelte/vite.config.ts
+++ b/packages/stacks-svelte/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
             "@testing-library/svelte",
             "@testing-library/user-event",
             "@stackoverflow/stacks-icons/icons",
+            "@stackoverflow/stacks-icons-legacy/icons",
         ],
     },
     resolve: {


### PR DESCRIPTION
[SPARK-101](https://stackoverflow.atlassian.net/browse/SPARK-101)

This PR integrates the [new beta stacks icons](https://beta.icons.stackoverflow.design/) (and spots) in the monorepo. 

Since we cannot simply remove the old v6 icons the changes create an alias for that package (`@stackoverflow/stacks-icons-legacy`). The main reason this PR is touching many files is because the docs and the stacks svelte components still utilize the old icons for now. 

We will gradually migrate to the new icons as we work on components and updating the stacks docs. 
Ultimately the goal would be to remove every reference of the legacy icon package and uninstall it. 

The only places where we can see the new icons are the following as of now:
- [Stacks Docs Icons Page](https://deploy-preview-2025--stacks.netlify.app/product/foundation/icons/)
- [Stacks Docs Spot Illustration Page](https://deploy-preview-2025--stacks.netlify.app/product/foundation/spots/) (This is marked explicitly as a WIP since we have only 1 Spot)
- [Storybook Stacks Svelte Icon Documentation](https://deploy-preview-2025--stacks-svelte.netlify.app/?path=/docs/components-icon--docs)  