### PR TITLE
chore(popover): replace close icon

### DIFF
--- a/.changeset/silly-spiders-swim.md
+++ b/.changeset/silly-spiders-swim.md
@@ -1,0 +1,6 @@
+---
+"@stackoverflow/stacks": patch
+"@stackoverflow/stacks-svelte": patch
+---
+
+Change popover close icon to Cross

--- a/packages/stacks-classic/lib/components/popover/popover.less
+++ b/packages/stacks-classic/lib/components/popover/popover.less
@@ -31,7 +31,7 @@
         float: right; // Use floats for title wrapping
         top: calc(var(--su8) * -1); // Compensate for s-popover's padding
         right: calc(var(--su8) * -1); // Compensate for s-popover's padding
-        padding: var(--su8) !important;
+        padding: var(--su6) !important;
     }
 
     & &--content {

--- a/packages/stacks-docs/product/components/popovers.html
+++ b/packages/stacks-docs/product/components/popovers.html
@@ -283,7 +283,7 @@ tags: components
     <div id="popover-example" class="s-popover is-visible" role="menu">
         <button class="s-popover--close s-btn s-btn__muted" aria-label="Close"
             data-action="s-popover#toggle">
-            @Svg.ClearSm
+            @Svg.Cross16
         </button>
         <div class="s-popover--content">
             …
@@ -293,7 +293,7 @@ tags: components
 {% endhighlight %}
         <div class="stacks-preview--example bg-black-100">
             <div class="s-popover ps-relative is-visible">
-                <button class="s-popover--close s-btn s-btn__muted" aria-label="Close">{% icon "ClearSm" %}</button>
+                <button class="s-popover--close s-btn s-btn__muted" aria-label="Close">{% icon "Cross16" %}</button>
                 <div class="s-popover--content">
                     <p class="mb0">Dismissible persistent popover presented with a close button</p>
                 </div>

--- a/packages/stacks-docs/product/components/popovers.html
+++ b/packages/stacks-docs/product/components/popovers.html
@@ -283,7 +283,7 @@ tags: components
     <div id="popover-example" class="s-popover is-visible" role="menu">
         <button class="s-popover--close s-btn s-btn__muted" aria-label="Close"
             data-action="s-popover#toggle">
-            @Svg.Cross16
+            @Svg.Cross
         </button>
         <div class="s-popover--content">
             …
@@ -293,7 +293,7 @@ tags: components
 {% endhighlight %}
         <div class="stacks-preview--example bg-black-100">
             <div class="s-popover ps-relative is-visible">
-                <button class="s-popover--close s-btn s-btn__muted" aria-label="Close">{% icon "Cross16" %}</button>
+                <button class="s-popover--close s-btn s-btn__muted" aria-label="Close">{% icon "Cross" %}</button>
                 <div class="s-popover--content">
                     <p class="mb0">Dismissible persistent popover presented with a close button</p>
                 </div>

--- a/packages/stacks-svelte/src/components/Popover/PopoverCloseButton.svelte
+++ b/packages/stacks-svelte/src/components/Popover/PopoverCloseButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import Icon from "../Icon/Icon.svelte";
-    import { IconClear } from "@stackoverflow/stacks-icons-legacy/icons";
+    import { IconCross16 } from "@stackoverflow/stacks-icons/icons";
     import { usePopoverContext } from "./Popover.svelte";
 
     interface Props {
@@ -34,5 +34,5 @@
     type="button"
     onclick={handleClick}
 >
-    <Icon src={IconClear} />
+    <Icon src={IconCross16} />
 </button>

--- a/packages/stacks-svelte/src/components/Popover/PopoverCloseButton.svelte
+++ b/packages/stacks-svelte/src/components/Popover/PopoverCloseButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import Icon from "../Icon/Icon.svelte";
-    import { IconCross16 } from "@stackoverflow/stacks-icons/icons";
+    import { IconCross } from "@stackoverflow/stacks-icons/icons";
     import { usePopoverContext } from "./Popover.svelte";
 
     interface Props {
@@ -34,5 +34,5 @@
     type="button"
     onclick={handleClick}
 >
-    <Icon src={IconCross16} />
+    <Icon src={IconCross} />
 </button>


### PR DESCRIPTION
[SPARK-106](https://stackoverflow.atlassian.net/browse/SPARK-106)

---

This PR switches the close icon used in Popovers from `ClearSm` to `Cross`. I also adjusted the `.s-popover--close` button padding slightly (`--su8` → `--su6`) to compensate for the slightly larger icon (previous was 18x18, new is 20x20).

### Before

[<img width="378" height="69" alt="Here's an image of the old icon applied in the popover before I changed it. This image links to the song Here I am by Al Green because a) the popover image says here I am but also because b) the song is a banger. Not his best but up there, for sure. Enjoy!" src="https://github.com/user-attachments/assets/3350e79e-f8ee-4635-aefa-14b2b1a93cbe" />](https://www.youtube.com/watch?v=aTpDFXhgGjM&list=RDaTpDFXhgGjM&t=50s)


### After

[<img width="385" height="70" alt="Here's an image of the new icon applied in the popover. Also, you should listen to Al Green. He was killing it in the 1970s. Best soul singer IMO. I'm not big into Greatest Hits compilations, but his is a great one. Otherwise, you can't go wrong with Let's Stay Together or Gets Next to You. I haven't fully watched the linked live performance so YMMV, although it seems solid especially considering he's probably like 60 years old there." src="https://github.com/user-attachments/assets/0a02fdbd-c491-4ff0-a8e8-4646c839caca" />](https://www.youtube.com/watch?v=JOUBNg2lkwo&list=RDJOUBNg2lkwo&t=1835s)
