### PR TITLE
feat(popover): add onoutclick fn prop to svelte component

### DIFF
--- a/.changeset/smooth-colts-make.md
+++ b/.changeset/smooth-colts-make.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks-svelte": patch
+---
+
+Add `onoutclick` to Popover component

--- a/packages/stacks-svelte/src/components/Popover/Popover.svelte
+++ b/packages/stacks-svelte/src/components/Popover/Popover.svelte
@@ -88,6 +88,11 @@
          */
         onclose?: () => void;
         /**
+         * Callback fired when a click occurs outside the popover.
+         * Use this to control what happens on outside clicks (e.g., close the popover in manually controlling visibility).
+         */
+        onoutclick?: () => void;
+        /**
          * Children snippet with visible, open, and close parameters
          */
         children?: Snippet<
@@ -112,6 +117,7 @@
         tooltip = false,
         onopen,
         onclose,
+        onoutclick,
         children,
     }: Props = $props();
 
@@ -181,6 +187,7 @@
             return;
         }
 
+        onoutclick?.();
         close();
     };
 

--- a/packages/stacks-svelte/src/components/Popover/Popover.test.ts
+++ b/packages/stacks-svelte/src/components/Popover/Popover.test.ts
@@ -375,6 +375,28 @@ describe("Popover", () => {
         expect(screen.queryByRole("dialog")).not.to.exist;
     });
 
+    it("should fire onoutclick callback when clicking outside the popover", async () => {
+        const onOutsideClickSpy = sinon.spy();
+
+        render(Popover, {
+            props: {
+                ...defaultProps,
+                autoshow: true,
+                onoutclick: onOutsideClickSpy,
+                children: createSvelteComponentsSnippet([
+                    defaultChildren.reference,
+                    defaultChildren.content,
+                ]),
+            },
+        });
+
+        expect(screen.getByRole("dialog")).to.exist;
+
+        await userEvent.click(document.body);
+        expect(onOutsideClickSpy).to.have.been.calledOnce;
+        expect(screen.queryByRole("dialog")).not.to.exist;
+    });
+
     it("should trap focus within the popover content when the trapFocus prop is set to true", async () => {
         render(Popover, {
             props: {


### PR DESCRIPTION
This PR adds an `onoutclick` prop to the `Popover` component to allow consumers to execute a function on a click outside the popover.

This came up out of a need to both control the popover visibility manually and retain the outside click behavior that hid the popover.
