### PR TITLE
Update TextInput.svelte to not emit a self-closing tag on the `<input>` element

### DIFF
--- a/packages/stacks-svelte/src/components/TextInput/TextInput.svelte
+++ b/packages/stacks-svelte/src/components/TextInput/TextInput.svelte
@@ -222,7 +222,7 @@
                 on:focus
                 on:blur
                 on:paste
-            />
+            >
 
             {#if state}
                 <div class="s-input-icon">


### PR DESCRIPTION
Was running some output from a Svelte component that used `<TextInput/>` through W3C's HTML validator and got this informational message:

<img width="1565" height="174" alt="image" src="https://github.com/user-attachments/assets/ffc46494-27e9-4bea-a920-22687aadd655" />

It links to this guidance:
https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-in-void-element-start-tags-do-not-mark-the-start-tags-as-self-closing

TL;DR: it does nothing so we shouldn't emit it

It doesn't bother me too much personally, but it does check off a validation box 🤷 