### PR TITLE
Input tweaks

### DIFF
--- a/packages/stacks-classic/lib/components/input-icon/input-icon.less
+++ b/packages/stacks-classic/lib/components/input-icon/input-icon.less
@@ -1,6 +1,6 @@
 .s-input-icon {
     --_ii-fc: unset;
-    --_ii-r: 0.7em;
+    --_ii-r: calc((var(--su-static8) + var(--su-static2))); // 10px
 
     // MODIFIERS
     .has-error & {
@@ -32,13 +32,13 @@
         --_ii-r: auto;
 
         color: var(--black-400);
-        left: 0.7em;
+        left:  calc((var(--su-static8) + var(--su-static2))); // 10px
     }
 
     color: var(--_ii-fc);
     right: var(--_ii-r);
 
-    margin-top: calc((var(--su-static8) + var(--su-static1)) * -1); // -9px - Half the icon's height at 18px for centering;
+    margin-top: calc((var(--su-static8) + var(--su-static2)) * -1); // -10px - Half the icon's height at 20px for centering;
     pointer-events: none;
     position: absolute;
     top: 50%;

--- a/packages/stacks-classic/lib/components/input_textarea/input_textarea.less
+++ b/packages/stacks-classic/lib/components/input_textarea/input_textarea.less
@@ -47,12 +47,14 @@
     &&__sm {
         --_in-fs: var(--fs-caption);
         --_in-lh: var(--lh-sm);
+        --_in-px: calc(var(--su12) - var(--su2)); // 10px
         --_in-py: calc(var(--su4) + var(--su1)); // 5px
     }
 
     &&__lg {
         --_in-fs: var(--fs-body3);
         --_in-lh: var(--lh-lg);
+        --_in-px: calc(var(--su12) + var(--su1)); // 13px
     }
     
     // CHILD ELEMENTS

--- a/packages/stacks-classic/lib/components/input_textarea/input_textarea.less
+++ b/packages/stacks-classic/lib/components/input_textarea/input_textarea.less
@@ -1,18 +1,16 @@
 .s-input,
 .s-textarea {
-    --_in-bc: var(--bc-darker);
+    --_in-bc: var(--black-300);
     --_in-bg: var(--white);
     --_in-br: var(--br-md);
     --_in-bw: var(--su-static1);
     --_in-c: unset;
-    --_in-fc: var(--fc-dark);
+    --_in-fc: var(--black-600);
     --_in-fs: var(--fs-body1);
-    --_in-o: unset;
+    --_in-lh: var(--lh-base);
     --_in-px: calc(var(--su12) - var(--su1)); // 11px
-    --_in-py: var(--su4);
+    --_in-py: var(--su8);
     --_in-placeholder-fc: var(--black-300);
-    --_in-default-h: calc(var(--su32) + var(--su4)); // 36px
-    --_in-min-h: var(--_in-default-h);
 
     // CONTEXTUAL STYLES
     .highcontrast-mode({
@@ -24,17 +22,16 @@
     fieldset[disabled] &,
     &[disabled] {
         --_in-c: not-allowed;
-        --_in-o: var(--_o-disabled-static);
     }
 
     &[readonly],
     .is-readonly & {
         .highcontrast-mode({
-            --_in-fc: var(--fc-medium);
+            --_in-fc: var(--black-500);
         });
 
         --_in-bg: var(--black-150);
-        --_in-bc: var(--bc-light);
+        --_in-bc: var(--black-200);
         --_in-c: default;
         --_in-fc: var(--black-400);
     }
@@ -48,15 +45,14 @@
 
     // Sizes
     &&__sm {
-        .size-styles(sm; in; @styles: fs);
-        --_in-min-h: calc(var(--su32) - var(--su4)); // 28px
-        --_in-px: calc(var(--su8) + var(--su2)); // 10px
+        --_in-fs: var(--fs-caption);
+        --_in-lh: var(--lh-sm);
+        --_in-py: calc(var(--su4) + var(--su1)); // 5px
     }
 
     &&__lg {
-        .size-styles(md; in; @styles: br, fs);
-        --_in-min-h: calc(var(--su48) - var(--su4)); // 44px
-        --_in-px: calc(var(--su12) + var(--su2)); // 14px
+        --_in-fs: var(--fs-body3);
+        --_in-lh: var(--lh-lg);
     }
     
     // CHILD ELEMENTS
@@ -67,7 +63,7 @@
 
     &&__creditcard,
     &&__search {
-        --_in-pl: var(--su-static32);
+        --_in-pl: calc(var(--su-static32) + var(--su-static4)); // 36px
     }
 
     // INTERACTION
@@ -80,17 +76,19 @@
     @scrollbar-styles();
     background-color: var(--_in-bg);
     border: var(--_in-bw) solid var(--_in-bc);
-    border-radius: var(--_in-br);
     color: var(--_in-fc);
     cursor: var(--_in-c);
     font-size: var(--_in-fs);
-    opacity: var(--_in-o);
+    line-height: var(--_in-lh);
     padding: var(--_in-py) var(--_in-px) var(--_in-py) var(--_in-pl, var(--_in-px));
-    line-height: var(--lh-md);
+
+    align-items: center;
+    border-radius: var(--br-md);
+    display: flex;
+    flex: 1 1 0;
     font-family: inherit;
     margin: 0; // A guard against Core's default margins
     width: 100%;
-    min-height: var(--_in-min-h);
 }
 
 .s-input {
@@ -100,11 +98,19 @@
 
     // Nested Inputs
     & & {
-        //Subtract borders from min-height so it fits correctly
-        --_in-min-h: calc(var(--_in-default-h) - var(--_in-bw) * 2);
+        --_in-bg: transparent;
+        --_in-bw: 0;
+        --_in-px: 0;
+
+        box-shadow: none;
+        margin: calc(var(--_in-py) * -1) 0;
     }
+
     &:has(&) {
-        --_in-py: 0;
+        --_in-px: var(--_in-py);
+
+        flex-wrap: wrap;
+        gap: var(--su8);
     }
 }
 

--- a/packages/stacks-docs/product/components/inputs.html
+++ b/packages/stacks-docs/product/components/inputs.html
@@ -206,6 +206,7 @@ tags: components
                     <label class="flex--item s-label" for="example-warning">Username</label>
                     <div class="d-flex ps-relative">
                         <input class="s-input" id="example-warning" type="text" value="AA" aria-describedby="example-warning-desc" />
+                        <!-- TODO SHINE change to updated 20px Alert icon -->
                         {% icon "Alert", "s-input-icon" %}
                     </div>
                     <p id="example-warning-desc" class="flex--item s-input-message mb0">Caps lock is on! <a href="#">Having trouble entering your username?</a></p>
@@ -236,6 +237,7 @@ tags: components
                     <label class="flex--item s-label" for="example-error">Username</label>
                     <div class="d-flex ps-relative">
                         <input class="s-input" id="example-error" type="text" aria-describedby="example-error-desc" />
+                        <!-- TODO SHINE change to updated 20px AlertCircle icon -->
                         {% icon "AlertCircle", "s-input-icon" %}
                     </div>
                     <p id="example-error-desc" class="flex--item s-input-message mb0">You must provide a username. <a href="#">Forgot your username?</a></p>
@@ -262,7 +264,7 @@ tags: components
                     <label class="flex--item s-label" for="example-success">Username</label>
                     <div class="d-flex ps-relative">
                         <input class="s-input" id="example-success" type="text" value="aaronshekey" aria-describedby="example-success-desc" />
-                        {% icon "Checkmark", "s-input-icon" %}
+                        {% icon "Check", "s-input-icon" %}
                     </div>
                     <p id="example-success-desc" class="flex--item s-input-message mb0">That name is available! <a href="#">Why do we require a username?</a></p>
                 </div>
@@ -417,8 +419,8 @@ tags: components
 {% highlight html %}
 <div class="d-flex fd-column g4">
     <label class="s-label" for="tag-selector">Tags</label>
-    <div class="s-input d-flex fw-wrap gx8 ai-center">
-        <span>
+    <div class="s-input">
+        <div class="d-flex fw-wrap gx8 myn4">
             <span class="s-tag">
                 svelte
                 <button class="s-tag--dismiss" type="button" title="Remove tag">
@@ -426,19 +428,15 @@ tags: components
                     @Svg.ClearSm
                 </button>
             </span>
-        </span>
-        <input
-            id="tag-selector"
-            class="s-input bs-none fl-grow1 p0 w-auto baw0"
-            type="text"
-            …>
+        </div>
+        <input id="tag-selector" class="s-input" type="text" role="presentation" placeholder="enter up to 5 tags">
     </div>
 </div>
 {% endhighlight %}
         <div class="stacks-preview--example d-flex fd-column g4">
             <label class="s-label" for="tag-selector">Tags</label>
-            <div class="s-input d-flex fw-wrap gx8 ai-center">
-                <span>
+            <div class="s-input">
+                <div class="d-flex fw-wrap gx8 myn4">
                     <span class="s-tag">
                         svelte
                         <button class="s-tag--dismiss" type="button">
@@ -446,8 +444,8 @@ tags: components
                             {% icon "ClearSm" %}
                         </button>
                     </span>
-                </span>
-                <input id="tag-selector" class="s-input bs-none fl-grow1 p0 w-auto baw0" type="text" role="presentation" placeholder="enter up to 5 tags">
+                </div>
+                <input id="tag-selector" class="s-input" type="text" role="presentation" placeholder="enter up to 5 tags">
             </div>
         </div>
     </div>


### PR DESCRIPTION
This PR contains minor tweaks to the input component that I think gets reasonably close to our desired input sizes/layouts while keeping them pretty maintainable and flexible.

## Changes

### Sizing

This PR modifies the line-height and padding properties to achieve our desired input heights for each size within .5px of the mocks. Here's a table showing the difference in heights between the Figma mocks and the input sizes in this PR:

| Size | Figma | This PR | Diff | 
|-|-|-|-|
| `sm` | 28px | 27.7px | -0.3px |
| default | 36px | 35.9px | -0.1px |
| `lg` | 46px | 46.2px | +0.2px |

We should be able to apply the same sizing to other similar element to achieve the same heights

<details>
<summary>Screenshots</summary>

<img width="909" height="94" alt="image" src="https://github.com/user-attachments/assets/b2f4dac8-c926-4e4a-8c40-3e06a23209c3" />
<img width="903" height="87" alt="image" src="https://github.com/user-attachments/assets/d22789ea-e223-4dcf-a50a-69a104d89c62" />
<img width="914" height="95" alt="image" src="https://github.com/user-attachments/assets/30db29b9-e8be-4988-b976-a0f031a4c972" />

</details>

### Nested input

I tried to keep the extra CSS to support this as minimal as possible while providing sensible defaults that account for the different likely states of this configuration. Below, you can see a tag input with in various states (one tag, no tags, many tags):

<img width="991" height="261" alt="image" src="https://github.com/user-attachments/assets/3de32983-ce9d-43fc-9776-6a817bcb40ae" />

This would still require some atomic classes on the element containing the tags, which I feel is a reasonable compromise.

### Icons within/over inputs

Since we're switching to 20px² icons, I've updated some sizing/positioning to support this change and I've added TODOs to the docs to update examples to the appropriate icons once they're available.

### Alias colors

We have various aliased colors for different properties in the form of custom properties. They look like `--bc-darker`, `fc-light`, etc. I'd like the library to move away from using these aliased properties as I think they are a bit intuitive and used inconsistently. For these reasons, I've replaced them with the actual color variable they reference (e.g. `--bc-darker` becomes `--black-300`).