### PR TITLE
Checkbox, radio refactor

### DIFF
--- a/packages/stacks-classic/lib/components/check-control/check-control.less
+++ b/packages/stacks-classic/lib/components/check-control/check-control.less
@@ -1,14 +1,105 @@
-.s-check-control { // TODO would _love_ to use .s-check instead, with no class on the input itself
+.s-check-control {
     --_cc-ai: center;
+    --_cc-fc: unset;
+    --_cc-after-fc: unset;
+    --_cc-cursor: pointer;
+    --_cc-label-fc: var(--_cc-fc);
 
     // CONTEXTUAL STYLES
-    .s-check-group & {
-        --_cc-ai: flex-start; // manually align the checkboxes and radios to the top of the group
+    fieldset[disabled] & {
+        --_cc-fc: var(--black-300);
+    }
+
+    // MODIFIERS
+    &&__checkmark {
+        --_cc-fc: var(--theme-secondary);
+        --_cc-after-fc: unset;      
+
+        // CONTEXTUAL STYLES
+        &:has(> input:focus-visible) {
+            .focus-styles(true, false);
+        }
+
+        &:has(> input:checked) {
+            --_cc-after-fc: var(--_cc-fc);
+        }
+
+        &:has(> input[disabled]) {
+            --_cc-cursor: not-allowed;
+        }
+
+        &:has(> input:checked[disabled]) {
+            --_cc-fc: var(--theme-secondary-300);
+        }
+
+        // CHILD ELEMENTS
+        input,
+        &:after {
+            height: var(--su16);
+            margin-left: 100%;
+            // pointer-events: none;
+            width: var(--su16);
+        }
+
+        &:after {
+            background-color: var(--_cc-after-fc);
+            content: "";
+            flex-shrink: 0;
+            margin-left: auto;
+            mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='m14 3.88-.44.44-7.34 7.35-.44.44-.44-.44-2.9-2.9L2 8.34l.89-.88.44.44 2.45 2.45 6.9-6.9.44-.44z'/%3E%3C/svg%3E"); // check16
+            mask-size: contain;
+            mask-repeat: no-repeat;
+        }
+
+        input {
+            appearance: none;
+            opacity: 0;
+            position: absolute;
+            right: 0;
+            z-index: -1;
+        }
+
+        .s-label {
+            flex-grow: 1;
+        }
+
+        border-radius: var(--br-md);
+        color: var(--_cc-fc);
+        cursor: var(--_cc-cursor);
+
+        width: 100%;
     }
 
     // CHILD ELEMENTS
     .s-label {
+        color: var(--_cc-label-fc);
+        font-size: var(--fs-body1);
         font-weight: normal;
+    }
+
+    &:has(> input[disabled]) {
+        .s-label {
+            --_cc-label-fc: var(--black-300);
+        }
+    }
+
+    &:not(> input[disabled]) {
+        &:has(input:checked),
+        &:has(input:indeterminate) {
+            .s-label {
+                --_cc-label-fc: var(--black-600);
+            }
+        }
+    }
+
+    &:has(> .s-label .s-description),
+    &:has(> .s-label .s-input-message) {
+        --_cc-ai: flex-start;
+
+        .s-checkbox,
+        .s-radio {
+            margin-top: var(--su2);
+        }
     }
 
     align-items: var(--_cc-ai);

--- a/packages/stacks-classic/lib/components/check-control/check-control.less
+++ b/packages/stacks-classic/lib/components/check-control/check-control.less
@@ -4,6 +4,7 @@
     --_cc-after-fc: unset;
     --_cc-cursor: pointer;
     --_cc-label-fc: var(--_cc-fc);
+    --_cc-gap: var(--su8);
 
     // CONTEXTUAL STYLES
     fieldset[disabled] & {
@@ -13,6 +14,7 @@
     // MODIFIERS
     &&__checkmark {
         --_cc-fc: var(--theme-secondary);
+        --_cc-gap: var(--su4);
         --_cc-after-fc: unset;      
 
         // CONTEXTUAL STYLES
@@ -37,7 +39,6 @@
         &:after {
             height: var(--su16);
             margin-left: 100%;
-            // pointer-events: none;
             width: var(--su16);
         }
 
@@ -104,5 +105,5 @@
 
     align-items: var(--_cc-ai);
     display: flex;
-    gap: var(--su8);
+    gap: var(--_cc-gap);
 }

--- a/packages/stacks-classic/lib/components/checkbox_radio/checkbox_radio.less
+++ b/packages/stacks-classic/lib/components/checkbox_radio/checkbox_radio.less
@@ -1,65 +1,43 @@
-.s-checkbox,
 .s-radio,
-.s-checkmark {
-    --_ch-bg-image: unset;
-
-    // CONTEXTUAL STYLES
-    fieldset[disabled] &,
-    &[disabled] {
-        cursor: not-allowed;
-    }
-
-    .s-check-group & {
-        margin-top: calc(var(--su2) + var(--su1)); // 3px
-    }
-
-    input& {
-        flex-shrink: 0;
-    }
-
-    appearance: none;
-    cursor: pointer;
-    font-size: inherit;
-    height: 1em;
-    margin: 0; // A guard against Core's default margins
-    outline: 0;
-    vertical-align: middle;
-    width: 1em;
-}
-
-.s-checkbox,
-.s-radio {
+.s-checkbox {
     --_ch-baw: var(--su-static1);
     --_ch-bc: var(--black-350);
     --_ch-bg: var(--white);
+    --_ch-bg-image: unset;
+    --_ch-cursor: pointer;
+    --_ch-h: calc(var(--su-static12) + var(--su-static2)); // 14px
 
     // CONTEXTUAL STYLES
     fieldset[disabled] &,
     &[disabled] {
-        --_ch-bc: var(--theme-secondary-300);
-    }
+        --_ch-bc: var(--black-300);
+        --_ch-cursor: not-allowed;
 
-    .s-check-control & {
-        &[disabled] + .s-label {
-            color: var(--theme-secondary-300);
-        }
-        &:checked + .s-label,
-        &:indeterminate + .s-label {
-            color: var(--black-600);
-        }
-        &[disabled]:checked + .s-label,
-        &[disabled]:indeterminate + .s-label {
-            color: var(--theme-secondary-300);
+        &:checked {
+            --_ch-bc: var(--theme-secondary-300);
         }
     }
 
-    // INTERACTION
-    &:focus {
+    &:focus-visible {
         .focus-styles();
     }
 
+    &:not(:checked) {
+        .validation-states(ch);
+    }
+
+    appearance: none;
     background-color: var(--_ch-bg);
     border: var(--_ch-baw) solid var(--_ch-bc);
+    cursor: var(--_ch-cursor);
+    height: var(--_ch-h);
+    
+    aspect-ratio: 1 / 1;
+    flex-shrink: 0;
+    font-size: inherit;
+    margin: 0; // A guard against Core's default margins
+    outline: 0;
+    vertical-align: middle;
 }
 
 .s-checkbox {
@@ -79,14 +57,7 @@
         }
     });
 
-    .highcontrast-dark-mode({
-        &:checked, &:indeterminate {
-            --_ch-bc: var(--black) !important;
-            --_ch-bg: var(--black);
-        }
-    });
-
-    @media (forced-colors: active) {
+    @media (forced-colors: active) { // This is for Windows High Contrast Mode
         &:checked,
         &:indeterminate {
             --_ch-bg: ButtonText !important;
@@ -95,7 +66,7 @@
 
     // STATES
     &:checked, &:indeterminate {
-        --_ch-bc: var(--theme-secondary) !important;
+        --_ch-bc: var(--theme-secondary);
         --_ch-bg: var(--theme-secondary);
     }
 
@@ -125,180 +96,12 @@
 }
 
 .s-radio {
-
-    // CONTEXTUAL STYLES
-    .highcontrast-dark-mode({
-        &:checked {
-            --_ch-bc: var(--black);
-            outline: var(--su-static1) solid var(--black);
-        }
-    });
-
     // STATES
     &:checked {
-        --_ch-baw: 0.30769231em;
+        --_ch-baw: calc(var(--_ch-h) / 3); // 14px / 3 = ~4.67px
         --_ch-bc: var(--theme-secondary);
         --_ch-bg: var(--white);
     }
 
-    // Disabled state overrides checked state
-    fieldset[disabled] &,
-    &[disabled] {
-        &:checked {
-            --_ch-bc: var(--theme-secondary-300);
-        }
-    }
-
     border-radius: var(--br-circle);
-}
-
-.s-checkmark {
-    // Less variables for check icon fill color
-    @ch-icon-fill: .set-black()[600];
-    @ch-icon-fill-dark: .set-black-dark()[400];
-    @ch-icon-fill-disabled: .set-black()[300];
-    @ch-icon-fill-disabled-dark: .set-black-dark()[300];
-    @ch-icon-fill-esc: escape("@{ch-icon-fill}"); // color escaped for URL usage
-    @ch-icon-fill-dark-esc: escape("@{ch-icon-fill-dark}"); // color escaped for URL usage
-    @ch-icon-fill-disabled-esc: escape("@{ch-icon-fill-disabled}"); // color escaped for URL usage
-    @ch-icon-fill-disabled-dark-esc: escape("@{ch-icon-fill-disabled-dark}"); // color escaped for URL usage
-
-    // Base styles
-    --_ch-baw: 0;
-    --_ch-bc: transparent;
-    --_ch-bg: transparent;
-
-    // CONTEXTUAL STYLES
-    .s-check-control & {
-        &[disabled] {
-            ~ .s-label {
-                color: var(--theme-secondary-300) !important;
-            }
-        }
-        &:checked {
-            ~ .s-label {
-                color: var(--black-600) !important;
-            }
-        }
-        &[disabled]:checked {
-            ~ .s-label {
-                color: var(--theme-secondary-300) !important;
-            }
-        }
-    }
-    
-    // Handle label that comes before input using :has() on parent
-    .s-check-control:has(&:checked) .s-label {
-        color: var(--black-600) !important;
-    }
-    
-    .s-check-control:has(&[disabled]) .s-label {
-        color: var(--theme-secondary-300) !important;
-    }
-    
-    .s-check-control:has(&[disabled]:checked) .s-label {
-        color: var(--theme-secondary-300) !important;
-    }
-
-    // No focus style
-    &:focus {
-        outline: 0;
-        box-shadow: none;
-    }
-
-    // Remove all button-like styling
-    background-color: transparent;
-    border: 0;
-
-    // CONTEXTUAL STYLES
-    .dark-mode({
-        &:checked {
-            --_ch-bg-image: url("data:image/svg+xml;,%3Csvg width='16' height='16' viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M18.1567 5.00146L17.6265 5.53174L7.54639 15.6128L7.01611 16.1431L1.98584 11.1128L3.04639 10.0522L7.01514 14.021L16.5659 4.47119L17.0962 3.94092L18.1567 5.00146Z' fill='@{ch-icon-fill-dark-esc}'/%3E%3C/svg%3E");
-        }
-        fieldset[disabled] &,
-        &[disabled] {
-            &:checked {
-                --_ch-bg-image: url("data:image/svg+xml;,%3Csvg width='16' height='16' viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M18.1567 5.00146L17.6265 5.53174L7.54639 15.6128L7.01611 16.1431L1.98584 11.1128L3.04639 10.0522L7.01514 14.021L16.5659 4.47119L17.0962 3.94092L18.1567 5.00146Z' fill='@{ch-icon-fill-disabled-dark-esc}'/%3E%3C/svg%3E");
-            }
-        }
-    });
-
-    // STATES
-    &:checked {
-        --_ch-bg-image: url("data:image/svg+xml;,%3Csvg width='16' height='16' viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M18.1567 5.00146L17.6265 5.53174L7.54639 15.6128L7.01611 16.1431L1.98584 11.1128L3.04639 10.0522L7.01514 14.021L16.5659 4.47119L17.0962 3.94092L18.1567 5.00146Z' fill='@{ch-icon-fill-esc}'/%3E%3C/svg%3E");
-    }
-
-    // Disabled state overrides checked state
-    fieldset[disabled] &,
-    &[disabled] {
-        &:checked {
-            --_ch-bg-image: url("data:image/svg+xml;,%3Csvg width='16' height='16' viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M18.1567 5.00146L17.6265 5.53174L7.54639 15.6128L7.01611 16.1431L1.98584 11.1128L3.04639 10.0522L7.01514 14.021L16.5659 4.47119L17.0962 3.94092L18.1567 5.00146Z' fill='@{ch-icon-fill-disabled-esc}'/%3E%3C/svg%3E");
-        }
-    }
-
-    background-image: var(--_ch-bg-image);
-    background-position: center center;
-    background-repeat: no-repeat;
-    background-size: contain;
-}
-
-.s-checkbox,
-.s-radio:not(:checked) {
-    .validation-states(ch);
-}
-
-.s-check-control { // TODO would _love_ to use .s-check instead, with no class on the input itself
-    --_cc-ai: center;
-
-    // CONTEXTUAL STYLES
-    .s-check-group & {
-        --_cc-ai: flex-start; // manually align the checkboxes and radios to the top of the group
-    }
-
-    // CHILD ELEMENTS
-    .s-label {
-        color: var(--black-500);
-        font-size: var(--fs-body1);
-        font-weight: normal;
-    }
-
-
-    &&__checkmark {
-        --_cc-ai: center; // Override to center align for checkmark
-        gap: var(--su-static4);
-        
-        .s-checkmark {
-            align-self: baseline;
-        }
-
-        // Style icon when checkmark is disabled
-        &:has(.s-checkmark[disabled]) svg,
-        &:has(.s-checkmark[disabled]) .svg-icon {
-            color: var(--theme-secondary-300);
-        }
-    }
-
-    align-items: var(--_cc-ai);
-    display: flex;
-    gap: var(--su8);
-}
-
-.s-check-group {
-    --_cg-fd: column;
-
-    // MODIFIERS
-    &&__horizontal {
-        --_cg-fd: row;
-    }
-
-    // CHILD ELEMENTS
-    // TODO HACK? <legend> isn't respecting gap...
-    legend.s-label {
-        margin-bottom: var(--su8);
-    }
-
-    flex-direction: var(--_cg-fd);
-
-    display: flex;
-    gap: var(--su8);
 }

--- a/packages/stacks-docs/product/components/checkbox.html
+++ b/packages/stacks-docs/product/components/checkbox.html
@@ -203,72 +203,72 @@ tags: components
                     <div class="fs-caption fs-italic" style="width: 100px;">Unchecked</div>
                     <!-- Unchecked without icon -->
                     <div style="width: 120px;">
-                        <div class="s-check-control s-check-control__checkmark">
-                            <label class="s-label" for="example-checkmark-no-icon">Default</label>
-                            <input class="s-checkmark" type="radio" name="example-name-checkmark-unchecked" id="example-checkmark-no-icon" />
-                        </div>
+                        <label class="s-check-control s-check-control__checkmark">
+                            <span class="s-label" for="example-checkmark-no-icon">Default</span>
+                            <input type="radio" name="example-name-checkmark-unchecked" id="example-checkmark-no-icon" />
+                        </label>
                     </div>
                     <!-- Unchecked disabled without icon -->
                     <div style="width: 120px;">
-                        <div class="s-check-control s-check-control__checkmark">
-                            <label class="s-label" for="example-checkmark-disabled-no-icon">Disabled</label>
-                            <input class="s-checkmark" type="radio" name="example-name-checkmark-unchecked" id="example-checkmark-disabled-no-icon" disabled />
-                        </div>
+                        <label class="s-check-control s-check-control__checkmark">
+                            <span class="s-label" for="example-checkmark-disabled-no-icon">Disabled</span>
+                            <input type="radio" name="example-name-checkmark-unchecked" id="example-checkmark-disabled-no-icon" disabled />
+                        </label>
                     </div>
                 </div>
                 <div style="display: inline-flex; gap: 65px;">
                     <div class="fs-caption fs-italic" style="width: 100px;"></div>
                     <!-- Base -->
                     <div style="width: 120px;">
-                        <div class="s-check-control s-check-control__checkmark">
+                        <label class="s-check-control s-check-control__checkmark">
                             {% icon "Dashboard" %}
-                            <label class="s-label" for="example-checkmark">Default</label>
-                            <input class="s-checkmark" type="radio" name="example-name-checkmark-unchecked" id="example-checkmark" />
-                        </div>
+                            <span class="s-label" for="example-checkmark">Default</span>
+                            <input type="radio" name="example-name-checkmark-unchecked" id="example-checkmark" />
+                        </label>
                     </div>
                     <!-- Unchecked disabled with icon -->
                     <div style="width: 120px;">
-                        <div class="s-check-control s-check-control__checkmark">
+                        <label class="s-check-control s-check-control__checkmark">
                             {% icon "Dashboard" %}
-                            <label class="s-label" for="example-checkmark-disabled">Disabled</label>
-                            <input class="s-checkmark" type="radio" name="example-name-checkmark-unchecked" id="example-checkmark-disabled" disabled />
-                        </div>
+                            <span class="s-label" for="example-checkmark-disabled">Disabled</span>
+                            <input type="radio" name="example-name-checkmark-unchecked" id="example-checkmark-disabled" disabled />
+                        </label>
                     </div>
                 </div>
                 <div style="display: inline-flex; gap: 65px;">
                     <div class="fs-caption fs-italic" style="width: 100px;">Checked</div>
                     <!-- Checked without icon -->
                     <div style="width: 120px;">
-                        <div class="s-check-control s-check-control__checkmark">
-                            <label class="s-label" for="example-checkmark-no-icon-checked">Default</label>
-                            <input class="s-checkmark" type="checkbox" name="example-name-checkmark-no-icon-3" id="example-checkmark-no-icon-checked" checked />
-                        </div>
+                        <label class="s-check-control s-check-control__checkmark">
+                            <span class="s-label" for="example-checkmark-no-icon-checked">Default</span>
+                            <input type="checkbox" name="example-name-checkmark-no-icon-3" id="example-checkmark-no-icon-checked" checked />
+                        </label>
                     </div>
                     <!-- Checked disabled without icon -->
                     <div style="width: 120px;">
-                        <div class="s-check-control s-check-control__checkmark">
-                            <label class="s-label" for="example-checkmark-disabled-checked-no-icon">Disabled</label>
-                            <input class="s-checkmark" type="checkbox" name="example-name-checkmark-disabled-checked-no-icon" id="example-checkmark-disabled-checked-no-icon" checked disabled />
-                        </div>
+                        <label class="s-check-control s-check-control__checkmark">
+                            <span class="s-label" for="example-checkmark-disabled-checked-no-icon">Disabled</span>
+                            <input type="checkbox" name="example-name-checkmark-disabled-checked-no-icon" id="example-checkmark-disabled-checked-no-icon" checked disabled />
+                        </label>
                     </div>
                 </div>
                 <div style="display: inline-flex; gap: 65px;">
                     <div class="fs-caption fs-italic" style="width: 100px;"></div>
                     <!-- Checked -->
                     <div style="width: 120px;">
-                        <div class="s-check-control s-check-control__checkmark">
+                        <label class="s-check-control s-check-control__checkmark">
                             {% icon "Dashboard" %}
-                            <label class="s-label" for="example-checkmark-checked">Default</label>
-                            <input class="s-checkmark" type="checkbox" name="example-name-checkmark-checked-1" id="example-checkmark-checked" checked />
-                        </div>
+                            <span class="s-label" for="example-checkmark-checked">Default</span>
+                            <input type="checkbox" name="example-name-checkmark-checked-1" id="example-checkmark-checked" checked />
+                        </label>
                     </div>
                     <!-- Disabled and checked -->
                     <div style="width: 120px;">
-                        <div class="s-check-control s-check-control__checkmark">
+                        <label class="s-check-control s-check-control__checkmark">
                             {% icon "Dashboard" %}
-                            <label class="s-label" for="example-checkmark-disabled-checked">Disabled</label>
-                            <input class="s-checkmark" type="checkbox" name="example-name-checkmark-disabled-checked" id="example-checkmark-disabled-checked" checked disabled />
-                        </div>
+                            <span class="s-label" for="example-checkmark-disabled-checked">Disabled</span>
+                            <input type="checkbox" name="example-name-checkmark-disabled-checked" id="example-checkmark-disabled-checked" checked disabled />
+                        </label>
                     </div>
                 </div>
             </div>
@@ -410,22 +410,22 @@ tags: components
                     <ul class="s-menu" role="menu">
                         <li class="s-menu--title" role="separator">Sort by</li>
                         <li class="s-menu--item" role="menuitem">
-                            <div class="s-check-control s-check-control__checkmark">
-                                <label class="s-label" for="choice-vert-checkmark-1">Relevant</label>
-                                <input class="s-checkmark" type="radio" name="choice-vert-checkmark" id="choice-vert-checkmark-1" checked/>
-                            </div>
+                            <label class="s-check-control s-check-control__checkmark">
+                                <span class="s-label">Relevant</span>
+                                <input type="radio" name="choice-vert-checkmark" id="choice-vert-checkmark-1" checked/>
+                            </label>
                         </li>
                         <li class="s-menu--item" role="menuitem">
-                            <div class="s-check-control s-check-control__checkmark">
-                                <label class="s-label" for="choice-vert-checkmark-2">Recent activity</label>
-                                <input class="s-checkmark" type="radio" name="choice-vert-checkmark" id="choice-vert-checkmark-2"/>
-                            </div>
+                            <label class="s-check-control s-check-control__checkmark">
+                                <span class="s-label">Recent activity</span>
+                                <input type="radio" name="choice-vert-checkmark" id="choice-vert-checkmark-2"/>
+                            </label>
                         </li>
                         <li class="s-menu--item" role="menuitem">
-                            <div class="s-check-control s-check-control__checkmark">
-                                <label class="s-label" for="choice-vert-checkmark-3">Most frequent</label>
-                                <input class="s-checkmark" type="radio" name="choice-vert-checkmark" id="choice-vert-checkmark-3"/>
-                            </div>
+                            <label class="s-check-control s-check-control__checkmark">
+                                <span class="s-label">Most frequent</span>
+                                <input type="radio" name="choice-vert-checkmark" id="choice-vert-checkmark-3"/>
+                            </label>
                         </li>
                     </ul>
                 </div>
@@ -433,18 +433,18 @@ tags: components
                     <ul class="s-menu" role="menu">
                         <li class="s-menu--title" role="separator">Layout</li>
                         <li class="s-menu--item" role="menuitem">
-                            <div class="s-check-control s-check-control__checkmark">
+                            <label class="s-check-control s-check-control__checkmark">
                                 {% icon "Dashboard" %}
-                                <label class="s-label" for="choice-vert-checkmark-4">Expanded</label>
-                                <input class="s-checkmark" type="radio" name="choice-vert-checkmark-layout" id="choice-vert-checkmark-4" checked/>
-                            </div>
+                                <span class="s-label">Expanded</span>
+                                <input type="radio" name="choice-vert-checkmark-layout" id="choice-vert-checkmark-4" checked/>
+                            </label>
                         </li>
                         <li class="s-menu--item" role="menuitem">
-                            <div class="s-check-control s-check-control__checkmark">
+                            <label class="s-check-control s-check-control__checkmark">
                                 {% icon "Dashboard" %}
-                                <label class="s-label" for="choice-vert-checkmark-5">Compact</label>
-                                <input class="s-checkmark" type="radio" name="choice-vert-checkmark-layout" id="choice-vert-checkmark-5"/>
-                            </div>
+                                <span class="s-label">Compact</span>
+                                <input type="radio" name="choice-vert-checkmark-layout" id="choice-vert-checkmark-5"/>
+                            </label>
                         </li>
                     </ul>
                 </div>
@@ -472,8 +472,8 @@ tags: components
     </div>
 </fieldset>
 
- <!-- Radio -->
- <fieldset class="s-check-group s-check-group__horizontal">
+<!-- Radio -->
+<fieldset class="s-check-group s-check-group__horizontal">
     <legend class="s-label">Which fruit do you like best?</legend>
     <div class="s-check-control">
         <input class="s-radio" type="radio" name="choice-horz-radio" id="choice-horz-radio-1" />
@@ -519,7 +519,7 @@ tags: components
                     <label class="s-label" for="choice-horz-radio-2">Oranges</label>
                 </div>
                 <div class="s-check-control">
-                    <input class="s-radio" type="checkbox" name="choice-horz-radio" id="choice-horz-radio-3" />
+                    <input class="s-radio" type="radio" name="choice-horz-radio" id="choice-horz-radio-3" />
                     <label class="s-label" for="choice-horz-radio-3">Bananas</label>
                 </div>
             </fieldset>
@@ -559,34 +559,34 @@ tags: components
         <ul class="s-menu" role="menu">
             <li class="s-menu--title" role="separator">Sort answers by</li>
             <li class="s-menu--item" role="menuitem">
-                <div class="s-check-control s-check-control__checkmark">
+                <label class="s-check-control s-check-control__checkmark">
                     {% icon "Dashboard" %}
-                    <label class="s-label" for="choice-description-copy-checkmark-1">
+                    <span class="s-label">
                         Trending
                         <p class="s-description">Highest vote counts more</p>
-                    </label>
-                    <input class="s-checkmark" type="radio" name="choice-description-copy-checkmark" id="choice-description-copy-checkmark-1" checked/>
-                </div>
+                    </span>
+                    <input type="radio" name="choice-description-copy-checkmark" id="choice-description-copy-checkmark-1" checked/>
+                </label>
             </li>
             <li class="s-menu--item" role="menuitem">
-                <div class="s-check-control s-check-control__checkmark">
+                <label class="s-check-control s-check-control__checkmark">
                     {% icon "Question" %}
-                    <label class="s-label" for="choice-description-copy-checkmark-2">
+                    <span class="s-label">
                         Date modified
                         <p class="s-description">Newest first</p>
-                    </label>
-                    <input class="s-checkmark" type="radio" name="choice-description-copy-checkmark" id="choice-description-copy-checkmark-2"/>
-                </div>
+                    </span>
+                    <input type="radio" name="choice-description-copy-checkmark" id="choice-description-copy-checkmark-2"/>
+                </label>
             </li>
             <li class="s-menu--item" role="menuitem">
-                <div class="s-check-control s-check-control__checkmark">
+                <label class="s-check-control s-check-control__checkmark">
                     {% icon "Inbox" %}
-                    <label class="s-label" for="choice-description-copy-checkmark-3">
+                    <span class="s-label">
                         Date created
                         <p class="s-description">Oldest first</p>
-                    </label>
-                    <input class="s-checkmark" type="radio" name="choice-description-copy-checkmark" id="choice-description-copy-checkmark-3"/>
-                </div>
+                    </span>
+                    <input type="radio" name="choice-description-copy-checkmark" id="choice-description-copy-checkmark-3"/>
+                </label>
             </li>
         </ul>
     </div>
@@ -594,34 +594,34 @@ tags: components
         <ul class="s-menu" role="menu">
             <li class="s-menu--title" role="separator">Select answers by</li>
             <li class="s-menu--item" role="menuitem">
-                <div class="s-check-control s-check-control__checkmark">
+                <label class="s-check-control s-check-control__checkmark">
                     {% icon "Dashboard" %}
-                    <label class="s-label" for="choice-description-copy-checkmark-4">
+                    <span class="s-label">
                         Trending
                         <p class="s-description">Highest vote counts more</p>
-                    </label>
-                    <input class="s-checkmark" type="checkbox" name="choice-description-copy-checkmark-checkbox" id="choice-description-copy-checkmark-4" checked/>
-                </div>
+                    </span>
+                    <input type="checkbox" name="choice-description-copy-checkmark-checkbox" id="choice-description-copy-checkmark-4" checked/>
+                </label>
             </li>
             <li class="s-menu--item" role="menuitem">
-                <div class="s-check-control s-check-control__checkmark">
+                <label class="s-check-control s-check-control__checkmark">
                     {% icon "Question" %}
-                    <label class="s-label" for="choice-description-copy-checkmark-5">
+                    <span class="s-label">
                         Date modified
                         <p class="s-description">Newest first</p>
-                    </label>
-                    <input class="s-checkmark" type="checkbox" name="choice-description-copy-checkmark-checkbox" id="choice-description-copy-checkmark-5" checked/>
-                </div>
+                    </span>
+                    <input type="checkbox" name="choice-description-copy-checkmark-checkbox" id="choice-description-copy-checkmark-5" checked/>
+                </label>
             </li>
             <li class="s-menu--item" role="menuitem">
-                <div class="s-check-control s-check-control__checkmark">
+                <label class="s-check-control s-check-control__checkmark">
                     {% icon "Inbox" %}
-                    <label class="s-label" for="choice-description-copy-checkmark-6">
+                    <span class="s-label">
                         Date created
                         <p class="s-description">Oldest first</p>
-                    </label>
-                    <input class="s-checkmark" type="checkbox" name="choice-description-copy-checkmark-checkbox" id="choice-description-copy-checkmark-6"/>
-                </div>
+                    </span>
+                    <input type="checkbox" name="choice-description-copy-checkmark-checkbox" id="choice-description-copy-checkmark-6"/>
+                </label>
             </li>
         </ul>
     </div>
@@ -683,34 +683,34 @@ tags: components
                     <ul class="s-menu" role="menu">
                         <li class="s-menu--title" role="separator">Sort answers by</li>
                         <li class="s-menu--item" role="menuitem">
-                            <div class="s-check-control s-check-control__checkmark">
+                            <label class="s-check-control s-check-control__checkmark">
                                 {% icon "Dashboard" %}
-                                <label class="s-label" for="choice-description-copy-checkmark-1">
+                                <span class="s-label" for="choice-description-copy-checkmark-1">
                                     Trending
                                     <p class="s-description">Highest vote counts more</p>
-                                </label>
-                                <input class="s-checkmark" type="radio" name="choice-description-copy-checkmark" id="choice-description-copy-checkmark-1" checked/>
-                            </div>
+                                </span>
+                                <input type="radio" name="choice-description-copy-checkmark" id="choice-description-copy-checkmark-1" checked/>
+                            </label>
                         </li>
                         <li class="s-menu--item" role="menuitem">
-                            <div class="s-check-control s-check-control__checkmark">
+                            <label class="s-check-control s-check-control__checkmark">
                                 {% icon "Question" %}
-                                <label class="s-label" for="choice-description-copy-checkmark-2">
+                                <span class="s-label" for="choice-description-copy-checkmark-2">
                                     Date modified
                                     <p class="s-description">Newest first</p>
-                                </label>
-                                <input class="s-checkmark" type="radio" name="choice-description-copy-checkmark" id="choice-description-copy-checkmark-2"/>
-                            </div>
+                                </span>
+                                <input type="radio" name="choice-description-copy-checkmark" id="choice-description-copy-checkmark-2"/>
+                            </label>
                         </li>
                         <li class="s-menu--item" role="menuitem">
-                            <div class="s-check-control s-check-control__checkmark">
+                            <label class="s-check-control s-check-control__checkmark">
                                 {% icon "Inbox" %}
-                                <label class="s-label" for="choice-description-copy-checkmark-3">
+                                <span class="s-label" for="choice-description-copy-checkmark-3">
                                     Date created
                                     <p class="s-description">Oldest first</p>
-                                </label>
-                                <input class="s-checkmark" type="radio" name="choice-description-copy-checkmark" id="choice-description-copy-checkmark-3"/>
-                            </div>
+                                </span>
+                                <input type="radio" name="choice-description-copy-checkmark" id="choice-description-copy-checkmark-3"/>
+                            </label>
                         </li>
                     </ul>
                 </div>
@@ -718,34 +718,34 @@ tags: components
                     <ul class="s-menu" role="menu">
                         <li class="s-menu--title" role="separator">Select answers by</li>
                         <li class="s-menu--item" role="menuitem">
-                            <div class="s-check-control s-check-control__checkmark">
+                            <label class="s-check-control s-check-control__checkmark">
                                 {% icon "Dashboard" %}
-                                <label class="s-label" for="choice-description-copy-checkmark-4">
+                                <span class="s-label" for="choice-description-copy-checkmark-4">
                                     Trending
                                     <p class="s-description">Highest vote counts more</p>
-                                </label>
-                                <input class="s-checkmark" type="checkbox" name="choice-description-copy-checkmark-checkbox" id="choice-description-copy-checkmark-4" checked/>
-                            </div>
+                                </span>
+                                <input type="checkbox" name="choice-description-copy-checkmark-checkbox" id="choice-description-copy-checkmark-4" checked/>
+                            </label>
                         </li>
                         <li class="s-menu--item" role="menuitem">
-                            <div class="s-check-control s-check-control__checkmark">
+                            <label class="s-check-control s-check-control__checkmark">
                                 {% icon "Question" %}
-                                <label class="s-label" for="choice-description-copy-checkmark-5">
+                                <span class="s-label" for="choice-description-copy-checkmark-5">
                                     Date modified
                                     <p class="s-description">Newest first</p>
-                                </label>
-                                <input class="s-checkmark" type="checkbox" name="choice-description-copy-checkmark-checkbox" id="choice-description-copy-checkmark-5" checked/>
-                            </div>
+                                </span>
+                                <input type="checkbox" name="choice-description-copy-checkmark-checkbox" id="choice-description-copy-checkmark-5" checked/>
+                            </label>
                         </li>
                         <li class="s-menu--item" role="menuitem">
-                            <div class="s-check-control s-check-control__checkmark">
+                            <label class="s-check-control s-check-control__checkmark">
                                 {% icon "Inbox" %}
-                                <label class="s-label" for="choice-description-copy-checkmark-6">
+                                <span class="s-label" for="choice-description-copy-checkmark-6">
                                     Date created
                                     <p class="s-description">Oldest first</p>
-                                </label>
-                                <input class="s-checkmark" type="checkbox" name="choice-description-copy-checkmark-checkbox" id="choice-description-copy-checkmark-6"/>
-                            </div>
+                                </span>
+                                <input type="checkbox" name="choice-description-copy-checkmark-checkbox" id="choice-description-copy-checkmark-6"/>
+                            </label>
                         </li>
                     </ul>
                 </div>
@@ -887,7 +887,7 @@ tags: components
                 </div>
                 <div class="s-check-control has-success">
                     <input class="s-checkbox" type="checkbox" name="" id="choice-valid-checkbox-3" />
-                    <label class="d-block mb4 s-label fw-normal" for="choice-valid-checkbox-3">
+                    <label class="s-label" for="choice-valid-checkbox-3">
                         Bananas
                         <p class="s-input-message">You’ve successfully selected the most amazing fruit in the world.</p>
                     </label>


### PR DESCRIPTION
This PR builds on the changes in https://github.com/StackExchange/Stacks/pull/2060.

It includes the following:

- Moves all `.s-check-control` and `.s-check-group` back to their respective files
  - These are separate components from `.s-checkbox` and `.s-radio` with their own tests, so we should maintain the existing file structure
- Replaces `.s-checkmark` solely with the `.s-check-group__checkmark` modifier class to simplify markup and Less
  - It also now expects this class + modifier combo to be used on a `label` element which wraps the label text and input, ensuring the element is accessible by making the entire row interactive. I made light adjustments to the examples in the docs to reflect this.
- Changes to when we use theme colors vs black shades for consistency and among input and label colors

### Remaining issues

- The docs need special attention. I noticed lots of inline styles and duplicate examples. They should use stacks classes instead of inline styles and the examples should be combined/simplified when possible.
- The Menu component should be updated as part of checkbox/radio changes to instead rely on `.s-check-control.s-check-control__checkmark`. This will allow us to remove much of the duplicate code in Menu.less
- I'm not 100% confident on the sizing of the white dot within selected radio elements.
- I didn't look into the Svelte components at all, so I'm unsure what they'll need.