### PR TITLE
fix(navigation): final minor fixes

### DIFF
--- a/.changeset/young-views-join.md
+++ b/.changeset/young-views-join.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks": patch
+---
+
+Navigation: adjust margin top of navigation title

--- a/packages/stacks-classic/lib/components/navigation/navigation.less
+++ b/packages/stacks-classic/lib/components/navigation/navigation.less
@@ -8,7 +8,7 @@
     --_na-item-fs: unset;
     --_na-item-p: calc(var(--su12) - var(--su1)) var(--su16);
     --_na-item-ws: nowrap;
-    --_na-item-bg-hover: var(--black-150);
+    --_na-item-bg-hover: var(--black-100);
     --_na-item-fc-hover: var(--_na-item-fc);
     --_na-item-selected-bg: none;
     --_na-item-selected-fc: var(--black-600);

--- a/packages/stacks-classic/lib/components/navigation/navigation.less
+++ b/packages/stacks-classic/lib/components/navigation/navigation.less
@@ -156,7 +156,7 @@
         margin-top: var(--_na-title-mt);
         font-size: var(--fs-fine);
         color: var(--black-400);
-        padding: var(--su16) var(--su8);
+        padding: calc(var(--su16) + var(--su2)) var(--su8);
     }
 
     & &--icon {

--- a/packages/stacks-classic/lib/components/navigation/navigation.less
+++ b/packages/stacks-classic/lib/components/navigation/navigation.less
@@ -149,6 +149,10 @@
             --_na-title-mt: 0;
         }
 
+        & .s-btn {
+            color: var(--black-400);
+        }
+
         margin-top: var(--_na-title-mt);
         font-size: var(--fs-fine);
         color: var(--black-400);

--- a/packages/stacks-classic/lib/components/navigation/navigation.less
+++ b/packages/stacks-classic/lib/components/navigation/navigation.less
@@ -15,7 +15,7 @@
     --_na-item-selected-bg-hover: var(--_na-item-bg-hover);
     --_na-item-selected-h: var(--su-static2);
     --_na-item-text-ta: center;
-    --_na-title-mt: var(--su16);
+    --_na-title-mt: var(--su24);
     --_na-after-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3E%3Cpath d='M11.35 4.35 6 9.71.65 4.35l.7-.7L6 8.29l4.65-4.64z'/%3E%3C/svg%3E");
     --_na-after-bg-color: var(--black-400);
 

--- a/packages/stacks-svelte/src/components/Navigation/Navigation.stories.svelte
+++ b/packages/stacks-svelte/src/components/Navigation/Navigation.stories.svelte
@@ -358,7 +358,7 @@
                                 weight="clear"
                                 aria-label="Edit Section"
                             >
-                                <Icon src={IconCompose} class="fc-black-400" />
+                                <Icon src={IconCompose} />
                             </Button>
                         {/if}
                         {#if isCollapsed && groupItems.some((i) => i.activity)}
@@ -380,10 +380,7 @@
                                     : 0}deg)"
                                 style:transition="transform 0.2s ease"
                             >
-                                <Icon
-                                    src={IconChevronUp}
-                                    class="fc-black-400"
-                                />
+                                <Icon src={IconChevronUp} />
                             </span>
                         </Button>
                     </div>

--- a/packages/stacks-svelte/src/components/Navigation/Navigation.stories.svelte
+++ b/packages/stacks-svelte/src/components/Navigation/Navigation.stories.svelte
@@ -23,7 +23,7 @@
         IconHomeFill,
         IconJobs,
         IconJobsFill,
-        IconChevron16Up,
+        IconChevronUp,
         IconQuestion,
         IconQuestionFill,
         IconChallenge,
@@ -40,6 +40,7 @@
         IconHelpFill,
         IconStar,
         IconStarFill,
+        IconCompose,
     } from "@stackoverflow/stacks-icons/icons";
     const { Story } = defineMeta({
         title: "Components/Navigation",
@@ -342,29 +343,53 @@
                 (item) => item.group === group
             )}
             {@const isCollapsed = tCollapsed[group]}
-            <NavigationTitle title={group} class="bc-black-200 bt ps-relative">
-                {#snippet trailing()}
-                    <Button
-                        class="ps-absolute r0"
-                        size="xs"
-                        weight="clear"
-                        onclick={() => (tCollapsed[group] = !tCollapsed[group])}
-                        aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${group} Section`}
-                    >
-                        <span
-                            style:display="inline-block"
-                            style:transform="rotate({isCollapsed ? 180 : 0}deg)"
-                            style:transition="transform 0.2s ease"
-                        >
-                            <Icon src={IconChevron16Up} class="fc-black-400" />
-                        </span>
-                    </Button>
-                {/snippet}
-            </NavigationTitle>
-
             {@const selectedItem = groupItems.find(
                 (item) => tSelected === item.text
             )}
+            <NavigationTitle
+                title={group}
+                class={`bc-black-200 bt ps-relative ${isCollapsed && !selectedItem ? "mbn24" : ""}`}
+            >
+                {#snippet trailing()}
+                    <div class="ps-absolute r0 as-center d-flex ai-center">
+                        {#if !isCollapsed && group === "Resources"}
+                            <Button
+                                class="p6"
+                                weight="clear"
+                                aria-label="Edit Section"
+                            >
+                                <Icon src={IconCompose} class="fc-black-400" />
+                            </Button>
+                        {/if}
+                        {#if isCollapsed && groupItems.some((i) => i.activity)}
+                            <ActivityIndicator
+                                label="There is one or more activity in this section"
+                            />
+                        {/if}
+                        <Button
+                            class="p6"
+                            weight="clear"
+                            onclick={() =>
+                                (tCollapsed[group] = !tCollapsed[group])}
+                            aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${group} Section`}
+                        >
+                            <span
+                                style:display="inline-block"
+                                style:transform="rotate({isCollapsed
+                                    ? 180
+                                    : 0}deg)"
+                                style:transition="transform 0.2s ease"
+                            >
+                                <Icon
+                                    src={IconChevronUp}
+                                    class="fc-black-400"
+                                />
+                            </span>
+                        </Button>
+                    </div>
+                {/snippet}
+            </NavigationTitle>
+
             {@const selectedIndex = groupItems.findIndex(
                 (item) => tSelected === item.text
             )}

--- a/packages/stacks-svelte/src/components/Navigation/Navigation.stories.svelte
+++ b/packages/stacks-svelte/src/components/Navigation/Navigation.stories.svelte
@@ -356,7 +356,7 @@
                             style:transform="rotate({isCollapsed ? 180 : 0}deg)"
                             style:transition="transform 0.2s ease"
                         >
-                            <Icon src={IconChevron16Up} />
+                            <Icon src={IconChevron16Up} class="fc-black-400" />
                         </span>
                     </Button>
                 {/snippet}


### PR DESCRIPTION
[SPARK-130](https://stackoverflow.atlassian.net/browse/SPARK-130)

> Top margin of section title is 16px in Stacks classic, design says this should be 24px.

> Chevron and any other icons in the section header should be black-400

Those 2 points have been addressed directly in stacks classic. The rest are all updates of the storybook trailing story to show one way of achieving the desired final spec. Consumer  can take heavy inspiration from that story but they will ultimately have to replicate something simlar for their concrete use case.

> Chevron icon used should be the default size (20x20) — we don’t have all the 16x16 sizes for components like compose and we’ll need to add that compose icon later for editing the communities list.

> Override the button small padding to use p6 (for chevron and other button icons like compose)

Addressed in the storybook trailing story.

> Chevron rotation: I’m assuming the devs chose to rotate IconChevronUp instead of using IconChevronDown to create the animation of it twirling

I kept this as it was in the trailing story. I personally think the added complexity is not worth it. That said if @kylejrp wants to use his approach with the extra fade effect he can by all mean. The example is just an example and can be tweaked depending on the use case. There is no plan of adding those animation directly in the system libraries for now.

> Get rid of the extra margin space when a section header is collapsed

Addressed in the trailing story with a conditional `mn24` class being applied. Again this is something that the consumers of Stacks can decide how to best handle.

> Include example of the editable icon or collapsed activity icon alongside the expandable icon

This have been added to the trailing story to show how it can be achieved by consumers of Stacks.

> Footer

Out of scope, it should certainly be a separate navigation (`nav`) landmark. I think for the time being consumers can implement that using the `Link` components. If we feel the need to standardize the footer we should extract it as we have done in the past for the topbar but that's a totally different story.

[Trailing Story](https://deploy-preview-2081--stacks-svelte.netlify.app/?path=/story/components-navigation--trailing)

Extra changes:

> Hover state should be black-100 (different than the selected state)

This has been addressed. It is a stacks classic change. 

> Is it possible to set a min height to the section title container with the label? Because we're not matching the icon size anymore (because it's in a button now) we loose some of the height because the label text is only ~15px. Can we make this be closer to a min height of 20px?

A similar effect has been achieved by making the padding vertical of `s-navigation--title` elements 18 instead of 16. 
