### PR TITLE
Default width/height in Avatar.svelte

### DIFF
--- a/packages/stacks-svelte/src/components/Avatar/Avatar.svelte
+++ b/packages/stacks-svelte/src/components/Avatar/Avatar.svelte
@@ -89,7 +89,7 @@
     {...restProps}
 >
     {#if src}
-        <img class="s-avatar--image" {src} alt="" role="presentation" />
+        <img class="s-avatar--image" {src} alt="" width={size} height={size} role="presentation" />
     {:else if letter}
         <span class="s-avatar--letter" aria-hidden="true">{letter}</span>
     {/if}


### PR DESCRIPTION
## Summary

This PR adds a default height/width to the <Avatar> Stacks-Svelte component based on the `size` prop to prevent layout shifts as the image loads.

(I haven't done any testing, I just did this edit from the GitHub UI)