### PR TITLE
chore(input): fix non text input styles

### DIFF
--- a/.changeset/sour-jobs-collect.md
+++ b/.changeset/sour-jobs-collect.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks": patch
+---
+
+chore(input): fix non text input styles

--- a/packages/stacks-classic/lib/components/input_textarea/input_textarea.less
+++ b/packages/stacks-classic/lib/components/input_textarea/input_textarea.less
@@ -89,18 +89,19 @@
     line-height: var(--_in-lh);
     padding: var(--_in-py) var(--_in-px) var(--_in-py) var(--_in-pl, var(--_in-px));
     
-    align-items: center;
     border-radius: var(--br-md);
-    display: flex;
-    flex: 1 1 0;
     font-family: inherit;
     margin: 0; // A guard against Core's default margins
     width: 100%;
 }
 
-input.s-input:not([type="text"]) {
-    // We need `display: flex` for 'Nested Inputs'. But for other types we need block level rendering
-    display: inline-block;
+//Nested inputs (E.g. Tag selection control) need a flex layout.
+.s-input:has(> input.s-input) {
+    display: flex;
+    align-items: center;
+    input.s-input {
+         flex: 1 1 0;
+    }
 }
 
 .s-input {

--- a/packages/stacks-classic/lib/components/input_textarea/input_textarea.less
+++ b/packages/stacks-classic/lib/components/input_textarea/input_textarea.less
@@ -1,6 +1,6 @@
 .s-input,
 .s-textarea,
-//The :has selector here allows us to use these vars for sibling icons in textarea components
+//The :has selector here allows us to use these vars for sibling icons in textarea components (See .s-textarea -> ~ .s-input-icon)
 :has(> .s-textarea) { 
     --_in-bc: var(--black-300);
     --_in-bg: var(--white);
@@ -96,6 +96,11 @@
     font-family: inherit;
     margin: 0; // A guard against Core's default margins
     width: 100%;
+}
+
+input.s-input:not([type="text"]) {
+    // We need `display: flex` for 'Nested Inputs'. But for other types we need block level rendering
+    display: inline-block;
 }
 
 .s-input {


### PR DESCRIPTION
# Summary

This PR fixes a bug I introduced in #2070 which breaks the non-text type inputs styles by pushing the date picker etc to the left: https://beta.svelte.stackoverflow.design/?path=/docs/components-textinput--docs
<img width="50" src="https://github.com/user-attachments/assets/fb1c3ee1-3106-427e-8ae9-dcb26cb215bd" />

# How to Test

* Confirm all the inputs looks okay for the TextInput Svelte Component. Most importantly the various **Types** we have: https://deploy-preview-2088--stacks-svelte.netlify.app/?path=/story/components-textinput--types
* The icons should be properly right aligned now
* Confirm Nested inputs still look okay and aren't broken visually after this change: https://deploy-preview-2088--stacks.netlify.app/product/components/inputs/#nested-inputs