### PR TITLE
Update NavigationTitle.svelte to support aria-owns

### DIFF
--- a/packages/stacks-svelte/src/components/Navigation/NavigationTitle.svelte
+++ b/packages/stacks-svelte/src/components/Navigation/NavigationTitle.svelte
@@ -10,11 +10,15 @@
          */
         class?: string;
         /**
+         * IDs corresponding to NavigationItems this NavigationTitle controls
+         */
+        ariaOwns?: string;
+        /**
          * Optional content rendered at the end of the navigation title.
          */
         trailing?: Snippet;
     }
-    let { title, class: className = "", trailing }: Props = $props();
+    let { title, class: className = "", 'aria-owns': ariaOwns, trailing }: Props = $props();
     const getClasses = (className: string) => {
         const base = "s-navigation--title";
         let classes = "d-flex jc-space-between " + base;
@@ -26,7 +30,7 @@
     const classes = $derived(getClasses(className));
 </script>
 
-<li class={classes} role="separator">
+<li class={classes} aria-owns={ariaOwns} role="separator">
     {title}
     {@render trailing?.()}
 </li>


### PR DESCRIPTION
I'm able to define a `aria-controls` relationship between expand/collapse buttons in the trailing section. However, I'm unable to define an accessible parent/child relationship between a <NavigationTitle> and its children <NavigationItem>s. 

This PR should fix it (assuming I got the syntax right - I did this from GitHub's web IDE to avoid pulling the whole repo locally, so I may have got some syntax wrong)

Example possible usage (again, probably missing some required props, but this shows off the usage well enough):

```
<script lang="ts">
    import { Navigation, NavigationTitle, NavigationItem, Button } from "@stackoverflow/stacks-svelte";
    import { Icon } from "@stackoverflow/stacks-svelte";
    import { IconChevronUp, IconChevronDown } from "@stackoverflow/stacks-icons/icons";
    let expanded = $state(true);
</script>

<Navigation orientation="vertical">
    <NavigationTitle aria-owns="item-1 item-2 item-3" title="Throwaway">
        {#snippet trailing()}
            <Button type="button" aria-expended={expanded} aria-controls="item-1 item-3" onclick={() => expanded = !expanded}>
                <Icon src={expanded ? IconChevronUp : IconChevronDown} class="w16 h16" />
            </Button>
        {/snippet}
    </NavigationTitle>
    <NavigationItem href="#" id="item-1" text="Item 1" class={!expanded ? "d-none" : ""}/>
    <NavigationItem href="#" id="item-2" selected={true} text="Item 2" />
    <NavigationItem href="#" id="item-3" text="Item 3" class={!expanded ? "d-none" : ""}/>
</Navigation>
```

Which would result in this accessibility tree for the title (controls all three elements):

<img width="494" height="452" alt="image" src="https://github.com/user-attachments/assets/6ef74cb5-64a4-4b49-9e00-4df8bf17b1d5" />  


And this accessibility tree for the expand/collapse button (controls just the non-selected elements):

<img width="255" height="285" alt="image" src="https://github.com/user-attachments/assets/5d05bdb7-add9-4a43-880a-8a6eec938e24" />
