### PR TITLE
docs(icons): fix icon class appending

### DIFF
--- a/packages/stacks-docs/plugins/icons.js
+++ b/packages/stacks-docs/plugins/icons.js
@@ -6,7 +6,10 @@ const Icons = { ...LegacyIcons, ...BetaIcons };
 const Spots = { ...LegacySpots, ...BetaSpots };
 
 function modifySvg(content, type, name, classes, dimension) {
-  var defaultClasses = `svg-${type} ${type.charAt(0).toUpperCase() + type.slice(1)}${name}`;
+  // Legacy icons use lowercase class names (iconClear), new icons use capitalized (IconHome)
+  // Try both patterns to support both icon libraries
+  var legacyClasses = `svg-${type} ${type}${name}`;
+  var newClasses = `svg-${type} ${type.charAt(0).toUpperCase() + type.slice(1)}${name}`;
 
   if (!content) {
     return `<span class="fc-danger">Invalid ${type}: ${name}</span>`;
@@ -14,7 +17,13 @@ function modifySvg(content, type, name, classes, dimension) {
 
   // If we have classes, add them
   if (classes != null) {
-    content = content.replace(defaultClasses, defaultClasses + " " + classes);
+    // Try to replace with new class pattern first, then fall back to legacy
+    var updatedContent = content.replace(newClasses, newClasses + " " + classes);
+    if (updatedContent === content) {
+      // If new pattern didn't match, try legacy pattern
+      updatedContent = content.replace(legacyClasses, legacyClasses + " " + classes);
+    }
+    content = updatedContent;
   }
 
   // If we need to change the size, do that too


### PR DESCRIPTION
This PR resolves an issue where classes specified for icons in the Stacks docs would not be appended to the icon when rendered.