### PR TITLE
chore(home-page): fix puzzle icon on home page

### DIFF
--- a/packages/stacks-docs/_includes/layouts/home.html
+++ b/packages/stacks-docs/_includes/layouts/home.html
@@ -197,7 +197,7 @@
         <nav class="d-grid grid__4 lg:grid__2 sm:grid__1 g16 w100 wmx12 mx-auto" aria-label="Global">
             <a class="d-flex s-card p16 bs-sm bar-md h:bs-md sm:ai-center" href="{{ "/product/develop/using-stacks" | url }}">
                 <div class="flex--item fc-theme-primary-400 mr16">
-                    {% spot "Puzzle" %}
+                    {% spot "Puzzle", "native h48 w48" %}
                 </div>
 
                 <div class="flex--item">


### PR DESCRIPTION
# Summary

This PR fixes the puzzle icon on the home page.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="250" height="191" alt="{D5307D24-BD24-43CD-A9E1-0DC5D303477D}" src="https://github.com/user-attachments/assets/28af0006-b1bf-4924-a8b4-44e7a50299a4" />
</td>
<td>
<img width="250" height="126" alt="{631B98A3-A622-49D7-83FE-D9A8EF3588EB}" src="https://github.com/user-attachments/assets/16eefdc3-cf3a-4fdb-82bd-c229d339a321" />
</td>
</tr>
</table>

<img width="1395" height="144" alt="{D0EB5FBA-FA00-4C71-8E96-965DB2C6D62E}" src="https://github.com/user-attachments/assets/b3768cc7-a480-4530-ba71-ec4d2405855d" />


# How to Test

See for yourself: https://deploy-preview-2101--stacks.netlify.app/