### PR TITLE
chore(inputs): adjust icons

### DIFF
--- a/.changeset/seven-dryers-smile.md
+++ b/.changeset/seven-dryers-smile.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks": patch
+---
+
+chore(inputs): adjust alert icon

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@rollup/plugin-commonjs": "^26.0.1",
                 "@rollup/plugin-replace": "^6.0.3",
                 "@stackoverflow/prettier-config": "^1.0.0",
-                "@stackoverflow/stacks-icons": "^7.0.0-beta.7",
+                "@stackoverflow/stacks-icons": "^7.0.0-beta.10",
                 "@stackoverflow/stacks-icons-legacy": "npm:@stackoverflow/stacks-icons@^6.6.1",
                 "@storybook/addon-docs": "^9.1.5",
                 "@storybook/addon-links": "^9.1.3",
@@ -119,7 +119,6 @@
             "integrity": "sha512-IcsDlbXnBf8cHzbM1YBv3JcTyLB35EK88QexmVyFdVJVgUU6bh9g687rpxryJirHzo06PuwnYaEEdVZQfIgRGg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@11ty/dependency-tree": "^4.0.0",
                 "@11ty/dependency-tree-esm": "^2.0.0",
@@ -404,7 +403,6 @@
             "integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@keyv/serialize": "^1.1.1"
             }
@@ -767,7 +765,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -791,7 +788,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1780,15 +1776,13 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.3.0.tgz",
             "integrity": "sha512-L9X8uHCYU310o99L3/MpJKYxPzXPOS7S0NmBaM7UO/x2Kb2WbmMLSkfvdr1KxRIFYOpbY0Jhn7CfLSUDzL8arQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@lezer/highlight": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
             "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@lezer/common": "^1.3.0"
             }
@@ -2924,9 +2918,9 @@
             "license": "MIT"
         },
         "node_modules/@stackoverflow/stacks-icons": {
-            "version": "7.0.0-beta.7",
-            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-7.0.0-beta.7.tgz",
-            "integrity": "sha512-ECcRBn4OTeFxvdrwX23umlxoSgdB7SisT++Y0KNScr7s5PIgWjMWwGRl0GGstxtNGbcrNsAZL/MSQEVOpgulAg==",
+            "version": "7.0.0-beta.10",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-7.0.0-beta.10.tgz",
+            "integrity": "sha512-+lN6VOhmB2tzG0Uh363GYb5Hg568VwZM8O52LnMxv0YYBXnvYmSZRPnIB6Wp1pOquyuT9GnXcVeoQyGuoi0ZUw==",
             "license": "Apache-2.0"
         },
         "node_modules/@stackoverflow/stacks-icons-legacy": {
@@ -3098,7 +3092,6 @@
             "integrity": "sha512-TmzrdDHUKtKG7x1CqYuMIHjfXMqS85EwIF3Of/LV+laBtDhKrgioPJW82dIOJ44w1nryH8Yeh1Hdx9O+cPWfVw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ts-dedent": "^2.0.0",
                 "type-fest": "~2.19"
@@ -3210,7 +3203,6 @@
             "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
                 "debug": "^4.4.1",
@@ -3251,7 +3243,6 @@
             "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -3529,7 +3520,6 @@
             "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -3725,7 +3715,6 @@
             "integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -3924,7 +3913,6 @@
             "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.46.2",
                 "@typescript-eslint/types": "8.46.2",
@@ -4916,7 +4904,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5377,7 +5364,6 @@
             "integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
             "dev": true,
             "license": "MPL-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -5670,7 +5656,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.19",
                 "caniuse-lite": "^1.0.30001751",
@@ -6483,6 +6468,7 @@
             "integrity": "sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-what": "^3.14.1"
             },
@@ -6793,7 +6779,8 @@
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/dashdash": {
             "version": "1.14.1",
@@ -7019,8 +7006,7 @@
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1508733.tgz",
             "integrity": "sha512-QJ1R5gtck6nDcdM+nlsaJXcelPEI7ZxSMw1ujHpO1c4+9l+Nue5qlebi9xO1Z2MGr92bFOQTW7/rrheh5hHxDg==",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/diff": {
             "version": "5.2.0",
@@ -7462,7 +7448,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -7580,7 +7565,6 @@
             "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -7641,7 +7625,6 @@
             "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -8882,7 +8865,6 @@
             "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
             "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
             "license": "BSD-3-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=12.0.0"
             }
@@ -9141,6 +9123,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "bin": {
                 "image-size": "bin/image-size.js"
             },
@@ -9601,7 +9584,8 @@
             "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
             "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/is-windows": {
             "version": "1.0.2",
@@ -10117,6 +10101,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "prr": "~1.0.1"
             },
@@ -10131,6 +10116,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "pify": "^4.0.1",
                 "semver": "^5.6.0"
@@ -10146,6 +10132,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "bin": {
                 "mime": "cli.js"
             },
@@ -10160,6 +10147,7 @@
             "dev": true,
             "license": "ISC",
             "optional": true,
+            "peer": true,
             "bin": {
                 "semver": "bin/semver"
             }
@@ -10171,6 +10159,7 @@
             "dev": true,
             "license": "BSD-3-Clause",
             "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10929,6 +10918,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "iconv-lite": "^0.6.3",
                 "sax": "^1.2.4"
@@ -10947,6 +10937,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -11486,6 +11477,7 @@
             "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.10"
             }
@@ -11835,7 +11827,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -12495,7 +12486,6 @@
             "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -12550,7 +12540,6 @@
             "integrity": "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "posthtml-parser": "^0.11.0",
                 "posthtml-render": "^3.0.0"
@@ -12703,7 +12692,6 @@
             "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -12879,7 +12867,6 @@
             "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
             "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "orderedmap": "^2.0.0"
             }
@@ -12909,7 +12896,6 @@
             "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
             "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.0.0",
                 "prosemirror-transform": "^1.0.0",
@@ -12940,7 +12926,6 @@
             "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.3.tgz",
             "integrity": "sha512-SqMiYMUQNNBP9kfPhLO8WXEk/fon47vc52FQsUiJzTBuyjKgEcoAwMyF04eQ4WZ2ArMn7+ReypYL60aKngbACQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.20.0",
                 "prosemirror-state": "^1.0.0",
@@ -13198,7 +13183,6 @@
             "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13209,7 +13193,6 @@
             "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -13679,7 +13662,6 @@
             "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -14624,7 +14606,6 @@
             "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "chokidar": "^4.0.0",
                 "immutable": "^5.0.2",
@@ -14710,7 +14691,6 @@
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -15281,7 +15261,6 @@
             "integrity": "sha512-es7uDdEwRVVUAt7XLAZZ1hicOq9r4ov5NFeFPpa2YEyAsyHYOCr0CTlHBfslWG6D5EVNWK3kVIIuW8GHB6hEig==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@storybook/global": "^5.0.0",
                 "@testing-library/jest-dom": "^6.6.3",
@@ -15755,7 +15734,6 @@
             "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.42.2.tgz",
             "integrity": "sha512-iSry5jsBHispVczyt9UrBX/1qu3HQ/UyKPAIjqlvlu3o/eUvc+kpyMyRS2O4HLLx4MvLurLGIUOyyP11pyD59g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/remapping": "^2.3.4",
                 "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -16220,7 +16198,6 @@
             "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
                 "acorn": "^8.15.0",
@@ -16567,7 +16544,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -16803,7 +16779,6 @@
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -16922,7 +16897,6 @@
             "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
                 "@vitest/expect": "3.2.4",
@@ -17061,7 +17035,6 @@
             "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -17111,7 +17084,6 @@
             "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.6.1",
                 "@webpack-cli/configtest": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-replace": "^6.0.3",
         "@stackoverflow/prettier-config": "^1.0.0",
-        "@stackoverflow/stacks-icons": "^7.0.0-beta.7",
+        "@stackoverflow/stacks-icons": "^7.0.0-beta.10",
         "@stackoverflow/stacks-icons-legacy": "npm:@stackoverflow/stacks-icons@^6.6.1",
         "@storybook/addon-docs": "^9.1.5",
         "@storybook/addon-links": "^9.1.3",

--- a/packages/stacks-docs/product/components/inputs.html
+++ b/packages/stacks-docs/product/components/inputs.html
@@ -206,7 +206,6 @@ tags: components
                     <label class="s-label" for="example-warning">Username</label>
                     <div class="d-flex ps-relative">
                         <input class="s-input" id="example-warning" type="text" value="AA" aria-describedby="example-warning-desc" />
-                        <!-- TODO SHINE change to updated 20px Alert icon -->
                         {% icon "Alert", "s-input-icon" %}
                     </div>
                     <p id="example-warning-desc" class="s-input-message mb0">Caps lock is on! <a href="#">Having trouble entering your username?</a></p>
@@ -226,7 +225,7 @@ tags: components
     <label class="s-label" for="example-error">Username</label>
     <div class="d-flex ps-relative">
         <input class="s-input" id="example-error" type="text" placeholder="e.g. johndoe111" aria-describedby="example-error-desc" aria-invalid="true" />
-        @Svg.AlertCircle.With("s-input-icon")
+        @Svg.AlertFill.With("s-input-icon")
     </div>
     <p id="example-error-desc" class="s-input-message mb0">You must provide a username. <a href="#">Forgot your username?</a></p>
 </div>
@@ -237,8 +236,7 @@ tags: components
                     <label class="s-label" for="example-error">Username</label>
                     <div class="d-flex ps-relative">
                         <input class="s-input" id="example-error" type="text" aria-describedby="example-error-desc" />
-                        <!-- TODO SHINE change to updated 20px AlertCircle icon -->
-                        {% icon "AlertCircle", "s-input-icon" %}
+                        {% icon "AlertFill", "s-input-icon" %}
                     </div>
                     <p id="example-error-desc" class="s-input-message mb0">You must provide a username. <a href="#">Forgot your username?</a></p>
                 </div>

--- a/packages/stacks-docs/product/components/select.html
+++ b/packages/stacks-docs/product/components/select.html
@@ -170,7 +170,7 @@ tags: components
             <option value="rail">Train</option>
             <option value="fly">Plane</option>
         </select>
-        @Svg.AlertCircle.With("s-input-icon")
+        @Svg.AlertFill.With("s-input-icon")
     </div>
 </div>
 {% endhighlight %}
@@ -189,7 +189,7 @@ tags: components
                         <option value="rail">Train</option>
                         <option value="fly">Plane</option>
                     </select>
-                    {% icon "AlertCircle", "s-input-icon" %}
+                    {% icon "AlertFill", "s-input-icon" %}
                 </div>
             </div>
         </div>

--- a/packages/stacks-svelte/src/components/Button/Button.stories.svelte
+++ b/packages/stacks-svelte/src/components/Button/Button.stories.svelte
@@ -3,7 +3,7 @@
     import Button from "./Button.svelte";
     import type { Brand, Size, Variant, Weight } from "./Button.svelte";
     import Icon from "../Icon/Icon.svelte";
-    import { IconTrash } from "@stackoverflow/stacks-icons-legacy/icons";
+    import { IconTrash } from "@stackoverflow/stacks-icons/icons";
 
     const ButtonBrands: Brand[] = ["", "facebook", "github", "google"];
     const ButtonSizes: Size[] = ["", "xs", "sm", "lg"];

--- a/packages/stacks-svelte/src/components/Notice/Notice.stories.svelte
+++ b/packages/stacks-svelte/src/components/Notice/Notice.stories.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-    import { IconAlert } from "@stackoverflow/stacks-icons-legacy/icons";
+    import { IconAlertFill } from "@stackoverflow/stacks-icons/icons";
 
     import Notice, { type Variant } from "./Notice.svelte";
     import { defineMeta } from "@storybook/addon-svelte-csf";
@@ -102,7 +102,7 @@
 </Story>
 
 <Story name="With Icon" asChild>
-    <Notice variant="danger" icon={IconAlert} iconTitle="Alert Icon">
+    <Notice variant="danger" icon={IconAlertFill} iconTitle="Alert Icon">
         I am a notice with an icon
     </Notice>
 </Story>

--- a/packages/stacks-svelte/src/components/Notice/Notice.test.ts
+++ b/packages/stacks-svelte/src/components/Notice/Notice.test.ts
@@ -1,7 +1,7 @@
 import { createRawSnippet } from "svelte";
 import { expect } from "@open-wc/testing";
 import { render, screen } from "@testing-library/svelte";
-import { IconAlert } from "@stackoverflow/stacks-icons-legacy/icons";
+import { IconAlertFill } from "@stackoverflow/stacks-icons/icons";
 import { createSvelteComponentsSnippet } from "../../../test-utils";
 import sinon from "sinon";
 import userEvent from "@testing-library/user-event";
@@ -20,7 +20,7 @@ describe("Notice", () => {
     });
 
     it("should render the icon", () => {
-        render(Notice, { icon: IconAlert, iconTitle: "test title", children });
+        render(Notice, { icon: IconAlertFill, iconTitle: "test title", children });
         const icon = document.querySelector("svg.iconAlert");
         expect(icon).to.exist;
         expect(screen.getByRole("status")).to.exist;

--- a/packages/stacks-svelte/src/components/Notice/Notice.test.ts
+++ b/packages/stacks-svelte/src/components/Notice/Notice.test.ts
@@ -25,7 +25,7 @@ describe("Notice", () => {
             iconTitle: "test title",
             children,
         });
-        const icon = document.querySelector("svg.iconAlert");
+        const icon = document.querySelector("svg.iconAlertFill");
         expect(icon).to.exist;
         expect(screen.getByRole("status")).to.exist;
     });
@@ -72,7 +72,7 @@ describe("Notice", () => {
         expect(closeButton).to.exist;
 
         // Assert that the IconClear is rendered inside the button
-        const closeIcon = closeButton.querySelector("svg.iconClear");
+        const closeIcon = closeButton.querySelector("svg.iconCross");
         expect(closeIcon).to.exist;
 
         // Assert that the button has the s-notice--btn class

--- a/packages/stacks-svelte/src/components/Notice/Notice.test.ts
+++ b/packages/stacks-svelte/src/components/Notice/Notice.test.ts
@@ -20,7 +20,11 @@ describe("Notice", () => {
     });
 
     it("should render the icon", () => {
-        render(Notice, { icon: IconAlertFill, iconTitle: "test title", children });
+        render(Notice, {
+            icon: IconAlertFill,
+            iconTitle: "test title",
+            children,
+        });
         const icon = document.querySelector("svg.iconAlert");
         expect(icon).to.exist;
         expect(screen.getByRole("status")).to.exist;

--- a/packages/stacks-svelte/src/components/Notice/NoticeAction.svelte
+++ b/packages/stacks-svelte/src/components/Notice/NoticeAction.svelte
@@ -2,7 +2,7 @@
     import type { Snippet } from "svelte";
     import Button from "../Button/Button.svelte";
     import Icon from "../Icon/Icon.svelte";
-    import { IconClear } from "@stackoverflow/stacks-icons-legacy/icons";
+    import { IconCross } from "@stackoverflow/stacks-icons/icons";
     import type { Props as ButtonProps } from "../Button/Button.svelte";
 
     interface Props {
@@ -31,7 +31,7 @@
 
 <Button class={"s-notice--btn " + className} {...restProps}>
     {#if type === "close"}
-        <Icon src={IconClear} title={i18nCloseButtonLabel}></Icon>
+        <Icon src={IconCross} title={i18nCloseButtonLabel}></Icon>
     {:else if children}
         {@render children()}
     {/if}

--- a/packages/stacks-svelte/src/components/PostSummary/PostSummary.svelte
+++ b/packages/stacks-svelte/src/components/PostSummary/PostSummary.svelte
@@ -35,13 +35,8 @@
     import PopoverContent from "../Popover/PopoverContent.svelte";
     import PopoverReference from "../Popover/PopoverReference.svelte";
     import UserCard from "../UserCard/UserCard.svelte";
-    import {
-        IconShield,
-    } from "@stackoverflow/stacks-icons-legacy/icons";
-    import { 
-        IconCheck,
-        IconMore16V,
-    } from "@stackoverflow/stacks-icons/icons";
+    import { IconShield } from "@stackoverflow/stacks-icons-legacy/icons";
+    import { IconCheck, IconMore16V } from "@stackoverflow/stacks-icons/icons";
 
     /**
      * The URL to navigate to when the post title is clicked

--- a/packages/stacks-svelte/src/components/PostSummary/PostSummary.svelte
+++ b/packages/stacks-svelte/src/components/PostSummary/PostSummary.svelte
@@ -36,10 +36,12 @@
     import PopoverReference from "../Popover/PopoverReference.svelte";
     import UserCard from "../UserCard/UserCard.svelte";
     import {
-        IconEllipsisVertical,
         IconShield,
     } from "@stackoverflow/stacks-icons-legacy/icons";
-    import { IconCheck } from "@stackoverflow/stacks-icons/icons";
+    import { 
+        IconCheck,
+        IconMore16V,
+    } from "@stackoverflow/stacks-icons/icons";
 
     /**
      * The URL to navigate to when the post title is clicked
@@ -352,7 +354,7 @@
                         class="s-post-summary--content-menu-button"
                         variant="tonal"
                     >
-                        <Icon src={IconEllipsisVertical} />
+                        <Icon src={IconMore16V} />
                         <span class="v-visible-sr"
                             >{i18nActionMenuButtonText}</span
                         >

--- a/packages/stacks-svelte/src/components/Select/Select.svelte
+++ b/packages/stacks-svelte/src/components/Select/Select.svelte
@@ -24,11 +24,11 @@
 <script lang="ts">
     import Icon from "../Icon/Icon.svelte";
     import Label from "../Label/Label.svelte";
-    import {
-        IconAlert,
-        IconAlertCircle,
-    } from "@stackoverflow/stacks-icons-legacy/icons";
-    import { IconCheck } from "@stackoverflow/stacks-icons/icons";
+    import { 
+        IconAlert, 
+        IconAlertFill, 
+        IconCheck 
+    } from "@stackoverflow/stacks-icons/icons";
     import { setContext } from "svelte";
     import type { Snippet } from "svelte";
     import type { HTMLSelectAttributes } from "svelte/elements";
@@ -184,7 +184,7 @@
         {#if vState}
             <div class="s-input-icon">
                 {#if vState === "error"}
-                    <Icon src={IconAlertCircle} />
+                    <Icon src={IconAlertFill} />
                 {:else if vState === "success"}
                     <Icon src={IconCheck} />
                 {:else}

--- a/packages/stacks-svelte/src/components/Select/Select.svelte
+++ b/packages/stacks-svelte/src/components/Select/Select.svelte
@@ -24,10 +24,10 @@
 <script lang="ts">
     import Icon from "../Icon/Icon.svelte";
     import Label from "../Label/Label.svelte";
-    import { 
-        IconAlert, 
-        IconAlertFill, 
-        IconCheck 
+    import {
+        IconAlert,
+        IconAlertFill,
+        IconCheck,
     } from "@stackoverflow/stacks-icons/icons";
     import { setContext } from "svelte";
     import type { Snippet } from "svelte";

--- a/packages/stacks-svelte/src/components/Tag/Tag.stories.svelte
+++ b/packages/stacks-svelte/src/components/Tag/Tag.stories.svelte
@@ -3,10 +3,8 @@
     import { createRawSnippet, type Snippet } from "svelte";
     import Tag, { type Size, type Variant } from "./Tag.svelte";
     import Icon from "../Icon/Icon.svelte";
-    import {
-        IconMicrosoft,
-        IconWave,
-    } from "@stackoverflow/stacks-icons-legacy/icons";
+    import { IconWave } from "@stackoverflow/stacks-icons-legacy/icons";
+    import { IconServiceMicrosoft } from "@stackoverflow/stacks-icons/icons";
 
     const TagSizes: Size[] = ["", "sm", "lg"];
     const TagVariants: Variant[] = ["", "moderator", "required"];
@@ -113,7 +111,7 @@
     <Tag>
         microsoft
         {#snippet sponsor()}
-            <Icon src={IconMicrosoft} native class="as-center w16" />
+            <Icon src={IconServiceMicrosoft} native class="as-center w16" />
         {/snippet}
     </Tag>
 </Story>

--- a/packages/stacks-svelte/src/components/Tag/Tag.svelte
+++ b/packages/stacks-svelte/src/components/Tag/Tag.svelte
@@ -6,7 +6,7 @@
 <script lang="ts">
     import type { Snippet } from "svelte";
     import Icon from "../Icon/Icon.svelte";
-    import { IconClearSm } from "@stackoverflow/stacks-icons-legacy/icons";
+    import { IconCross16 } from "@stackoverflow/stacks-icons/icons";
     import type {
         HTMLAnchorAttributes,
         HTMLButtonAttributes,
@@ -194,7 +194,7 @@
     {#if dismissable && !href}
         <button class="s-tag--dismiss" type="button" onclick={ondismiss}>
             <span class="v-visible-sr">{i18nDismissButtonText}</span><Icon
-                src={IconClearSm}
+                src={IconCross16}
             />
         </button>
     {/if}

--- a/packages/stacks-svelte/src/components/TextArea/TextArea.svelte
+++ b/packages/stacks-svelte/src/components/TextArea/TextArea.svelte
@@ -12,7 +12,7 @@
         IconAlert,
         IconAlertFill,
         IconCheck,
-    } from "@stackoverflow/stacks-icons/icons";;
+    } from "@stackoverflow/stacks-icons/icons";
 
     interface Props extends Omit<HTMLTextareaAttributes, "size"> {
         /**

--- a/packages/stacks-svelte/src/components/TextArea/TextArea.svelte
+++ b/packages/stacks-svelte/src/components/TextArea/TextArea.svelte
@@ -10,9 +10,9 @@
     import Label from "../Label/Label.svelte";
     import {
         IconAlert,
-        IconAlertCircle,
-        IconCheckmark,
-    } from "@stackoverflow/stacks-icons-legacy/icons";
+        IconAlertFill,
+        IconCheck,
+    } from "@stackoverflow/stacks-icons/icons";;
 
     interface Props extends Omit<HTMLTextareaAttributes, "size"> {
         /**
@@ -166,9 +166,9 @@
         {#if state}
             <div class="s-input-icon">
                 {#if state === "error"}
-                    <Icon src={IconAlertCircle} />
+                    <Icon src={IconAlertFill} />
                 {:else if state === "success"}
-                    <Icon src={IconCheckmark} />
+                    <Icon src={IconCheck} />
                 {:else}
                     <Icon src={IconAlert} />
                 {/if}

--- a/packages/stacks-svelte/src/components/TextInput/TextInput.svelte
+++ b/packages/stacks-svelte/src/components/TextInput/TextInput.svelte
@@ -31,9 +31,7 @@
         IconSearch,
     } from "@stackoverflow/stacks-icons/icons";
 
-    import {
-        IconCreditCard,
-    } from "@stackoverflow/stacks-icons-legacy/icons";
+    import { IconCreditCard } from "@stackoverflow/stacks-icons-legacy/icons";
 
     interface Props extends Omit<HTMLInputAttributes, "size" | "type"> {
         /**

--- a/packages/stacks-svelte/src/components/TextInput/TextInput.svelte
+++ b/packages/stacks-svelte/src/components/TextInput/TextInput.svelte
@@ -26,10 +26,13 @@
 
     import {
         IconAlert,
-        IconAlertCircle,
-        IconCheckmark,
-        IconCreditCard,
+        IconAlertFill,
+        IconCheck,
         IconSearch,
+    } from "@stackoverflow/stacks-icons/icons";
+
+    import {
+        IconCreditCard,
     } from "@stackoverflow/stacks-icons-legacy/icons";
 
     interface Props extends Omit<HTMLInputAttributes, "size" | "type"> {
@@ -245,9 +248,9 @@
             {#if state}
                 <div class="s-input-icon">
                     {#if state === "error"}
-                        <Icon src={IconAlertCircle} />
+                        <Icon src={IconAlertFill} />
                     {:else if state === "success"}
-                        <Icon src={IconCheckmark} />
+                        <Icon src={IconCheck} />
                     {:else}
                         <Icon src={IconAlert} />
                     {/if}

--- a/packages/stacks-svelte/src/components/Toast/Toast.stories.svelte
+++ b/packages/stacks-svelte/src/components/Toast/Toast.stories.svelte
@@ -1,9 +1,6 @@
 <script lang="ts" module>
-    import {
-        IconWave,
-        IconAlert,
-    } from "@stackoverflow/stacks-icons-legacy/icons";
-
+    import { IconWave } from "@stackoverflow/stacks-icons-legacy/icons";
+    import { IconAlertFill } from "@stackoverflow/stacks-icons/icons";
     import Toaster, { showToast, hideToast } from "./Toast.svelte";
     import { defineMeta } from "@storybook/addon-svelte-csf";
     import Button from "../Button/Button.svelte";
@@ -83,7 +80,7 @@
             onclick={() =>
                 showToast("I am a toast component with the an icon", {
                     variant: "danger",
-                    icon: IconAlert,
+                    icon: IconAlertFill,
                     iconTitle: "Alert Icon",
                 })}>Toast with an Icon</Button
         >

--- a/packages/stacks-svelte/src/components/Toast/Toast.test.ts
+++ b/packages/stacks-svelte/src/components/Toast/Toast.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@open-wc/testing";
 import { render, screen, waitFor } from "@testing-library/svelte";
-import { IconAlert } from "@stackoverflow/stacks-icons-legacy/icons";
+import { IconAlertFill } from "@stackoverflow/stacks-icons/icons";
 import userEvent from "@testing-library/user-event";
 import sinon from "sinon";
 import { createRawSnippet, mount, unmount } from "svelte";
@@ -40,7 +40,7 @@ describe("showToast", () => {
 
     it("should render a toast with an Icon when an icon is set", async () => {
         render(Toaster);
-        showToast("Test Toast", { icon: IconAlert, iconTitle: "Alert" });
+        showToast("Test Toast", { icon: IconAlertFill, iconTitle: "Alert" });
         await waitFor(() => expect(screen.getByTitle("Alert")).to.exist);
     });
 

--- a/packages/stacks-svelte/src/components/UserCard/UserCard.svelte
+++ b/packages/stacks-svelte/src/components/UserCard/UserCard.svelte
@@ -8,7 +8,7 @@
     import Avatar, { type Size as AvatarSize } from "../Avatar/Avatar.svelte";
     import Bling from "../Bling/Bling.svelte";
     import Icon from "../Icon/Icon.svelte";
-    import { IconPerson } from "@stackoverflow/stacks-icons-legacy/icons";
+    import { IconUserFill } from "@stackoverflow/stacks-icons/icons";
 
     interface Props {
         /**
@@ -185,7 +185,7 @@
 
     {#if deleted}
         <Icon
-            src={IconPerson}
+            src={IconUserFill}
             class="bar-md fc-white bg-black-225 s-user-card--avatar {iconSizeClasses}"
             title={name}
         />

--- a/packages/stacks-svelte/src/components/UserCard/UserCard.test.ts
+++ b/packages/stacks-svelte/src/components/UserCard/UserCard.test.ts
@@ -114,7 +114,7 @@ describe("UserCard", () => {
         ).to.have.class("s-user-card__deleted");
     });
 
-    it("should render the Icon Person instead of Avatar and name unlinked when deleted prop is true", () => {
+    it("should render the Icon UserFill instead of Avatar and name unlinked when deleted prop is true", () => {
         render(UserCard, {
             name: "John Doe",
             avatar: "https://picsum.photos/128",
@@ -124,7 +124,7 @@ describe("UserCard", () => {
         const avatarImg = screen
             .getByTitle("John Doe")
             .closest(".s-user-card--avatar");
-        expect(avatarImg).to.have.class("iconUserFill");
+        expect(avatarImg).to.have.class("IconUserFill");
     });
 
     it("should not render many properties when the deleted prop is true", () => {

--- a/packages/stacks-svelte/src/components/UserCard/UserCard.test.ts
+++ b/packages/stacks-svelte/src/components/UserCard/UserCard.test.ts
@@ -124,7 +124,7 @@ describe("UserCard", () => {
         const avatarImg = screen
             .getByTitle("John Doe")
             .closest(".s-user-card--avatar");
-        expect(avatarImg).to.have.class("iconPerson");
+        expect(avatarImg).to.have.class("iconUserFill");
     });
 
     it("should not render many properties when the deleted prop is true", () => {


### PR DESCRIPTION
# Summary

This PR adjusts the alert icons for Inputs and Selects with an error state. It also updates all icons with new versions available in the Svelte component to the latest beta revision.

# How to Test

## Main Changes

The main purpose of this PR was to update the Alert icons for Input, TextArea, and Select:

* Check out the new error state icon for `input`: https://deploy-preview-2103--stacks.netlify.app/product/components/inputs/#error
* Check out the new error state icon for `select`: https://deploy-preview-2103--stacks.netlify.app/product/components/select/#error

## Bonus Changes

I additionally updated other icons to their newer versions where available:

* Check buttons with the new trash icon: https://deploy-preview-2103--stacks-svelte.netlify.app/?path=/story/components-button--additional-styles
* Check notice close and alert icons: https://deploy-preview-2103--stacks-svelte.netlify.app/?path=/docs/components-notice--docs#actions
* Check post summary ellipsis icon: https://deploy-preview-2103--stacks-svelte.netlify.app/?path=/docs/components-postsummary--docs#optional-slots
* Confirm tag dismiss button looks good: https://deploy-preview-2103--stacks-svelte.netlify.app/?path=/docs/components-tag--docs#additional-styles-1
* Confirm toast error icon looks good: https://deploy-preview-2103--stacks-svelte.netlify.app/?path=/docs/components-toast--docs#with-icon-3
* Check user card deleted user avatar icon: https://deploy-preview-2103--stacks-svelte.netlify.app/?path=/story/components-usercard--deleted 