### PR TITLE
chore(navigation): make avatar background transparent by default

### DIFF
--- a/.changeset/clever-carrots-lie.md
+++ b/.changeset/clever-carrots-lie.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks": patch
+---
+
+Make avatar background in navigation components transparent

--- a/packages/stacks-classic/lib/components/navigation/navigation.less
+++ b/packages/stacks-classic/lib/components/navigation/navigation.less
@@ -166,6 +166,7 @@
 
     & &--avatar {
         margin-right: var(--su8);
+        background: transparent;
     }
 
     flex-direction: var(--_na-fd);


### PR DESCRIPTION
For navigation items there is no need to enforce a white static background for avatars. In fact we have a need for the transparency of the images to be respected. This PR simply specify that for avatar included in navigation items background should remain transparent.

See [this slack thread](https://stackexchange.slack.com/archives/C096063B1PH/p1766136670129519?thread_ts=1766101431.015539&cid=C096063B1PH) for full context. 