### PR TITLE
Swap email signature to orange

### DIFF
--- a/packages/stacks-docs/email/components/signatures.html
+++ b/packages/stacks-docs/email/components/signatures.html
@@ -22,7 +22,8 @@ description: Signatures are a useful option when you need to send more formal em
         </tr>
         <tr>
             <td border="0" cellpadding="0" cellspacing="0" height="24" width="190">
-                <a href="https://stackoverflow.co/"><img src="https://cdn.sstatic.net/Img/email/logo-stack-overflow-enterprise.png" width="190" height="24" alt="Stack Overflow"></a>
+                <a href="https://stackoverflow.co/"><img src="https://cdn.sstatic.net/Img/email/logo-employee-email-signature.png" width="194" height="26" alt="Stack Overflow">
+</a>
             </td>
         </tr>
     </tbody>
@@ -40,7 +41,8 @@ description: Signatures are a useful option when you need to send more formal em
                         </tr>
                         <tr>
                             <td border="0" cellpadding="0" cellspacing="0" height="24" width="190">
-                                <a href="https://stackoverflow.co/"><img src="https://cdn.sstatic.net/Img/email/logo-stack-overflow-enterprise.png" width="190" height="24" alt="Stack Overflow"></a>
+                                <a href="https://stackoverflow.co/"><img src="https://cdn.sstatic.net/Img/email/logo-employee-email-signature.png" width="194" height="26" alt="Stack Overflow">
+</a>
                             </td>
                         </tr>
                     </tbody>
@@ -62,7 +64,8 @@ description: Signatures are a useful option when you need to send more formal em
         </tr>
         <tr>
             <td border="0" cellpadding="0" cellspacing="0" height="24" width="190">
-                <a href="https://stackoverflow.co/"><img src="https://cdn.sstatic.net/Img/email/logo-stack-overflow-enterprise.png" width="190" height="24" alt="Stack Overflow"></a>
+                <a href="https://stackoverflow.co/"><img src="https://cdn.sstatic.net/Img/email/logo-employee-email-signature.png" width="194" height="26" alt="Stack Overflow">
+</a>
             </td>
         </tr>
         <tr>
@@ -87,7 +90,8 @@ description: Signatures are a useful option when you need to send more formal em
                         </tr>
                         <tr>
                             <td border="0" cellpadding="0" cellspacing="0" height="24" width="190">
-                                <a href="https://stackoverflow.co/"><img src="https://cdn.sstatic.net/Img/email/logo-stack-overflow-enterprise.png" width="190" height="24" alt="Stack Overflow"></a>
+                                <a href="https://stackoverflow.co/"><img src="https://cdn.sstatic.net/Img/email/logo-employee-email-signature.png" width="194" height="26" alt="Stack Overflow">
+</a>
                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
https://deploy-preview-2111--stacks.netlify.app/email/components/signatures/

The current email signature is a bit hard to dark mode so this swaps it for an orange variant that should work well on light and dark backgrounds.

### Before

<img width="224" height="198" alt="Screenshot 2025-12-19 at 18 16 09" src="https://github.com/user-attachments/assets/dea0f309-d46a-4ba7-9051-6db7932d7c4c" />

### After

<img width="229" height="201" alt="Screenshot 2025-12-19 at 18 17 47" src="https://github.com/user-attachments/assets/d5666e82-1f80-46b4-bf65-4f1c11167e0e" />
