### PR TITLE
Adding aria-label and aria-labelledby to PopoverContent

### DIFF
--- a/.changeset/true-guests-drive.md
+++ b/.changeset/true-guests-drive.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks-svelte": minor
+---
+
+Added aria-label and aria-labelledby props to PopoverContent

--- a/packages/stacks-svelte/src/components/Popover/Popover.test.ts
+++ b/packages/stacks-svelte/src/components/Popover/Popover.test.ts
@@ -193,6 +193,75 @@ describe("Popover", () => {
         expect(innerContentElement).to.have.class("custom-class");
     });
 
+    it("should add aria-label to the popover when the aria-label prop is provided", async () => {
+        render(Popover, {
+            props: {
+                ...defaultProps,
+                autoshow: true,
+                children: createSvelteComponentsSnippet([
+                    defaultChildren.reference,
+                    {
+                        component: PopoverContent,
+                        props: {
+                            "aria-label": "Popover with content",
+                            children: createRawSnippet(() => ({
+                                render: () => "<span>Popover Content</span>",
+                            })),
+                        },
+                    },
+                ]),
+            },
+        });
+
+        expect(screen.getByRole("dialog")).to.have.attribute(
+            "aria-label",
+            "Popover with content"
+        );
+    });
+
+    it("should add aria-labelledby to the popover when the aria-labelledby prop is provided", async () => {
+        render(Popover, {
+            props: {
+                ...defaultProps,
+                autoshow: true,
+                children: createSvelteComponentsSnippet([
+                    defaultChildren.reference,
+                    {
+                        component: PopoverContent,
+                        props: {
+                            "aria-labelledby": "my-label-id",
+                            children: createRawSnippet(() => ({
+                                render: () => "<span>Popover Content</span>",
+                            })),
+                        },
+                    },
+                ]),
+            },
+        });
+
+        expect(screen.getByRole("dialog")).to.have.attribute(
+            "aria-labelledby",
+            "my-label-id"
+        );
+    });
+
+    it("should not add aria-label or aria-labelledby when not provided", async () => {
+        render(Popover, {
+            props: {
+                ...defaultProps,
+                autoshow: true,
+                children: createSvelteComponentsSnippet([
+                    defaultChildren.reference,
+                    defaultChildren.content,
+                ]),
+            },
+        });
+
+        const dialog = screen.getByRole("dialog");
+        expect(dialog).not.to.have.attribute("aria-label");
+        expect(dialog).not.to.have.attribute("aria-labelledby");
+    });
+
     it("add classes to the popover close button component when the class prop is provided", async () => {
         render(Popover, {
             props: {

--- a/packages/stacks-svelte/src/components/Popover/Popover.test.ts
+++ b/packages/stacks-svelte/src/components/Popover/Popover.test.ts
@@ -193,7 +193,7 @@ describe("Popover", () => {
         expect(innerContentElement).to.have.class("custom-class");
     });
 
-    it("should add aria-label to the popover when the aria-label prop is provided", async () => {
+    it("should add aria-label to the popover when the ariaLabel prop is provided", async () => {
         render(Popover, {
             props: {
                 ...defaultProps,
@@ -203,8 +203,8 @@ describe("Popover", () => {
                     {
                         component: PopoverContent,
                         props: {
-                            "aria-label": "Popover with content",
-                            "children": createRawSnippet(() => ({
+                            ariaLabel: "Popover with content",
+                            children: createRawSnippet(() => ({
                                 render: () => "<span>Popover Content</span>",
                             })),
                         },
@@ -219,7 +219,7 @@ describe("Popover", () => {
         );
     });
 
-    it("should add aria-labelledby to the popover when the aria-labelledby prop is provided", async () => {
+    it("should add aria-labelledby to the popover when the ariaLabelledby prop is provided", async () => {
         render(Popover, {
             props: {
                 ...defaultProps,
@@ -229,8 +229,8 @@ describe("Popover", () => {
                     {
                         component: PopoverContent,
                         props: {
-                            "aria-labelledby": "my-label-id",
-                            "children": createRawSnippet(() => ({
+                            ariaLabelledby: "my-label-id",
+                            children: createRawSnippet(() => ({
                                 render: () => "<span>Popover Content</span>",
                             })),
                         },

--- a/packages/stacks-svelte/src/components/Popover/Popover.test.ts
+++ b/packages/stacks-svelte/src/components/Popover/Popover.test.ts
@@ -204,7 +204,7 @@ describe("Popover", () => {
                         component: PopoverContent,
                         props: {
                             "aria-label": "Popover with content",
-                            children: createRawSnippet(() => ({
+                            "children": createRawSnippet(() => ({
                                 render: () => "<span>Popover Content</span>",
                             })),
                         },
@@ -230,7 +230,7 @@ describe("Popover", () => {
                         component: PopoverContent,
                         props: {
                             "aria-labelledby": "my-label-id",
-                            children: createRawSnippet(() => ({
+                            "children": createRawSnippet(() => ({
                                 render: () => "<span>Popover Content</span>",
                             })),
                         },

--- a/packages/stacks-svelte/src/components/Popover/PopoverContent.svelte
+++ b/packages/stacks-svelte/src/components/Popover/PopoverContent.svelte
@@ -10,6 +10,14 @@
          */
         role?: string | null;
         /**
+         * Accessible label for the popover
+         */
+        "aria-label"?: string;
+        /**
+         * ID of an element that labels the popover
+         */
+        "aria-labelledby"?: string;
+        /**
          * Additional CSS classes added to the s-popover element
          */
         class?: string;
@@ -25,6 +33,8 @@
 
     let {
         role = null,
+        "aria-label": ariaLabel,
+        "aria-labelledby": ariaLabelledby,
         class: className = "",
         contentClass = "",
         children,
@@ -65,6 +75,8 @@
     id={`${pstate.id}-popover`}
     class={computedClass}
     role={computedRole}
+    aria-label={ariaLabel}
+    aria-labelledby={ariaLabelledby}
     use:pstate.floatingContent
     use:focusTrap={{ active: pstate.trapFocus && !!pstate.visible }}
     use:clickOutside

--- a/packages/stacks-svelte/src/components/Popover/PopoverContent.svelte
+++ b/packages/stacks-svelte/src/components/Popover/PopoverContent.svelte
@@ -8,34 +8,34 @@
          * The aria role of the popover
          * (if not specified, it will default to 'dialog' for popovers or 'tooltip' when in tooltip mode)
          */
-        "role"?: string | null;
+        role?: string | null;
         /**
          * Accessible label for the popover
          */
-        "aria-label"?: string;
+        ariaLabel?: string;
         /**
          * ID of an element that labels the popover
          */
-        "aria-labelledby"?: string;
+        ariaLabelledby?: string;
         /**
          * Additional CSS classes added to the s-popover element
          */
-        "class"?: string;
+        class?: string;
         /**
          * Additional CSS classes added to the s-popover--content element
          */
-        "contentClass"?: string;
+        contentClass?: string;
         /**
          * Children snippet
          */
-        "children"?: Snippet;
+        children?: Snippet;
     }
 
     let {
         role = null,
-        "aria-label": ariaLabel,
-        "aria-labelledby": ariaLabelledby,
-        "class": className = "",
+        ariaLabel,
+        ariaLabelledby,
+        class: className = "",
         contentClass = "",
         children,
     }: Props = $props();

--- a/packages/stacks-svelte/src/components/Popover/PopoverContent.svelte
+++ b/packages/stacks-svelte/src/components/Popover/PopoverContent.svelte
@@ -8,7 +8,7 @@
          * The aria role of the popover
          * (if not specified, it will default to 'dialog' for popovers or 'tooltip' when in tooltip mode)
          */
-        role?: string | null;
+        "role"?: string | null;
         /**
          * Accessible label for the popover
          */
@@ -20,22 +20,22 @@
         /**
          * Additional CSS classes added to the s-popover element
          */
-        class?: string;
+        "class"?: string;
         /**
          * Additional CSS classes added to the s-popover--content element
          */
-        contentClass?: string;
+        "contentClass"?: string;
         /**
          * Children snippet
          */
-        children?: Snippet;
+        "children"?: Snippet;
     }
 
     let {
         role = null,
         "aria-label": ariaLabel,
         "aria-labelledby": ariaLabelledby,
-        class: className = "",
+        "class": className = "",
         contentClass = "",
         children,
     }: Props = $props();


### PR DESCRIPTION
## Summary 
This PR adds accessibility props, aria-label and aria-labelledby to the PopoverContent component. I have added tests to ensure the props are added when provided and excluded when not.