### PR TITLE
fix(font-size): properly set rem values

### DIFF
--- a/.changeset/four-planets-own.md
+++ b/.changeset/four-planets-own.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks": patch
+---
+
+Fix rem font size values

--- a/packages/stacks-classic/lib/base/body.less
+++ b/packages/stacks-classic/lib/base/body.less
@@ -20,7 +20,7 @@ html,
 body {
     color: var(--theme-body-font-color, var(--black-600));
     font-family: var(--theme-body-font-family);
-    font-size: var(--fs-base);
+    font-size: var(--fs-body1);
     line-height: var(--lh-base);
 }
 

--- a/packages/stacks-classic/lib/components/popover/popover.less
+++ b/packages/stacks-classic/lib/components/popover/popover.less
@@ -3,7 +3,7 @@
     --_po-bc: var(--bc-medium);
     --_po-bs: var(--bs-md);
     --_po-d: none;
-    --_po-wmn: 12rem;
+    --_po-wmn: 10.5rem;
     --_po-w: 100%;
     // content
     // --_po-topbar-height assumes the topbar height based on topbar styles
@@ -51,7 +51,7 @@
     border-radius: var(--br-md);
     color: var(--fc-dark);
     font-size: var(--fs-body1);
-    max-width: 24rem;
+    max-width: 21rem;
     padding: var(--su12);
     position: absolute;
     white-space: normal; // Guard against popovers being in a container with white-space: nowrap. Without this, the content pops *out* of the popover.

--- a/packages/stacks-classic/lib/components/post-summary/post-summary.less
+++ b/packages/stacks-classic/lib/components/post-summary/post-summary.less
@@ -270,8 +270,8 @@
             font-size: var(--fs-body3);
             font-weight: normal;
             line-height: var(--lh-md);
-            margin-bottom: 0.3846rem;
-            margin-top: -0.15rem; // Optical alignment to compensate for title's containing block
+            margin-bottom: 0.3365rem;
+            margin-top: -0.125rem; // Optical alignment to compensate for title's containing block
             padding-right: var(--su24);
         }
 

--- a/packages/stacks-classic/lib/components/prose/prose.less
+++ b/packages/stacks-classic/lib/components/prose/prose.less
@@ -49,11 +49,11 @@
     &&__xs,
     &&__sm,
     &&__md {
-        --_pr-h1-fs: var(--fs-headline1-relative);
-        --_pr-h2-fs: var(--fs-title-relative);
-        --_pr-h3-fs: var(--fs-subheading-relative);
-        --_pr-h4-fs: var(--fs-body3-relative);
-        --_pr-h5-fs: var(--fs-body2-relative);
+        --_pr-h1-fs: 1.75em;
+        --_pr-h2-fs: 1.375em;
+        --_pr-h3-fs: 1.25em;
+        --_pr-h4-fs: 1.125em;
+        --_pr-h5-fs: 1em;
     }
 
     &&__xs {

--- a/packages/stacks-classic/lib/components/toast/toast.less
+++ b/packages/stacks-classic/lib/components/toast/toast.less
@@ -13,7 +13,7 @@
 
     .s-notice {
         box-shadow: var(--bs-sm);
-        max-width: 44rem;
+        max-width: 38.5rem;
         padding-bottom: var(--su8);
         padding-top: var(--su8);
         pointer-events: all;

--- a/packages/stacks-classic/lib/exports/constants-helpers.less
+++ b/packages/stacks-classic/lib/exports/constants-helpers.less
@@ -52,7 +52,7 @@ body {
     --transition-time:                   var(--default-transition-duration);
 
     // Sizing
-    --s-full: 97.2307692rem; // Based on a pixel size of 1264px;
+    --s-full: 79rem; // Based on a pixel size of 1264px;
     --s-step: calc(var(--s-full) / 12);
 }
 

--- a/packages/stacks-classic/lib/exports/constants-type.less
+++ b/packages/stacks-classic/lib/exports/constants-type.less
@@ -108,7 +108,7 @@ body {
     --fs-title:         1.375rem;   // 22px
     --fs-headline1:     1.75rem;    // 28px
     --fs-headline2:     2.25rem;    // 36px
-    --fs-display1:      2.875;      // 46px
+    --fs-display1:      2.875rem;      // 46px
     --fs-display2:      3.625rem;   // 58px
     --fs-display3:      4.5rem;     // 72px
     --fs-display4:      6.25rem;    // 100px

--- a/packages/stacks-classic/lib/exports/constants-type.less
+++ b/packages/stacks-classic/lib/exports/constants-type.less
@@ -88,48 +88,30 @@
     Menlo, Monaco, Consolas, // A few sensible system font choices
     monospace; // The final fallback for rendering in monospace.
 
-html,
+html {
+    font-size: 100%;
+}
+
 body {
     --ff-sans: @ff-sans;
     --ff-serif: @ff-serif;
     --ff-mono: @ff-mono;
     --theme-body-font-family: var(--ff-sans);
 
-    //  ============================================================================
-    //  $   FONT SIZES (fs-)
-    //      Base font-size is 13px.
-    //  ----------------------------------------------------------------------------
-    --fs-fine:           12px;
-    --fs-caption:        13px;
-    --fs-body1:          14px;
-
-    //  Relative to the root element
-    --fs-body2:               1.143rem; // 16px
-    --fs-body3:               1.286rem; // 18px
-    --fs-subheading:          1.429rem; // 20px
-    --fs-title:               1.571rem; // 22px
-    --fs-headline1:           2rem;     // 28px
-    --fs-headline2:           2.571rem; // 36px
-    --fs-display1:            3.286rem; // 46px
-    --fs-display2:            4.143rem; // 58px
-    --fs-display3:            5.143rem; // 72px
-    --fs-display4:            7.143rem; // 100px
-
-    //  Relative to the parent
-    --fs-body2-relative:      1.143rem; // 16px
-    --fs-body3-relative:      1.286rem; // 18px
-    --fs-subheading-relative: 1.429rem; // 20px
-    --fs-title-relative:      1.571rem; // 22px
-    --fs-headline1-relative:  2rem;     // 28px
-    --fs-headline2-relative:  2.571rem; // 36px
-    --fs-display1-relative:   3.286rem; // 46px
-    --fs-display2-relative:   4.143rem; // 58px
-    --fs-display3-relative:   5.143rem; // 72px
-    --fs-display4-relative:   7.143rem; // 100px
-
-    // this value is not using spacing units because the calc involved results
-    // in unexpected sizing. I'm not sure why, honestly.
-    --fs-base: 14px;
+    // All rem values are relative to the font size applied to <html> (16px by default).
+    --fs-fine:          0.75rem;    // 12px
+    --fs-caption:       0.8125rem;  // 13px
+    --fs-body1:         0.875rem;   // 14px (base font size applied to <body>)
+    --fs-body2:         1rem;       // 16px
+    --fs-body3:         1.125rem;   // 18px
+    --fs-subheading:    1.25rem;    // 20px
+    --fs-title:         1.375rem;   // 22px
+    --fs-headline1:     1.75rem;    // 28px
+    --fs-headline2:     2.25rem;    // 36px
+    --fs-display1:      2.875;      // 46px
+    --fs-display2:      3.625rem;   // 58px
+    --fs-display3:      4.5rem;     // 72px
+    --fs-display4:      6.25rem;    // 100px
 
     //  ============================================================================
     //  $   LINE HEIGHT (lh-)

--- a/packages/stacks-docs/assets/less/stacks-documentation.less
+++ b/packages/stacks-docs/assets/less/stacks-documentation.less
@@ -252,7 +252,7 @@
     > pre.s-code-block {
         border-radius: var(--br-md) var(--br-md) 0 0;
         border: 1px solid var(--bc-medium);
-        max-height: 24rem;
+        max-height: 21rem;
 
         .dark-mode({
             border-color: var(--bc-lighter);


### PR DESCRIPTION
This PR fixes a bug with our font sizing that had downstream effects on styles that leveraged our `--s-full` custom property. Previously, we were setting our base font size to a static `14px` value at the `html` level. This resulted in values uses in classes such as our atomic static width/height classes to be inflated.

For example, check out the width of the `.s-topbar--container` in our [docs](https://beta.stackoverflow.design/product/develop/using-stacks/):

<img width="1476" height="120" alt="image" src="https://github.com/user-attachments/assets/f9206eb9-aed1-48c0-a821-cd11871a4e0f" />

Notice that it is `1361.23px` wide. It has `width: var(--s-full)`, which should result in a width of `1264px`. With the changes in this PR, we get the intended width:

<img width="1411" height="118" alt="image" src="https://github.com/user-attachments/assets/6947d217-8299-4f83-8db0-01bdd726b1a0" />

As a bonus, this simplifies our usage of rem values dramatically since sizing more often tends to be divisible by `16px` (the default base font size set on the `html` tag - keep reading for more details on this). This should also make the upcoming atomic size class updates simpler 🤞 

## How this works

Standard browser default font size is `16px`. By setting `font-size: 100%` on `html`, you're saying _use 100% of the size of the browser's set font size_. If the user overrides that font size, the user's preference will instead be applied.

On the `body` tag, a `rem`-based font size can be set. This will be relative to the font size set on `html`. Since the default is `16px`, we can achieve our desired base font-size by setting the `body` font size to `0.825rem` (which computes to `14px`).

From [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-size#pixels):
> If a font-size has not been set on any of the `<p>`'s ancestors, then `1em` will equal the default browser `font-size`, which is usually `16px`. So, by default `1em` is equivalent to `16px`, and `2em` is equivalent to `32px`.[…]

> [!NOTE]
> The above quote mentions `em` but the same logic applies to `rem` when operating at the `body` tag level.

## Notable changes

- As mentioned, `html` now has a `font-size` or `100%`
- I've replace the single usage of `--fs-base` with `--fs-body1` and removed `--fs-base` altogether
- I've fixed a bug where `.s-prose` of different sizes should have had font sizes that scaled relative to the parent's font size. We were using `rem` values when we should use `em`.
  - This also allowed me to remove all `--fs-*-relative` custom properties. They we're working as intended and were all either referenced in `.s-prose` or not at all
- I've updated all `rem` values through our codebase to their base-16 equivelent values (this [px to rem converter](https://nekocalc.com/px-to-rem-converter) is handy if you'd like to check my math)

## Other details

This should result nearly zero changes to the look of components (I think the `.s-prose` sizes are the most notable change). I'm relieved to see that the visual regression tests have passed 😅 

## How to test

I suggest hitting the local instance (or deploy preview) and just poking around a bunch. Notice that the docs site is no longer _too wide_. Verify that the font sizes compute to what is expected. Verify that any modified component still renders as expected.

For bonus points, try scaling your browser font size and notice the text scale with it (more work will need to be done in [SPARK-154](https://stackoverflow.atlassian.net/browse/SPARK-154) to have all scaling live in harmony).