### PR TITLE
chore(stacks-svelte): adjust peer deps

### DIFF
--- a/.changeset/cold-months-mix.md
+++ b/.changeset/cold-months-mix.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks-svelte": patch
+---
+
+Adjust stacks svelte peer deps

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,8 @@
   ],
   "commit": false,
   "access": "public",
-  "baseBranch": "beta"
+  "baseBranch": "beta",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,7 +119,6 @@
             "integrity": "sha512-IcsDlbXnBf8cHzbM1YBv3JcTyLB35EK88QexmVyFdVJVgUU6bh9g687rpxryJirHzo06PuwnYaEEdVZQfIgRGg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@11ty/dependency-tree": "^4.0.0",
                 "@11ty/dependency-tree-esm": "^2.0.0",
@@ -404,7 +403,6 @@
             "integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@keyv/serialize": "^1.1.1"
             }
@@ -767,7 +765,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -791,7 +788,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1780,15 +1776,13 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.3.0.tgz",
             "integrity": "sha512-L9X8uHCYU310o99L3/MpJKYxPzXPOS7S0NmBaM7UO/x2Kb2WbmMLSkfvdr1KxRIFYOpbY0Jhn7CfLSUDzL8arQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@lezer/highlight": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
             "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@lezer/common": "^1.3.0"
             }
@@ -3102,7 +3096,6 @@
             "integrity": "sha512-TmzrdDHUKtKG7x1CqYuMIHjfXMqS85EwIF3Of/LV+laBtDhKrgioPJW82dIOJ44w1nryH8Yeh1Hdx9O+cPWfVw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ts-dedent": "^2.0.0",
                 "type-fest": "~2.19"
@@ -3214,7 +3207,6 @@
             "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
                 "debug": "^4.4.1",
@@ -3255,7 +3247,6 @@
             "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -3533,7 +3524,6 @@
             "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -3729,7 +3719,6 @@
             "integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -3928,7 +3917,6 @@
             "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.46.2",
                 "@typescript-eslint/types": "8.46.2",
@@ -4920,7 +4908,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5381,7 +5368,6 @@
             "integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
             "dev": true,
             "license": "MPL-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -5674,7 +5660,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.19",
                 "caniuse-lite": "^1.0.30001751",
@@ -6487,6 +6472,7 @@
             "integrity": "sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-what": "^3.14.1"
             },
@@ -6797,7 +6783,8 @@
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/dashdash": {
             "version": "1.14.1",
@@ -7029,8 +7016,7 @@
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1508733.tgz",
             "integrity": "sha512-QJ1R5gtck6nDcdM+nlsaJXcelPEI7ZxSMw1ujHpO1c4+9l+Nue5qlebi9xO1Z2MGr92bFOQTW7/rrheh5hHxDg==",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/diff": {
             "version": "5.2.0",
@@ -7472,7 +7458,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -7590,7 +7575,6 @@
             "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -7651,7 +7635,6 @@
             "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -8892,7 +8875,6 @@
             "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
             "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
             "license": "BSD-3-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=12.0.0"
             }
@@ -9151,6 +9133,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "bin": {
                 "image-size": "bin/image-size.js"
             },
@@ -9611,7 +9594,8 @@
             "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
             "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/is-windows": {
             "version": "1.0.2",
@@ -10127,6 +10111,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "prr": "~1.0.1"
             },
@@ -10141,6 +10126,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "pify": "^4.0.1",
                 "semver": "^5.6.0"
@@ -10156,6 +10142,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "bin": {
                 "mime": "cli.js"
             },
@@ -10170,6 +10157,7 @@
             "dev": true,
             "license": "ISC",
             "optional": true,
+            "peer": true,
             "bin": {
                 "semver": "bin/semver"
             }
@@ -10181,6 +10169,7 @@
             "dev": true,
             "license": "BSD-3-Clause",
             "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10939,6 +10928,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "iconv-lite": "^0.6.3",
                 "sax": "^1.2.4"
@@ -10957,6 +10947,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -11496,6 +11487,7 @@
             "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.10"
             }
@@ -11845,7 +11837,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -12505,7 +12496,6 @@
             "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -12560,7 +12550,6 @@
             "integrity": "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "posthtml-parser": "^0.11.0",
                 "posthtml-render": "^3.0.0"
@@ -12713,7 +12702,6 @@
             "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -12889,7 +12877,6 @@
             "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
             "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "orderedmap": "^2.0.0"
             }
@@ -12919,7 +12906,6 @@
             "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
             "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.0.0",
                 "prosemirror-transform": "^1.0.0",
@@ -12950,7 +12936,6 @@
             "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.3.tgz",
             "integrity": "sha512-SqMiYMUQNNBP9kfPhLO8WXEk/fon47vc52FQsUiJzTBuyjKgEcoAwMyF04eQ4WZ2ArMn7+ReypYL60aKngbACQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.20.0",
                 "prosemirror-state": "^1.0.0",
@@ -13208,7 +13193,6 @@
             "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13219,7 +13203,6 @@
             "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -13689,7 +13672,6 @@
             "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -14634,7 +14616,6 @@
             "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "chokidar": "^4.0.0",
                 "immutable": "^5.0.2",
@@ -14720,7 +14701,6 @@
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -15291,7 +15271,6 @@
             "integrity": "sha512-es7uDdEwRVVUAt7XLAZZ1hicOq9r4ov5NFeFPpa2YEyAsyHYOCr0CTlHBfslWG6D5EVNWK3kVIIuW8GHB6hEig==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@storybook/global": "^5.0.0",
                 "@testing-library/jest-dom": "^6.6.3",
@@ -15560,7 +15539,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@csstools/css-parser-algorithms": "^3.0.5",
                 "@csstools/css-tokenizer": "^3.0.4",
@@ -15789,7 +15767,6 @@
             "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.42.2.tgz",
             "integrity": "sha512-iSry5jsBHispVczyt9UrBX/1qu3HQ/UyKPAIjqlvlu3o/eUvc+kpyMyRS2O4HLLx4MvLurLGIUOyyP11pyD59g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/remapping": "^2.3.4",
                 "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -16254,7 +16231,6 @@
             "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
                 "acorn": "^8.15.0",
@@ -16601,7 +16577,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -16837,7 +16812,6 @@
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -16956,7 +16930,6 @@
             "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
                 "@vitest/expect": "3.2.4",
@@ -17095,7 +17068,6 @@
             "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -17145,7 +17117,6 @@
             "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.6.1",
                 "@webpack-cli/configtest": "^3.0.1",
@@ -17648,12 +17619,12 @@
                 "@floating-ui/core": "^1.7.3",
                 "@stackoverflow/stacks-icons": "^7.0.0-beta.14",
                 "@stackoverflow/stacks-icons-legacy": "npm:@stackoverflow/stacks-icons@^6.9.0",
+                "@stackoverflow/stacks-utils": "^1.0.0-beta.0",
                 "svelte-floating-ui": "^1.6.2",
                 "svelte-sonner": "^1.0.5"
             },
             "peerDependencies": {
-                "@stackoverflow/stacks": "^3.0.0-beta.16",
-                "@stackoverflow/stacks-utils": "1.0.0-beta.0",
+                "@stackoverflow/stacks": "^2.0.0 || ^3.0.0-beta.0 || ^3.0.0",
                 "svelte": "^5.0.0"
             }
         },

--- a/packages/stacks-svelte/package.json
+++ b/packages/stacks-svelte/package.json
@@ -29,14 +29,14 @@
         "storybook:extract": "node tools/storybook-llms-extractor.js"
     },
     "peerDependencies": {
-        "@stackoverflow/stacks": "^3.0.0-beta.16",
-        "@stackoverflow/stacks-utils": "1.0.0-beta.0",
+        "@stackoverflow/stacks": "^2.0.0 || ^3.0.0-beta.0 || ^3.0.0",
         "svelte": "^5.0.0"
     },
     "dependencies": {
         "@floating-ui/core": "^1.7.3",
         "@stackoverflow/stacks-icons": "^7.0.0-beta.14",
         "@stackoverflow/stacks-icons-legacy": "npm:@stackoverflow/stacks-icons@^6.9.0",
+        "@stackoverflow/stacks-utils": "^1.0.0-beta.0",
         "svelte-floating-ui": "^1.6.2",
         "svelte-sonner": "^1.0.5"
     },


### PR DESCRIPTION
This PR adjust 2 things in the `@stackoverflow/stacks-svelte` package.json:
- Set the `onlyUpdatePeerDependentsWhenOutOfRange` experimental option of changeset to true so that the `@stackoverflow/stacks` peer dependency version is not overridden every time a new version is published. Specifically we need to keep also v2 as a peer dependency because in projects like our Core codebase stacks v2 and v3 will coexist together for a while and we don't want the npm algorithm to prevent installation (see [this Core PR](https://github.com/StackEng/StackOverflow/pull/24287) for context). We already added v2 as a peer dependency a while back but changeset overrode it when it upgraded the stacks library ([context](https://github.com/StackExchange/Stacks/commit/7ed7d323a3603616ca7443f0439b8dea4c354eb1)). The new flag should prevent that from happening in the future.
- Move the `@stackoverflow/stacks-utils` package from being a peer dependency to a regular dependency (so that consumer don't need to install it manually themselves and we retain more control over breaking changes within the package that affects stacks svelte). It is also consistent with what we do for the dependency on `@stackoverflow/stacks-icons`.
