### PR TITLE
fix(usercard) - remove nested <a> tags in user card

### DIFF
--- a/.changeset/cuddly-years-grin.md
+++ b/.changeset/cuddly-years-grin.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks-svelte": patch
+---
+
+Remove nested <a> tag in UserCard to fix node_invalid_placement_ssr warning

--- a/packages/stacks-svelte/src/components/PostSummary/PostSummaryAnswer.test.ts
+++ b/packages/stacks-svelte/src/components/PostSummary/PostSummaryAnswer.test.ts
@@ -61,7 +61,7 @@ describe("PostSummaryAnswer", () => {
         const avatar = avatarImg?.parentElement;
         expect(avatarImg).to.have.attr("src", baseArgs.userAvatar);
         expect(avatar).to.have.class("s-avatar");
-        expect(avatar).to.have.attr("href", baseArgs.userProfileUrl);
+        expect(avatar?.parentElement).to.have.attr("href", baseArgs.userProfileUrl);
 
         const reputation = screen.getByText(baseArgs.userReputation);
         expect(reputation).to.exist;

--- a/packages/stacks-svelte/src/components/PostSummary/PostSummaryAnswer.test.ts
+++ b/packages/stacks-svelte/src/components/PostSummary/PostSummaryAnswer.test.ts
@@ -61,7 +61,10 @@ describe("PostSummaryAnswer", () => {
         const avatar = avatarImg?.parentElement;
         expect(avatarImg).to.have.attr("src", baseArgs.userAvatar);
         expect(avatar).to.have.class("s-avatar");
-        expect(avatar?.parentElement).to.have.attr("href", baseArgs.userProfileUrl);
+        expect(avatar?.parentElement).to.have.attr(
+            "href",
+            baseArgs.userProfileUrl
+        );
 
         const reputation = screen.getByText(baseArgs.userReputation);
         expect(reputation).to.exist;

--- a/packages/stacks-svelte/src/components/UserCard/UserCard.svelte
+++ b/packages/stacks-svelte/src/components/UserCard/UserCard.svelte
@@ -160,12 +160,7 @@
             href={profileUrl}
         >
             {#if avatar}
-                <Avatar
-                    {name}
-                    href={profileUrl}
-                    src={avatar}
-                    size={avatarSize}
-                />
+                <Avatar {name} src={avatar} size={avatarSize} />
             {/if}
             {#if name}
                 {#if originalPoster}

--- a/packages/stacks-svelte/src/components/UserCard/UserCard.test.ts
+++ b/packages/stacks-svelte/src/components/UserCard/UserCard.test.ts
@@ -54,18 +54,6 @@ describe("UserCard", () => {
         ).to.have.class("s-user-card__sm");
     });
 
-    it("should render the avatar and name as links", () => {
-        render(UserCard, {
-            name: "John Doe",
-            avatar: "https://picsum.photos/128",
-            profileUrl: "#",
-        });
-        const avatarLink = screen.getByRole("presentation").parentElement;
-        const nameLink = screen.getByRole("link", { name: "John Doe" });
-        expect(avatarLink).to.have.attr("href", "#");
-        expect(nameLink).to.have.attr("href", "#");
-    });
-
     it("should render the user card with arbitrary classes", () => {
         render(UserCard, {
             name: "John Doe",

--- a/packages/stacks-svelte/src/components/UserCard/UserCard.test.ts
+++ b/packages/stacks-svelte/src/components/UserCard/UserCard.test.ts
@@ -55,7 +55,7 @@ describe("UserCard", () => {
     });
 
     it("should render the avatar and name as links", () => {
-    render(UserCard, {
+        render(UserCard, {
             name: "John Doe",
             avatar: "https://picsum.photos/128",
             profileUrl: "#",

--- a/packages/stacks-svelte/src/components/UserCard/UserCard.test.ts
+++ b/packages/stacks-svelte/src/components/UserCard/UserCard.test.ts
@@ -60,8 +60,15 @@ describe("UserCard", () => {
             avatar: "https://picsum.photos/128",
             profileUrl: "#",
         });
-        const nameLink = screen.getByRole("link", { name: "John Doe" });
-        expect(nameLink).to.have.attr("href", "#");
+        // The avatar and name are now wrapped in a single link element
+        // The accessible name is "John Doe John Doe" (avatar screen reader text + username)
+        const link = screen.getByRole("link", { name: /John Doe/ });
+        expect(link).to.have.attr("href", "#");
+        // Verify both avatar and name are inside the same link
+        const avatarImg = screen.getByRole("presentation");
+        expect(avatarImg.closest("a")).to.equal(link);
+        const username = document.querySelector(".s-user-card--username");
+        expect(username?.closest("a")).to.equal(link);
     });
 
     it("should render the user card with arbitrary classes", () => {

--- a/packages/stacks-svelte/src/components/UserCard/UserCard.test.ts
+++ b/packages/stacks-svelte/src/components/UserCard/UserCard.test.ts
@@ -54,6 +54,16 @@ describe("UserCard", () => {
         ).to.have.class("s-user-card__sm");
     });
 
+    it("should render the avatar and name as links", () => {
+    render(UserCard, {
+            name: "John Doe",
+            avatar: "https://picsum.photos/128",
+            profileUrl: "#",
+        });
+        const nameLink = screen.getByRole("link", { name: "John Doe" });
+        expect(nameLink).to.have.attr("href", "#");
+    });
+
     it("should render the user card with arbitrary classes", () => {
         render(UserCard, {
             name: "John Doe",

--- a/packages/stacks-svelte/src/components/UserCard/UserCard.test.ts
+++ b/packages/stacks-svelte/src/components/UserCard/UserCard.test.ts
@@ -60,11 +60,8 @@ describe("UserCard", () => {
             avatar: "https://picsum.photos/128",
             profileUrl: "#",
         });
-        // The avatar and name are now wrapped in a single link element
-        // The accessible name is "John Doe John Doe" (avatar screen reader text + username)
         const link = screen.getByRole("link", { name: /John Doe/ });
         expect(link).to.have.attr("href", "#");
-        // Verify both avatar and name are inside the same link
         const avatarImg = screen.getByRole("presentation");
         expect(avatarImg.closest("a")).to.equal(link);
         const username = document.querySelector(".s-user-card--username");


### PR DESCRIPTION
[SPARK-163](https://stackoverflow.atlassian.net/browse/SPARK-163)

PR to remove the nested a tag in user card to fix the warning `node_invalid_placement_ssr`

Updated tests too.

This fix cannot be tested within Stacks. I will reach out to a core team to get them to test this when a new version of Stacks has been shipped