### PR TITLE
patch(badges): Add star icon for new user badges

### DIFF
--- a/.changeset/itchy-tomatoes-grin.md
+++ b/.changeset/itchy-tomatoes-grin.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks": patch
+---
+
+patch(badges): Add star icon for new user badges

--- a/packages/stacks-classic/lib/components/badge/badge.a11y.test.ts
+++ b/packages/stacks-classic/lib/components/badge/badge.a11y.test.ts
@@ -14,7 +14,7 @@ const variants = {
         "success",
         "featured",
     ],
-    users: ["admin", "moderator", "staff", "ai", "bot"],
+    users: ["admin", "moderator", "staff", "ai", "bot", "new"],
 };
 
 describe("badge", () => {

--- a/packages/stacks-classic/lib/components/badge/badge.less
+++ b/packages/stacks-classic/lib/components/badge/badge.less
@@ -133,9 +133,19 @@
         --_ba-sq-bg: var(--purple-200);
         --_ba-bc: var(--purple-400);
         --_ba-gap: var(--su2); // 2px gap between icon and text
-        --_ba-before-h: calc(var(--su12) + var(--su2)); // 14px
-        --_ba-before-w: calc(var(--su12) + var(--su2)); // 14px
-        --_ba-before-icon: url("data:image/svg+xml;,%3Csvg width='14' height='14' viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8 1a7 7 0 1 1 0 14A7 7 0 0 1 8 1m0 1.25a5.75 5.75 0 1 0 0 11.5 5.75 5.75 0 0 0 0-11.5m1 10.06H7V10.6h2zM8.14 4c1.78 0 2.77.96 2.77 2.5 0 1.79-2.1 2.2-2.1 3.25h-1.6c0-2 2-2.08 2-3.26 0-.54-.27-.96-1.02-.96-.7 0-1.03.46-1.1 1.23H5.4A2.75 2.75 0 0 1 8.13 4' fill='%23fff'/%3E%3C/svg%3E");
+        --_ba-before-h: calc(var(--su12) + var(--su4)); // 16px
+        --_ba-before-w: calc(var(--su12) + var(--su4)); // 16px
+        --_ba-before-icon: url("data:image/svg+xml;,%3Csvg width='20' height='20' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12.25 7h7.28l-5.89 4.29.68 2.08-2.07-1.5-.04-.12-.33-1.04.88-.64 2.16-1.56h-3.76l-.34-1.04L10 4.94l-.82 2.53-.34 1.04H5.08l2.16 1.56.88.64-.33 1.04-.83 2.54 2.16-1.57.87-.64 5.12 3.72.78 2.41L10 13.93l-5.9 4.28 2.26-6.92L.46 7h7.29L10 .08z' /%3E%3C/svg%3E");
+
+        &.s-badge__sm {
+            --_ba-before-h: calc(var(--su12) + var(--su2)); // 14px
+            --_ba-before-w: calc(var(--su12) + var(--su2)); // 14px
+        }
+
+        &.s-badge__lg {
+            --_ba-before-h: calc(var(--su12) + var(--su6)); // 18px
+            --_ba-before-w: calc(var(--su12) + var(--su6)); // 18px
+        }
 
         &:before {
             height: var(--_ba-before-h);

--- a/packages/stacks-classic/lib/components/badge/badge.visual.test.ts
+++ b/packages/stacks-classic/lib/components/badge/badge.visual.test.ts
@@ -15,7 +15,7 @@ const variants = {
         "success",
         "featured",
     ],
-    users: ["admin", "moderator", "staff", "ai", "bot"],
+    users: ["admin", "moderator", "staff", "ai", "bot", "new"],
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/stacks-classic/screenshots/Chromium/baseline/s-badge-dark-new.ico
+++ b/packages/stacks-classic/screenshots/Chromium/baseline/s-badge-dark-new.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d24b0100f8ab073884f803e72e912c3953a8a729954014ac6b9db2094e6dbb31
+size 2009

--- a/packages/stacks-classic/screenshots/Chromium/baseline/s-badge-highcontrast-dark-new.ico
+++ b/packages/stacks-classic/screenshots/Chromium/baseline/s-badge-highcontrast-dark-new.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7dfe21231c8b6e79cab2c341042b16969c335877aff2f0e7247b54b2a2377aa5
+size 1997

--- a/packages/stacks-classic/screenshots/Chromium/baseline/s-badge-highcontrast-light-new.ico
+++ b/packages/stacks-classic/screenshots/Chromium/baseline/s-badge-highcontrast-light-new.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9457e4587c757cc7fd57f18223ce4b2f54439a3b7bae6620514c5339cfccbbf4
+size 2005

--- a/packages/stacks-classic/screenshots/Chromium/baseline/s-badge-light-new.ico
+++ b/packages/stacks-classic/screenshots/Chromium/baseline/s-badge-light-new.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e8104694d9558af185dd2105c35dd09681d5004202757ff6b0bd3d61402e23a
+size 1984

--- a/packages/stacks-classic/screenshots/Firefox/baseline/s-badge-dark-new.ico
+++ b/packages/stacks-classic/screenshots/Firefox/baseline/s-badge-dark-new.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e75f9dee62bb0d3735fe46381c390f7e526625cda909e2e902a9055d58372e4a
+size 3077

--- a/packages/stacks-classic/screenshots/Firefox/baseline/s-badge-highcontrast-dark-new.ico
+++ b/packages/stacks-classic/screenshots/Firefox/baseline/s-badge-highcontrast-dark-new.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07960988ef01f3991ae3a46950a6bb139fc33cd596524ccdfcb054e628aba10d
+size 3092

--- a/packages/stacks-classic/screenshots/Firefox/baseline/s-badge-highcontrast-light-new.ico
+++ b/packages/stacks-classic/screenshots/Firefox/baseline/s-badge-highcontrast-light-new.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93ce2d4de253cf67784a63f10f45995bfc854f26bb191ea4f6e6f91be3f39b1f
+size 3090

--- a/packages/stacks-classic/screenshots/Firefox/baseline/s-badge-light-new.ico
+++ b/packages/stacks-classic/screenshots/Firefox/baseline/s-badge-light-new.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24b255da563d6587eef640056543294b33e33d0a8f71bbe730489ce99f38c547
+size 3060

--- a/packages/stacks-classic/screenshots/Webkit/baseline/s-badge-dark-new.ico
+++ b/packages/stacks-classic/screenshots/Webkit/baseline/s-badge-dark-new.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc8b70228df1199873aaae36a0beacf7f78696c416b22e554ea844a860cf2491
+size 2295

--- a/packages/stacks-classic/screenshots/Webkit/baseline/s-badge-highcontrast-dark-new.ico
+++ b/packages/stacks-classic/screenshots/Webkit/baseline/s-badge-highcontrast-dark-new.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef448a3f474a14e67d02e8f77a5987a44641f77ad10307cd8236d293760d8d67
+size 2299

--- a/packages/stacks-classic/screenshots/Webkit/baseline/s-badge-highcontrast-light-new.ico
+++ b/packages/stacks-classic/screenshots/Webkit/baseline/s-badge-highcontrast-light-new.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4f23716a7c9afd21585d70eeae9e58df26335b9736b179640de8a8bf4094421
+size 2304

--- a/packages/stacks-classic/screenshots/Webkit/baseline/s-badge-light-new.ico
+++ b/packages/stacks-classic/screenshots/Webkit/baseline/s-badge-light-new.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8205cacf3115bc2edd671355f038c3ebce5ae9c5ad9f46e466ad5379cd27bb4
+size 2324


### PR DESCRIPTION
# Summary

This PR adds the missing star icon to new user badges.

Before:
<img width="70" height="37" alt="{F38B21F2-0715-4EF3-9480-989DABD76A72}" src="https://github.com/user-attachments/assets/8ab3c32e-28fe-49ba-aaad-6ff88c4fcf09" />

After:
<img width="82" height="37" alt="image" src="https://github.com/user-attachments/assets/2ad20bd8-9926-42be-bde7-e46512d7b6e7" />

# How to Test

* Confirm you see the star icon on new user badges: https://deploy-preview-2168--stacks.netlify.app/product/components/badges/#user
* Confirm the height of the `new` user badge matches the height of the other user badges for all sizes: sm, base, lg