### PR TITLE
patch(buttons) - Add notice for xs size

### DIFF
--- a/.changeset/proud-items-study.md
+++ b/.changeset/proud-items-study.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks": patch
+---
+
+patch(buttons) - Add notice for xs size

--- a/packages/stacks-docs/product/components/buttons.html
+++ b/packages/stacks-docs/product/components/buttons.html
@@ -448,6 +448,12 @@ tags: components
 <section class="docs-section">
     {% header "h2", "Sizes" %}
     <p class="docs-copy">A button’s default font-size is determined by the <code>@body-fs</code> variable. To change the button’s font-size, use the following classes with <code>.s-btn</code>:</p>
+    
+    {% tip, "warning" %}
+        <span>
+            <b>Note:</b> Avoid using icons within the extra small button size. This variant is designed for tight spaces, and standard icons are too large to fit without breaking the button's height and layout.
+        </span>
+    {% endtip %}
 
     <div class="overflow-x-auto mb32" tabindex="0">
         <table class="docs-table s-table s-table__bx-simple">


### PR DESCRIPTION
# Summary

This is for [SPARK-165](https://stackoverflow.atlassian.net/browse/SPARK-165). It adds a notice to the buttons documentation to inform users not to use icons in xs buttons.

<img width="783" height="483" alt="image" src="https://github.com/user-attachments/assets/7c72d68f-57fd-49d5-a862-59b17422e5c5" />


# How to Test

Check out the new notice: https://deploy-preview-2176--stacks.netlify.app/product/components/buttons/#sizes