### PR TITLE
build(stacks-utils): ensure correct module resolution in nodejs

### DIFF
--- a/.changeset/breezy-sheep-exist.md
+++ b/.changeset/breezy-sheep-exist.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks-utils": patch
+---
+
+ensure correct module resolution in nodejs

--- a/packages/stacks-utils/package.json
+++ b/packages/stacks-utils/package.json
@@ -16,7 +16,7 @@
         "!dist/**/*.test.*"
     ],
     "scripts": {
-        "build": "tsc",
+        "build": "vite build && tsc --emitDeclarationOnly",
         "test": "vitest run",
         "test:watch": "vitest watch",
         "format": "prettier --write .",

--- a/packages/stacks-utils/src/DateTimeFormatter.ts
+++ b/packages/stacks-utils/src/DateTimeFormatter.ts
@@ -1,6 +1,6 @@
 ﻿import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime";
-import updateLocale from "dayjs/plugin/updateLocale";
+import relativeTime from "dayjs/plugin/relativeTime.js";
+import updateLocale from "dayjs/plugin/updateLocale.js";
 
 dayjs.extend(relativeTime);
 dayjs.extend(updateLocale);

--- a/packages/stacks-utils/vite.config.ts
+++ b/packages/stacks-utils/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "vite";
+import pkg from "./package.json" with { type: "json" };
+
+const external = Object.keys(pkg.dependencies ?? {});
+
+export default defineConfig({
+    build: {
+        lib: {
+            entry: "./src/index.ts",
+            formats: ["es"],
+        },
+        minify: false,
+        rollupOptions: {
+            external: (id) =>
+                external.some((dep) => id === dep || id.startsWith(`${dep}/`)),
+            output: {
+                preserveModules: true,
+                preserveModulesRoot: "src",
+                entryFileNames: "[name].js",
+            },
+        },
+    },
+});


### PR DESCRIPTION
The previous build (`tsc`) stripped type annotations but emitted imports without `.js` extensions (e.g. `"./NumberFormatter"`, `"dayjs/plugin/relativeTime"`). This caused `ERR_MODULE_NOT_FOUND` errors at runtime even though the target files existed in `dist/`.

This PR replaces the `tsc`-only build with `vite build && tsc --emitDeclarationOnly`:

- **Vite** compiles TypeScript to ESM-compliant JavaScript with correct `.js` extensions on all local imports
- **tsc** is limited to emitting declaration files (`.d.ts`)
- Runtime `dependencies` are automatically externalized from the bundle
- Output is unminified and preserves the original module structure (one output file per source file)

Vite was chosen because it is already a dev dependency of the monorepo.