### PR TITLE
fix(post-summary): wrap long title strings

### DIFF
--- a/.changeset/little-monkeys-shop.md
+++ b/.changeset/little-monkeys-shop.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks": patch
+---
+
+Wrap long post-summary titles

--- a/packages/stacks-classic/lib/components/post-summary/post-summary.less
+++ b/packages/stacks-classic/lib/components/post-summary/post-summary.less
@@ -253,6 +253,7 @@
         display: flex;
         gap: var(--su6);
         line-height: 1.563rem; // TODO use a standard line-height variable (currently 25px)
+        word-break: break-all;
     }
 
     & &--title-link {


### PR DESCRIPTION
[MOD-533](https://stackoverflow.atlassian.net/browse/MOD-533)

---

This PR fixes an issue where long, unbroken strings would cause the post summary to overflow unexpectedly.

## Screenshots

### Before
<img width="804" height="245" alt="image" src="https://github.com/user-attachments/assets/55aa5ad7-f64c-47cd-a250-de2a45620dda" />

### After
<img width="809" height="246" alt="image" src="https://github.com/user-attachments/assets/484ff1dd-f8bd-4ce0-a9ff-739683529cb1" />
