### PR TITLE
fix(expandable): expose expandable controller for legacy UI

### DIFF
--- a/packages/stacks-classic/lib/components/expandable/expandable.ts
+++ b/packages/stacks-classic/lib/components/expandable/expandable.ts
@@ -1,3 +1,4 @@
+// NOTE: This controller is deprecated and is only kept for backwards compatibility. It will be removed in a future version.
 import * as Stacks from "../../stacks";
 
 // Radio buttons only trigger a change event when they're *checked*, but not when

--- a/packages/stacks-classic/lib/controllers.ts
+++ b/packages/stacks-classic/lib/controllers.ts
@@ -4,6 +4,8 @@ export {
     hideBanner,
     showBanner,
 } from "./components/banner/banner";
+// NOTE: The ExpandableController is deprecated and is only kept for backwards compatibility. It will be removed in a future version.
+export { ExpandableController } from "./components/expandable/expandable";
 export {
     ModalController,
     hideModal,


### PR DESCRIPTION
This PR includes the expandable controller in the JS bundle for backwards compatibility. See https://github.com/StackEng/StackOverflow.UIComposer/pull/149 for more context.