### PR TITLE
`<Avatar>` dimensions and screen reader text

### DIFF
--- a/.changeset/strong-news-float.md
+++ b/.changeset/strong-news-float.md
@@ -1,0 +1,6 @@
+---
+"@stackoverflow/stacks-svelte": patch
+---
+
+* `<Avatar>` nested `<img>` dimensions.
+* Screen reader text for the private badge variant.

--- a/packages/stacks-svelte/src/components/Avatar/Avatar.svelte
+++ b/packages/stacks-svelte/src/components/Avatar/Avatar.svelte
@@ -88,8 +88,6 @@
     {/if}
     <span class="v-visible-sr">{name}</span>
     {#if badge}
-        <!-- TODO This badge is not purely decorative, so it should include descriptive text
-        (see https://stackoverflow.atlassian.net/browse/A11Y-126) -->
-        <Icon class="s-avatar--badge" src={IconShieldXSm} native />
+        <Icon class="s-avatar--badge" src={IconShieldXSm} native title="Private" />
     {/if}
 </svelte:element>

--- a/packages/stacks-svelte/src/components/Avatar/Avatar.svelte
+++ b/packages/stacks-svelte/src/components/Avatar/Avatar.svelte
@@ -42,6 +42,11 @@
          * Additional CSS classes added to the element
          */
         class?: string;
+
+        /**
+         * Localized translation for private communities icon title tag
+         */
+        i18nPrivateIconTitle?: string;
     }
 
     const {
@@ -53,6 +58,7 @@
         badge = false,
         class: className = "",
         role,
+        i18nPrivateIconTitle = "Private",
         ...restProps
     }: Props & HTMLAnchorAttributes = $props();
 
@@ -99,7 +105,7 @@
             class="s-avatar--badge"
             src={IconShieldXSm}
             native
-            title="Private"
+            title={i18nPrivateIconTitle}
         />
     {/if}
 </svelte:element>

--- a/packages/stacks-svelte/src/components/Avatar/Avatar.svelte
+++ b/packages/stacks-svelte/src/components/Avatar/Avatar.svelte
@@ -82,7 +82,7 @@
     {...restProps}
 >
     {#if src}
-        <img class="s-avatar--image" {src} alt="" role="presentation" />
+        <img class="s-avatar--image" {src} alt="" role="presentation" width={size} height={size} />
     {:else if letter}
         <span class="s-avatar--letter" aria-hidden="true">{letter}</span>
     {/if}

--- a/packages/stacks-svelte/src/components/Avatar/Avatar.svelte
+++ b/packages/stacks-svelte/src/components/Avatar/Avatar.svelte
@@ -82,12 +82,24 @@
     {...restProps}
 >
     {#if src}
-        <img class="s-avatar--image" {src} alt="" role="presentation" width={size} height={size} />
+        <img
+            class="s-avatar--image"
+            {src}
+            alt=""
+            role="presentation"
+            width={size}
+            height={size}
+        />
     {:else if letter}
         <span class="s-avatar--letter" aria-hidden="true">{letter}</span>
     {/if}
     <span class="v-visible-sr">{name}</span>
     {#if badge}
-        <Icon class="s-avatar--badge" src={IconShieldXSm} native title="Private" />
+        <Icon
+            class="s-avatar--badge"
+            src={IconShieldXSm}
+            native
+            title="Private"
+        />
     {/if}
 </svelte:element>

--- a/packages/stacks-svelte/src/components/Avatar/Avatar.test.ts
+++ b/packages/stacks-svelte/src/components/Avatar/Avatar.test.ts
@@ -35,6 +35,33 @@ describe("Avatar", () => {
         expect(screen.getByText("test avatar")).to.exist;
     });
 
+    it("should set width and height on the image from size", () => {
+        const { container } = render(Avatar, {
+            name: "test avatar",
+            src: "https://picsum.photos/128",
+            size: 48,
+        });
+        const imageElement = container.querySelector(
+            ".s-avatar--image"
+        ) as HTMLImageElement | null;
+        expect(imageElement).to.exist;
+        expect(imageElement).to.have.attr("width", "48");
+        expect(imageElement).to.have.attr("height", "48");
+    });
+
+    it("should default image width and height to 16 when size is omitted", () => {
+        const { container } = render(Avatar, {
+            name: "test avatar",
+            src: "https://picsum.photos/128",
+        });
+        const imageElement = container.querySelector(
+            ".s-avatar--image"
+        ) as HTMLImageElement | null;
+        expect(imageElement).to.exist;
+        expect(imageElement).to.have.attr("width", "16");
+        expect(imageElement).to.have.attr("height", "16");
+    });
+
     it("should render the avatar with the provided letter", () => {
         render(Avatar, {
             name: "test avatar",
@@ -55,6 +82,27 @@ describe("Avatar", () => {
             .getByText("test avatar")
             .parentElement?.querySelector(".s-avatar--badge");
         expect(badgeElement).to.exist;
+    });
+
+    it("should use default i18nPrivateIconTitle for the badge icon", () => {
+        const { container } = render(Avatar, {
+            name: "test avatar",
+            badge: true,
+        });
+        const title = container.querySelector(".s-avatar--badge title");
+        expect(title).to.exist;
+        expect(title?.textContent).to.equal("Private");
+    });
+
+    it("should use custom i18nPrivateIconTitle for the badge icon", () => {
+        const { container } = render(Avatar, {
+            name: "test avatar",
+            badge: true,
+            i18nPrivateIconTitle: "Community privée",
+        });
+        const title = container.querySelector(".s-avatar--badge title");
+        expect(title).to.exist;
+        expect(title?.textContent).to.equal("Community privée");
     });
 
     it("should render the avatar with artbirary classes", () => {


### PR DESCRIPTION
* Closes #2205 to avoid the layout shift before an image loads.
* Begins to address A11Y-126 by using the title prop i.e.,`<Icon title="Private">`, which removes the `aria-hidden="true"`.