### PR TITLE
fix(stacks-svelte): pre-bundle dayjs plugins with .js extension to fix CI test flake

### DIFF
--- a/.changeset/swift-clocks-ring.md
+++ b/.changeset/swift-clocks-ring.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks-svelte": patch
+---
+
+Pre-bundle dayjs plugins with .js extension in optimizeDeps

--- a/packages/stacks-svelte/vite.config.ts
+++ b/packages/stacks-svelte/vite.config.ts
@@ -21,7 +21,9 @@ export default defineConfig({
             "@stackoverflow/stacks-icons-legacy/icons",
             "dayjs",
             "dayjs/plugin/relativeTime",
+            "dayjs/plugin/relativeTime.js",
             "dayjs/plugin/updateLocale",
+            "dayjs/plugin/updateLocale.js",
             // svelte-sonner must be pre-bundled to ensure its virtual CSS modules
             // (from <style global> blocks) are properly resolved during test execution.
             // Without pre-bundling, CI environments may trigger mid-test re-optimization,


### PR DESCRIPTION
## Summary

- `stacks-utils/src/DateTimeFormatter.ts` imports `dayjs/plugin/relativeTime.js` and `dayjs/plugin/updateLocale.js` with explicit `.js` extensions
- `vite.config.ts` listed these in `optimizeDeps.include` without the `.js` suffix, so Vite didn't recognise them as pre-bundled
- On a cold cache (every CI run), Vite discovered the `.js`-suffixed variants mid-test, triggered a re-optimisation + server reload, and killed the in-flight Navigation test module fetch — causing `TypeError: Failed to fetch dynamically imported module`
- Locally the cache persists between runs so the issue never surfaces

Fix: add `dayjs/plugin/relativeTime.js` and `dayjs/plugin/updateLocale.js` alongside the existing entries so both forms are pre-bundled before tests start.

## Test plan

- [ ] CI `Unit Tests (stacks-svelte)` job passes on this branch
- [ ] No `✨ optimized dependencies changed. reloading` in the test runner output
- [ ] All 36 test files / 554+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)