### PR TITLE
fix: quiet build warnings

### DIFF
--- a/packages/stacks-classic/lib/atomic/border-radius.less
+++ b/packages/stacks-classic/lib/atomic/border-radius.less
@@ -22,17 +22,17 @@
 .bbrr-md { border-bottom-right-radius: var(--br-md) !important; }
 
 // Top left and right
-.btr0 { .btlr0; .btrr0; }
-.btr-md { .btlr-md; .btrr-md; }
+.btr0 { .btlr0(); .btrr0(); }
+.btr-md { .btlr-md(); .btrr-md(); }
 
 // Top and bottom right
-.brr0 { .btrr0; .bbrr0; }
-.brr-md { .btrr-md; .bbrr-md; }
+.brr0 { .btrr0(); .bbrr0(); }
+.brr-md { .btrr-md(); .bbrr-md(); }
 
 // Bottom left and right
-.bbr0 { .bblr0; .bbrr0; }
-.bbr-md { .bblr-md; .bbrr-md; }
+.bbr0 { .bblr0(); .bbrr0(); }
+.bbr-md { .bblr-md(); .bbrr-md(); }
 
 // Top and bottom left
-.blr0 { .btlr0; .bblr0; }
-.blr-md { .btlr-md; .bblr-md; }
+.blr0 { .btlr0(); .bblr0(); }
+.blr-md { .btlr-md(); .bblr-md(); }

--- a/packages/stacks-classic/lib/atomic/borders.less
+++ b/packages/stacks-classic/lib/atomic/borders.less
@@ -1,13 +1,13 @@
 @import (reference) "../base/internal.less";
 
 // BORDER
-#stacks-internals #responsify('.ba', { .bas-solid; .baw1; });
-#stacks-internals #responsify('.bt', { .bts-solid; .btw1; });
-#stacks-internals #responsify('.br', { .brs-solid; .brw1; });
-#stacks-internals #responsify('.bb', { .bbs-solid; .bbw1; });
-#stacks-internals #responsify('.bl', { .bls-solid; .blw1; });
-.bx { .bls-solid; .brs-solid; .bxw1; }
-.by { .bts-solid; .bbs-solid; .byw1; }
+#stacks-internals #responsify('.ba', { .bas-solid(); .baw1(); });
+#stacks-internals #responsify('.bt', { .bts-solid(); .btw1(); });
+#stacks-internals #responsify('.br', { .brs-solid(); .brw1(); });
+#stacks-internals #responsify('.bb', { .bbs-solid(); .bbw1(); });
+#stacks-internals #responsify('.bl', { .bls-solid(); .blw1(); });
+.bx { .bls-solid(); .brs-solid(); .bxw1(); }
+.by { .bts-solid(); .bbs-solid(); .byw1(); }
 
 // BORDER WIDTH
 #stacks-internals #responsify('.baw0', { border-width: 0 !important; });
@@ -41,16 +41,16 @@
 .blw3 { border-left-width: var(--su4) !important; }
 
 // Top and bottom border width
-.byw0 { .btw0; .bbw0; }
-.byw1 { .btw1; .bbw1; }
-.byw2 { .btw2; .bbw2; }
-.byw3 { .btw3; .bbw3; }
+.byw0 { .btw0(); .bbw0(); }
+.byw1 { .btw1(); .bbw1(); }
+.byw2 { .btw2(); .bbw2(); }
+.byw3 { .btw3(); .bbw3(); }
 
 // Left and right border width
-.bxw0 { .brw0; .blw0; }
-.bxw1 { .brw1; .blw1; }
-.bxw2 { .brw2; .blw2; }
-.bxw3 { .brw3; .blw3; }
+.bxw0 { .brw0(); .blw0(); }
+.bxw1 { .brw1(); .blw1(); }
+.bxw2 { .brw2(); .blw2(); }
+.bxw3 { .brw3(); .blw3(); }
 
 // BORDER STYLE
 .bas-solid { border-style: solid !important; }

--- a/packages/stacks-classic/lib/atomic/flex.less
+++ b/packages/stacks-classic/lib/atomic/flex.less
@@ -301,8 +301,7 @@
 .ac-stretch { align-content: stretch !important; }
 
 // Align items
-#stacks-internals #build-classes(
-    '.ai',
+#stacks-internals #build-classes('.ai',
     {
         .template(@value) when (@value=start), (@value=end) { align-items: ~"flex-@{value}" !important; }
         .template(@value) when (default()) { align-items: @value !important; };
@@ -316,13 +315,12 @@
 //      Use this class when you want both.
 //  ----------------------------------------------------------------------------
 .flex__center {
-    .jc-center;
-    .ai-center;
+    .jc-center();
+    .ai-center();
 }
 
 // Align self
-#stacks-internals #build-classes(
-    '.as',
+#stacks-internals #build-classes('.as',
     {
         .template(@value) when (@value=start), (@value=end) { align-self: ~"flex-@{value}" !important; }
         .template(@value) when (default()) { align-self: @value !important; };

--- a/packages/stacks-classic/lib/atomic/outline.less
+++ b/packages/stacks-classic/lib/atomic/outline.less
@@ -6,6 +6,6 @@
 .f\:outline-ring {
     &:focus,
     &:focus-within {
-        .outline-ring;
+        .outline-ring();
     }
 }

--- a/packages/stacks-classic/lib/components/input_textarea/input_textarea.less
+++ b/packages/stacks-classic/lib/components/input_textarea/input_textarea.less
@@ -45,8 +45,7 @@
         --_in-fc: var(--black-400);
     }
 
-    .validation-states(
-        in,
+    .validation-states(in,
         { .highcontrast-mode({ --_in-bc: var(--red-400); }); },
         { .highcontrast-mode({ --_in-bc: var(--green-400); }); },
         { .highcontrast-mode({ --_in-bc: var(--yellow-500); }); }

--- a/packages/stacks-classic/lib/components/menu/menu.less
+++ b/packages/stacks-classic/lib/components/menu/menu.less
@@ -107,5 +107,5 @@
         margin-top: var(--su12);
     }
 
-    .list-reset;
+    .list-reset();
 }

--- a/packages/stacks-classic/lib/components/modal/modal.less
+++ b/packages/stacks-classic/lib/components/modal/modal.less
@@ -32,7 +32,7 @@
         --_mo-dialog-pt: var(--su64);
 
         .s-modal--dialog {
-            .bg-confetti-animated;
+            .bg-confetti-animated();
         }
     }
 

--- a/packages/stacks-classic/lib/components/user-card/user-card.less
+++ b/packages/stacks-classic/lib/components/user-card/user-card.less
@@ -145,7 +145,7 @@
             gap: var(--su2);
         }
 
-        .list-reset;
+        .list-reset();
     }
 
     & &--row {

--- a/packages/stacks-classic/lib/exports/mixins.less
+++ b/packages/stacks-classic/lib/exports/mixins.less
@@ -100,8 +100,7 @@
  * @param {boolean} [negative=false] - Whether to generate negative value classes.
  */
 .generate-sizing(@prefix, @properties, @values, @type: 'px', @responsive: false, @negative: false) {
-    #stacks-internals #build-classes(
-        @prefix,
+    #stacks-internals #build-classes(@prefix,
         {
             .template(@value) {
                 each(@properties, #(@prop) {
@@ -141,8 +140,7 @@
  */
 .generate-su-sizing(@prefix, @property) {
     @su-values: 128, 256, 344, 448, 512, 640, 768, 848, 960, 1024, 1120, 1280;
-    #stacks-internals #build-classes(
-        @prefix,
+    #stacks-internals #build-classes(@prefix,
         {
             .template(@value) {
                 @su-value: extract(@su-values, @value);

--- a/packages/stacks-classic/webpack.config.mjs
+++ b/packages/stacks-classic/webpack.config.mjs
@@ -79,6 +79,7 @@ const baseConfig = (isProd, minify) => ({
         }),
     ],
     resolve: commonResolve,
+    performance: false,
 });
 
 export { tsRule, lessRule, commonResolve };

--- a/packages/stacks-docs/webpack.config.mjs
+++ b/packages/stacks-docs/webpack.config.mjs
@@ -46,6 +46,7 @@ export default (_, argv) => {
         },
         plugins: [new MiniCssExtractPlugin()],
         resolve: commonResolve,
+        performance: false,
         devServer: {
             webSocketURL: {
                 // 11ty/browsersync steal the default port (8080), so set it to something else

--- a/packages/stacks-svelte/test-utils.d.ts
+++ b/packages/stacks-svelte/test-utils.d.ts
@@ -1,8 +1,0 @@
-import { type Component, type ComponentProps, type SvelteComponent } from "svelte";
-declare const createRawComponent: (code: string) => Promise<typeof SvelteComponent>;
-interface ComponentMeta<T extends Component> {
-    component: T;
-    props: ComponentProps<T>;
-}
-declare const createSvelteComponentsSnippet: (components: ComponentMeta<any>[]) => import("svelte").Snippet<[]>;
-export { createRawComponent, createSvelteComponentsSnippet, type ComponentMeta, };

--- a/packages/stacks-svelte/test-utils.d.ts
+++ b/packages/stacks-svelte/test-utils.d.ts
@@ -1,0 +1,8 @@
+import { type Component, type ComponentProps, type SvelteComponent } from "svelte";
+declare const createRawComponent: (code: string) => Promise<typeof SvelteComponent>;
+interface ComponentMeta<T extends Component> {
+    component: T;
+    props: ComponentProps<T>;
+}
+declare const createSvelteComponentsSnippet: (components: ComponentMeta<any>[]) => import("svelte").Snippet<[]>;
+export { createRawComponent, createSvelteComponentsSnippet, type ComponentMeta, };


### PR DESCRIPTION
We have several warnings that create noise when building our library.

## Warning examples

### Less mixin deprecation warnings

```
DEPRECATED WARNING: Calling a mixin without parentheses is deprecated in /home/runner/work/Stacks/Stacks/packages/stacks-classic/lib/atomic/borders.less on line 47, column 14:
  <w> 47 .byw3 { .btw3; .bbw3; }
```

### Performance warning

```
WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  docs.css (510 KiB)
  docs.js (289 KiB)
  entry.stacks-editor.js (1.52 MiB)
```

This PR resolves the Less deprecation issues and quiets performance warnings.