### PR TITLE
fix(stacks-docs-next): conditional banner margin and dupe description fix

### DIFF
--- a/packages/stacks-docs-next/src/docs/public/system/base/flex.md
+++ b/packages/stacks-docs-next/src/docs/public/system/base/flex.md
@@ -1,6 +1,6 @@
 ---
 title: Flex
-description: Stacks provides extensive utility and helper classes for flex layouts. If you are new to flex layouts, check out this <a href="https://www.joshwcomeau.com/css/interactive-guide-to-flexbox/" rel="external">interactive introduction</a> by Joshua Comeau.</p>
+description: Stacks provides extensive utility and helper classes for flex layouts. If you are new to flex layouts, check out this <a href="https://www.joshwcomeau.com/css/interactive-guide-to-flexbox/" rel="external">interactive introduction</a> by Joshua Comeau.
 updated: 2025-12-05
 ---
 
@@ -375,8 +375,6 @@ updated: 2025-12-05
     padding: var(--su8)
   }
 </style>
-
-Stacks provides extensive utility and helper classes for flex layouts. If you are new to flex layouts, check out this <a href="https://www.joshwcomeau.com/css/interactive-guide-to-flexbox/" rel="external">interactive introduction</a> by Joshua Comeau.
 
 ## Basic flex layout
 

--- a/packages/stacks-docs-next/src/routes/[category]/[[section]]/[subsection]/+page.svelte
+++ b/packages/stacks-docs-next/src/routes/[category]/[[section]]/[subsection]/+page.svelte
@@ -45,7 +45,7 @@
 
 <article class="d-flex md:fd-column mx-auto pl32 md:pr32 sm:pl24 sm:pr24">
   <div class="doc flex--item9 wmn1 s-prose fs-body2 pt24">
-    <div class="d-flex gs4 ai-center mb128">
+    <div class="d-flex gs4 ai-center {data?.active?.image ? 'mb128' : 'mb24'}">
       <nav class="flex--item fs-body2 mr-auto" aria-label="breadcrumb">
         {#each data.breadcrumb as crumb, index (crumb.path)}
           <a href={resolve(crumb.path)} class="pr6 s-link">{crumb.label}</a>{#if index !== data.breadcrumb.length - 1}<span class="fc-black-300 mr6">/</span>{/if}


### PR DESCRIPTION
## Summary

- On pages without a banner image, the breadcrumb row had an unconditional `mb128` (128px) gap before the page title, which created an awkward large blank space. This is now conditional: `mb128` when a banner image is present, `mb24` otherwise.
- `flex.md` had its description text duplicated: once in the frontmatter `description:` field (rendered by the page template in the styled header area) and once as a standalone paragraph near the end of the file's content. The body duplicate is removed. Also fixes a stray `</p>` at the end of the frontmatter value.

## Related Issue

[STACKS-843](https://stackoverflow.atlassian.net/browse/STACKS-843)

## Changes

**`packages/stacks-docs-next`**
- `src/routes/[category]/[[section]]/[subsection]/+page.svelte` — make `mb128` on breadcrumb row conditional on `data?.active?.image`
- `src/docs/public/system/base/flex.md` — remove duplicate description paragraph from content body; fix stray `</p>` in frontmatter

## Testing

These are docs-only changes. Verify visually:
- A page with a banner image (e.g. `/brand/logo`) should have the large gap between breadcrumbs and title as before
- A page without a banner image (e.g. `/system/accessibility/intro`) should have a smaller `mb24` gap instead of the previous `mb128`
- The `/system/base/flex` page should not show the description text twice once legacy is removed

---

> This PR was generated by a developer using an AI agent with the
> [stacks-v3-dev](https://github.com/StackEngLabs/stackskills/tree/main/skills/stacks-v3-dev) skill