### PR TITLE
fix(docs-next): External url paths in sidebar are truncated

### DIFF
--- a/packages/stacks-docs-next/src/components/Navigation.svelte
+++ b/packages/stacks-docs-next/src/components/Navigation.svelte
@@ -61,11 +61,11 @@
             <ul class="s-navigation s-navigation__vertical pl24">
               {#each category.items as subsection (subsection.slug)}
                 <li>
-                  <a
+                  {@const subsectionHref = subsection.externalUrl ? subsection.externalUrl : resolve(`/${category.slug}/${subsection.slug}/${subsection?.items ? subsection?.items[0]?.slug : ''}`)}
+                  <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+                  <a href={subsectionHref}
                     class="s-navigation--item jc-space-between mb1"
                     class:is-selected={sectionSlug === subsection.slug || subsectionSlug === subsection.slug}
-                    <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-                    href={subsection.externalUrl ? subsection.externalUrl : resolve(`/${category.slug}/${subsection.slug}/${subsection?.items ? subsection?.items[0]?.slug : ''}`)}
                     rel={subsection.externalUrl ? "external" : undefined}
                     data-sveltekit-reload={subsection.private ? true : undefined}
                   >
@@ -93,11 +93,11 @@
                       <ul class="s-navigation s-navigation__vertical ml24">
                         {#each subsection?.items as item (item.slug)}
                           <li>
-                            <a
+                          {@const itemHref = item.externalUrl ? item.externalUrl : resolve(`/${category.slug}/${subsection.slug}/${item.slug}/`)}
+                          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+                            <a href={itemHref}
                               class="s-navigation--item jc-space-between mb1"
                               class:is-selected={subsectionSlug === item.slug}
-                              <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-                              href={item.externalUrl ? item.externalUrl : resolve(`/${category.slug}/${subsection.slug}/${item.slug}/`)}
                               rel={subsection.externalUrl ? "external" : undefined}
                               data-sveltekit-reload={item.private ? true : undefined}
                             >

--- a/packages/stacks-docs-next/src/components/Navigation.svelte
+++ b/packages/stacks-docs-next/src/components/Navigation.svelte
@@ -64,7 +64,8 @@
 
                 <li>
                   <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-                  <a href={subsectionHref}
+                  <a
+                    href={subsectionHref}
                     class="s-navigation--item jc-space-between mb1"
                     class:is-selected={sectionSlug === subsection.slug || subsectionSlug === subsection.slug}
                     rel={subsection.externalUrl ? "external" : undefined}
@@ -93,23 +94,24 @@
                     <div transition:slide={{ duration: 200 }}>
                       <ul class="s-navigation s-navigation__vertical ml24">
                         {#each subsection?.items as item (item.slug)}
-                            {@const itemHref = item.externalUrl ? item.externalUrl : resolve(`/${category.slug}/${subsection.slug}/${item.slug}/`)}
+                          {@const itemHref = item.externalUrl ? item.externalUrl : resolve(`/${category.slug}/${subsection.slug}/${item.slug}/`)}
 
-                            <li>
-                                <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-                                <a href={itemHref}
-                                    class="s-navigation--item jc-space-between mb1"
-                                    class:is-selected={subsectionSlug === item.slug}
-                                    rel={subsection.externalUrl ? "external" : undefined}
-                                    data-sveltekit-reload={item.private ? true : undefined}
-                                >
-                                <span>{item.title}</span>
+                          <li>
+                            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+                            <a
+                              href={itemHref}
+                              class="s-navigation--item jc-space-between mb1"
+                              class:is-selected={subsectionSlug === item.slug}
+                              rel={item.externalUrl ? "external" : undefined}
+                              data-sveltekit-reload={item.private ? true : undefined}
+                            >
+                              <span>{item.title}</span>
 
-                                {#if item.new}
-                                    <span class="s-activity-indicator s-activity-indicator__sm ba"><span class="v-visible-sr">new</span></span>
-                                {/if}
-                                </a>
-                            </li>
+                              {#if item.new}
+                                <span class="s-activity-indicator s-activity-indicator__sm ba"><span class="v-visible-sr">new</span></span>
+                              {/if}
+                            </a>
+                          </li>
                         {/each}
                       </ul>
                     </div>

--- a/packages/stacks-docs-next/src/components/Navigation.svelte
+++ b/packages/stacks-docs-next/src/components/Navigation.svelte
@@ -64,7 +64,7 @@
                   <a
                     class="s-navigation--item jc-space-between mb1"
                     class:is-selected={sectionSlug === subsection.slug || subsectionSlug === subsection.slug}
-                    href={resolve(subsection.externalUrl || `/${category.slug}/${subsection.slug}/${subsection?.items ? subsection?.items[0]?.slug : ''}`)}
+                    href={subsection.externalUrl ? subsection.externalUrl : resolve(`/${category.slug}/${subsection.slug}/${subsection?.items ? subsection?.items[0]?.slug : ''}`)}
                     data-sveltekit-reload={subsection.private ? true : undefined}
                   >
                     <span>{subsection.title}</span>
@@ -82,7 +82,7 @@
                         {#if subsection.externalUrl}
                           <Icon src={IconArrowUpRightBox} />
                         {/if}
-                      </span> 
+                      </span>
                     {/if}
                   </a>
 
@@ -94,7 +94,7 @@
                             <a
                               class="s-navigation--item jc-space-between mb1"
                               class:is-selected={subsectionSlug === item.slug}
-                              href={resolve(item.externalUrl || `/${category.slug}/${subsection.slug}/${item.slug}/`)}
+                              href={item.externalUrl ? item.externalUrl : resolve(`/${category.slug}/${subsection.slug}/${item.slug}/`)}
                               data-sveltekit-reload={item.private ? true : undefined}
                             >
                               <span>{item.title}</span>

--- a/packages/stacks-docs-next/src/components/Navigation.svelte
+++ b/packages/stacks-docs-next/src/components/Navigation.svelte
@@ -64,7 +64,9 @@
                   <a
                     class="s-navigation--item jc-space-between mb1"
                     class:is-selected={sectionSlug === subsection.slug || subsectionSlug === subsection.slug}
+                    <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
                     href={subsection.externalUrl ? subsection.externalUrl : resolve(`/${category.slug}/${subsection.slug}/${subsection?.items ? subsection?.items[0]?.slug : ''}`)}
+                    rel={subsection.externalUrl ? "external" : undefined}
                     data-sveltekit-reload={subsection.private ? true : undefined}
                   >
                     <span>{subsection.title}</span>
@@ -94,7 +96,9 @@
                             <a
                               class="s-navigation--item jc-space-between mb1"
                               class:is-selected={subsectionSlug === item.slug}
+                              <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
                               href={item.externalUrl ? item.externalUrl : resolve(`/${category.slug}/${subsection.slug}/${item.slug}/`)}
+                              rel={subsection.externalUrl ? "external" : undefined}
                               data-sveltekit-reload={item.private ? true : undefined}
                             >
                               <span>{item.title}</span>

--- a/packages/stacks-docs-next/src/components/Navigation.svelte
+++ b/packages/stacks-docs-next/src/components/Navigation.svelte
@@ -60,8 +60,9 @@
           <div transition:slide={{ duration: 200 }}>
             <ul class="s-navigation s-navigation__vertical pl24">
               {#each category.items as subsection (subsection.slug)}
+                {@const subsectionHref = subsection.externalUrl ? subsection.externalUrl : resolve(`/${category.slug}/${subsection.slug}/${subsection?.items ? subsection?.items[0]?.slug : ''}`)}
+
                 <li>
-                  {@const subsectionHref = subsection.externalUrl ? subsection.externalUrl : resolve(`/${category.slug}/${subsection.slug}/${subsection?.items ? subsection?.items[0]?.slug : ''}`)}
                   <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
                   <a href={subsectionHref}
                     class="s-navigation--item jc-space-between mb1"
@@ -92,22 +93,23 @@
                     <div transition:slide={{ duration: 200 }}>
                       <ul class="s-navigation s-navigation__vertical ml24">
                         {#each subsection?.items as item (item.slug)}
-                          <li>
-                          {@const itemHref = item.externalUrl ? item.externalUrl : resolve(`/${category.slug}/${subsection.slug}/${item.slug}/`)}
-                          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-                            <a href={itemHref}
-                              class="s-navigation--item jc-space-between mb1"
-                              class:is-selected={subsectionSlug === item.slug}
-                              rel={subsection.externalUrl ? "external" : undefined}
-                              data-sveltekit-reload={item.private ? true : undefined}
-                            >
-                              <span>{item.title}</span>
+                            {@const itemHref = item.externalUrl ? item.externalUrl : resolve(`/${category.slug}/${subsection.slug}/${item.slug}/`)}
 
-                              {#if item.new}
-                                <span class="s-activity-indicator s-activity-indicator__sm ba"><span class="v-visible-sr">new</span></span>
-                              {/if}
-                            </a>
-                          </li>
+                            <li>
+                                <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+                                <a href={itemHref}
+                                    class="s-navigation--item jc-space-between mb1"
+                                    class:is-selected={subsectionSlug === item.slug}
+                                    rel={subsection.externalUrl ? "external" : undefined}
+                                    data-sveltekit-reload={item.private ? true : undefined}
+                                >
+                                <span>{item.title}</span>
+
+                                {#if item.new}
+                                    <span class="s-activity-indicator s-activity-indicator__sm ba"><span class="v-visible-sr">new</span></span>
+                                {/if}
+                                </a>
+                            </li>
                         {/each}
                       </ul>
                     </div>

--- a/packages/stacks-docs-next/src/components/Navigation.svelte
+++ b/packages/stacks-docs-next/src/components/Navigation.svelte
@@ -64,8 +64,7 @@
 
                 <li>
                   <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-                  <a
-                    href={subsectionHref}
+                  <a href={subsectionHref}
                     class="s-navigation--item jc-space-between mb1"
                     class:is-selected={sectionSlug === subsection.slug || subsectionSlug === subsection.slug}
                     rel={subsection.externalUrl ? "external" : undefined}
@@ -98,8 +97,7 @@
 
                           <li>
                             <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-                            <a
-                              href={itemHref}
+                            <a href={itemHref}
                               class="s-navigation--item jc-space-between mb1"
                               class:is-selected={subsectionSlug === item.slug}
                               rel={item.externalUrl ? "external" : undefined}


### PR DESCRIPTION
Currently they are passed to [`resolve()`](https://svelte.dev/docs/kit/$app-paths#resolve) which removes the first char of the string and prefixes with the base url.

<img width="295" height="163" alt="Screenshot 2026-04-24 at 12 06 35" src="https://github.com/user-attachments/assets/55fcb86c-369b-48c0-8343-6a978e2175d0" />