### PR TITLE
fix(docs-next): label search button

### DIFF
--- a/packages/stacks-docs-next/src/components/Search.svelte
+++ b/packages/stacks-docs-next/src/components/Search.svelte
@@ -47,5 +47,6 @@
 {#if searchEnabled}
 	<Button icon weight="clear" class="h:fc-blue-400 px0" onclick={openSearch}>
 		<Icon src={IconSearch} />
+		<span class="v-visible-sr">Search</span>
 	</Button>
 {/if}


### PR DESCRIPTION
## Summary

- Adds screen-reader-only text to the docs-next left navigation search button so the icon-only control has a discernible accessible name.
- Preserves the existing visual icon-only button presentation.

## Testing

- Go to [any docs page](https://deploy-preview-2247--stacks.netlify.app/)
- Load up your screenreader of choice
- Tab to the search icon button
- Confirm it announces “Search”
- Confirm the button still appears icon-only visually.

### Alternatively
- Go to [any docs page](https://deploy-preview-2247--stacks.netlify.app/)
- Inspect the search icon button in the top left
- Verify that it includes screenreader-only text of "Search"

## Example gifs

<details>
<summary>Before</summary>
<img width="900" height="200" alt="20260428-153636" src="https://github.com/user-attachments/assets/9c2d5780-8c17-4115-af7d-fd4aab467fb6" />


</details>


<details>
<summary>After</summary>
<img width="900" height="200" alt="20260428-153604" src="https://github.com/user-attachments/assets/bdf6cac0-7cbc-4397-9c55-3b8442570343" />


</details>



## Issue

- [STACKS-886](https://stackoverflow.atlassian.net/browse/STACKS-886)