### PR TITLE
fix(docs-next): Legacy email redirect

### DIFF
--- a/packages/stacks-docs-next/_redirects
+++ b/packages/stacks-docs-next/_redirects
@@ -4,7 +4,7 @@ https://beta.stackoverflow.design/*              https://stackoverflow.design/:s
 
 
 # Email section → v2 docs
-/email*                                         https://v2.stackoverflow.design/email:splat     302
+/email/*                                         https://v2.stackoverflow.design/email:splat     302
 
 # Redirects from v2 urls
 /product                                        /system/develop/using-stacks/                   302


### PR DESCRIPTION
Fixes an issue with deep link email guidelines e.g.,

https://stackoverflow.design/email/guidelines/getting-started/

currently goes to

https://v2.stackoverflow.design/emailguidelines/getting-started/

rather than

https://v2.stackoverflow.design/email/guidelines/getting-started/