### PR TITLE
fix(ci): provide auth secret during release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,8 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta'
     needs: [build-and-test]
     runs-on: ubuntu-latest
+    env:
+      BETTER_AUTH_SECRET: ${{ secrets.AUTH_SECRET || 'ci-build-placeholder-secret' }}
     outputs:
       published: ${{ steps.changesets.outputs.published }}
     steps:


### PR DESCRIPTION
## Summary
- Adds a release-job `BETTER_AUTH_SECRET` fallback so Better Auth does not abort docs builds during release.
- Matches the placeholder secret behavior already used by the reusable build/test workflow.

## Testing
- `git diff --check`
- Not run: `npm run build` locally because `npm` is not available on this shell's PATH.