### PR TITLE
chore(docs): Update auth URLs for previews

### DIFF
--- a/packages/stacks-docs/src/lib/auth.ts
+++ b/packages/stacks-docs/src/lib/auth.ts
@@ -5,8 +5,10 @@ import { sveltekitCookies } from "better-auth/svelte-kit";
 import { env } from "$env/dynamic/private";
 import { getRequestEvent } from "$app/server";
 
-// TODO: Make dynamic once we figure out Netlify env vars at runtime
-const baseURL = "https://stackoverflow.design";
+// baseURL is set per deploy from Netlify's build-time env vars
+// DEPLOY_PRIME_URL tracks the current deploy context
+// Static url is the production fallback
+const baseURL = env.DEPLOY_PRIME_URL || env.URL || "https://stackoverflow.design";
 
 export const auth = betterAuth({
     baseURL,

--- a/packages/stacks-docs/src/lib/auth.ts
+++ b/packages/stacks-docs/src/lib/auth.ts
@@ -13,7 +13,11 @@ const baseURL = env.DEPLOY_PRIME_URL || env.URL || "https://stackoverflow.design
 export const auth = betterAuth({
     baseURL,
 
-    trustedOrigins: [baseURL, "https://*.stackoverflow.design"],
+    trustedOrigins: [
+        "https://stackoverflow.design",
+        "https://*.stackoverflow.design",
+        "https://*.private-preview.stackoverflow.design",
+    ],
 
     // Secret for signing cookies and tokens
     // openssl rand -base64 32


### PR DESCRIPTION
[STACKS-888](https://stackoverflow.atlassian.net/browse/STACKS-888)

* Removes the hard coded baseUrl in favour of [Netlify variables](https://docs.netlify.com/build/configure-builds/environment-variables/).
* Updates `trustedOrigins` for the new preview domain.
