### PR TITLE
fix(docs): point v2 site URLs at v2.stackoverflow.design

### DIFF
--- a/packages/stacks-docs/.eleventy.js
+++ b/packages/stacks-docs/.eleventy.js
@@ -19,7 +19,7 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(headerPlugin);
   eleventyConfig.addPlugin(tipPlugin);
   eleventyConfig.addPlugin(llmsTxtPlugin, {
-    siteUrl: 'https://stackoverflow.design',
+    siteUrl: 'https://v2.stackoverflow.design',
     collections: ['base', 'components', 'develop', 'foundation'],
     additionalMetadata: ['description'],
     normalizeWhitespace: true,

--- a/packages/stacks-docs/_data/site.json
+++ b/packages/stacks-docs/_data/site.json
@@ -1,6 +1,6 @@
 {
   "title": "Stacks",
-  "url": "https://stackoverflow.design",
+  "url": "https://v2.stackoverflow.design",
   "description": "Stacks provides everything you need to quickly design, build, and ship coherent experiences across all of Stack Overflow—from the brand and product itself, down to how we send emails and write copy.",
   "baseurl": ""
 }


### PR DESCRIPTION
## Summary
- The v2 docs site is served from `v2.stackoverflow.design`, but the eleventy-plugin-llms-txt `siteUrl` and `_data/site.json` `url` were both set to the v3 host. As a result, `v2.stackoverflow.design/llms.txt` emitted v3-domain links for every page and `og:url` meta tags pointed off-site.
- Update both values to `https://v2.stackoverflow.design` so generated links and OG metadata match the actual host.

## Test plan
- [ ] Build the v2 docs and confirm `/llms.txt` header reads `# Site URL: https://v2.stackoverflow.design` and every `URL:` line uses the v2 host.
- [ ] Inspect any page's `<head>` and confirm `<meta property="og:url" content="https://v2.stackoverflow.design">`.
- [ ] Post-deploy: `curl https://v2.stackoverflow.design/llms.txt | head` shows the v2 host.

JIRA: [STACKS-864](https://stackoverflow.atlassian.net/browse/STACKS-864)
