### PR TITLE
fix(docs): Email redirect format in _redirects file

### DIFF
--- a/packages/stacks-docs/_redirects
+++ b/packages/stacks-docs/_redirects
@@ -2,9 +2,8 @@
 https://alpha.stackoverflow.design/*             https://stackoverflow.design/:splat            301
 https://beta.stackoverflow.design/*              https://stackoverflow.design/:splat            302
 
-
 # Email section → v2 docs
-/email/*                                         https://v2.stackoverflow.design/email:splat     302
+/email/*                                         https://v2.stackoverflow.design/email/:splat   302
 
 # Redirects from v2 urls
 /product                                        /system/develop/using-stacks/                   302


### PR DESCRIPTION
Updated email redirect to include a forward slash before the splat. Example:

`https://stackoverflow.design/email/components/team-identification/`

Currently redirects to:

`https://v2.stackoverflow.design/emailcomponents/team-identification/`