### PR TITLE
fix(popover): backport focus-leave dismissal to v2

### DIFF
--- a/.changeset/two-goats-press.md
+++ b/.changeset/two-goats-press.md
@@ -1,0 +1,6 @@
+---
+"@stackoverflow/stacks": minor
+"@stackoverflow/stacks-svelte": minor
+---
+
+Fix popover focus-leave dismissal

--- a/packages/stacks-classic/lib/components/popover/popover.test.ts
+++ b/packages/stacks-classic/lib/components/popover/popover.test.ts
@@ -1,0 +1,225 @@
+import { html, fixture, expect } from "@open-wc/testing";
+import { screen, waitFor } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
+import "../../index";
+
+const user = userEvent.setup();
+
+const createPopover = ({
+    content = html`<a href="#" data-testid="popover-link">View more</a>`,
+    hideOnOutsideClick = "always",
+    renderOutsideButton = true,
+    role = "menu",
+}: {
+    content?: ReturnType<typeof html>;
+    hideOnOutsideClick?: string;
+    renderOutsideButton?: boolean;
+    role?: string;
+} = {}) => html`
+    <button
+        class="s-btn"
+        aria-controls="popover-example"
+        data-controller="s-popover"
+        data-action="s-popover#toggle"
+        data-s-popover-hide-on-outside-click="${hideOnOutsideClick}"
+        data-testid="popover-trigger"
+    >
+        Toggle popover
+    </button>
+    <div
+        class="s-popover"
+        id="popover-example"
+        role="${role}"
+        data-testid="popover"
+    >
+        <div class="s-popover--content">${content}</div>
+    </div>
+    ${renderOutsideButton
+        ? html`<button data-testid="outside-button">Outside button</button>`
+        : null}
+`;
+
+describe("popover", () => {
+    it('should set aria-expanded="true" when shown and "false" when hidden', async () => {
+        await fixture(createPopover({ renderOutsideButton: false }));
+
+        const trigger = screen.getByTestId("popover-trigger");
+        const popover = screen.getByTestId("popover");
+
+        await waitFor(() =>
+            expect(trigger).to.have.attribute("aria-expanded", "false")
+        );
+
+        await user.click(trigger);
+
+        await waitFor(() => expect(popover).to.have.class("is-visible"));
+        expect(trigger).to.have.attribute("aria-expanded", "true");
+
+        await user.click(trigger);
+
+        await waitFor(() => expect(popover).not.to.have.class("is-visible"));
+        expect(trigger).to.have.attribute("aria-expanded", "false");
+    });
+
+    it("should stay open when focus moves from the trigger into the popover", async () => {
+        await fixture(createPopover());
+
+        const trigger = screen.getByTestId("popover-trigger");
+        const popover = screen.getByTestId("popover");
+        const link = screen.getByTestId("popover-link");
+
+        await user.click(trigger);
+        await waitFor(() => expect(popover).to.have.class("is-visible"));
+
+        await user.tab();
+
+        expect(link).to.have.focus;
+        expect(popover).to.have.class("is-visible");
+        expect(trigger).to.have.attribute("aria-expanded", "true");
+    });
+
+    it("should stay open when focus moves from the popover back to the trigger", async () => {
+        await fixture(createPopover());
+
+        const trigger = screen.getByTestId("popover-trigger");
+        const popover = screen.getByTestId("popover");
+        const link = screen.getByTestId("popover-link");
+
+        await user.click(trigger);
+        await waitFor(() => expect(popover).to.have.class("is-visible"));
+
+        await user.tab();
+        expect(link).to.have.focus;
+
+        await user.tab({ shift: true });
+
+        expect(trigger).to.have.focus;
+        expect(popover).to.have.class("is-visible");
+        expect(trigger).to.have.attribute("aria-expanded", "true");
+    });
+
+    it("should hide when focus moves from the popover to an outside button", async () => {
+        await fixture(createPopover());
+
+        const trigger = screen.getByTestId("popover-trigger");
+        const popover = screen.getByTestId("popover");
+        const outsideButton = screen.getByTestId("outside-button");
+
+        await user.click(trigger);
+        await waitFor(() => expect(popover).to.have.class("is-visible"));
+
+        await user.tab();
+        await user.tab();
+
+        expect(outsideButton).to.have.focus;
+        await waitFor(() => expect(popover).not.to.have.class("is-visible"));
+        expect(trigger).to.have.attribute("aria-expanded", "false");
+    });
+
+    it("should hide when focus leaves a popover containing a menu", async () => {
+        await fixture(
+            createPopover({
+                content: html`
+                    <ul class="s-menu" role="menu">
+                        <li class="s-menu--item" role="menuitem">
+                            <button
+                                class="s-menu--action"
+                                data-testid="popover-link"
+                            >
+                                View more
+                            </button>
+                        </li>
+                    </ul>
+                `,
+                role: "dialog",
+            })
+        );
+
+        const trigger = screen.getByTestId("popover-trigger");
+        const popover = screen.getByTestId("popover");
+        const outsideButton = screen.getByTestId("outside-button");
+
+        await user.click(trigger);
+        await waitFor(() => expect(popover).to.have.class("is-visible"));
+
+        await user.tab();
+        await user.tab();
+
+        expect(outsideButton).to.have.focus;
+        await waitFor(() => expect(popover).not.to.have.class("is-visible"));
+        expect(trigger).to.have.attribute("aria-expanded", "false");
+    });
+
+    it("should stay open when focus moves outside a non-menu popover", async () => {
+        await fixture(createPopover({ role: "dialog" }));
+
+        const trigger = screen.getByTestId("popover-trigger");
+        const popover = screen.getByTestId("popover");
+        const outsideButton = screen.getByTestId("outside-button");
+
+        await user.click(trigger);
+        await waitFor(() => expect(popover).to.have.class("is-visible"));
+
+        await user.tab();
+        await user.tab();
+
+        expect(outsideButton).to.have.focus;
+        expect(popover).to.have.class("is-visible");
+        expect(trigger).to.have.attribute("aria-expanded", "true");
+    });
+
+    it("should stay open when focus leaves a menu popover that disables auto-dismissal", async () => {
+        await fixture(createPopover({ hideOnOutsideClick: "never" }));
+
+        const trigger = screen.getByTestId("popover-trigger");
+        const popover = screen.getByTestId("popover");
+        const outsideButton = screen.getByTestId("outside-button");
+
+        await user.click(trigger);
+        await waitFor(() => expect(popover).to.have.class("is-visible"));
+
+        await user.tab();
+        await user.tab();
+
+        expect(outsideButton).to.have.focus;
+        expect(popover).to.have.class("is-visible");
+        expect(trigger).to.have.attribute("aria-expanded", "true");
+    });
+
+    it("should hide when focus moves from the trigger to an outside button", async () => {
+        await fixture(createPopover({ content: html`<span>View more</span>` }));
+
+        const trigger = screen.getByTestId("popover-trigger");
+        const popover = screen.getByTestId("popover");
+        const outsideButton = screen.getByTestId("outside-button");
+
+        await user.click(trigger);
+        await waitFor(() => expect(popover).to.have.class("is-visible"));
+
+        await user.tab();
+
+        expect(outsideButton).to.have.focus;
+        await waitFor(() => expect(popover).not.to.have.class("is-visible"));
+        expect(trigger).to.have.attribute("aria-expanded", "false");
+    });
+
+    it("should hide when focus leaves with no related target", async () => {
+        await fixture(createPopover());
+
+        const trigger = screen.getByTestId("popover-trigger");
+        const popover = screen.getByTestId("popover");
+
+        await user.click(trigger);
+        await waitFor(() => expect(popover).to.have.class("is-visible"));
+
+        trigger.dispatchEvent(
+            new FocusEvent("focusout", {
+                bubbles: true,
+                relatedTarget: null,
+            })
+        );
+
+        expect(popover).not.to.have.class("is-visible");
+        expect(trigger).to.have.attribute("aria-expanded", "false");
+    });
+});

--- a/packages/stacks-classic/lib/components/popover/popover.ts
+++ b/packages/stacks-classic/lib/components/popover/popover.ts
@@ -86,6 +86,17 @@ export abstract class BasePopoverController extends Stacks.StacksController {
     }
 
     /**
+     * Only menu popovers dismiss when focus leaves the reference/popover pair.
+     */
+    protected get shouldHideOnFocusLeave() {
+        return (
+            this.shouldHideOnOutsideClick &&
+            (this.popoverElement?.getAttribute("role") === "menu" ||
+                !!this.popoverElement?.querySelector('[role="menu"]'))
+        );
+    }
+
+    /**
      * Initializes and validates controller variables
      */
     connect() {
@@ -322,6 +333,7 @@ export class PopoverController extends BasePopoverController {
 
     private boundHideOnOutsideClick!: (event: MouseEvent) => void;
     private boundHideOnEscapePress!: (event: KeyboardEvent) => void;
+    private boundHideOnFocusOut!: (event: FocusEvent) => void;
 
     /**
      * Toggles optional classes and accessibility attributes in addition to BasePopoverController.shown
@@ -358,9 +370,19 @@ export class PopoverController extends BasePopoverController {
             this.boundHideOnOutsideClick || this.hideOnOutsideClick.bind(this);
         this.boundHideOnEscapePress =
             this.boundHideOnEscapePress || this.hideOnEscapePress.bind(this);
+        this.boundHideOnFocusOut =
+            this.boundHideOnFocusOut || this.hideOnFocusOut.bind(this);
 
         document.addEventListener("mousedown", this.boundHideOnOutsideClick);
         document.addEventListener("keyup", this.boundHideOnEscapePress);
+        this.referenceElement.addEventListener(
+            "focusout",
+            this.boundHideOnFocusOut
+        );
+        this.popoverElement.addEventListener(
+            "focusout",
+            this.boundHideOnFocusOut
+        );
     }
 
     /**
@@ -369,6 +391,14 @@ export class PopoverController extends BasePopoverController {
     protected unbindDocumentEvents() {
         document.removeEventListener("mousedown", this.boundHideOnOutsideClick);
         document.removeEventListener("keyup", this.boundHideOnEscapePress);
+        this.referenceElement.removeEventListener(
+            "focusout",
+            this.boundHideOnFocusOut
+        );
+        this.popoverElement.removeEventListener(
+            "focusout",
+            this.boundHideOnFocusOut
+        );
     }
 
     /**
@@ -403,6 +433,28 @@ export class PopoverController extends BasePopoverController {
         // note: .contains also returns true if the node itself matches the target element
         if (this.popoverElement.contains(<Node>e.target)) {
             this.referenceElement.focus();
+        }
+
+        this.hide(e);
+    }
+
+    /**
+     * Forces the popover to hide if keyboard focus leaves both the reference element and the popover.
+     * @param {FocusEvent} e - The focusout event from the reference or popover element
+     */
+    private hideOnFocusOut(e: FocusEvent) {
+        if (!this.shouldHideOnFocusLeave) {
+            return;
+        }
+
+        const relatedTarget = e.relatedTarget;
+
+        if (
+            relatedTarget instanceof Node &&
+            (this.referenceElement.contains(relatedTarget) ||
+                this.popoverElement.contains(relatedTarget))
+        ) {
+            return;
         }
 
         this.hide(e);

--- a/packages/stacks-docs/product/components/popovers.html
+++ b/packages/stacks-docs/product/components/popovers.html
@@ -301,6 +301,80 @@ tags: components
         </div>
     </div>
 
+    {% header "h4", "Menu popovers" %}
+    <p class="stacks-copy">Menu popovers are dismissed when keyboard focus leaves the reference and popover. Apply <code class="stacks-code">role="menu"</code> to the contained menu, or to the <code class="stacks-code">.s-popover</code> root, to enable this behavior. Generic popovers that keep the default <code class="stacks-code">role="dialog"</code> stay open when focus moves outside.</p>
+
+    <div class="stacks-preview">
+{% highlight html %}
+<button class="s-btn s-btn__dropdown"
+        aria-controls="menu-popover-example"
+        aria-expanded="false"
+        data-controller="s-popover"
+        data-action="s-popover#toggle"
+        data-s-popover-placement="bottom-start">
+    Actions
+</button>
+<div class="s-popover" id="menu-popover-example">
+    <div class="s-popover--content p0">
+        <ul class="s-menu" role="menu">
+            <li class="s-menu--item" role="none">
+                <button class="s-menu--action" type="button" role="menuitem">Share</button>
+            </li>
+            <li class="s-menu--item" role="none">
+                <button class="s-menu--action" type="button" role="menuitem">Edit</button>
+            </li>
+            <li class="s-menu--item" role="none">
+                <button class="s-menu--action" type="button" role="menuitem">Follow</button>
+            </li>
+        </ul>
+    </div>
+</div>
+{% endhighlight %}
+        <div class="stacks-preview--example d-flex ai-start g16 fw-wrap">
+            <button class="s-btn s-btn__filled s-btn__dropdown"
+                    aria-controls="popover-menu-focus-example"
+                    aria-expanded="false"
+                    data-controller="s-popover"
+                    data-action="s-popover#toggle"
+                    data-s-popover-placement="bottom-start">
+                Menu popover
+            </button>
+            <div class="s-popover wmn-initial w-auto" id="popover-menu-focus-example">
+                <div class="s-popover--arrow"></div>
+                <div class="s-popover--content p0">
+                    <ul class="s-menu" role="menu">
+                        <li class="s-menu--item" role="none">
+                            <button class="s-menu--action" type="button" role="menuitem">Share</button>
+                        </li>
+                        <li class="s-menu--item" role="none">
+                            <button class="s-menu--action" type="button" role="menuitem">Edit</button>
+                        </li>
+                        <li class="s-menu--item" role="none">
+                            <button class="s-menu--action" type="button" role="menuitem">Follow</button>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
+            <button class="s-btn s-btn__filled s-btn__dropdown"
+                    aria-controls="popover-default-focus-example"
+                    aria-expanded="false"
+                    data-controller="s-popover"
+                    data-action="s-popover#toggle"
+                    data-s-popover-placement="bottom-start">
+                Default popover
+            </button>
+            <div class="s-popover wmn-initial w-auto" id="popover-default-focus-example" role="dialog">
+                <div class="s-popover--arrow"></div>
+                <div class="s-popover--content">
+                    <button class="s-btn s-btn__sm" type="button">Default action</button>
+                </div>
+            </div>
+
+            <button class="s-btn s-btn__muted">Outside focus target</button>
+        </div>
+    </div>
+
     {% header "h4", "Dismissible" %}
     <p class="stacks-copy">In the case of new feature callouts, it may be appropriate to include an explicit dismiss button. You can add one using the styling provided by <code class="stacks-code">.s-popover--close</code>.</p>
     <p class="stacks-copy">In order for to close the popover with an explicit close button, you’ll need to add the controller to a parent as illustrated in the following example code:</p>

--- a/packages/stacks-svelte/src/components/Popover/Popover.svelte
+++ b/packages/stacks-svelte/src/components/Popover/Popover.svelte
@@ -4,21 +4,28 @@
     import type { Placement } from "@floating-ui/core";
     import { getContext } from "svelte";
 
+    export interface CloseOptions {
+        delay?: number;
+        restoreFocus?: boolean;
+    }
+
     export interface PopoverState {
         id: string;
         controlled: boolean;
         visible: boolean | undefined;
         dismissible: boolean;
         trapFocus: boolean;
+        closeOnFocusLeave: boolean;
         computedPlacement: Placement;
         tooltip: boolean;
         floatingRef: (element: HTMLElement) => void;
         floatingContent: (element: HTMLElement) => void;
         arrowEl: Writable<HTMLElement>;
         onOutclick: (e: CustomEvent<HTMLElement>) => void;
+        onFocusOut: (e: FocusEvent) => void;
         open: () => void;
         openTooltip: () => void;
-        close: () => void;
+        close: (options?: CloseOptions) => void;
         closeTooltip: () => void;
         toggle: () => void;
     }
@@ -124,6 +131,7 @@
     const TOOLTIP_CLOSE_DELAY = 100;
 
     let reference: HTMLElement;
+    let content: HTMLElement;
     let activeTimeout: number;
     const arrowEl = writable<HTMLElement>();
 
@@ -167,16 +175,19 @@
 
     const closeTooltip = () => {
         if (!tooltip) return;
-        close(TOOLTIP_CLOSE_DELAY);
+        close({ delay: TOOLTIP_CLOSE_DELAY });
     };
 
-    const close = (delay: number = 0) => {
+    const close = ({
+        delay = 0,
+        restoreFocus = !tooltip,
+    }: CloseOptions = {}) => {
         window.clearTimeout(activeTimeout);
         if (controlled) return;
         if (pstate.visible) {
             activeTimeout = window.setTimeout(() => {
                 pstate.visible = false;
-                if (!tooltip) {
+                if (restoreFocus) {
                     reference.focus();
                 }
                 // Fires when the popover is closed
@@ -197,6 +208,33 @@
         close();
     };
 
+    const onFocusOut = (e: FocusEvent) => {
+        if (
+            tooltip ||
+            !pstate.visible ||
+            !pstate.closeOnFocusLeave ||
+            !dismissible
+        ) {
+            return;
+        }
+
+        const relatedTarget = e.relatedTarget;
+        if (
+            relatedTarget instanceof Node &&
+            (reference?.contains(relatedTarget) ||
+                content?.contains(relatedTarget))
+        ) {
+            return;
+        }
+
+        if (controlled) {
+            onclose?.();
+            return;
+        }
+
+        close({ restoreFocus: false });
+    };
+
     const onKeypress = (e: KeyboardEvent) => {
         if (e.key === "Escape" && dismissible) {
             close();
@@ -209,15 +247,20 @@
         visible: autoshow,
         dismissible,
         trapFocus,
+        closeOnFocusLeave: false,
         computedPlacement: placement,
         tooltip,
         floatingRef: (element) => {
             reference = element;
             floatingRef(element);
         },
-        floatingContent,
+        floatingContent: (element) => {
+            content = element;
+            floatingContent(element);
+        },
         arrowEl,
         onOutclick,
+        onFocusOut,
         open,
         openTooltip,
         close,

--- a/packages/stacks-svelte/src/components/Popover/Popover.test.ts
+++ b/packages/stacks-svelte/src/components/Popover/Popover.test.ts
@@ -2,7 +2,7 @@ import { mount, unmount, tick, createRawSnippet } from "svelte";
 import type { Strategy } from "@floating-ui/core";
 import sinon from "sinon";
 import { expect } from "@open-wc/testing";
-import { render, screen } from "@testing-library/svelte";
+import { render, screen, waitFor } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
 import { setViewport } from "@web/test-runner-commands";
 import { createSvelteComponentsSnippet } from "../../../test-utils";
@@ -42,6 +42,12 @@ const defaultChildren = {
         },
     },
 };
+
+afterEach(() => {
+    document
+        .querySelectorAll("[data-testid='popover-outside-button']")
+        .forEach((el) => el.remove());
+});
 
 describe("Popover", () => {
     it("should show/hide the popover content when the user click on the reference", async () => {
@@ -515,6 +521,61 @@ describe("Popover", () => {
     });
 
     describe("when not in tooltip mode", () => {
+        const focusableContent = {
+            component: PopoverContent,
+            props: {
+                children: createRawSnippet(() => ({
+                    render: () =>
+                        '<button type="button">Popover action</button>',
+                })),
+            },
+        };
+
+        const focusableMenuContent = {
+            component: PopoverContent,
+            props: {
+                role: "menu",
+                children: createRawSnippet(() => ({
+                    render: () =>
+                        '<button type="button" role="menuitem">Popover action</button>',
+                })),
+            },
+        };
+
+        const focusableNestedMenuContent = {
+            component: PopoverContent,
+            props: {
+                children: createRawSnippet(() => ({
+                    render: () => `
+                        <ul class="s-menu" role="menu">
+                            <li class="s-menu--item" role="none">
+                                <button type="button" role="menuitem">Popover action</button>
+                            </li>
+                        </ul>
+                    `,
+                })),
+            },
+        };
+
+        const menuContent = {
+            component: PopoverContent,
+            props: {
+                role: "menu",
+                children: createRawSnippet(() => ({
+                    render: () => "<span>Popover Content</span>",
+                })),
+            },
+        };
+
+        const addOutsideButton = () => {
+            const outsideButton = document.createElement("button");
+            outsideButton.type = "button";
+            outsideButton.textContent = "Outside action";
+            outsideButton.dataset.testid = "popover-outside-button";
+            document.body.append(outsideButton);
+            return outsideButton;
+        };
+
         it("should throw an error if the reference element provided is not of role button", () => {
             expect(() =>
                 render(Popover, {
@@ -561,6 +622,257 @@ describe("Popover", () => {
 
             await userEvent.click(reference);
             expect(reference).to.have.attribute("aria-expanded", "false");
+        });
+
+        it("should keep the popover open when focus moves from the reference into the content", async () => {
+            render(Popover, {
+                props: {
+                    ...defaultProps,
+                    children: createSvelteComponentsSnippet([
+                        defaultChildren.reference,
+                        focusableMenuContent,
+                    ]),
+                },
+            });
+
+            const reference = screen.getByRole("button", { name: "Trigger" });
+
+            await userEvent.click(reference);
+            expect(screen.getByRole("menu")).to.exist;
+
+            await userEvent.tab();
+
+            expect(screen.getByRole("menuitem", { name: "Popover action" })).to
+                .have.focus;
+            expect(screen.getByRole("menu")).to.exist;
+            expect(reference).to.have.attribute("aria-expanded", "true");
+        });
+
+        it("should keep the popover open when focus moves from the content back to the reference", async () => {
+            render(Popover, {
+                props: {
+                    ...defaultProps,
+                    children: createSvelteComponentsSnippet([
+                        defaultChildren.reference,
+                        focusableMenuContent,
+                    ]),
+                },
+            });
+
+            const reference = screen.getByRole("button", { name: "Trigger" });
+
+            await userEvent.click(reference);
+            expect(screen.getByRole("menu")).to.exist;
+
+            await userEvent.tab();
+            expect(screen.getByRole("menuitem", { name: "Popover action" })).to
+                .have.focus;
+
+            await userEvent.tab({ shift: true });
+
+            expect(reference).to.have.focus;
+            expect(screen.getByRole("menu")).to.exist;
+            expect(reference).to.have.attribute("aria-expanded", "true");
+        });
+
+        it("should close the popover without restoring focus when focus moves outside", async () => {
+            render(Popover, {
+                props: {
+                    ...defaultProps,
+                    children: createSvelteComponentsSnippet([
+                        defaultChildren.reference,
+                        focusableMenuContent,
+                    ]),
+                },
+            });
+            const outsideButton = addOutsideButton();
+
+            const reference = screen.getByRole("button", { name: "Trigger" });
+
+            await userEvent.click(reference);
+            expect(screen.getByRole("menu")).to.exist;
+
+            await userEvent.tab();
+            await userEvent.tab();
+
+            expect(outsideButton).to.have.focus;
+            await waitFor(
+                () => expect(screen.queryByRole("menu")).not.to.exist
+            );
+            expect(reference).to.have.attribute("aria-expanded", "false");
+            expect(reference).not.to.have.focus;
+        });
+
+        it("should close the popover when focus leaves a popover containing a menu", async () => {
+            render(Popover, {
+                props: {
+                    ...defaultProps,
+                    children: createSvelteComponentsSnippet([
+                        defaultChildren.reference,
+                        focusableNestedMenuContent,
+                    ]),
+                },
+            });
+            const outsideButton = addOutsideButton();
+
+            const reference = screen.getByRole("button", { name: "Trigger" });
+
+            await userEvent.click(reference);
+            expect(screen.getByRole("menu")).to.exist;
+
+            await userEvent.tab();
+            await userEvent.tab();
+
+            expect(outsideButton).to.have.focus;
+            await waitFor(
+                () => expect(screen.queryByRole("menu")).not.to.exist
+            );
+            expect(reference).to.have.attribute("aria-expanded", "false");
+            expect(reference).not.to.have.focus;
+        });
+
+        it("should stay open when focus moves outside a non-menu popover", async () => {
+            render(Popover, {
+                props: {
+                    ...defaultProps,
+                    children: createSvelteComponentsSnippet([
+                        defaultChildren.reference,
+                        focusableContent,
+                    ]),
+                },
+            });
+            const outsideButton = addOutsideButton();
+
+            const reference = screen.getByRole("button", { name: "Trigger" });
+
+            await userEvent.click(reference);
+            expect(screen.getByRole("dialog")).to.exist;
+
+            await userEvent.tab();
+            await userEvent.tab();
+
+            expect(outsideButton).to.have.focus;
+            expect(screen.getByRole("dialog")).to.exist;
+            expect(reference).to.have.attribute("aria-expanded", "true");
+            expect(reference).not.to.have.focus;
+        });
+
+        it("should stay open when focus leaves a menu popover that is not dismissible", async () => {
+            render(Popover, {
+                props: {
+                    ...defaultProps,
+                    dismissible: false,
+                    children: createSvelteComponentsSnippet([
+                        defaultChildren.reference,
+                        focusableMenuContent,
+                    ]),
+                },
+            });
+            const outsideButton = addOutsideButton();
+
+            const reference = screen.getByRole("button", { name: "Trigger" });
+
+            await userEvent.click(reference);
+            expect(screen.getByRole("menu")).to.exist;
+
+            await userEvent.tab();
+            await userEvent.tab();
+
+            expect(outsideButton).to.have.focus;
+            expect(screen.getByRole("menu")).to.exist;
+            expect(reference).to.have.attribute("aria-expanded", "true");
+            expect(reference).not.to.have.focus;
+        });
+
+        it("should close the popover when focus moves from the reference directly outside", async () => {
+            render(Popover, {
+                props: {
+                    ...defaultProps,
+                    children: createSvelteComponentsSnippet([
+                        defaultChildren.reference,
+                        menuContent,
+                    ]),
+                },
+            });
+            const outsideButton = addOutsideButton();
+
+            const reference = screen.getByRole("button", { name: "Trigger" });
+
+            await userEvent.click(reference);
+            expect(screen.getByRole("menu")).to.exist;
+
+            await userEvent.tab();
+
+            expect(outsideButton).to.have.focus;
+            await waitFor(
+                () => expect(screen.queryByRole("menu")).not.to.exist
+            );
+            expect(reference).to.have.attribute("aria-expanded", "false");
+            expect(reference).not.to.have.focus;
+        });
+
+        it("should close the popover when focus leaves with no related target", async () => {
+            render(Popover, {
+                props: {
+                    ...defaultProps,
+                    children: createSvelteComponentsSnippet([
+                        defaultChildren.reference,
+                        menuContent,
+                    ]),
+                },
+            });
+
+            const reference = screen.getByRole("button", { name: "Trigger" });
+
+            await userEvent.click(reference);
+            expect(screen.getByRole("menu")).to.exist;
+
+            reference.dispatchEvent(
+                new FocusEvent("focusout", {
+                    bubbles: true,
+                    relatedTarget: null,
+                })
+            );
+
+            await waitFor(
+                () => expect(screen.queryByRole("menu")).not.to.exist
+            );
+            expect(reference).to.have.attribute("aria-expanded", "false");
+        });
+
+        it("should request close without mutating visibility when a controlled popover loses focus", async () => {
+            const onCloseSpy = sinon.spy();
+            const { rerender } = render(Popover, {
+                props: {
+                    ...defaultProps,
+                    visible: true,
+                    onclose: onCloseSpy,
+                    children: createSvelteComponentsSnippet([
+                        defaultChildren.reference,
+                        focusableMenuContent,
+                    ]),
+                },
+            });
+            const outsideButton = addOutsideButton();
+
+            const reference = screen.getByRole("button", { name: "Trigger" });
+
+            await userEvent.tab();
+            expect(reference).to.have.focus;
+
+            await userEvent.tab();
+            expect(screen.getByRole("menuitem", { name: "Popover action" })).to
+                .have.focus;
+            expect(onCloseSpy).not.to.have.been.called;
+
+            await userEvent.tab();
+            expect(outsideButton).to.have.focus;
+            expect(onCloseSpy).to.have.been.calledOnce;
+            expect(screen.getByRole("menu")).to.exist;
+
+            rerender({ visible: false });
+            await tick();
+            expect(screen.queryByRole("menu")).not.to.exist;
         });
 
         it("should not show/hide the tooltip content when the user hovers on the reference", async () => {

--- a/packages/stacks-svelte/src/components/Popover/PopoverContent.svelte
+++ b/packages/stacks-svelte/src/components/Popover/PopoverContent.svelte
@@ -22,6 +22,7 @@
     let { role = null, class: className = "", children }: Props = $props();
 
     let pstate = usePopoverContext("PopoverContent");
+    let contentElement: HTMLElement | undefined;
 
     const arrowEl = pstate.arrowEl;
 
@@ -43,6 +44,18 @@
     let computedRole = $derived(
         role || (pstate.tooltip ? "tooltip" : "dialog")
     );
+
+    const onFocusOut = (e: FocusEvent) => {
+        pstate.closeTooltip();
+        pstate.onFocusOut(e);
+    };
+
+    $effect(() => {
+        pstate.closeOnFocusLeave =
+            !pstate.tooltip &&
+            (computedRole === "menu" ||
+                !!contentElement?.querySelector('[role="menu"]'));
+    });
 </script>
 
 <!-- data-popper-placement is needed for compatibility with stacks classic popover styles -->
@@ -57,8 +70,9 @@
     onmouseenter={pstate.openTooltip}
     onmouseleave={pstate.closeTooltip}
     onfocusin={pstate.openTooltip}
-    onfocusout={pstate.closeTooltip}
+    onfocusout={onFocusOut}
     data-popper-placement={pstate.computedPlacement}
+    bind:this={contentElement}
 >
     <div class="s-popover--arrow" bind:this={$arrowEl}></div>
     <div class="s-popover--content p12 mn12">

--- a/packages/stacks-svelte/src/components/Popover/PopoverReference.svelte
+++ b/packages/stacks-svelte/src/components/Popover/PopoverReference.svelte
@@ -49,7 +49,11 @@
         ref.setAttribute("aria-controls", `${pstate.id}-popover`);
         const toggle = pstate.dismissible ? pstate.toggle : pstate.open;
         ref.addEventListener("click", toggle);
-        return () => ref.removeEventListener("click", toggle);
+        ref.addEventListener("focusout", pstate.onFocusOut);
+        return () => {
+            ref.removeEventListener("click", toggle);
+            ref.removeEventListener("focusout", pstate.onFocusOut);
+        };
     };
 
     const setupTooltip = (ref: HTMLElement, pstate: PopoverState) => {
@@ -66,13 +70,20 @@
         };
     };
 
+    const setupControlledPopover = (ref: HTMLElement, pstate: PopoverState) => {
+        if (!pstate.tooltip) {
+            ref.addEventListener("focusout", pstate.onFocusOut);
+        }
+        return () => ref.removeEventListener("focusout", pstate.onFocusOut);
+    };
+
     onMount(() => {
         reference = setupRef(elementId, referenceWrapper, pstate);
 
         // if the popover is controlled, we delegate all the behavior to the consumer
-        if (pstate.controlled) return;
+        if (pstate.controlled) return setupControlledPopover(reference, pstate);
 
-        pstate.tooltip
+        return pstate.tooltip
             ? setupTooltip(reference, pstate)
             : setupPopover(reference, pstate);
     });


### PR DESCRIPTION
## Summary

Backports the popover focus-leave dismissal behavior from PR #2298 to the v2 branch.

- Adds Classic popover focusout handling so menu popovers close when keyboard focus leaves the reference/popover pair.
- Adds Svelte popover focus-leave handling, including controlled popover close requests and nested role="menu" detection.
- Adds v2 docs guidance for menu popovers and restores the PR #2298 changeset.

## Validation

- npm run lint:ts -w packages/stacks-classic passed.
- npm exec -w packages/stacks-svelte -- eslint src/components/Popover/Popover.svelte src/components/Popover/PopoverContent.svelte src/components/Popover/PopoverReference.svelte src/components/Popover/Popover.test.ts passed.
- npm run build:dependencies -w packages/stacks-svelte passed with existing Less and bundle-size warnings.

## Local validation blockers

- Classic web-test-runner starts but fails before assertions because existing unit test imports hit local dependency module export errors from aria-query/lz-string.
- Svelte web-test-runner fails before assertions because the local icon package does not export existing symbols such as IconShieldXSm.
- npm run lint -w packages/stacks-svelte is blocked by the same existing missing icon exports across unrelated Svelte components/stories.
- Root npx prettier could not parse the existing v2 docs HTML because of a pre-existing unmatched </kbd>; Svelte files were formatted via the workspace Prettier command instead.