### PR TITLE
fix(transitions): restore atomic import

### DIFF
--- a/.changeset/transition-import-fix.md
+++ b/.changeset/transition-import-fix.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks": patch
+---
+
+Restore transition atomic utilities to the static CSS bundle.

--- a/packages/stacks-classic/lib/stacks-static.less
+++ b/packages/stacks-classic/lib/stacks-static.less
@@ -38,6 +38,7 @@
 @import "atomic/overflow.less";
 @import "atomic/padding.less";
 @import "atomic/positioning.less";
+@import "atomic/transitions.less";
 @import "atomic/truncation.less";
 @import "atomic/vertical-alignment.less";
 @import "atomic/visibility.less";


### PR DESCRIPTION
## Summary

Restores the atomic transitions Less import to the static Stacks CSS bundle.

## Related Issue

[STACKS-907](https://stackoverflow.atlassian.net/browse/STACKS-907)

## Changes

- Adds back `@import "atomic/transitions.less";` in `packages/stacks-classic/lib/stacks-static.less`

## Testing

- `npm run test:less -w packages/stacks-classic`
- Verify that the transitions classes are in the stacks.css bundle

---

> This PR was generated by a developer using an AI agent with the Stacks v3 dev workflow.