### PR TITLE
test(bundle): add complete Less snapshot

### DIFF
--- a/packages/stacks-classic/lib/__snapshots__/stacks.less.test.ts.snap
+++ b/packages/stacks-classic/lib/__snapshots__/stacks.less.test.ts.snap
@@ -11056,6 +11056,36 @@ ol {
 .ln100 {
   left: -100% !important;
 }
+.t {
+  transition-duration: var(--transition-time);
+  transition-property: all;
+  transition-timing-function: var(--te-ease-in);
+  transition-delay: 0s;
+}
+.t-slow {
+  transition-duration: 0.25s !important;
+}
+.t-fast {
+  transition-duration: 0.05s !important;
+}
+.t-unset {
+  transition-property: none !important;
+}
+.t-bg {
+  transition-property: background-color !important;
+}
+.t-opacity {
+  transition-property: opacity !important;
+}
+.t-shadow {
+  transition-property: box-shadow !important;
+}
+.t-delay {
+  transition-delay: 0.25s !important;
+}
+.t-delay-unset {
+  transition-delay: 0s !important;
+}
 .truncate {
   overflow: hidden;
   max-width: 100%;

--- a/packages/stacks-classic/lib/__snapshots__/stacks.less.test.ts.snap
+++ b/packages/stacks-classic/lib/__snapshots__/stacks.less.test.ts.snap
@@ -1,0 +1,22422 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`stacks complete bundle > should output all stacks styles 1`] = `
+"/* stylelint-disable */
+/* normalize.css v7.0.0 | MIT License | github.com/necolas/normalize.css */
+/* Document
+   ========================================================================== */
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in
+ *    IE on Windows Phone and in iOS.
+ */
+html {
+    line-height: 1.15;
+  /* 1 */
+    -ms-text-size-adjust: 100%;
+  /* 2 */
+    -webkit-text-size-adjust: 100%;
+  /* 2 */
+}
+/* Sections
+   ========================================================================== */
+/**
+ * Remove the margin in all browsers (opinionated).
+ */
+body {
+    margin: 0;
+}
+/**
+ * Add the correct display in IE 9-.
+ */
+article,
+aside,
+footer,
+header,
+nav,
+section {
+    display: block;
+}
+/**
+ * Correct the font size and margin on \`h1\` elements within \`section\` and
+ * \`article\` contexts in Chrome, Firefox, and Safari.
+ */
+h1 {
+    margin: 0.67em 0;
+    font-size: 2em;
+}
+/* Grouping content
+   ========================================================================== */
+/**
+ * Add the correct display in IE 9-.
+ * 1. Add the correct display in IE.
+ */
+figcaption,
+figure,
+main {
+  /* 1 */
+    display: block;
+}
+/**
+ * Add the correct margin in IE 8.
+ */
+figure {
+    margin: 1em calc(var(--su32) + var(--su8));
+}
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+hr {
+    overflow: visible;
+  /* 2 */
+    box-sizing: content-box;
+  /* 1 */
+    height: 0;
+  /* 1 */
+}
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd \`em\` font sizing in all browsers.
+ */
+pre {
+    font-family: monospace, monospace;
+  /* 1 */
+    font-size: 1em;
+  /* 2 */
+}
+/* Text-level semantics
+   ========================================================================== */
+/**
+ * 1. Remove the gray background on active links in IE 10.
+ * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
+ */
+a {
+    background-color: transparent;
+  /* 1 */
+    -webkit-text-decoration-skip: objects;
+  /* 2 */
+}
+/**
+ * 1. Remove the bottom border in Chrome 57- and Firefox 39-.
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+abbr[title] {
+    border-bottom: none;
+  /* 1 */
+    text-decoration: underline;
+  /* 2 */
+    -webkit-text-decoration: underline dotted;
+    text-decoration: underline dotted;
+  /* 2 */
+}
+/**
+ * Prevent the duplicate application of \`bolder\` by the next rule in Safari 6.
+ */
+b,
+strong {
+    font-weight: inherit;
+}
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+b,
+strong {
+    font-weight: bolder;
+}
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd \`em\` font sizing in all browsers.
+ */
+code,
+kbd,
+samp {
+    font-family: monospace, monospace;
+  /* 1 */
+    font-size: 1em;
+  /* 2 */
+}
+/**
+ * Add the correct font style in Android 4.3-.
+ */
+dfn {
+    font-style: italic;
+}
+/**
+ * Add the correct background and color in IE 9-.
+ */
+mark {
+    background-color: #ff0;
+    color: #000;
+}
+/**
+ * Add the correct font size in all browsers.
+ */
+small {
+    font-size: 80%;
+}
+/**
+ * Prevent \`sub\` and \`sup\` elements from affecting the line height in
+ * all browsers.
+ */
+sub,
+sup {
+    position: relative;
+    font-size: 75%;
+    line-height: 0;
+    vertical-align: baseline;
+}
+
+sub {
+    bottom: -0.25em;
+}
+
+sup {
+    top: -0.5em;
+}
+/* Embedded content
+   ========================================================================== */
+/**
+ * Add the correct display in IE 9-.
+ */
+audio,
+video {
+    display: inline-block;
+}
+/**
+ * Add the correct display in iOS 4-7.
+ */
+audio:not([controls]) {
+    display: none;
+    height: 0;
+}
+/**
+ * Remove the border on images inside links in IE 10-.
+ */
+img {
+    border-style: none;
+}
+/**
+ * Hide the overflow in IE.
+ */
+svg:not(:root) {
+    overflow: hidden;
+}
+/* Forms
+   ========================================================================== */
+/**
+ * 1. Change the font styles in all browsers (opinionated).
+ * 2. Remove the margin in Firefox and Safari.
+ */
+button,
+input,
+optgroup,
+select,
+textarea {
+    margin: 0;
+  /* 2 */
+    font-family: sans-serif;
+  /* 1 */
+    font-size: 100%;
+  /* 1 */
+    line-height: 1.15;
+  /* 1 */
+}
+/**
+ * Show the overflow in IE.
+ * 1. Show the overflow in Edge.
+ */
+button,
+input {
+  /* 1 */
+    overflow: visible;
+}
+/**
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
+ */
+button,
+select {
+  /* 1 */
+    text-transform: none;
+}
+/**
+ * 1. Prevent a WebKit bug where (2) destroys native \`audio\` and \`video\`
+ *    controls in Android 4.
+ * 2. Correct the inability to style clickable types in iOS and Safari.
+ */
+button,
+html [type="button"],
+[type="reset"],
+[type="submit"] {
+    -webkit-appearance: button;
+  /* 2 */
+}
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+    padding: 0;
+    border-style: none;
+}
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+    outline: var(--su1) dotted ButtonText;
+}
+/**
+ * Correct the padding in Firefox.
+ */
+fieldset {
+    padding: 0.35em 0.75em 0.625em;
+}
+/**
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Correct the color inheritance from \`fieldset\` elements in IE.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *    \`fieldset\` elements in all browsers.
+ */
+legend {
+    display: table;
+  /* 1 */
+    box-sizing: border-box;
+  /* 1 */
+    max-width: 100%;
+  /* 1 */
+    padding: 0;
+  /* 3 */
+    color: inherit;
+  /* 2 */
+    white-space: normal;
+  /* 1 */
+}
+/**
+ * 1. Add the correct display in IE 9-.
+ * 2. Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+progress {
+    display: inline-block;
+  /* 1 */
+    vertical-align: baseline;
+  /* 2 */
+}
+/**
+ * Remove the default vertical scrollbar in IE.
+ */
+textarea {
+    overflow: auto;
+}
+/**
+ * 1. Add the correct box sizing in IE 10-.
+ * 2. Remove the padding in IE 10-.
+ */
+[type="checkbox"],
+[type="radio"] {
+    box-sizing: border-box;
+  /* 1 */
+    padding: 0;
+  /* 2 */
+}
+/**
+ * Correct the cursor style of increment and decrement buttons in Chrome.
+ */
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+    height: auto;
+}
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+[type="search"] {
+    -webkit-appearance: textfield;
+  /* 1 */
+    outline-offset: var(--sun2);
+}
+/**
+ * Remove the inner padding and cancel buttons in Chrome and Safari on macOS.
+ */
+[type="search"]::-webkit-search-cancel-button,
+[type="search"]::-webkit-search-decoration {
+    -webkit-appearance: none;
+}
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to \`inherit\` in Safari.
+ */
+::-webkit-file-upload-button {
+    -webkit-appearance: button;
+  /* 1 */
+    font: inherit;
+  /* 2 */
+}
+/* Interactive
+   ========================================================================== */
+/*
+ * Add the correct display in IE 9-.
+ * 1. Add the correct display in Edge, IE, and Firefox.
+ */
+details,
+menu {
+    display: block;
+}
+/*
+ * Add the correct display in all browsers.
+ */
+summary {
+    display: list-item;
+}
+/* Scripting
+   ========================================================================== */
+/**
+ * Add the correct display in IE 9-.
+ */
+canvas {
+    display: inline-block;
+}
+/**
+ * Add the correct display in IE.
+ */
+template {
+    display: none;
+}
+/* Hidden
+   ========================================================================== */
+/**
+ * Add the correct display in IE 10-.
+ */
+[hidden] {
+    display: none;
+}
+
+fieldset {
+    border: 0;
+    min-width: 0;
+    padding: 0;
+}
+
+.svg-icon,
+.svg-spot {
+    vertical-align: bottom;
+}
+
+.svg-icon:not(.native) *,
+.svg-spot:not(.native) * {
+    fill: currentColor;
+}
+
+.is-disabled,
+.is-readonly,
+.has-success,
+.has-error,
+.has-warning {
+    position: relative;
+}
+
+@font-face {
+    font-family: "Segoe UI Adjusted";
+  src: local(Segoe UI);
+  ascent-override: 95%;
+}
+
+@font-face {
+    font-family: "Segoe UI Adjusted";
+  src: local(Segoe UI Italic);
+  ascent-override: 95%;
+  font-style: italic;
+}
+
+@font-face {
+    font-family: "Segoe UI Adjusted";
+  src: local(Segoe UI Semibold);
+  ascent-override: 95%;
+  font-weight: 600;
+}
+
+@font-face {
+    font-family: "Segoe UI Adjusted";
+  src: local(Segoe UI Semibold Italic);
+  ascent-override: 95%;
+  font-style: italic;
+  font-weight: 600;
+}
+
+@font-face {
+    font-family: "Segoe UI Adjusted";
+  src: local(Segoe UI Bold);
+  ascent-override: 90%;
+  font-weight: 700;
+}
+
+@font-face {
+    font-family: "Segoe UI Adjusted";
+  src: local(Segoe UI Bold Italic);
+  ascent-override: 95%;
+  font-style: italic;
+  font-weight: 700;
+}
+
+@font-face {
+    font-family: "Segoe UI Adjusted";
+  src: local(Segoe UI Black);
+  ascent-override: 95%;
+  font-weight: 800;
+}
+
+@font-face {
+    font-family: "Segoe UI Adjusted";
+  src: local(Segoe UI Black Italic);
+  ascent-override: 95%;
+  font-style: italic;
+  font-weight: 800;
+}
+
+html {
+    font-size: 100%;
+}
+
+body {
+    --ff-sans: -apple-system, BlinkMacSystemFont, "Segoe UI Adjusted", "Segoe UI", "Liberation Sans", sans-serif;
+    --ff-serif: Georgia, Cambria, "Times New Roman", Times, serif;
+    --ff-mono: ui-monospace, "Cascadia Mono", "Segoe UI Mono", "Liberation Mono", Menlo, Monaco, Consolas, monospace;
+    --theme-body-font-family: var(--ff-sans);
+    --fs-fine: 0.75rem;
+    --fs-caption: 0.8125rem;
+    --fs-body1: 0.875rem;
+    --fs-body2: 1rem;
+    --fs-body3: 1.125rem;
+    --fs-subheading: 1.25rem;
+    --fs-title: 1.375rem;
+    --fs-headline1: 1.75rem;
+    --fs-headline2: 2.25rem;
+    --fs-display1: 2.875rem;
+    --fs-display2: 3.625rem;
+    --fs-display3: 4.5rem;
+    --fs-display4: 6.25rem;
+    --stacks-internals-lh-unit: 14;
+    --lh-xs: 1;
+    --lh-sm: calc((var(--stacks-internals-lh-unit) + 2) / var(--stacks-internals-lh-unit));
+    --lh-md: calc((var(--stacks-internals-lh-unit) + 4) / var(--stacks-internals-lh-unit));
+    --lh-lg: calc((var(--stacks-internals-lh-unit) + 8) / var(--stacks-internals-lh-unit));
+    --lh-xl: calc((var(--stacks-internals-lh-unit) + 12) / var(--stacks-internals-lh-unit));
+    --lh-xxl: 2;
+    --lh-base: var(--lh-md);
+    --lh-6: ((var(--stacks-internals-lh-unit) + 6) / var(--stacks-internals-lh-unit));
+}
+
+body {
+    --zi-hide: -1;
+    --zi-base: 0;
+    --zi-selected: 25;
+    --zi-active: 30;
+    --zi-dropdown: 1000;
+    --zi-popovers: 2000;
+    --zi-tooltips: 3000;
+    --zi-banners: 4000;
+    --zi-navigation: 5000;
+    --zi-navigation-fixed: 5050;
+    --zi-modals-background: 8050;
+    --zi-modals: 9000;
+    --br-md: calc(var(--su4) + var(--su6));
+    --br-circle: 50%;
+    --br-pill: 1000px;
+    --br-sm: var(--br-md);
+    --br-lg: var(--br-md);
+    --te-smooth-slow: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    --te-smooth: cubic-bezier(0.165, 0.84, 0.44, 1);
+    --te-smooth-quick: cubic-bezier(0.19, 1, 0.22, 1);
+    --te-back-out: cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    --te-back-in-out: cubic-bezier(0.68, -0.55, 0.265, 1.55);
+    --te-ease-in: cubic-bezier(0.47, 0, 0.745, 0.715);
+    --te-ease-in-out: cubic-bezier(0.445, 0.05, 0.55, 0.95);
+    --te-ease-out: cubic-bezier(0.39, 0.575, 0.565, 1);
+    --default-transition-duration: 0.1s;
+    --transition-time: var(--default-transition-duration);
+}
+
+body {
+    --_o-disabled: 0.55;
+    --_o-disabled-static: 0.55;
+    --_black-static: #000000;
+    --_white-static: #ffffff;
+}
+
+body:not(.theme-dark),
+body.theme-highcontrast:not(.theme-dark),
+body:not(.theme-highcontrast):not(.theme-dark),
+body.theme-dark .theme-light__forced,
+body.theme-highcontrast.theme-dark .theme-light__forced,
+body:not(.theme-highcontrast).theme-dark .theme-light__forced,
+body.theme-system .theme-light__forced,
+body.theme-highcontrast.theme-system .theme-light__forced,
+body:not(.theme-highcontrast).theme-system .theme-light__forced,
+body.theme-dark,
+body.theme-highcontrast.theme-dark,
+body:not(.theme-highcontrast).theme-dark,
+body:not(.theme-dark) .theme-dark__forced,
+body.theme-highcontrast:not(.theme-dark) .theme-dark__forced,
+body:not(.theme-highcontrast):not(.theme-dark) .theme-dark__forced {
+    --bg-error: var(--red-400);
+    --bg-danger: var(--red-400);
+    --bg-success: var(--green-400);
+    --bg-warning: var(--yellow-500);
+    --bc-error: var(--red-400);
+    --bc-danger: var(--red-400);
+    --bc-success: var(--green-400);
+    --bc-warning: var(--yellow-500);
+    --fc-light: var(--black-400);
+    --fc-medium: var(--black-500);
+    --fc-dark: var(--black-600);
+    --fc-error: var(--red-400);
+    --fc-danger: var(--red-400);
+    --fc-success: var(--green-400);
+    --fc-warning: var(--yellow-500);
+}
+
+@media (prefers-color-scheme: dark) {
+    body.theme-system,
+  body.theme-highcontrast.theme-system,
+  body:not(.theme-highcontrast).theme-system {
+        --bg-error: var(--red-400);
+        --bg-danger: var(--red-400);
+        --bg-success: var(--green-400);
+        --bg-warning: var(--yellow-500);
+        --bc-error: var(--red-400);
+        --bc-danger: var(--red-400);
+        --bc-success: var(--green-400);
+        --bc-warning: var(--yellow-500);
+        --fc-light: var(--black-400);
+        --fc-medium: var(--black-500);
+        --fc-dark: var(--black-600);
+        --fc-error: var(--red-400);
+        --fc-danger: var(--red-400);
+        --fc-success: var(--green-400);
+        --fc-warning: var(--yellow-500);
+    }
+}
+
+body:not(.theme-highcontrast):not(.theme-dark),
+body:not(.theme-highcontrast).theme-dark .theme-light__forced,
+body:not(.theme-highcontrast).theme-system .theme-light__forced,
+body:not(.theme-highcontrast):not(.theme-dark).themed,
+body:not(.theme-highcontrast).theme-dark .theme-light__forced.themed,
+body:not(.theme-highcontrast).theme-system .theme-light__forced.themed,
+body:not(.theme-highcontrast):not(.theme-dark) .themed,
+body:not(.theme-highcontrast).theme-dark .theme-light__forced .themed,
+body:not(.theme-highcontrast).theme-system .theme-light__forced .themed {
+    --white: #ffffff;
+    --black-050: #ffffff;
+    --black-100: #f7f6f5;
+    --black-150: #f0efed;
+    --black-200: #dee0e3;
+    --black-225: #d7d8db;
+    --black-250: #c9ccd1;
+    --black-300: #a7aab0;
+    --black-350: #84878c;
+    --black-400: #6b6d73;
+    --black-500: #46484d;
+    --black-600: #211d1e;
+    --black: #000000;
+    --orange-100: #fff7f2;
+    --orange-200: #ffd5bd;
+    --orange-300: #f59056;
+    --orange-400: #e86113;
+    --orange-500: #bf4904;
+    --orange-600: #702d06;
+    --blue-100: #f0f4ff;
+    --blue-200: #c8d4fa;
+    --blue-300: #88a2f7;
+    --blue-400: #5076f2;
+    --blue-500: #2445b3;
+    --blue-600: #0f2466;
+    --green-100: #f4faeb;
+    --green-200: #cce6a1;
+    --green-300: #9fbf67;
+    --green-400: #6c991f;
+    --green-500: #4d730b;
+    --green-600: #324d04;
+    --red-100: #fceded;
+    --red-200: #f5b9b8;
+    --red-300: #e67373;
+    --red-400: #bf3030;
+    --red-500: #8c0e0e;
+    --red-600: #590404;
+    --yellow-100: #fcf8e8;
+    --yellow-200: #f5e39d;
+    --yellow-300: #edc10e;
+    --yellow-400: #ab8900;
+    --yellow-500: #806600;
+    --yellow-600: #4d3d00;
+    --purple-100: #f0edfc;
+    --purple-200: #d0c6f7;
+    --purple-300: #a591f2;
+    --purple-400: #6e50e6;
+    --purple-500: #4526bf;
+    --purple-600: #200b73;
+    --pink-100: #fbedfc;
+    --pink-200: #ebb6f2;
+    --pink-300: #e685f2;
+    --pink-400: #d34ae8;
+    --pink-500: #a224b3;
+    --pink-600: #670b73;
+    --gold-100: hsl(46, 100%, 91%);
+    --gold-200: hsl(46, 100%, 74%);
+    --gold-300: hsl(45, 100%, 42%);
+    --gold-400: hsl(46, 92%, 26%);
+    --silver-100: hsl(0, 0%, 95%);
+    --silver-200: hsl(0, 0%, 84%);
+    --silver-300: hsl(210, 5%, 68%);
+    --silver-400: hsl(210, 2%, 40%);
+    --bronze-100: hsl(28, 40%, 92%);
+    --bronze-200: hsl(30, 47%, 83%);
+    --bronze-300: hsl(28, 43%, 65%);
+    --bronze-400: hsl(28, 43%, 39%);
+    --bc-lightest: var(--black-100);
+    --bc-lighter: var(--black-150);
+    --bc-light: var(--black-200);
+    --bc-medium: var(--black-225);
+    --bc-dark: var(--black-250);
+    --bc-darker: var(--black-300);
+    --bs-sm: 0 1px 2px hsla(0, 0%, 0%, 0.05), 0 1px 4px hsla(0, 0%, 0%, 0.05), 0 2px 8px hsla(0, 0%, 0%, 0.05);
+    --bs-md: 0 1px 3px hsla(0, 0%, 0%, 0.06), 0 2px 6px hsla(0, 0%, 0%, 0.06), 0 3px 8px hsla(0, 0%, 0%, 0.09);
+    --bs-lg: 0 1px 4px hsla(0, 0%, 0%, 0.09), 0 3px 8px hsla(0, 0%, 0%, 0.09), 0 4px 13px hsla(0, 0%, 0%, 0.13);
+    --bs-xl: 0 10px 24px hsla(0, 0%, 0%, 0.05), 0 20px 48px hsla(0, 0%, 0%, 0.05), 0 1px 4px hsla(0, 0%, 0%, 0.1);
+    --translucent-secondary: var(--theme-secondary-custom-translucent, rgba(115, 115, 115, 0.15));
+    --translucent-success: hsla(140, 40%, 75%, 0.4);
+    --translucent-warning: hsla(47, 79%, 58%, 0.4);
+    --translucent-error: hsla(358, 62%, 47%, 0.15);
+    --translucent-muted: hsla(210, 8%, 15%, 0.1);
+    --focus-neutral: var(--white);
+    --focus-theme: var(--theme-secondary);
+    --focus-ring: var(--theme-secondary-custom-focus-ring, rgba(115, 115, 115, 0.15));
+    --focus-ring-success: hsla(140, 40%, 75%, 0.4);
+    --focus-ring-warning: hsla(47, 79%, 58%, 0.4);
+    --focus-ring-error: hsla(358, 62%, 47%, 0.15);
+    --focus-ring-muted: hsla(210, 8%, 15%, 0.1);
+    --highlight-addition: var(--green-500);
+    --highlight-attribute: hsl(206, 98.5%, 29%);
+    --highlight-bg: hsl(0, 0%, 96.5%);
+    --highlight-color: var(--black-600);
+    --highlight-comment: var(--black-400);
+    --highlight-deletion: var(--red-500);
+    --highlight-keyword: hsl(206, 98.5%, 29%);
+    --highlight-literal: hsl(27, 99%, 36%);
+    --highlight-namespace: hsl(27, 99%, 36%);
+    --highlight-punctuation: var(--black-500);
+    --highlight-symbol: hsl(306, 43%, 35%);
+    --highlight-variable: hsl(80, 80.5%, 26.5%);
+    --scrollbar: hsla(0, 0%, 0%, 0.2);
+    --brand: #FF5E00;
+    --brand-black: #201C1D;
+    --brand-off-white: #F0EFEE;
+    --brand-blue-light: #C6D1E1;
+    --brand-blue: #5074EF;
+    --brand-blue-dark: #00165E;
+    --brand-brown-light: #998B7A;
+    --brand-green: #86AF25;
+    --brand-green-dark: #263603;
+    --brand-orange-medium: #6E1527;
+    --brand-orange-dark: #31070F;
+    --brand-pink: #F39FFF;
+    --brand-pink-dark: #4D1955;
+    --brand-purple: #9D9CFF;
+    --brand-purple-dark: #390A91;
+    --brand-yellow: #FFCC00;
+    --brand-yellow-dark: #423101;
+    --theme-primary: var(--theme-primary-custom, var(--orange-400));
+    --theme-primary-100: var(--theme-primary-custom-100, var(--orange-100));
+    --theme-primary-200: var(--theme-primary-custom-200, var(--orange-200));
+    --theme-primary-300: var(--theme-primary-custom-300, var(--orange-300));
+    --theme-primary-400: var(--theme-primary-custom-400, var(--orange-400));
+    --theme-primary-500: var(--theme-primary-custom-500, var(--orange-500));
+    --theme-primary-600: var(--theme-primary-custom-600, var(--orange-600));
+    --theme-secondary: var(--theme-secondary-custom, var(--black));
+    --theme-secondary-100: var(--theme-secondary-custom-100, var(--black-100));
+    --theme-secondary-200: var(--theme-secondary-custom-200, var(--black-200));
+    --theme-secondary-300: var(--theme-secondary-custom-300, var(--black-300));
+    --theme-secondary-400: var(--theme-secondary-custom-400, var(--black-400));
+    --theme-secondary-500: var(--theme-secondary-custom-500, var(--black-500));
+    --theme-secondary-600: var(--theme-secondary-custom-600, var(--black-600));
+    --theme-primary-custom-100: hsl(var(--theme-base-primary-color-h), var(--theme-base-primary-color-s), calc(var(--theme-base-primary-color-l) + ((100% - var(--theme-base-primary-color-l)) * .9)));
+    --theme-primary-custom-200: hsl(var(--theme-base-primary-color-h), var(--theme-base-primary-color-s), calc(var(--theme-base-primary-color-l) + ((100% - var(--theme-base-primary-color-l)) * .75)));
+    --theme-primary-custom-300: hsl(var(--theme-base-primary-color-h), var(--theme-base-primary-color-s), calc(var(--theme-base-primary-color-l) + ((100% - var(--theme-base-primary-color-l)) * .5)));
+    --theme-primary-custom-400: hsl(var(--theme-base-primary-color-h), var(--theme-base-primary-color-s), var(--theme-base-primary-color-l));
+    --theme-primary-custom-500: hsl(var(--theme-base-primary-color-h), var(--theme-base-primary-color-s), calc(var(--theme-base-primary-color-l) + (var(--theme-base-primary-color-l) * -.3)));
+    --theme-primary-custom-600: hsl(var(--theme-base-primary-color-h), var(--theme-base-primary-color-s), calc(var(--theme-base-primary-color-l) + (var(--theme-base-primary-color-l) * -.6)));
+    --theme-primary-custom: var(--theme-primary-custom-400);
+    --theme-secondary-custom-100: hsl(var(--theme-base-secondary-color-h), var(--theme-base-secondary-color-s), calc(var(--theme-base-secondary-color-l) + ((100% - var(--theme-base-secondary-color-l)) * .9)));
+    --theme-secondary-custom-200: hsl(var(--theme-base-secondary-color-h), var(--theme-base-secondary-color-s), calc(var(--theme-base-secondary-color-l) + ((100% - var(--theme-base-secondary-color-l)) * .75)));
+    --theme-secondary-custom-300: hsl(var(--theme-base-secondary-color-h), var(--theme-base-secondary-color-s), calc(var(--theme-base-secondary-color-l) + ((100% - var(--theme-base-secondary-color-l)) * .5)));
+    --theme-secondary-custom-400: hsl(var(--theme-base-secondary-color-h), var(--theme-base-secondary-color-s), var(--theme-base-secondary-color-l));
+    --theme-secondary-custom-500: hsl(var(--theme-base-secondary-color-h), var(--theme-base-secondary-color-s), calc(var(--theme-base-secondary-color-l) + (var(--theme-base-secondary-color-l) * -.3)));
+    --theme-secondary-custom-600: hsl(var(--theme-base-secondary-color-h), var(--theme-base-secondary-color-s), calc(var(--theme-base-secondary-color-l) + (var(--theme-base-secondary-color-l) * -.6)));
+    --theme-secondary-custom: var(--theme-secondary-custom-400);
+    --theme-secondary-custom-focus-ring: hsla(var(--theme-base-secondary-color-h), var(--theme-base-secondary-color-s), var(--theme-base-secondary-color-l), 0.15);
+    --theme-secondary-custom-translucent: hsla(var(--theme-base-secondary-color-h), var(--theme-base-secondary-color-s), var(--theme-base-secondary-color-l), 0.15);
+    color: var(--theme-body-font-color, var(--black-600));
+}
+
+body:not(.theme-highcontrast).theme-dark,
+body:not(.theme-highcontrast):not(.theme-dark) .theme-dark__forced,
+body:not(.theme-highcontrast).theme-dark.themed,
+body:not(.theme-highcontrast):not(.theme-dark) .theme-dark__forced.themed,
+body:not(.theme-highcontrast).theme-dark .themed,
+body:not(.theme-highcontrast):not(.theme-dark) .theme-dark__forced .themed {
+    --white: #141414;
+    --black-050: #141414;
+    --black-100: #262626;
+    --black-150: #333333;
+    --black-200: #575757;
+    --black-225: #666666;
+    --black-250: #737373;
+    --black-300: #8c8c8c;
+    --black-350: #a6a6a6;
+    --black-400: #d9d3ce;
+    --black-500: #f2ede9;
+    --black-600: #ffffff;
+    --black: #ffffff;
+    --orange-100: #401f0d;
+    --orange-200: #733c1c;
+    --orange-300: #c78c69;
+    --orange-400: #e6ab8a;
+    --orange-500: #fcccb1;
+    --orange-600: #fadac8;
+    --blue-100: #22304d;
+    --blue-200: #4d6699;
+    --blue-300: #7b9de0;
+    --blue-400: #a6c3ff;
+    --blue-500: #ccddff;
+    --blue-600: #e6eeff;
+    --green-100: #28380b;
+    --green-200: #5c7334;
+    --green-300: #96b364;
+    --green-400: #c4e68a;
+    --green-500: #cce6a1;
+    --green-600: #ecffcc;
+    --red-100: #330f0f;
+    --red-200: #662e2e;
+    --red-300: #b35d5d;
+    --red-400: #faafaf;
+    --red-500: #fccaca;
+    --red-600: #ffe6e6;
+    --yellow-100: #332b0a;
+    --yellow-200: #594c16;
+    --yellow-300: #a6944b;
+    --yellow-400: #e6d17e;
+    --yellow-500: #e3d59f;
+    --yellow-600: #fffae6;
+    --purple-100: #22174d;
+    --purple-200: #3d2d80;
+    --purple-300: #7262b3;
+    --purple-400: #b6a6f7;
+    --purple-500: #d2c8fa;
+    --purple-600: #e8e3fc;
+    --pink-100: #2e0a33;
+    --pink-200: #5e2466;
+    --pink-300: #bf81c7;
+    --pink-400: #f3bbfa;
+    --pink-500: #f7cffc;
+    --pink-600: #fae3fc;
+    --gold-100: hsl(45, 29%, 24%);
+    --gold-200: hsl(45, 47%, 37%);
+    --gold-300: hsl(45, 92%, 62%);
+    --gold-400: hsl(46, 93%, 78%);
+    --silver-100: hsl(220, 2%, 26%);
+    --silver-200: hsl(220, 1%, 46%);
+    --silver-300: hsl(216, 4%, 69%);
+    --silver-400: hsl(214, 8%, 83%);
+    --bronze-100: hsl(28, 13%, 27%);
+    --bronze-200: hsl(28, 27%, 45%);
+    --bronze-300: hsl(28, 58%, 67%);
+    --bronze-400: hsl(28, 59%, 83%);
+    --bc-lightest: var(--black-100);
+    --bc-lighter: var(--black-150);
+    --bc-light: var(--black-200);
+    --bc-medium: var(--black-225);
+    --bc-dark: var(--black-250);
+    --bc-darker: var(--black-300);
+    --bs-sm: 0 1px 2px hsla(0, 0%, 0%, 0.1), 0 1px 4px hsla(0, 0%, 0%, 0.1), 0 2px 8px hsla(0, 0%, 0%, 0.1);
+    --bs-md: 0 1px 3px hsla(0, 0%, 0%, 0.11), 0 2px 6px hsla(0, 0%, 0%, 0.11), 0 3px 8px hsla(0, 0%, 0%, 0.14);
+    --bs-lg: 0 1px 4px hsla(0, 0%, 0%, 0.14), 0 3px 8px hsla(0, 0%, 0%, 0.14), 0 4px 13px hsla(0, 0%, 0%, 0.18);
+    --bs-xl: 0 10px 24px hsla(0, 0%, 0%, 0.1), 0 20px 48px hsla(0, 0%, 0%, 0.1), 0 1px 4px hsla(0, 0%, 0%, 0.15);
+    --translucent-secondary: var(--theme-dark-secondary-custom-translucent, rgba(217, 211, 206, 0.25));
+    --translucent-success: hsla(140, 40%, 75%, 0.4);
+    --translucent-warning: hsla(47, 79%, 58%, 0.4);
+    --translucent-error: hsla(358, 62%, 47%, 0.15);
+    --translucent-muted: hsla(210, 8%, 15%, 0.1);
+    --focus-neutral: var(--white);
+    --focus-theme: var(--theme-secondary);
+    --focus-ring: var(--theme-dark-secondary-custom-focus-ring, rgba(217, 211, 206, 0.25));
+    --focus-ring-success: hsla(140, 40%, 75%, 0.4);
+    --focus-ring-warning: hsla(47, 79%, 58%, 0.4);
+    --focus-ring-error: hsla(358, 62%, 47%, 0.15);
+    --focus-ring-muted: hsla(210, 8%, 15%, 0.1);
+    --highlight-addition: var(--green-500);
+    --highlight-attribute: var(--blue-400);
+    --highlight-bg: hsl(0, 2%, 11%);
+    --highlight-color: var(--black);
+    --highlight-comment: var(--black-400);
+    --highlight-deletion: var(--red-500);
+    --highlight-keyword: var(--blue-400);
+    --highlight-literal: hsl(27, 95%, 65%);
+    --highlight-namespace: hsl(27, 95%, 65%);
+    --highlight-punctuation: hsl(0, 0%, 80%);
+    --highlight-symbol: hsl(306, 50%, 75%);
+    --highlight-variable: hsl(65.5, 39%, 57.5%);
+    --scrollbar: hsla(0, 0%, 100%, 0.2);
+    --brand: #FF5E00;
+    --brand-black: #201C1D;
+    --brand-off-white: #F0EFEE;
+    --brand-blue-light: #C6D1E1;
+    --brand-blue: #5074EF;
+    --brand-blue-dark: #00165E;
+    --brand-brown-light: #998B7A;
+    --brand-green: #86AF25;
+    --brand-green-dark: #263603;
+    --brand-orange-medium: #6E1527;
+    --brand-orange-dark: #31070F;
+    --brand-pink: #F39FFF;
+    --brand-pink-dark: #4D1955;
+    --brand-purple: #9D9CFF;
+    --brand-purple-dark: #390A91;
+    --brand-yellow: #FFCC00;
+    --brand-yellow-dark: #423101;
+    --theme-primary: var(--theme-dark-primary-custom, var(--orange-400));
+    --theme-primary-100: var(--theme-dark-primary-custom-100, var(--orange-100));
+    --theme-primary-200: var(--theme-dark-primary-custom-200, var(--orange-200));
+    --theme-primary-300: var(--theme-dark-primary-custom-300, var(--orange-300));
+    --theme-primary-400: var(--theme-dark-primary-custom-400, var(--orange-400));
+    --theme-primary-500: var(--theme-dark-primary-custom-500, var(--orange-500));
+    --theme-primary-600: var(--theme-dark-primary-custom-600, var(--orange-600));
+    --theme-secondary: var(--theme-dark-secondary-custom, var(--black));
+    --theme-secondary-100: var(--theme-dark-secondary-custom-100, var(--black-100));
+    --theme-secondary-200: var(--theme-dark-secondary-custom-200, var(--black-200));
+    --theme-secondary-300: var(--theme-dark-secondary-custom-300, var(--black-300));
+    --theme-secondary-400: var(--theme-dark-secondary-custom-400, var(--black-400));
+    --theme-secondary-500: var(--theme-dark-secondary-custom-500, var(--black-500));
+    --theme-secondary-600: var(--theme-dark-secondary-custom-600, var(--black-600));
+    --theme-dark-primary-custom-100: hsl(var(--theme-dark-primary-color-h), calc(var(--theme-dark-primary-color-s) + (var(--theme-dark-primary-color-s) * -.6)), calc(var(--theme-dark-primary-color-l) + (var(--theme-dark-primary-color-l) * -.7)));
+    --theme-dark-primary-custom-200: hsl(var(--theme-dark-primary-color-h), calc(var(--theme-dark-primary-color-s) + (var(--theme-dark-primary-color-s) * -.4)), calc(var(--theme-dark-primary-color-l) + (var(--theme-dark-primary-color-l) * -.5)));
+    --theme-dark-primary-custom-300: hsl(var(--theme-dark-primary-color-h), calc(var(--theme-dark-primary-color-s) + (var(--theme-dark-primary-color-s) * -.3)), calc(var(--theme-dark-primary-color-l) + (var(--theme-dark-primary-color-l) * -.2)));
+    --theme-dark-primary-custom-400: hsl(var(--theme-dark-primary-color-h), var(--theme-dark-primary-color-s), var(--theme-dark-primary-color-l));
+    --theme-dark-primary-custom-500: hsl(var(--theme-dark-primary-color-h), var(--theme-dark-primary-color-s), calc(var(--theme-dark-primary-color-l) + ((100% - var(--theme-dark-primary-color-l)) * .5)));
+    --theme-dark-primary-custom-600: hsl(var(--theme-dark-primary-color-h), var(--theme-dark-primary-color-s), calc(var(--theme-dark-primary-color-l) + ((100% - var(--theme-dark-primary-color-l)) * .8)));
+    --theme-dark-primary-custom: var(--theme-dark-primary-custom-400);
+    --theme-dark-secondary-custom-100: hsl(var(--theme-dark-secondary-color-h), calc(var(--theme-dark-secondary-color-s) + (var(--theme-dark-secondary-color-s) * -.6)), calc(var(--theme-dark-secondary-color-l) + (var(--theme-dark-secondary-color-l) * -.7)));
+    --theme-dark-secondary-custom-200: hsl(var(--theme-dark-secondary-color-h), calc(var(--theme-dark-secondary-color-s) + (var(--theme-dark-secondary-color-s) * -.4)), calc(var(--theme-dark-secondary-color-l) + (var(--theme-dark-secondary-color-l) * -.5)));
+    --theme-dark-secondary-custom-300: hsl(var(--theme-dark-secondary-color-h), calc(var(--theme-dark-secondary-color-s) + (var(--theme-dark-secondary-color-s) * -.3)), calc(var(--theme-dark-secondary-color-l) + (var(--theme-dark-secondary-color-l) * -.2)));
+    --theme-dark-secondary-custom-400: hsl(var(--theme-dark-secondary-color-h), var(--theme-dark-secondary-color-s), var(--theme-dark-secondary-color-l));
+    --theme-dark-secondary-custom-500: hsl(var(--theme-dark-secondary-color-h), var(--theme-dark-secondary-color-s), calc(var(--theme-dark-secondary-color-l) + ((100% - var(--theme-dark-secondary-color-l)) * .5)));
+    --theme-dark-secondary-custom-600: hsl(var(--theme-dark-secondary-color-h), var(--theme-dark-secondary-color-s), calc(var(--theme-dark-secondary-color-l) + ((100% - var(--theme-dark-secondary-color-l)) * .8)));
+    --theme-dark-secondary-custom: var(--theme-dark-secondary-custom-400);
+    --theme-dark-secondary-custom-focus-ring: hsla(var(--theme-dark-secondary-color-h), var(--theme-dark-secondary-color-s), var(--theme-dark-secondary-color-l), 0.25);
+    --theme-dark-secondary-custom-translucent: hsla(var(--theme-dark-secondary-color-h), var(--theme-dark-secondary-color-s), var(--theme-dark-secondary-color-l), 0.25);
+    color: var(--theme-body-font-color, var(--black-600));
+}
+
+@media (prefers-color-scheme: dark) {
+    body:not(.theme-highcontrast).theme-system,
+  body:not(.theme-highcontrast).theme-system.themed,
+  body:not(.theme-highcontrast).theme-system .themed {
+        --white: #141414;
+        --black-050: #141414;
+        --black-100: #262626;
+        --black-150: #333333;
+        --black-200: #575757;
+        --black-225: #666666;
+        --black-250: #737373;
+        --black-300: #8c8c8c;
+        --black-350: #a6a6a6;
+        --black-400: #d9d3ce;
+        --black-500: #f2ede9;
+        --black-600: #ffffff;
+        --black: #ffffff;
+        --orange-100: #401f0d;
+        --orange-200: #733c1c;
+        --orange-300: #c78c69;
+        --orange-400: #e6ab8a;
+        --orange-500: #fcccb1;
+        --orange-600: #fadac8;
+        --blue-100: #22304d;
+        --blue-200: #4d6699;
+        --blue-300: #7b9de0;
+        --blue-400: #a6c3ff;
+        --blue-500: #ccddff;
+        --blue-600: #e6eeff;
+        --green-100: #28380b;
+        --green-200: #5c7334;
+        --green-300: #96b364;
+        --green-400: #c4e68a;
+        --green-500: #cce6a1;
+        --green-600: #ecffcc;
+        --red-100: #330f0f;
+        --red-200: #662e2e;
+        --red-300: #b35d5d;
+        --red-400: #faafaf;
+        --red-500: #fccaca;
+        --red-600: #ffe6e6;
+        --yellow-100: #332b0a;
+        --yellow-200: #594c16;
+        --yellow-300: #a6944b;
+        --yellow-400: #e6d17e;
+        --yellow-500: #e3d59f;
+        --yellow-600: #fffae6;
+        --purple-100: #22174d;
+        --purple-200: #3d2d80;
+        --purple-300: #7262b3;
+        --purple-400: #b6a6f7;
+        --purple-500: #d2c8fa;
+        --purple-600: #e8e3fc;
+        --pink-100: #2e0a33;
+        --pink-200: #5e2466;
+        --pink-300: #bf81c7;
+        --pink-400: #f3bbfa;
+        --pink-500: #f7cffc;
+        --pink-600: #fae3fc;
+        --gold-100: hsl(45, 29%, 24%);
+        --gold-200: hsl(45, 47%, 37%);
+        --gold-300: hsl(45, 92%, 62%);
+        --gold-400: hsl(46, 93%, 78%);
+        --silver-100: hsl(220, 2%, 26%);
+        --silver-200: hsl(220, 1%, 46%);
+        --silver-300: hsl(216, 4%, 69%);
+        --silver-400: hsl(214, 8%, 83%);
+        --bronze-100: hsl(28, 13%, 27%);
+        --bronze-200: hsl(28, 27%, 45%);
+        --bronze-300: hsl(28, 58%, 67%);
+        --bronze-400: hsl(28, 59%, 83%);
+        --bc-lightest: var(--black-100);
+        --bc-lighter: var(--black-150);
+        --bc-light: var(--black-200);
+        --bc-medium: var(--black-225);
+        --bc-dark: var(--black-250);
+        --bc-darker: var(--black-300);
+        --bs-sm: 0 1px 2px hsla(0, 0%, 0%, 0.1), 0 1px 4px hsla(0, 0%, 0%, 0.1), 0 2px 8px hsla(0, 0%, 0%, 0.1);
+        --bs-md: 0 1px 3px hsla(0, 0%, 0%, 0.11), 0 2px 6px hsla(0, 0%, 0%, 0.11), 0 3px 8px hsla(0, 0%, 0%, 0.14);
+        --bs-lg: 0 1px 4px hsla(0, 0%, 0%, 0.14), 0 3px 8px hsla(0, 0%, 0%, 0.14), 0 4px 13px hsla(0, 0%, 0%, 0.18);
+        --bs-xl: 0 10px 24px hsla(0, 0%, 0%, 0.1), 0 20px 48px hsla(0, 0%, 0%, 0.1), 0 1px 4px hsla(0, 0%, 0%, 0.15);
+        --translucent-secondary: var(--theme-dark-secondary-custom-translucent, rgba(217, 211, 206, 0.25));
+        --translucent-success: hsla(140, 40%, 75%, 0.4);
+        --translucent-warning: hsla(47, 79%, 58%, 0.4);
+        --translucent-error: hsla(358, 62%, 47%, 0.15);
+        --translucent-muted: hsla(210, 8%, 15%, 0.1);
+        --focus-neutral: var(--white);
+        --focus-theme: var(--theme-secondary);
+        --focus-ring: var(--theme-dark-secondary-custom-focus-ring, rgba(217, 211, 206, 0.25));
+        --focus-ring-success: hsla(140, 40%, 75%, 0.4);
+        --focus-ring-warning: hsla(47, 79%, 58%, 0.4);
+        --focus-ring-error: hsla(358, 62%, 47%, 0.15);
+        --focus-ring-muted: hsla(210, 8%, 15%, 0.1);
+        --highlight-addition: var(--green-500);
+        --highlight-attribute: var(--blue-400);
+        --highlight-bg: hsl(0, 2%, 11%);
+        --highlight-color: var(--black);
+        --highlight-comment: var(--black-400);
+        --highlight-deletion: var(--red-500);
+        --highlight-keyword: var(--blue-400);
+        --highlight-literal: hsl(27, 95%, 65%);
+        --highlight-namespace: hsl(27, 95%, 65%);
+        --highlight-punctuation: hsl(0, 0%, 80%);
+        --highlight-symbol: hsl(306, 50%, 75%);
+        --highlight-variable: hsl(65.5, 39%, 57.5%);
+        --scrollbar: hsla(0, 0%, 100%, 0.2);
+        --brand: #FF5E00;
+        --brand-black: #201C1D;
+        --brand-off-white: #F0EFEE;
+        --brand-blue-light: #C6D1E1;
+        --brand-blue: #5074EF;
+        --brand-blue-dark: #00165E;
+        --brand-brown-light: #998B7A;
+        --brand-green: #86AF25;
+        --brand-green-dark: #263603;
+        --brand-orange-medium: #6E1527;
+        --brand-orange-dark: #31070F;
+        --brand-pink: #F39FFF;
+        --brand-pink-dark: #4D1955;
+        --brand-purple: #9D9CFF;
+        --brand-purple-dark: #390A91;
+        --brand-yellow: #FFCC00;
+        --brand-yellow-dark: #423101;
+        --theme-primary: var(--theme-dark-primary-custom, var(--orange-400));
+        --theme-primary-100: var(--theme-dark-primary-custom-100, var(--orange-100));
+        --theme-primary-200: var(--theme-dark-primary-custom-200, var(--orange-200));
+        --theme-primary-300: var(--theme-dark-primary-custom-300, var(--orange-300));
+        --theme-primary-400: var(--theme-dark-primary-custom-400, var(--orange-400));
+        --theme-primary-500: var(--theme-dark-primary-custom-500, var(--orange-500));
+        --theme-primary-600: var(--theme-dark-primary-custom-600, var(--orange-600));
+        --theme-secondary: var(--theme-dark-secondary-custom, var(--black));
+        --theme-secondary-100: var(--theme-dark-secondary-custom-100, var(--black-100));
+        --theme-secondary-200: var(--theme-dark-secondary-custom-200, var(--black-200));
+        --theme-secondary-300: var(--theme-dark-secondary-custom-300, var(--black-300));
+        --theme-secondary-400: var(--theme-dark-secondary-custom-400, var(--black-400));
+        --theme-secondary-500: var(--theme-dark-secondary-custom-500, var(--black-500));
+        --theme-secondary-600: var(--theme-dark-secondary-custom-600, var(--black-600));
+        --theme-dark-primary-custom-100: hsl(var(--theme-dark-primary-color-h), calc(var(--theme-dark-primary-color-s) + (var(--theme-dark-primary-color-s) * -.6)), calc(var(--theme-dark-primary-color-l) + (var(--theme-dark-primary-color-l) * -.7)));
+        --theme-dark-primary-custom-200: hsl(var(--theme-dark-primary-color-h), calc(var(--theme-dark-primary-color-s) + (var(--theme-dark-primary-color-s) * -.4)), calc(var(--theme-dark-primary-color-l) + (var(--theme-dark-primary-color-l) * -.5)));
+        --theme-dark-primary-custom-300: hsl(var(--theme-dark-primary-color-h), calc(var(--theme-dark-primary-color-s) + (var(--theme-dark-primary-color-s) * -.3)), calc(var(--theme-dark-primary-color-l) + (var(--theme-dark-primary-color-l) * -.2)));
+        --theme-dark-primary-custom-400: hsl(var(--theme-dark-primary-color-h), var(--theme-dark-primary-color-s), var(--theme-dark-primary-color-l));
+        --theme-dark-primary-custom-500: hsl(var(--theme-dark-primary-color-h), var(--theme-dark-primary-color-s), calc(var(--theme-dark-primary-color-l) + ((100% - var(--theme-dark-primary-color-l)) * .5)));
+        --theme-dark-primary-custom-600: hsl(var(--theme-dark-primary-color-h), var(--theme-dark-primary-color-s), calc(var(--theme-dark-primary-color-l) + ((100% - var(--theme-dark-primary-color-l)) * .8)));
+        --theme-dark-primary-custom: var(--theme-dark-primary-custom-400);
+        --theme-dark-secondary-custom-100: hsl(var(--theme-dark-secondary-color-h), calc(var(--theme-dark-secondary-color-s) + (var(--theme-dark-secondary-color-s) * -.6)), calc(var(--theme-dark-secondary-color-l) + (var(--theme-dark-secondary-color-l) * -.7)));
+        --theme-dark-secondary-custom-200: hsl(var(--theme-dark-secondary-color-h), calc(var(--theme-dark-secondary-color-s) + (var(--theme-dark-secondary-color-s) * -.4)), calc(var(--theme-dark-secondary-color-l) + (var(--theme-dark-secondary-color-l) * -.5)));
+        --theme-dark-secondary-custom-300: hsl(var(--theme-dark-secondary-color-h), calc(var(--theme-dark-secondary-color-s) + (var(--theme-dark-secondary-color-s) * -.3)), calc(var(--theme-dark-secondary-color-l) + (var(--theme-dark-secondary-color-l) * -.2)));
+        --theme-dark-secondary-custom-400: hsl(var(--theme-dark-secondary-color-h), var(--theme-dark-secondary-color-s), var(--theme-dark-secondary-color-l));
+        --theme-dark-secondary-custom-500: hsl(var(--theme-dark-secondary-color-h), var(--theme-dark-secondary-color-s), calc(var(--theme-dark-secondary-color-l) + ((100% - var(--theme-dark-secondary-color-l)) * .5)));
+        --theme-dark-secondary-custom-600: hsl(var(--theme-dark-secondary-color-h), var(--theme-dark-secondary-color-s), calc(var(--theme-dark-secondary-color-l) + ((100% - var(--theme-dark-secondary-color-l)) * .8)));
+        --theme-dark-secondary-custom: var(--theme-dark-secondary-custom-400);
+        --theme-dark-secondary-custom-focus-ring: hsla(var(--theme-dark-secondary-color-h), var(--theme-dark-secondary-color-s), var(--theme-dark-secondary-color-l), 0.25);
+        --theme-dark-secondary-custom-translucent: hsla(var(--theme-dark-secondary-color-h), var(--theme-dark-secondary-color-s), var(--theme-dark-secondary-color-l), 0.25);
+        color: var(--theme-body-font-color, var(--black-600));
+    }
+}
+
+body.theme-highcontrast:not(.theme-dark),
+body.theme-highcontrast.theme-dark .theme-light__forced,
+body.theme-highcontrast.theme-system .theme-light__forced {
+    --white: #ffffff;
+    --black-050: #ffffff;
+    --black-100: #f7f6f5;
+    --black-150: #f0efed;
+    --black-200: #dee0e3;
+    --black-225: #d7d8db;
+    --black-250: #c9ccd1;
+    --black-300: #91939c;
+    --black-350: #54585c;
+    --black-400: #505355;
+    --black-500: #44464b;
+    --black-600: #211d1e;
+    --black: #000000;
+    --orange-100: #fff7f2;
+    --orange-200: #fff7f2;
+    --orange-300: #e86113;
+    --orange-400: #963903;
+    --orange-500: #6e2c05;
+    --orange-600: #6e2c05;
+    --blue-100: #f0f4ff;
+    --blue-200: #f0f4ff;
+    --blue-300: #5076f2;
+    --blue-400: #2445b3;
+    --blue-500: #0f2466;
+    --blue-600: #0f2466;
+    --green-100: #f4faeb;
+    --green-200: #f4faeb;
+    --green-300: #72a120;
+    --green-400: #406107;
+    --green-500: #324d04;
+    --green-600: #324d04;
+    --red-100: #fceded;
+    --red-200: #fceded;
+    --red-300: #bf3030;
+    --red-400: #8c0e0e;
+    --red-500: #590404;
+    --red-600: #590404;
+    --yellow-100: #fcf8e8;
+    --yellow-200: #fcf8e8;
+    --yellow-300: #ab8900;
+    --yellow-400: #6b5600;
+    --yellow-500: #4d3d00;
+    --yellow-600: #4d3d00;
+    --purple-100: #f0edfc;
+    --purple-200: #f0edfc;
+    --purple-300: #6e50e6;
+    --purple-400: #4526bf;
+    --purple-500: #200b73;
+    --purple-600: #200b73;
+    --pink-100: #fbedfc;
+    --pink-200: #fbedfc;
+    --pink-300: #d34ae8;
+    --pink-400: #8f209e;
+    --pink-500: #670b73;
+    --pink-600: #670b73;
+    --gold-100: hsl(46, 100%, 91%);
+    --gold-200: hsl(46, 100%, 91%);
+    --gold-300: hsl(45, 100%, 42%);
+    --gold-400: hsl(46, 92%, 26%);
+    --silver-100: hsl(0, 0%, 95%);
+    --silver-200: hsl(0, 0%, 95%);
+    --silver-300: hsl(210, 5%, 68%);
+    --silver-400: hsl(210, 2%, 40%);
+    --bronze-100: hsl(28, 40%, 92%);
+    --bronze-200: hsl(28, 40%, 92%);
+    --bronze-300: hsl(28, 43%, 65%);
+    --bronze-400: hsl(28, 43%, 39%);
+    --bc-lightest: var(--black-400);
+    --bc-lighter: var(--black-400);
+    --bc-light: var(--black-400);
+    --bc-medium: var(--black-400);
+    --bc-dark: var(--black-500);
+    --bc-darker: var(--black-600);
+    --bs-sm: none;
+    --bs-md: none;
+    --bs-lg: none;
+    --bs-xl: none;
+    --translucent-secondary: hsla(204, 6%, 35%, 0.9);
+    --translucent-success: hsla(140, 40%, 40%, 0.9);
+    --translucent-warning: hsla(47, 76%, 46%, 0.9);
+    --translucent-error: hsla(358, 62%, 47%, 0.9);
+    --translucent-muted: hsla(210, 8%, 55%, 0.95);
+    --focus-neutral: var(--white);
+    --focus-theme: var(--theme-secondary);
+    --focus-ring: rgba(115, 115, 115, 0.9);
+    --focus-ring-success: hsla(140, 40%, 40%, 0.9);
+    --focus-ring-warning: hsla(47, 76%, 46%, 0.9);
+    --focus-ring-error: hsla(358, 62%, 47%, 0.9);
+    --focus-ring-muted: hsla(210, 8%, 55%, 0.95);
+    --highlight-addition: var(--green-500);
+    --highlight-attribute: hsl(215, 100%, 35%);
+    --highlight-bg: hsl(0, 0%, 96.5%);
+    --highlight-color: var(--black-600);
+    --highlight-comment: var(--black-400);
+    --highlight-deletion: var(--red-400);
+    --highlight-keyword: hsl(215, 100%, 35%);
+    --highlight-literal: hsl(16, 94%, 31%);
+    --highlight-namespace: hsl(16, 94%, 31%);
+    --highlight-punctuation: var(--black-500);
+    --highlight-symbol: hsl(309, 45%, 31%);
+    --highlight-variable: hsl(88, 100%, 18%);
+    --scrollbar: var(--black);
+    --brand: #FF5E00;
+    --brand-black: #201C1D;
+    --brand-off-white: #F0EFEE;
+    --brand-blue-light: #C6D1E1;
+    --brand-blue: #5074EF;
+    --brand-blue-dark: #00165E;
+    --brand-brown-light: #998B7A;
+    --brand-green: #86AF25;
+    --brand-green-dark: #263603;
+    --brand-orange-medium: #6E1527;
+    --brand-orange-dark: #31070F;
+    --brand-pink: #F39FFF;
+    --brand-pink-dark: #4D1955;
+    --brand-purple: #9D9CFF;
+    --brand-purple-dark: #390A91;
+    --brand-yellow: #FFCC00;
+    --brand-yellow-dark: #423101;
+    --theme-primary: var(--orange-400);
+    --theme-primary-100: var(--orange-100);
+    --theme-primary-200: var(--orange-200);
+    --theme-primary-300: var(--orange-300);
+    --theme-primary-400: var(--orange-400);
+    --theme-primary-500: var(--orange-500);
+    --theme-primary-600: var(--orange-600);
+    --theme-secondary: var(--black);
+    --theme-secondary-100: var(--black-100);
+    --theme-secondary-200: var(--black-200);
+    --theme-secondary-300: var(--black-300);
+    --theme-secondary-400: var(--black-400);
+    --theme-secondary-500: var(--black-500);
+    --theme-secondary-600: var(--black-600);
+    --_o-disabled: 0.8;
+}
+
+body.theme-highcontrast.theme-dark,
+body.theme-highcontrast:not(.theme-dark) .theme-dark__forced {
+    --white: #000000;
+    --black-050: #141414;
+    --black-100: #262626;
+    --black-150: #333333;
+    --black-200: #575757;
+    --black-225: #666666;
+    --black-250: #737373;
+    --black-300: #8c8c8c;
+    --black-350: #a6a6a6;
+    --black-400: #d9d3ce;
+    --black-500: #f2ede9;
+    --black-600: #ffffff;
+    --black: #ffffff;
+    --orange-100: #401f0d;
+    --orange-200: #401f0d;
+    --orange-300: #dead90;
+    --orange-400: #fcccb1;
+    --orange-500: #fadac8;
+    --orange-600: #fadac8;
+    --blue-100: #22304d;
+    --blue-200: #22304d;
+    --blue-300: #a6c3ff;
+    --blue-400: #ccddff;
+    --blue-500: #e6eeff;
+    --blue-600: #e6eeff;
+    --green-100: #28380b;
+    --green-200: #28380b;
+    --green-300: #c4e68a;
+    --green-400: #cce6a1;
+    --green-500: #ecffcc;
+    --green-600: #ecffcc;
+    --red-100: #330f0f;
+    --red-200: #330f0f;
+    --red-300: #faafaf;
+    --red-400: #fccaca;
+    --red-500: #ffe6e6;
+    --red-600: #ffe6e6;
+    --yellow-100: #332b0a;
+    --yellow-200: #332b0a;
+    --yellow-300: #e6d17e;
+    --yellow-400: #e3d59f;
+    --yellow-500: #fffae6;
+    --yellow-600: #fffae6;
+    --purple-100: #22174d;
+    --purple-200: #22174d;
+    --purple-300: #b6a6f7;
+    --purple-400: #d2c8fa;
+    --purple-500: #e8e3fc;
+    --purple-600: #e8e3fc;
+    --pink-100: #2e0a33;
+    --pink-200: #2e0a33;
+    --pink-300: #f3bbfa;
+    --pink-400: #f7cffc;
+    --pink-500: #fae3fc;
+    --pink-600: #fae3fc;
+    --gold-100: hsl(45, 22%, 25%);
+    --gold-200: hsl(45, 22%, 25%);
+    --gold-300: hsl(45, 92%, 62%);
+    --gold-400: hsl(46, 93%, 78%);
+    --silver-100: hsl(220, 2%, 26%);
+    --silver-200: hsl(220, 2%, 26%);
+    --silver-300: hsl(220, 4%, 69%);
+    --silver-400: hsl(214, 8%, 83%);
+    --bronze-100: hsl(27, 13%, 27%);
+    --bronze-200: hsl(27, 13%, 27%);
+    --bronze-300: hsl(28, 58%, 67%);
+    --bronze-400: hsl(28, 59%, 83%);
+    --bc-lightest: var(--black-400);
+    --bc-lighter: var(--black-400);
+    --bc-light: var(--black-400);
+    --bc-medium: var(--black-400);
+    --bc-dark: var(--black-500);
+    --bc-darker: var(--black-600);
+    --bs-sm: none;
+    --bs-md: none;
+    --bs-lg: none;
+    --bs-xl: none;
+    --translucent-secondary: hsla(204, 6%, 35%, 0.9);
+    --translucent-success: hsla(140, 40%, 40%, 0.9);
+    --translucent-warning: hsla(47, 76%, 46%, 0.9);
+    --translucent-error: hsla(358, 62%, 47%, 0.9);
+    --translucent-muted: hsla(210, 8%, 55%, 0.95);
+    --focus-neutral: var(--white);
+    --focus-theme: var(--theme-secondary);
+    --focus-ring: rgba(115, 115, 115, 0.9);
+    --focus-ring-success: hsla(140, 40%, 40%, 0.9);
+    --focus-ring-warning: hsla(47, 76%, 46%, 0.9);
+    --focus-ring-error: hsla(358, 62%, 47%, 0.9);
+    --focus-ring-muted: hsla(210, 8%, 55%, 0.95);
+    --highlight-addition: var(--green-500);
+    --highlight-attribute: hsl(200, 57%, 85%);
+    --highlight-bg: hsl(0, 0%, 10%);
+    --highlight-color: hsl(0, 0%, 100%);
+    --highlight-comment: var(--black-400);
+    --highlight-deletion: var(--red-500);
+    --highlight-keyword: hsl(200, 57%, 85%);
+    --highlight-literal: hsl(36, 96%, 71%);
+    --highlight-namespace: hsl(36, 96%, 71%);
+    --highlight-punctuation: hsl(0, 0%, 99%);
+    --highlight-symbol: hsl(304, 39%, 85%);
+    --highlight-variable: hsl(62, 71%, 81%);
+    --scrollbar: var(--black);
+    --brand: #FF5E00;
+    --brand-black: #201C1D;
+    --brand-off-white: #F0EFEE;
+    --brand-blue-light: #C6D1E1;
+    --brand-blue: #5074EF;
+    --brand-blue-dark: #00165E;
+    --brand-brown-light: #998B7A;
+    --brand-green: #86AF25;
+    --brand-green-dark: #263603;
+    --brand-orange-medium: #6E1527;
+    --brand-orange-dark: #31070F;
+    --brand-pink: #F39FFF;
+    --brand-pink-dark: #4D1955;
+    --brand-purple: #9D9CFF;
+    --brand-purple-dark: #390A91;
+    --brand-yellow: #FFCC00;
+    --brand-yellow-dark: #423101;
+    --theme-primary: var(--orange-400);
+    --theme-primary-100: var(--orange-100);
+    --theme-primary-200: var(--orange-200);
+    --theme-primary-300: var(--orange-300);
+    --theme-primary-400: var(--orange-400);
+    --theme-primary-500: var(--orange-500);
+    --theme-primary-600: var(--orange-600);
+    --theme-secondary: var(--black);
+    --theme-secondary-100: var(--black-100);
+    --theme-secondary-200: var(--black-200);
+    --theme-secondary-300: var(--black-300);
+    --theme-secondary-400: var(--black-400);
+    --theme-secondary-500: var(--black-500);
+    --theme-secondary-600: var(--black-600);
+    --_o-disabled: 0.8;
+}
+
+@media (prefers-color-scheme: dark) {
+    body.theme-highcontrast.theme-system {
+        --white: #000000;
+        --black-050: #141414;
+        --black-100: #262626;
+        --black-150: #333333;
+        --black-200: #575757;
+        --black-225: #666666;
+        --black-250: #737373;
+        --black-300: #8c8c8c;
+        --black-350: #a6a6a6;
+        --black-400: #d9d3ce;
+        --black-500: #f2ede9;
+        --black-600: #ffffff;
+        --black: #ffffff;
+        --orange-100: #401f0d;
+        --orange-200: #401f0d;
+        --orange-300: #dead90;
+        --orange-400: #fcccb1;
+        --orange-500: #fadac8;
+        --orange-600: #fadac8;
+        --blue-100: #22304d;
+        --blue-200: #22304d;
+        --blue-300: #a6c3ff;
+        --blue-400: #ccddff;
+        --blue-500: #e6eeff;
+        --blue-600: #e6eeff;
+        --green-100: #28380b;
+        --green-200: #28380b;
+        --green-300: #c4e68a;
+        --green-400: #cce6a1;
+        --green-500: #ecffcc;
+        --green-600: #ecffcc;
+        --red-100: #330f0f;
+        --red-200: #330f0f;
+        --red-300: #faafaf;
+        --red-400: #fccaca;
+        --red-500: #ffe6e6;
+        --red-600: #ffe6e6;
+        --yellow-100: #332b0a;
+        --yellow-200: #332b0a;
+        --yellow-300: #e6d17e;
+        --yellow-400: #e3d59f;
+        --yellow-500: #fffae6;
+        --yellow-600: #fffae6;
+        --purple-100: #22174d;
+        --purple-200: #22174d;
+        --purple-300: #b6a6f7;
+        --purple-400: #d2c8fa;
+        --purple-500: #e8e3fc;
+        --purple-600: #e8e3fc;
+        --pink-100: #2e0a33;
+        --pink-200: #2e0a33;
+        --pink-300: #f3bbfa;
+        --pink-400: #f7cffc;
+        --pink-500: #fae3fc;
+        --pink-600: #fae3fc;
+        --gold-100: hsl(45, 22%, 25%);
+        --gold-200: hsl(45, 22%, 25%);
+        --gold-300: hsl(45, 92%, 62%);
+        --gold-400: hsl(46, 93%, 78%);
+        --silver-100: hsl(220, 2%, 26%);
+        --silver-200: hsl(220, 2%, 26%);
+        --silver-300: hsl(220, 4%, 69%);
+        --silver-400: hsl(214, 8%, 83%);
+        --bronze-100: hsl(27, 13%, 27%);
+        --bronze-200: hsl(27, 13%, 27%);
+        --bronze-300: hsl(28, 58%, 67%);
+        --bronze-400: hsl(28, 59%, 83%);
+        --bc-lightest: var(--black-400);
+        --bc-lighter: var(--black-400);
+        --bc-light: var(--black-400);
+        --bc-medium: var(--black-400);
+        --bc-dark: var(--black-500);
+        --bc-darker: var(--black-600);
+        --bs-sm: none;
+        --bs-md: none;
+        --bs-lg: none;
+        --bs-xl: none;
+        --translucent-secondary: hsla(204, 6%, 35%, 0.9);
+        --translucent-success: hsla(140, 40%, 40%, 0.9);
+        --translucent-warning: hsla(47, 76%, 46%, 0.9);
+        --translucent-error: hsla(358, 62%, 47%, 0.9);
+        --translucent-muted: hsla(210, 8%, 55%, 0.95);
+        --focus-neutral: var(--white);
+        --focus-theme: var(--theme-secondary);
+        --focus-ring: rgba(115, 115, 115, 0.9);
+        --focus-ring-success: hsla(140, 40%, 40%, 0.9);
+        --focus-ring-warning: hsla(47, 76%, 46%, 0.9);
+        --focus-ring-error: hsla(358, 62%, 47%, 0.9);
+        --focus-ring-muted: hsla(210, 8%, 55%, 0.95);
+        --highlight-addition: var(--green-500);
+        --highlight-attribute: hsl(200, 57%, 85%);
+        --highlight-bg: hsl(0, 0%, 10%);
+        --highlight-color: hsl(0, 0%, 100%);
+        --highlight-comment: var(--black-400);
+        --highlight-deletion: var(--red-500);
+        --highlight-keyword: hsl(200, 57%, 85%);
+        --highlight-literal: hsl(36, 96%, 71%);
+        --highlight-namespace: hsl(36, 96%, 71%);
+        --highlight-punctuation: hsl(0, 0%, 99%);
+        --highlight-symbol: hsl(304, 39%, 85%);
+        --highlight-variable: hsl(62, 71%, 81%);
+        --scrollbar: var(--black);
+        --brand: #FF5E00;
+        --brand-black: #201C1D;
+        --brand-off-white: #F0EFEE;
+        --brand-blue-light: #C6D1E1;
+        --brand-blue: #5074EF;
+        --brand-blue-dark: #00165E;
+        --brand-brown-light: #998B7A;
+        --brand-green: #86AF25;
+        --brand-green-dark: #263603;
+        --brand-orange-medium: #6E1527;
+        --brand-orange-dark: #31070F;
+        --brand-pink: #F39FFF;
+        --brand-pink-dark: #4D1955;
+        --brand-purple: #9D9CFF;
+        --brand-purple-dark: #390A91;
+        --brand-yellow: #FFCC00;
+        --brand-yellow-dark: #423101;
+        --theme-primary: var(--orange-400);
+        --theme-primary-100: var(--orange-100);
+        --theme-primary-200: var(--orange-200);
+        --theme-primary-300: var(--orange-300);
+        --theme-primary-400: var(--orange-400);
+        --theme-primary-500: var(--orange-500);
+        --theme-primary-600: var(--orange-600);
+        --theme-secondary: var(--black);
+        --theme-secondary-100: var(--black-100);
+        --theme-secondary-200: var(--black-200);
+        --theme-secondary-300: var(--black-300);
+        --theme-secondary-400: var(--black-400);
+        --theme-secondary-500: var(--black-500);
+        --theme-secondary-600: var(--black-600);
+        --_o-disabled: 0.8;
+    }
+}
+/**
+ * Applies styles rules when dark mode is active.
+ *
+ * Usage example:
+ * .dark-mode({ background-color: var(--black-100); });
+ */
+/**
+ * Applies styles rules when high contrast mode is active.
+ *
+ * Usage example:
+ * .highcontrast-mode({ background-color: var(--black-100); });
+ */
+/**
+ * Applies styles rules when high contrast and dark mode is active.
+ *
+ * Usage example:
+ * .highcontrast-dark-mode({ background-color: var(--black-100); });
+ */
+/**
+ * Applies focus styles for the given context.
+ *
+ * Usage example:
+ * .focus-styles(true, true);
+ *
+ * @inset: boolean - whether the focus style be placed inside the element.
+ * @border: boolean - whether the element's border color change to match the focus style.
+ */
+/**
+ * Generate base and responsive atomic sizing classes.
+ *
+ * Usage example:
+ * .generate-sizing('.m', margin, true);
+ * .generate-sizing('.ml', margin-left, true, percent);
+ * .generate-sizing('.mx'; margin-left, margin-right; true);
+ * .generate-sizing('.pr', padding-right);
+ *
+ * @param {string} prefix - What prefix to generate (e.g. \`.m\`, \`.pr\`, etc).
+ * @param {string|list} properties - What CSS properties to generate (e.g. \`margin\`, \`margin-right, margin-left\`, etc).
+ * @param {list} values - List of values to generate classes for.
+ * @param {string} [type='px'] - What set of values to generate. Options: \`px\` | \`percent\`.
+ * @param {boolean} [responsive=false] - Whether to generate responsive variants.
+ * @param {boolean} [negative=false] - Whether to generate negative value classes.
+ */
+/**
+ * Generate atomic sizing classes using predefined SU (spacing unit) values.
+ *
+ * Generates 12 utility classes (numbered 1-12) that map to specific SU values:
+ * 128, 256, 344, 448, 512, 640, 768, 848, 960, 1024, 1120, 1280.
+ *
+ * Usage example:
+ * .generate-su-sizing('.ws', width);
+ * .generate-su-sizing('.hs', height);
+ * .generate-su-sizing('.wmn', min-width);
+ *
+ * @param {string} prefix - Class prefix to generate (e.g. \`.ws\`, \`.hs\`, \`.wmn\`).
+ * @param {string} property - CSS property to set (e.g. \`width\`, \`height\`, \`min-width\`).
+ */
+body {
+  --su0: 0;
+  --su1: clamp(1px, 0.063rem, 0.063rem);
+  --su2: 0.125rem;
+  --su3: 0.1875rem;
+  --su4: 0.25rem;
+  --su6: 0.375rem;
+  --su8: 0.5rem;
+  --su12: 0.75rem;
+  --su16: 1rem;
+  --su24: 1.5rem;
+  --su32: 2rem;
+  --su48: 3rem;
+  --su64: 4rem;
+  --su96: 6rem;
+  --su128: 8rem;
+  --su256: 16rem;
+  --su344: 21.5rem;
+  --su448: 28rem;
+  --su512: 32rem;
+  --su640: 40rem;
+  --su768: 48rem;
+  --su848: 53rem;
+  --su960: 60rem;
+  --su1024: 64rem;
+  --su1120: 70rem;
+  --su1280: 80rem;
+  --su-max: var(--su1280);
+  --s-full: 79rem;
+  --s-step: calc(var(--s-full) / 12);
+  --sun1: calc(var(--su1) * -1);
+  --sun2: calc(var(--su2) * -1);
+  --sun3: calc(var(--su3) * -1);
+  --sun4: calc(var(--su4) * -1);
+  --sun6: calc(var(--su6) * -1);
+  --sun8: calc(var(--su8) * -1);
+  --sun12: calc(var(--su12) * -1);
+  --sun16: calc(var(--su16) * -1);
+  --sun24: calc(var(--su24) * -1);
+  --sun32: calc(var(--su32) * -1);
+  --sun48: calc(var(--su48) * -1);
+  --sun64: calc(var(--su64) * -1);
+  --sun96: calc(var(--su96) * -1);
+  --sun128: calc(var(--su128) * -1);
+}
+.bg-white,
+.h\\:bg-white:hover,
+.f\\:bg-white:focus,
+.f\\:bg-white:focus-within {
+  background-color: var(--white) !important;
+}
+.bc-white,
+.h\\:bc-white:hover,
+.f\\:bc-white:focus,
+.f\\:bc-white:focus-within {
+  border-color: var(--white) !important;
+}
+.fc-white,
+.h\\:fc-white:hover,
+.f\\:fc-white:focus,
+.f\\:fc-white:focus-within {
+  color: var(--white) !important;
+}
+.bg-black-050,
+.h\\:bg-black-050:hover,
+.f\\:bg-black-050:focus,
+.f\\:bg-black-050:focus-within {
+  background-color: var(--black-050) !important;
+}
+.bc-black-050,
+.h\\:bc-black-050:hover,
+.f\\:bc-black-050:focus,
+.f\\:bc-black-050:focus-within {
+  border-color: var(--black-050) !important;
+}
+.fc-black-050,
+.h\\:fc-black-050:hover,
+.f\\:fc-black-050:focus,
+.f\\:fc-black-050:focus-within {
+  color: var(--black-050) !important;
+}
+.bg-black-100,
+.h\\:bg-black-100:hover,
+.f\\:bg-black-100:focus,
+.f\\:bg-black-100:focus-within {
+  background-color: var(--black-100) !important;
+}
+.bc-black-100,
+.h\\:bc-black-100:hover,
+.f\\:bc-black-100:focus,
+.f\\:bc-black-100:focus-within {
+  border-color: var(--black-100) !important;
+}
+.fc-black-100,
+.h\\:fc-black-100:hover,
+.f\\:fc-black-100:focus,
+.f\\:fc-black-100:focus-within {
+  color: var(--black-100) !important;
+}
+.bg-black-150,
+.h\\:bg-black-150:hover,
+.f\\:bg-black-150:focus,
+.f\\:bg-black-150:focus-within {
+  background-color: var(--black-150) !important;
+}
+.bc-black-150,
+.h\\:bc-black-150:hover,
+.f\\:bc-black-150:focus,
+.f\\:bc-black-150:focus-within {
+  border-color: var(--black-150) !important;
+}
+.fc-black-150,
+.h\\:fc-black-150:hover,
+.f\\:fc-black-150:focus,
+.f\\:fc-black-150:focus-within {
+  color: var(--black-150) !important;
+}
+.bg-black-200,
+.h\\:bg-black-200:hover,
+.f\\:bg-black-200:focus,
+.f\\:bg-black-200:focus-within {
+  background-color: var(--black-200) !important;
+}
+.bc-black-200,
+.h\\:bc-black-200:hover,
+.f\\:bc-black-200:focus,
+.f\\:bc-black-200:focus-within {
+  border-color: var(--black-200) !important;
+}
+.fc-black-200,
+.h\\:fc-black-200:hover,
+.f\\:fc-black-200:focus,
+.f\\:fc-black-200:focus-within {
+  color: var(--black-200) !important;
+}
+.bg-black-225,
+.h\\:bg-black-225:hover,
+.f\\:bg-black-225:focus,
+.f\\:bg-black-225:focus-within {
+  background-color: var(--black-225) !important;
+}
+.bc-black-225,
+.h\\:bc-black-225:hover,
+.f\\:bc-black-225:focus,
+.f\\:bc-black-225:focus-within {
+  border-color: var(--black-225) !important;
+}
+.fc-black-225,
+.h\\:fc-black-225:hover,
+.f\\:fc-black-225:focus,
+.f\\:fc-black-225:focus-within {
+  color: var(--black-225) !important;
+}
+.bg-black-250,
+.h\\:bg-black-250:hover,
+.f\\:bg-black-250:focus,
+.f\\:bg-black-250:focus-within {
+  background-color: var(--black-250) !important;
+}
+.bc-black-250,
+.h\\:bc-black-250:hover,
+.f\\:bc-black-250:focus,
+.f\\:bc-black-250:focus-within {
+  border-color: var(--black-250) !important;
+}
+.fc-black-250,
+.h\\:fc-black-250:hover,
+.f\\:fc-black-250:focus,
+.f\\:fc-black-250:focus-within {
+  color: var(--black-250) !important;
+}
+.bg-black-300,
+.h\\:bg-black-300:hover,
+.f\\:bg-black-300:focus,
+.f\\:bg-black-300:focus-within {
+  background-color: var(--black-300) !important;
+}
+.bc-black-300,
+.h\\:bc-black-300:hover,
+.f\\:bc-black-300:focus,
+.f\\:bc-black-300:focus-within {
+  border-color: var(--black-300) !important;
+}
+.fc-black-300,
+.h\\:fc-black-300:hover,
+.f\\:fc-black-300:focus,
+.f\\:fc-black-300:focus-within {
+  color: var(--black-300) !important;
+}
+.bg-black-350,
+.h\\:bg-black-350:hover,
+.f\\:bg-black-350:focus,
+.f\\:bg-black-350:focus-within {
+  background-color: var(--black-350) !important;
+}
+.bc-black-350,
+.h\\:bc-black-350:hover,
+.f\\:bc-black-350:focus,
+.f\\:bc-black-350:focus-within {
+  border-color: var(--black-350) !important;
+}
+.fc-black-350,
+.h\\:fc-black-350:hover,
+.f\\:fc-black-350:focus,
+.f\\:fc-black-350:focus-within {
+  color: var(--black-350) !important;
+}
+.bg-black-400,
+.h\\:bg-black-400:hover,
+.f\\:bg-black-400:focus,
+.f\\:bg-black-400:focus-within {
+  background-color: var(--black-400) !important;
+}
+.bc-black-400,
+.h\\:bc-black-400:hover,
+.f\\:bc-black-400:focus,
+.f\\:bc-black-400:focus-within {
+  border-color: var(--black-400) !important;
+}
+.fc-black-400,
+.h\\:fc-black-400:hover,
+.f\\:fc-black-400:focus,
+.f\\:fc-black-400:focus-within {
+  color: var(--black-400) !important;
+}
+.bg-black-500,
+.h\\:bg-black-500:hover,
+.f\\:bg-black-500:focus,
+.f\\:bg-black-500:focus-within {
+  background-color: var(--black-500) !important;
+}
+.bc-black-500,
+.h\\:bc-black-500:hover,
+.f\\:bc-black-500:focus,
+.f\\:bc-black-500:focus-within {
+  border-color: var(--black-500) !important;
+}
+.fc-black-500,
+.h\\:fc-black-500:hover,
+.f\\:fc-black-500:focus,
+.f\\:fc-black-500:focus-within {
+  color: var(--black-500) !important;
+}
+.bg-black-600,
+.h\\:bg-black-600:hover,
+.f\\:bg-black-600:focus,
+.f\\:bg-black-600:focus-within {
+  background-color: var(--black-600) !important;
+}
+.bc-black-600,
+.h\\:bc-black-600:hover,
+.f\\:bc-black-600:focus,
+.f\\:bc-black-600:focus-within {
+  border-color: var(--black-600) !important;
+}
+.fc-black-600,
+.h\\:fc-black-600:hover,
+.f\\:fc-black-600:focus,
+.f\\:fc-black-600:focus-within {
+  color: var(--black-600) !important;
+}
+.bg-black,
+.h\\:bg-black:hover,
+.f\\:bg-black:focus,
+.f\\:bg-black:focus-within {
+  background-color: var(--black) !important;
+}
+.bc-black,
+.h\\:bc-black:hover,
+.f\\:bc-black:focus,
+.f\\:bc-black:focus-within {
+  border-color: var(--black) !important;
+}
+.fc-black,
+.h\\:fc-black:hover,
+.f\\:fc-black:focus,
+.f\\:fc-black:focus-within {
+  color: var(--black) !important;
+}
+.bg-orange-100,
+.h\\:bg-orange-100:hover,
+.f\\:bg-orange-100:focus,
+.f\\:bg-orange-100:focus-within {
+  background-color: var(--orange-100) !important;
+}
+.bc-orange-100,
+.h\\:bc-orange-100:hover,
+.f\\:bc-orange-100:focus,
+.f\\:bc-orange-100:focus-within {
+  border-color: var(--orange-100) !important;
+}
+.fc-orange-100,
+.h\\:fc-orange-100:hover,
+.f\\:fc-orange-100:focus,
+.f\\:fc-orange-100:focus-within {
+  color: var(--orange-100) !important;
+}
+.bg-orange-200,
+.h\\:bg-orange-200:hover,
+.f\\:bg-orange-200:focus,
+.f\\:bg-orange-200:focus-within {
+  background-color: var(--orange-200) !important;
+}
+.bc-orange-200,
+.h\\:bc-orange-200:hover,
+.f\\:bc-orange-200:focus,
+.f\\:bc-orange-200:focus-within {
+  border-color: var(--orange-200) !important;
+}
+.fc-orange-200,
+.h\\:fc-orange-200:hover,
+.f\\:fc-orange-200:focus,
+.f\\:fc-orange-200:focus-within {
+  color: var(--orange-200) !important;
+}
+.bg-orange-300,
+.h\\:bg-orange-300:hover,
+.f\\:bg-orange-300:focus,
+.f\\:bg-orange-300:focus-within {
+  background-color: var(--orange-300) !important;
+}
+.bc-orange-300,
+.h\\:bc-orange-300:hover,
+.f\\:bc-orange-300:focus,
+.f\\:bc-orange-300:focus-within {
+  border-color: var(--orange-300) !important;
+}
+.fc-orange-300,
+.h\\:fc-orange-300:hover,
+.f\\:fc-orange-300:focus,
+.f\\:fc-orange-300:focus-within {
+  color: var(--orange-300) !important;
+}
+.bg-orange-400,
+.h\\:bg-orange-400:hover,
+.f\\:bg-orange-400:focus,
+.f\\:bg-orange-400:focus-within {
+  background-color: var(--orange-400) !important;
+}
+.bc-orange-400,
+.h\\:bc-orange-400:hover,
+.f\\:bc-orange-400:focus,
+.f\\:bc-orange-400:focus-within {
+  border-color: var(--orange-400) !important;
+}
+.fc-orange-400,
+.h\\:fc-orange-400:hover,
+.f\\:fc-orange-400:focus,
+.f\\:fc-orange-400:focus-within {
+  color: var(--orange-400) !important;
+}
+.bg-orange-500,
+.h\\:bg-orange-500:hover,
+.f\\:bg-orange-500:focus,
+.f\\:bg-orange-500:focus-within {
+  background-color: var(--orange-500) !important;
+}
+.bc-orange-500,
+.h\\:bc-orange-500:hover,
+.f\\:bc-orange-500:focus,
+.f\\:bc-orange-500:focus-within {
+  border-color: var(--orange-500) !important;
+}
+.fc-orange-500,
+.h\\:fc-orange-500:hover,
+.f\\:fc-orange-500:focus,
+.f\\:fc-orange-500:focus-within {
+  color: var(--orange-500) !important;
+}
+.bg-orange-600,
+.h\\:bg-orange-600:hover,
+.f\\:bg-orange-600:focus,
+.f\\:bg-orange-600:focus-within {
+  background-color: var(--orange-600) !important;
+}
+.bc-orange-600,
+.h\\:bc-orange-600:hover,
+.f\\:bc-orange-600:focus,
+.f\\:bc-orange-600:focus-within {
+  border-color: var(--orange-600) !important;
+}
+.fc-orange-600,
+.h\\:fc-orange-600:hover,
+.f\\:fc-orange-600:focus,
+.f\\:fc-orange-600:focus-within {
+  color: var(--orange-600) !important;
+}
+.bg-blue-100,
+.h\\:bg-blue-100:hover,
+.f\\:bg-blue-100:focus,
+.f\\:bg-blue-100:focus-within {
+  background-color: var(--blue-100) !important;
+}
+.bc-blue-100,
+.h\\:bc-blue-100:hover,
+.f\\:bc-blue-100:focus,
+.f\\:bc-blue-100:focus-within {
+  border-color: var(--blue-100) !important;
+}
+.fc-blue-100,
+.h\\:fc-blue-100:hover,
+.f\\:fc-blue-100:focus,
+.f\\:fc-blue-100:focus-within {
+  color: var(--blue-100) !important;
+}
+.bg-blue-200,
+.h\\:bg-blue-200:hover,
+.f\\:bg-blue-200:focus,
+.f\\:bg-blue-200:focus-within {
+  background-color: var(--blue-200) !important;
+}
+.bc-blue-200,
+.h\\:bc-blue-200:hover,
+.f\\:bc-blue-200:focus,
+.f\\:bc-blue-200:focus-within {
+  border-color: var(--blue-200) !important;
+}
+.fc-blue-200,
+.h\\:fc-blue-200:hover,
+.f\\:fc-blue-200:focus,
+.f\\:fc-blue-200:focus-within {
+  color: var(--blue-200) !important;
+}
+.bg-blue-300,
+.h\\:bg-blue-300:hover,
+.f\\:bg-blue-300:focus,
+.f\\:bg-blue-300:focus-within {
+  background-color: var(--blue-300) !important;
+}
+.bc-blue-300,
+.h\\:bc-blue-300:hover,
+.f\\:bc-blue-300:focus,
+.f\\:bc-blue-300:focus-within {
+  border-color: var(--blue-300) !important;
+}
+.fc-blue-300,
+.h\\:fc-blue-300:hover,
+.f\\:fc-blue-300:focus,
+.f\\:fc-blue-300:focus-within {
+  color: var(--blue-300) !important;
+}
+.bg-blue-400,
+.h\\:bg-blue-400:hover,
+.f\\:bg-blue-400:focus,
+.f\\:bg-blue-400:focus-within {
+  background-color: var(--blue-400) !important;
+}
+.bc-blue-400,
+.h\\:bc-blue-400:hover,
+.f\\:bc-blue-400:focus,
+.f\\:bc-blue-400:focus-within {
+  border-color: var(--blue-400) !important;
+}
+.fc-blue-400,
+.h\\:fc-blue-400:hover,
+.f\\:fc-blue-400:focus,
+.f\\:fc-blue-400:focus-within {
+  color: var(--blue-400) !important;
+}
+.bg-blue-500,
+.h\\:bg-blue-500:hover,
+.f\\:bg-blue-500:focus,
+.f\\:bg-blue-500:focus-within {
+  background-color: var(--blue-500) !important;
+}
+.bc-blue-500,
+.h\\:bc-blue-500:hover,
+.f\\:bc-blue-500:focus,
+.f\\:bc-blue-500:focus-within {
+  border-color: var(--blue-500) !important;
+}
+.fc-blue-500,
+.h\\:fc-blue-500:hover,
+.f\\:fc-blue-500:focus,
+.f\\:fc-blue-500:focus-within {
+  color: var(--blue-500) !important;
+}
+.bg-blue-600,
+.h\\:bg-blue-600:hover,
+.f\\:bg-blue-600:focus,
+.f\\:bg-blue-600:focus-within {
+  background-color: var(--blue-600) !important;
+}
+.bc-blue-600,
+.h\\:bc-blue-600:hover,
+.f\\:bc-blue-600:focus,
+.f\\:bc-blue-600:focus-within {
+  border-color: var(--blue-600) !important;
+}
+.fc-blue-600,
+.h\\:fc-blue-600:hover,
+.f\\:fc-blue-600:focus,
+.f\\:fc-blue-600:focus-within {
+  color: var(--blue-600) !important;
+}
+.bg-green-100,
+.h\\:bg-green-100:hover,
+.f\\:bg-green-100:focus,
+.f\\:bg-green-100:focus-within {
+  background-color: var(--green-100) !important;
+}
+.bc-green-100,
+.h\\:bc-green-100:hover,
+.f\\:bc-green-100:focus,
+.f\\:bc-green-100:focus-within {
+  border-color: var(--green-100) !important;
+}
+.fc-green-100,
+.h\\:fc-green-100:hover,
+.f\\:fc-green-100:focus,
+.f\\:fc-green-100:focus-within {
+  color: var(--green-100) !important;
+}
+.bg-green-200,
+.h\\:bg-green-200:hover,
+.f\\:bg-green-200:focus,
+.f\\:bg-green-200:focus-within {
+  background-color: var(--green-200) !important;
+}
+.bc-green-200,
+.h\\:bc-green-200:hover,
+.f\\:bc-green-200:focus,
+.f\\:bc-green-200:focus-within {
+  border-color: var(--green-200) !important;
+}
+.fc-green-200,
+.h\\:fc-green-200:hover,
+.f\\:fc-green-200:focus,
+.f\\:fc-green-200:focus-within {
+  color: var(--green-200) !important;
+}
+.bg-green-300,
+.h\\:bg-green-300:hover,
+.f\\:bg-green-300:focus,
+.f\\:bg-green-300:focus-within {
+  background-color: var(--green-300) !important;
+}
+.bc-green-300,
+.h\\:bc-green-300:hover,
+.f\\:bc-green-300:focus,
+.f\\:bc-green-300:focus-within {
+  border-color: var(--green-300) !important;
+}
+.fc-green-300,
+.h\\:fc-green-300:hover,
+.f\\:fc-green-300:focus,
+.f\\:fc-green-300:focus-within {
+  color: var(--green-300) !important;
+}
+.bg-green-400,
+.h\\:bg-green-400:hover,
+.f\\:bg-green-400:focus,
+.f\\:bg-green-400:focus-within {
+  background-color: var(--green-400) !important;
+}
+.bc-green-400,
+.h\\:bc-green-400:hover,
+.f\\:bc-green-400:focus,
+.f\\:bc-green-400:focus-within {
+  border-color: var(--green-400) !important;
+}
+.fc-green-400,
+.h\\:fc-green-400:hover,
+.f\\:fc-green-400:focus,
+.f\\:fc-green-400:focus-within {
+  color: var(--green-400) !important;
+}
+.bg-green-500,
+.h\\:bg-green-500:hover,
+.f\\:bg-green-500:focus,
+.f\\:bg-green-500:focus-within {
+  background-color: var(--green-500) !important;
+}
+.bc-green-500,
+.h\\:bc-green-500:hover,
+.f\\:bc-green-500:focus,
+.f\\:bc-green-500:focus-within {
+  border-color: var(--green-500) !important;
+}
+.fc-green-500,
+.h\\:fc-green-500:hover,
+.f\\:fc-green-500:focus,
+.f\\:fc-green-500:focus-within {
+  color: var(--green-500) !important;
+}
+.bg-green-600,
+.h\\:bg-green-600:hover,
+.f\\:bg-green-600:focus,
+.f\\:bg-green-600:focus-within {
+  background-color: var(--green-600) !important;
+}
+.bc-green-600,
+.h\\:bc-green-600:hover,
+.f\\:bc-green-600:focus,
+.f\\:bc-green-600:focus-within {
+  border-color: var(--green-600) !important;
+}
+.fc-green-600,
+.h\\:fc-green-600:hover,
+.f\\:fc-green-600:focus,
+.f\\:fc-green-600:focus-within {
+  color: var(--green-600) !important;
+}
+.bg-red-100,
+.h\\:bg-red-100:hover,
+.f\\:bg-red-100:focus,
+.f\\:bg-red-100:focus-within {
+  background-color: var(--red-100) !important;
+}
+.bc-red-100,
+.h\\:bc-red-100:hover,
+.f\\:bc-red-100:focus,
+.f\\:bc-red-100:focus-within {
+  border-color: var(--red-100) !important;
+}
+.fc-red-100,
+.h\\:fc-red-100:hover,
+.f\\:fc-red-100:focus,
+.f\\:fc-red-100:focus-within {
+  color: var(--red-100) !important;
+}
+.bg-red-200,
+.h\\:bg-red-200:hover,
+.f\\:bg-red-200:focus,
+.f\\:bg-red-200:focus-within {
+  background-color: var(--red-200) !important;
+}
+.bc-red-200,
+.h\\:bc-red-200:hover,
+.f\\:bc-red-200:focus,
+.f\\:bc-red-200:focus-within {
+  border-color: var(--red-200) !important;
+}
+.fc-red-200,
+.h\\:fc-red-200:hover,
+.f\\:fc-red-200:focus,
+.f\\:fc-red-200:focus-within {
+  color: var(--red-200) !important;
+}
+.bg-red-300,
+.h\\:bg-red-300:hover,
+.f\\:bg-red-300:focus,
+.f\\:bg-red-300:focus-within {
+  background-color: var(--red-300) !important;
+}
+.bc-red-300,
+.h\\:bc-red-300:hover,
+.f\\:bc-red-300:focus,
+.f\\:bc-red-300:focus-within {
+  border-color: var(--red-300) !important;
+}
+.fc-red-300,
+.h\\:fc-red-300:hover,
+.f\\:fc-red-300:focus,
+.f\\:fc-red-300:focus-within {
+  color: var(--red-300) !important;
+}
+.bg-red-400,
+.h\\:bg-red-400:hover,
+.f\\:bg-red-400:focus,
+.f\\:bg-red-400:focus-within {
+  background-color: var(--red-400) !important;
+}
+.bc-red-400,
+.h\\:bc-red-400:hover,
+.f\\:bc-red-400:focus,
+.f\\:bc-red-400:focus-within {
+  border-color: var(--red-400) !important;
+}
+.fc-red-400,
+.h\\:fc-red-400:hover,
+.f\\:fc-red-400:focus,
+.f\\:fc-red-400:focus-within {
+  color: var(--red-400) !important;
+}
+.bg-red-500,
+.h\\:bg-red-500:hover,
+.f\\:bg-red-500:focus,
+.f\\:bg-red-500:focus-within {
+  background-color: var(--red-500) !important;
+}
+.bc-red-500,
+.h\\:bc-red-500:hover,
+.f\\:bc-red-500:focus,
+.f\\:bc-red-500:focus-within {
+  border-color: var(--red-500) !important;
+}
+.fc-red-500,
+.h\\:fc-red-500:hover,
+.f\\:fc-red-500:focus,
+.f\\:fc-red-500:focus-within {
+  color: var(--red-500) !important;
+}
+.bg-red-600,
+.h\\:bg-red-600:hover,
+.f\\:bg-red-600:focus,
+.f\\:bg-red-600:focus-within {
+  background-color: var(--red-600) !important;
+}
+.bc-red-600,
+.h\\:bc-red-600:hover,
+.f\\:bc-red-600:focus,
+.f\\:bc-red-600:focus-within {
+  border-color: var(--red-600) !important;
+}
+.fc-red-600,
+.h\\:fc-red-600:hover,
+.f\\:fc-red-600:focus,
+.f\\:fc-red-600:focus-within {
+  color: var(--red-600) !important;
+}
+.bg-yellow-100,
+.h\\:bg-yellow-100:hover,
+.f\\:bg-yellow-100:focus,
+.f\\:bg-yellow-100:focus-within {
+  background-color: var(--yellow-100) !important;
+}
+.bc-yellow-100,
+.h\\:bc-yellow-100:hover,
+.f\\:bc-yellow-100:focus,
+.f\\:bc-yellow-100:focus-within {
+  border-color: var(--yellow-100) !important;
+}
+.fc-yellow-100,
+.h\\:fc-yellow-100:hover,
+.f\\:fc-yellow-100:focus,
+.f\\:fc-yellow-100:focus-within {
+  color: var(--yellow-100) !important;
+}
+.bg-yellow-200,
+.h\\:bg-yellow-200:hover,
+.f\\:bg-yellow-200:focus,
+.f\\:bg-yellow-200:focus-within {
+  background-color: var(--yellow-200) !important;
+}
+.bc-yellow-200,
+.h\\:bc-yellow-200:hover,
+.f\\:bc-yellow-200:focus,
+.f\\:bc-yellow-200:focus-within {
+  border-color: var(--yellow-200) !important;
+}
+.fc-yellow-200,
+.h\\:fc-yellow-200:hover,
+.f\\:fc-yellow-200:focus,
+.f\\:fc-yellow-200:focus-within {
+  color: var(--yellow-200) !important;
+}
+.bg-yellow-300,
+.h\\:bg-yellow-300:hover,
+.f\\:bg-yellow-300:focus,
+.f\\:bg-yellow-300:focus-within {
+  background-color: var(--yellow-300) !important;
+}
+.bc-yellow-300,
+.h\\:bc-yellow-300:hover,
+.f\\:bc-yellow-300:focus,
+.f\\:bc-yellow-300:focus-within {
+  border-color: var(--yellow-300) !important;
+}
+.fc-yellow-300,
+.h\\:fc-yellow-300:hover,
+.f\\:fc-yellow-300:focus,
+.f\\:fc-yellow-300:focus-within {
+  color: var(--yellow-300) !important;
+}
+.bg-yellow-400,
+.h\\:bg-yellow-400:hover,
+.f\\:bg-yellow-400:focus,
+.f\\:bg-yellow-400:focus-within {
+  background-color: var(--yellow-400) !important;
+}
+.bc-yellow-400,
+.h\\:bc-yellow-400:hover,
+.f\\:bc-yellow-400:focus,
+.f\\:bc-yellow-400:focus-within {
+  border-color: var(--yellow-400) !important;
+}
+.fc-yellow-400,
+.h\\:fc-yellow-400:hover,
+.f\\:fc-yellow-400:focus,
+.f\\:fc-yellow-400:focus-within {
+  color: var(--yellow-400) !important;
+}
+.bg-yellow-500,
+.h\\:bg-yellow-500:hover,
+.f\\:bg-yellow-500:focus,
+.f\\:bg-yellow-500:focus-within {
+  background-color: var(--yellow-500) !important;
+}
+.bc-yellow-500,
+.h\\:bc-yellow-500:hover,
+.f\\:bc-yellow-500:focus,
+.f\\:bc-yellow-500:focus-within {
+  border-color: var(--yellow-500) !important;
+}
+.fc-yellow-500,
+.h\\:fc-yellow-500:hover,
+.f\\:fc-yellow-500:focus,
+.f\\:fc-yellow-500:focus-within {
+  color: var(--yellow-500) !important;
+}
+.bg-yellow-600,
+.h\\:bg-yellow-600:hover,
+.f\\:bg-yellow-600:focus,
+.f\\:bg-yellow-600:focus-within {
+  background-color: var(--yellow-600) !important;
+}
+.bc-yellow-600,
+.h\\:bc-yellow-600:hover,
+.f\\:bc-yellow-600:focus,
+.f\\:bc-yellow-600:focus-within {
+  border-color: var(--yellow-600) !important;
+}
+.fc-yellow-600,
+.h\\:fc-yellow-600:hover,
+.f\\:fc-yellow-600:focus,
+.f\\:fc-yellow-600:focus-within {
+  color: var(--yellow-600) !important;
+}
+.bg-purple-100,
+.h\\:bg-purple-100:hover,
+.f\\:bg-purple-100:focus,
+.f\\:bg-purple-100:focus-within {
+  background-color: var(--purple-100) !important;
+}
+.bc-purple-100,
+.h\\:bc-purple-100:hover,
+.f\\:bc-purple-100:focus,
+.f\\:bc-purple-100:focus-within {
+  border-color: var(--purple-100) !important;
+}
+.fc-purple-100,
+.h\\:fc-purple-100:hover,
+.f\\:fc-purple-100:focus,
+.f\\:fc-purple-100:focus-within {
+  color: var(--purple-100) !important;
+}
+.bg-purple-200,
+.h\\:bg-purple-200:hover,
+.f\\:bg-purple-200:focus,
+.f\\:bg-purple-200:focus-within {
+  background-color: var(--purple-200) !important;
+}
+.bc-purple-200,
+.h\\:bc-purple-200:hover,
+.f\\:bc-purple-200:focus,
+.f\\:bc-purple-200:focus-within {
+  border-color: var(--purple-200) !important;
+}
+.fc-purple-200,
+.h\\:fc-purple-200:hover,
+.f\\:fc-purple-200:focus,
+.f\\:fc-purple-200:focus-within {
+  color: var(--purple-200) !important;
+}
+.bg-purple-300,
+.h\\:bg-purple-300:hover,
+.f\\:bg-purple-300:focus,
+.f\\:bg-purple-300:focus-within {
+  background-color: var(--purple-300) !important;
+}
+.bc-purple-300,
+.h\\:bc-purple-300:hover,
+.f\\:bc-purple-300:focus,
+.f\\:bc-purple-300:focus-within {
+  border-color: var(--purple-300) !important;
+}
+.fc-purple-300,
+.h\\:fc-purple-300:hover,
+.f\\:fc-purple-300:focus,
+.f\\:fc-purple-300:focus-within {
+  color: var(--purple-300) !important;
+}
+.bg-purple-400,
+.h\\:bg-purple-400:hover,
+.f\\:bg-purple-400:focus,
+.f\\:bg-purple-400:focus-within {
+  background-color: var(--purple-400) !important;
+}
+.bc-purple-400,
+.h\\:bc-purple-400:hover,
+.f\\:bc-purple-400:focus,
+.f\\:bc-purple-400:focus-within {
+  border-color: var(--purple-400) !important;
+}
+.fc-purple-400,
+.h\\:fc-purple-400:hover,
+.f\\:fc-purple-400:focus,
+.f\\:fc-purple-400:focus-within {
+  color: var(--purple-400) !important;
+}
+.bg-purple-500,
+.h\\:bg-purple-500:hover,
+.f\\:bg-purple-500:focus,
+.f\\:bg-purple-500:focus-within {
+  background-color: var(--purple-500) !important;
+}
+.bc-purple-500,
+.h\\:bc-purple-500:hover,
+.f\\:bc-purple-500:focus,
+.f\\:bc-purple-500:focus-within {
+  border-color: var(--purple-500) !important;
+}
+.fc-purple-500,
+.h\\:fc-purple-500:hover,
+.f\\:fc-purple-500:focus,
+.f\\:fc-purple-500:focus-within {
+  color: var(--purple-500) !important;
+}
+.bg-purple-600,
+.h\\:bg-purple-600:hover,
+.f\\:bg-purple-600:focus,
+.f\\:bg-purple-600:focus-within {
+  background-color: var(--purple-600) !important;
+}
+.bc-purple-600,
+.h\\:bc-purple-600:hover,
+.f\\:bc-purple-600:focus,
+.f\\:bc-purple-600:focus-within {
+  border-color: var(--purple-600) !important;
+}
+.fc-purple-600,
+.h\\:fc-purple-600:hover,
+.f\\:fc-purple-600:focus,
+.f\\:fc-purple-600:focus-within {
+  color: var(--purple-600) !important;
+}
+.bg-pink-100,
+.h\\:bg-pink-100:hover,
+.f\\:bg-pink-100:focus,
+.f\\:bg-pink-100:focus-within {
+  background-color: var(--pink-100) !important;
+}
+.bc-pink-100,
+.h\\:bc-pink-100:hover,
+.f\\:bc-pink-100:focus,
+.f\\:bc-pink-100:focus-within {
+  border-color: var(--pink-100) !important;
+}
+.fc-pink-100,
+.h\\:fc-pink-100:hover,
+.f\\:fc-pink-100:focus,
+.f\\:fc-pink-100:focus-within {
+  color: var(--pink-100) !important;
+}
+.bg-pink-200,
+.h\\:bg-pink-200:hover,
+.f\\:bg-pink-200:focus,
+.f\\:bg-pink-200:focus-within {
+  background-color: var(--pink-200) !important;
+}
+.bc-pink-200,
+.h\\:bc-pink-200:hover,
+.f\\:bc-pink-200:focus,
+.f\\:bc-pink-200:focus-within {
+  border-color: var(--pink-200) !important;
+}
+.fc-pink-200,
+.h\\:fc-pink-200:hover,
+.f\\:fc-pink-200:focus,
+.f\\:fc-pink-200:focus-within {
+  color: var(--pink-200) !important;
+}
+.bg-pink-300,
+.h\\:bg-pink-300:hover,
+.f\\:bg-pink-300:focus,
+.f\\:bg-pink-300:focus-within {
+  background-color: var(--pink-300) !important;
+}
+.bc-pink-300,
+.h\\:bc-pink-300:hover,
+.f\\:bc-pink-300:focus,
+.f\\:bc-pink-300:focus-within {
+  border-color: var(--pink-300) !important;
+}
+.fc-pink-300,
+.h\\:fc-pink-300:hover,
+.f\\:fc-pink-300:focus,
+.f\\:fc-pink-300:focus-within {
+  color: var(--pink-300) !important;
+}
+.bg-pink-400,
+.h\\:bg-pink-400:hover,
+.f\\:bg-pink-400:focus,
+.f\\:bg-pink-400:focus-within {
+  background-color: var(--pink-400) !important;
+}
+.bc-pink-400,
+.h\\:bc-pink-400:hover,
+.f\\:bc-pink-400:focus,
+.f\\:bc-pink-400:focus-within {
+  border-color: var(--pink-400) !important;
+}
+.fc-pink-400,
+.h\\:fc-pink-400:hover,
+.f\\:fc-pink-400:focus,
+.f\\:fc-pink-400:focus-within {
+  color: var(--pink-400) !important;
+}
+.bg-pink-500,
+.h\\:bg-pink-500:hover,
+.f\\:bg-pink-500:focus,
+.f\\:bg-pink-500:focus-within {
+  background-color: var(--pink-500) !important;
+}
+.bc-pink-500,
+.h\\:bc-pink-500:hover,
+.f\\:bc-pink-500:focus,
+.f\\:bc-pink-500:focus-within {
+  border-color: var(--pink-500) !important;
+}
+.fc-pink-500,
+.h\\:fc-pink-500:hover,
+.f\\:fc-pink-500:focus,
+.f\\:fc-pink-500:focus-within {
+  color: var(--pink-500) !important;
+}
+.bg-pink-600,
+.h\\:bg-pink-600:hover,
+.f\\:bg-pink-600:focus,
+.f\\:bg-pink-600:focus-within {
+  background-color: var(--pink-600) !important;
+}
+.bc-pink-600,
+.h\\:bc-pink-600:hover,
+.f\\:bc-pink-600:focus,
+.f\\:bc-pink-600:focus-within {
+  border-color: var(--pink-600) !important;
+}
+.fc-pink-600,
+.h\\:fc-pink-600:hover,
+.f\\:fc-pink-600:focus,
+.f\\:fc-pink-600:focus-within {
+  color: var(--pink-600) !important;
+}
+.bg-gold-100,
+.h\\:bg-gold-100:hover,
+.f\\:bg-gold-100:focus,
+.f\\:bg-gold-100:focus-within {
+  background-color: var(--gold-100) !important;
+}
+.bc-gold-100,
+.h\\:bc-gold-100:hover,
+.f\\:bc-gold-100:focus,
+.f\\:bc-gold-100:focus-within {
+  border-color: var(--gold-100) !important;
+}
+.fc-gold-100,
+.h\\:fc-gold-100:hover,
+.f\\:fc-gold-100:focus,
+.f\\:fc-gold-100:focus-within {
+  color: var(--gold-100) !important;
+}
+.bg-gold-200,
+.h\\:bg-gold-200:hover,
+.f\\:bg-gold-200:focus,
+.f\\:bg-gold-200:focus-within {
+  background-color: var(--gold-200) !important;
+}
+.bc-gold-200,
+.h\\:bc-gold-200:hover,
+.f\\:bc-gold-200:focus,
+.f\\:bc-gold-200:focus-within {
+  border-color: var(--gold-200) !important;
+}
+.fc-gold-200,
+.h\\:fc-gold-200:hover,
+.f\\:fc-gold-200:focus,
+.f\\:fc-gold-200:focus-within {
+  color: var(--gold-200) !important;
+}
+.bg-gold-300,
+.h\\:bg-gold-300:hover,
+.f\\:bg-gold-300:focus,
+.f\\:bg-gold-300:focus-within {
+  background-color: var(--gold-300) !important;
+}
+.bc-gold-300,
+.h\\:bc-gold-300:hover,
+.f\\:bc-gold-300:focus,
+.f\\:bc-gold-300:focus-within {
+  border-color: var(--gold-300) !important;
+}
+.fc-gold-300,
+.h\\:fc-gold-300:hover,
+.f\\:fc-gold-300:focus,
+.f\\:fc-gold-300:focus-within {
+  color: var(--gold-300) !important;
+}
+.bg-gold-400,
+.h\\:bg-gold-400:hover,
+.f\\:bg-gold-400:focus,
+.f\\:bg-gold-400:focus-within {
+  background-color: var(--gold-400) !important;
+}
+.bc-gold-400,
+.h\\:bc-gold-400:hover,
+.f\\:bc-gold-400:focus,
+.f\\:bc-gold-400:focus-within {
+  border-color: var(--gold-400) !important;
+}
+.fc-gold-400,
+.h\\:fc-gold-400:hover,
+.f\\:fc-gold-400:focus,
+.f\\:fc-gold-400:focus-within {
+  color: var(--gold-400) !important;
+}
+.bg-silver-100,
+.h\\:bg-silver-100:hover,
+.f\\:bg-silver-100:focus,
+.f\\:bg-silver-100:focus-within {
+  background-color: var(--silver-100) !important;
+}
+.bc-silver-100,
+.h\\:bc-silver-100:hover,
+.f\\:bc-silver-100:focus,
+.f\\:bc-silver-100:focus-within {
+  border-color: var(--silver-100) !important;
+}
+.fc-silver-100,
+.h\\:fc-silver-100:hover,
+.f\\:fc-silver-100:focus,
+.f\\:fc-silver-100:focus-within {
+  color: var(--silver-100) !important;
+}
+.bg-silver-200,
+.h\\:bg-silver-200:hover,
+.f\\:bg-silver-200:focus,
+.f\\:bg-silver-200:focus-within {
+  background-color: var(--silver-200) !important;
+}
+.bc-silver-200,
+.h\\:bc-silver-200:hover,
+.f\\:bc-silver-200:focus,
+.f\\:bc-silver-200:focus-within {
+  border-color: var(--silver-200) !important;
+}
+.fc-silver-200,
+.h\\:fc-silver-200:hover,
+.f\\:fc-silver-200:focus,
+.f\\:fc-silver-200:focus-within {
+  color: var(--silver-200) !important;
+}
+.bg-silver-300,
+.h\\:bg-silver-300:hover,
+.f\\:bg-silver-300:focus,
+.f\\:bg-silver-300:focus-within {
+  background-color: var(--silver-300) !important;
+}
+.bc-silver-300,
+.h\\:bc-silver-300:hover,
+.f\\:bc-silver-300:focus,
+.f\\:bc-silver-300:focus-within {
+  border-color: var(--silver-300) !important;
+}
+.fc-silver-300,
+.h\\:fc-silver-300:hover,
+.f\\:fc-silver-300:focus,
+.f\\:fc-silver-300:focus-within {
+  color: var(--silver-300) !important;
+}
+.bg-silver-400,
+.h\\:bg-silver-400:hover,
+.f\\:bg-silver-400:focus,
+.f\\:bg-silver-400:focus-within {
+  background-color: var(--silver-400) !important;
+}
+.bc-silver-400,
+.h\\:bc-silver-400:hover,
+.f\\:bc-silver-400:focus,
+.f\\:bc-silver-400:focus-within {
+  border-color: var(--silver-400) !important;
+}
+.fc-silver-400,
+.h\\:fc-silver-400:hover,
+.f\\:fc-silver-400:focus,
+.f\\:fc-silver-400:focus-within {
+  color: var(--silver-400) !important;
+}
+.bg-bronze-100,
+.h\\:bg-bronze-100:hover,
+.f\\:bg-bronze-100:focus,
+.f\\:bg-bronze-100:focus-within {
+  background-color: var(--bronze-100) !important;
+}
+.bc-bronze-100,
+.h\\:bc-bronze-100:hover,
+.f\\:bc-bronze-100:focus,
+.f\\:bc-bronze-100:focus-within {
+  border-color: var(--bronze-100) !important;
+}
+.fc-bronze-100,
+.h\\:fc-bronze-100:hover,
+.f\\:fc-bronze-100:focus,
+.f\\:fc-bronze-100:focus-within {
+  color: var(--bronze-100) !important;
+}
+.bg-bronze-200,
+.h\\:bg-bronze-200:hover,
+.f\\:bg-bronze-200:focus,
+.f\\:bg-bronze-200:focus-within {
+  background-color: var(--bronze-200) !important;
+}
+.bc-bronze-200,
+.h\\:bc-bronze-200:hover,
+.f\\:bc-bronze-200:focus,
+.f\\:bc-bronze-200:focus-within {
+  border-color: var(--bronze-200) !important;
+}
+.fc-bronze-200,
+.h\\:fc-bronze-200:hover,
+.f\\:fc-bronze-200:focus,
+.f\\:fc-bronze-200:focus-within {
+  color: var(--bronze-200) !important;
+}
+.bg-bronze-300,
+.h\\:bg-bronze-300:hover,
+.f\\:bg-bronze-300:focus,
+.f\\:bg-bronze-300:focus-within {
+  background-color: var(--bronze-300) !important;
+}
+.bc-bronze-300,
+.h\\:bc-bronze-300:hover,
+.f\\:bc-bronze-300:focus,
+.f\\:bc-bronze-300:focus-within {
+  border-color: var(--bronze-300) !important;
+}
+.fc-bronze-300,
+.h\\:fc-bronze-300:hover,
+.f\\:fc-bronze-300:focus,
+.f\\:fc-bronze-300:focus-within {
+  color: var(--bronze-300) !important;
+}
+.bg-bronze-400,
+.h\\:bg-bronze-400:hover,
+.f\\:bg-bronze-400:focus,
+.f\\:bg-bronze-400:focus-within {
+  background-color: var(--bronze-400) !important;
+}
+.bc-bronze-400,
+.h\\:bc-bronze-400:hover,
+.f\\:bc-bronze-400:focus,
+.f\\:bc-bronze-400:focus-within {
+  border-color: var(--bronze-400) !important;
+}
+.fc-bronze-400,
+.h\\:fc-bronze-400:hover,
+.f\\:fc-bronze-400:focus,
+.f\\:fc-bronze-400:focus-within {
+  color: var(--bronze-400) !important;
+}
+.bg-brand,
+.h\\:bg-brand:hover,
+.f\\:bg-brand:focus,
+.f\\:bg-brand:focus-within {
+  background-color: var(--brand) !important;
+}
+.bc-brand,
+.h\\:bc-brand:hover,
+.f\\:bc-brand:focus,
+.f\\:bc-brand:focus-within {
+  border-color: var(--brand) !important;
+}
+.fc-brand,
+.h\\:fc-brand:hover,
+.f\\:fc-brand:focus,
+.f\\:fc-brand:focus-within {
+  color: var(--brand) !important;
+}
+.bg-brand-black,
+.h\\:bg-brand-black:hover,
+.f\\:bg-brand-black:focus,
+.f\\:bg-brand-black:focus-within {
+  background-color: var(--brand-black) !important;
+}
+.bc-brand-black,
+.h\\:bc-brand-black:hover,
+.f\\:bc-brand-black:focus,
+.f\\:bc-brand-black:focus-within {
+  border-color: var(--brand-black) !important;
+}
+.fc-brand-black,
+.h\\:fc-brand-black:hover,
+.f\\:fc-brand-black:focus,
+.f\\:fc-brand-black:focus-within {
+  color: var(--brand-black) !important;
+}
+.bg-brand-off-white,
+.h\\:bg-brand-off-white:hover,
+.f\\:bg-brand-off-white:focus,
+.f\\:bg-brand-off-white:focus-within {
+  background-color: var(--brand-off-white) !important;
+}
+.bc-brand-off-white,
+.h\\:bc-brand-off-white:hover,
+.f\\:bc-brand-off-white:focus,
+.f\\:bc-brand-off-white:focus-within {
+  border-color: var(--brand-off-white) !important;
+}
+.fc-brand-off-white,
+.h\\:fc-brand-off-white:hover,
+.f\\:fc-brand-off-white:focus,
+.f\\:fc-brand-off-white:focus-within {
+  color: var(--brand-off-white) !important;
+}
+.bg-brand-blue-light,
+.h\\:bg-brand-blue-light:hover,
+.f\\:bg-brand-blue-light:focus,
+.f\\:bg-brand-blue-light:focus-within {
+  background-color: var(--brand-blue-light) !important;
+}
+.bc-brand-blue-light,
+.h\\:bc-brand-blue-light:hover,
+.f\\:bc-brand-blue-light:focus,
+.f\\:bc-brand-blue-light:focus-within {
+  border-color: var(--brand-blue-light) !important;
+}
+.fc-brand-blue-light,
+.h\\:fc-brand-blue-light:hover,
+.f\\:fc-brand-blue-light:focus,
+.f\\:fc-brand-blue-light:focus-within {
+  color: var(--brand-blue-light) !important;
+}
+.bg-brand-blue,
+.h\\:bg-brand-blue:hover,
+.f\\:bg-brand-blue:focus,
+.f\\:bg-brand-blue:focus-within {
+  background-color: var(--brand-blue) !important;
+}
+.bc-brand-blue,
+.h\\:bc-brand-blue:hover,
+.f\\:bc-brand-blue:focus,
+.f\\:bc-brand-blue:focus-within {
+  border-color: var(--brand-blue) !important;
+}
+.fc-brand-blue,
+.h\\:fc-brand-blue:hover,
+.f\\:fc-brand-blue:focus,
+.f\\:fc-brand-blue:focus-within {
+  color: var(--brand-blue) !important;
+}
+.bg-brand-blue-dark,
+.h\\:bg-brand-blue-dark:hover,
+.f\\:bg-brand-blue-dark:focus,
+.f\\:bg-brand-blue-dark:focus-within {
+  background-color: var(--brand-blue-dark) !important;
+}
+.bc-brand-blue-dark,
+.h\\:bc-brand-blue-dark:hover,
+.f\\:bc-brand-blue-dark:focus,
+.f\\:bc-brand-blue-dark:focus-within {
+  border-color: var(--brand-blue-dark) !important;
+}
+.fc-brand-blue-dark,
+.h\\:fc-brand-blue-dark:hover,
+.f\\:fc-brand-blue-dark:focus,
+.f\\:fc-brand-blue-dark:focus-within {
+  color: var(--brand-blue-dark) !important;
+}
+.bg-brand-brown-light,
+.h\\:bg-brand-brown-light:hover,
+.f\\:bg-brand-brown-light:focus,
+.f\\:bg-brand-brown-light:focus-within {
+  background-color: var(--brand-brown-light) !important;
+}
+.bc-brand-brown-light,
+.h\\:bc-brand-brown-light:hover,
+.f\\:bc-brand-brown-light:focus,
+.f\\:bc-brand-brown-light:focus-within {
+  border-color: var(--brand-brown-light) !important;
+}
+.fc-brand-brown-light,
+.h\\:fc-brand-brown-light:hover,
+.f\\:fc-brand-brown-light:focus,
+.f\\:fc-brand-brown-light:focus-within {
+  color: var(--brand-brown-light) !important;
+}
+.bg-brand-green,
+.h\\:bg-brand-green:hover,
+.f\\:bg-brand-green:focus,
+.f\\:bg-brand-green:focus-within {
+  background-color: var(--brand-green) !important;
+}
+.bc-brand-green,
+.h\\:bc-brand-green:hover,
+.f\\:bc-brand-green:focus,
+.f\\:bc-brand-green:focus-within {
+  border-color: var(--brand-green) !important;
+}
+.fc-brand-green,
+.h\\:fc-brand-green:hover,
+.f\\:fc-brand-green:focus,
+.f\\:fc-brand-green:focus-within {
+  color: var(--brand-green) !important;
+}
+.bg-brand-green-dark,
+.h\\:bg-brand-green-dark:hover,
+.f\\:bg-brand-green-dark:focus,
+.f\\:bg-brand-green-dark:focus-within {
+  background-color: var(--brand-green-dark) !important;
+}
+.bc-brand-green-dark,
+.h\\:bc-brand-green-dark:hover,
+.f\\:bc-brand-green-dark:focus,
+.f\\:bc-brand-green-dark:focus-within {
+  border-color: var(--brand-green-dark) !important;
+}
+.fc-brand-green-dark,
+.h\\:fc-brand-green-dark:hover,
+.f\\:fc-brand-green-dark:focus,
+.f\\:fc-brand-green-dark:focus-within {
+  color: var(--brand-green-dark) !important;
+}
+.bg-brand-orange-medium,
+.h\\:bg-brand-orange-medium:hover,
+.f\\:bg-brand-orange-medium:focus,
+.f\\:bg-brand-orange-medium:focus-within {
+  background-color: var(--brand-orange-medium) !important;
+}
+.bc-brand-orange-medium,
+.h\\:bc-brand-orange-medium:hover,
+.f\\:bc-brand-orange-medium:focus,
+.f\\:bc-brand-orange-medium:focus-within {
+  border-color: var(--brand-orange-medium) !important;
+}
+.fc-brand-orange-medium,
+.h\\:fc-brand-orange-medium:hover,
+.f\\:fc-brand-orange-medium:focus,
+.f\\:fc-brand-orange-medium:focus-within {
+  color: var(--brand-orange-medium) !important;
+}
+.bg-brand-orange-dark,
+.h\\:bg-brand-orange-dark:hover,
+.f\\:bg-brand-orange-dark:focus,
+.f\\:bg-brand-orange-dark:focus-within {
+  background-color: var(--brand-orange-dark) !important;
+}
+.bc-brand-orange-dark,
+.h\\:bc-brand-orange-dark:hover,
+.f\\:bc-brand-orange-dark:focus,
+.f\\:bc-brand-orange-dark:focus-within {
+  border-color: var(--brand-orange-dark) !important;
+}
+.fc-brand-orange-dark,
+.h\\:fc-brand-orange-dark:hover,
+.f\\:fc-brand-orange-dark:focus,
+.f\\:fc-brand-orange-dark:focus-within {
+  color: var(--brand-orange-dark) !important;
+}
+.bg-brand-pink,
+.h\\:bg-brand-pink:hover,
+.f\\:bg-brand-pink:focus,
+.f\\:bg-brand-pink:focus-within {
+  background-color: var(--brand-pink) !important;
+}
+.bc-brand-pink,
+.h\\:bc-brand-pink:hover,
+.f\\:bc-brand-pink:focus,
+.f\\:bc-brand-pink:focus-within {
+  border-color: var(--brand-pink) !important;
+}
+.fc-brand-pink,
+.h\\:fc-brand-pink:hover,
+.f\\:fc-brand-pink:focus,
+.f\\:fc-brand-pink:focus-within {
+  color: var(--brand-pink) !important;
+}
+.bg-brand-pink-dark,
+.h\\:bg-brand-pink-dark:hover,
+.f\\:bg-brand-pink-dark:focus,
+.f\\:bg-brand-pink-dark:focus-within {
+  background-color: var(--brand-pink-dark) !important;
+}
+.bc-brand-pink-dark,
+.h\\:bc-brand-pink-dark:hover,
+.f\\:bc-brand-pink-dark:focus,
+.f\\:bc-brand-pink-dark:focus-within {
+  border-color: var(--brand-pink-dark) !important;
+}
+.fc-brand-pink-dark,
+.h\\:fc-brand-pink-dark:hover,
+.f\\:fc-brand-pink-dark:focus,
+.f\\:fc-brand-pink-dark:focus-within {
+  color: var(--brand-pink-dark) !important;
+}
+.bg-brand-purple,
+.h\\:bg-brand-purple:hover,
+.f\\:bg-brand-purple:focus,
+.f\\:bg-brand-purple:focus-within {
+  background-color: var(--brand-purple) !important;
+}
+.bc-brand-purple,
+.h\\:bc-brand-purple:hover,
+.f\\:bc-brand-purple:focus,
+.f\\:bc-brand-purple:focus-within {
+  border-color: var(--brand-purple) !important;
+}
+.fc-brand-purple,
+.h\\:fc-brand-purple:hover,
+.f\\:fc-brand-purple:focus,
+.f\\:fc-brand-purple:focus-within {
+  color: var(--brand-purple) !important;
+}
+.bg-brand-purple-dark,
+.h\\:bg-brand-purple-dark:hover,
+.f\\:bg-brand-purple-dark:focus,
+.f\\:bg-brand-purple-dark:focus-within {
+  background-color: var(--brand-purple-dark) !important;
+}
+.bc-brand-purple-dark,
+.h\\:bc-brand-purple-dark:hover,
+.f\\:bc-brand-purple-dark:focus,
+.f\\:bc-brand-purple-dark:focus-within {
+  border-color: var(--brand-purple-dark) !important;
+}
+.fc-brand-purple-dark,
+.h\\:fc-brand-purple-dark:hover,
+.f\\:fc-brand-purple-dark:focus,
+.f\\:fc-brand-purple-dark:focus-within {
+  color: var(--brand-purple-dark) !important;
+}
+.bg-brand-yellow,
+.h\\:bg-brand-yellow:hover,
+.f\\:bg-brand-yellow:focus,
+.f\\:bg-brand-yellow:focus-within {
+  background-color: var(--brand-yellow) !important;
+}
+.bc-brand-yellow,
+.h\\:bc-brand-yellow:hover,
+.f\\:bc-brand-yellow:focus,
+.f\\:bc-brand-yellow:focus-within {
+  border-color: var(--brand-yellow) !important;
+}
+.fc-brand-yellow,
+.h\\:fc-brand-yellow:hover,
+.f\\:fc-brand-yellow:focus,
+.f\\:fc-brand-yellow:focus-within {
+  color: var(--brand-yellow) !important;
+}
+.bg-brand-yellow-dark,
+.h\\:bg-brand-yellow-dark:hover,
+.f\\:bg-brand-yellow-dark:focus,
+.f\\:bg-brand-yellow-dark:focus-within {
+  background-color: var(--brand-yellow-dark) !important;
+}
+.bc-brand-yellow-dark,
+.h\\:bc-brand-yellow-dark:hover,
+.f\\:bc-brand-yellow-dark:focus,
+.f\\:bc-brand-yellow-dark:focus-within {
+  border-color: var(--brand-yellow-dark) !important;
+}
+.fc-brand-yellow-dark,
+.h\\:fc-brand-yellow-dark:hover,
+.f\\:fc-brand-yellow-dark:focus,
+.f\\:fc-brand-yellow-dark:focus-within {
+  color: var(--brand-yellow-dark) !important;
+}
+.fc-light,
+.h\\:fc-light:hover,
+.f\\:fc-light:focus,
+.f\\:fc-light:focus-within {
+  color: var(--fc-light) !important;
+}
+.fc-medium,
+.h\\:fc-medium:hover,
+.f\\:fc-medium:focus,
+.f\\:fc-medium:focus-within {
+  color: var(--fc-medium) !important;
+}
+.fc-dark,
+.h\\:fc-dark:hover,
+.f\\:fc-dark:focus,
+.f\\:fc-dark:focus-within {
+  color: var(--fc-dark) !important;
+}
+.fc-error,
+.h\\:fc-error:hover,
+.f\\:fc-error:focus,
+.f\\:fc-error:focus-within {
+  color: var(--fc-error) !important;
+}
+.fc-danger,
+.h\\:fc-danger:hover,
+.f\\:fc-danger:focus,
+.f\\:fc-danger:focus-within {
+  color: var(--fc-danger) !important;
+}
+.fc-success,
+.h\\:fc-success:hover,
+.f\\:fc-success:focus,
+.f\\:fc-success:focus-within {
+  color: var(--fc-success) !important;
+}
+.fc-warning,
+.h\\:fc-warning:hover,
+.f\\:fc-warning:focus,
+.f\\:fc-warning:focus-within {
+  color: var(--fc-warning) !important;
+}
+.bg-error,
+.h\\:bg-error:hover,
+.f\\:bg-error:focus,
+.f\\:bg-error:focus-within {
+  background-color: var(--bg-error) !important;
+}
+.bg-danger,
+.h\\:bg-danger:hover,
+.f\\:bg-danger:focus,
+.f\\:bg-danger:focus-within {
+  background-color: var(--bg-danger) !important;
+}
+.bg-success,
+.h\\:bg-success:hover,
+.f\\:bg-success:focus,
+.f\\:bg-success:focus-within {
+  background-color: var(--bg-success) !important;
+}
+.bg-warning,
+.h\\:bg-warning:hover,
+.f\\:bg-warning:focus,
+.f\\:bg-warning:focus-within {
+  background-color: var(--bg-warning) !important;
+}
+.bc-error,
+.h\\:bc-error:hover,
+.f\\:bc-error:focus,
+.f\\:bc-error:focus-within {
+  border-color: var(--bc-error) !important;
+}
+.bc-danger,
+.h\\:bc-danger:hover,
+.f\\:bc-danger:focus,
+.f\\:bc-danger:focus-within {
+  border-color: var(--bc-danger) !important;
+}
+.bc-success,
+.h\\:bc-success:hover,
+.f\\:bc-success:focus,
+.f\\:bc-success:focus-within {
+  border-color: var(--bc-success) !important;
+}
+.bc-warning,
+.h\\:bc-warning:hover,
+.f\\:bc-warning:focus,
+.f\\:bc-warning:focus-within {
+  border-color: var(--bc-warning) !important;
+}
+.bg-transparent,
+.h\\:bg-transparent:hover,
+.f\\:bg-transparent:focus,
+.f\\:bg-transparent:focus-within {
+  background-color: transparent !important;
+}
+.bc-transparent,
+.h\\:bc-transparent:hover,
+.f\\:bc-transparent:focus,
+.f\\:bc-transparent:focus-within {
+  border-color: transparent !important;
+}
+.bg-inherit,
+.h\\:bg-inherit:hover,
+.f\\:bg-inherit:focus,
+.f\\:bg-inherit:focus-within {
+  background-color: inherit !important;
+}
+.bc-inherit,
+.h\\:bc-inherit:hover,
+.f\\:bc-inherit:focus,
+.f\\:bc-inherit:focus-within {
+  border-color: inherit !important;
+}
+.bg-theme-primary,
+.h\\:bg-theme-primary:hover,
+.f\\:bg-theme-primary:focus,
+.f\\:bg-theme-primary:focus-within {
+  background-color: var(--theme-primary) !important;
+}
+.bc-theme-primary,
+.h\\:bc-theme-primary:hover,
+.f\\:bc-theme-primary:focus,
+.f\\:bc-theme-primary:focus-within {
+  border-color: var(--theme-primary) !important;
+}
+.fc-theme-primary,
+.h\\:fc-theme-primary:hover,
+.f\\:fc-theme-primary:focus,
+.f\\:fc-theme-primary:focus-within {
+  color: var(--theme-primary) !important;
+}
+.bg-theme-primary-100,
+.h\\:bg-theme-primary-100:hover,
+.f\\:bg-theme-primary-100:focus,
+.f\\:bg-theme-primary-100:focus-within {
+  background-color: var(--theme-primary-100) !important;
+}
+.bc-theme-primary-100,
+.h\\:bc-theme-primary-100:hover,
+.f\\:bc-theme-primary-100:focus,
+.f\\:bc-theme-primary-100:focus-within {
+  border-color: var(--theme-primary-100) !important;
+}
+.fc-theme-primary-100,
+.h\\:fc-theme-primary-100:hover,
+.f\\:fc-theme-primary-100:focus,
+.f\\:fc-theme-primary-100:focus-within {
+  color: var(--theme-primary-100) !important;
+}
+.bg-theme-primary-200,
+.h\\:bg-theme-primary-200:hover,
+.f\\:bg-theme-primary-200:focus,
+.f\\:bg-theme-primary-200:focus-within {
+  background-color: var(--theme-primary-200) !important;
+}
+.bc-theme-primary-200,
+.h\\:bc-theme-primary-200:hover,
+.f\\:bc-theme-primary-200:focus,
+.f\\:bc-theme-primary-200:focus-within {
+  border-color: var(--theme-primary-200) !important;
+}
+.fc-theme-primary-200,
+.h\\:fc-theme-primary-200:hover,
+.f\\:fc-theme-primary-200:focus,
+.f\\:fc-theme-primary-200:focus-within {
+  color: var(--theme-primary-200) !important;
+}
+.bg-theme-primary-300,
+.h\\:bg-theme-primary-300:hover,
+.f\\:bg-theme-primary-300:focus,
+.f\\:bg-theme-primary-300:focus-within {
+  background-color: var(--theme-primary-300) !important;
+}
+.bc-theme-primary-300,
+.h\\:bc-theme-primary-300:hover,
+.f\\:bc-theme-primary-300:focus,
+.f\\:bc-theme-primary-300:focus-within {
+  border-color: var(--theme-primary-300) !important;
+}
+.fc-theme-primary-300,
+.h\\:fc-theme-primary-300:hover,
+.f\\:fc-theme-primary-300:focus,
+.f\\:fc-theme-primary-300:focus-within {
+  color: var(--theme-primary-300) !important;
+}
+.bg-theme-primary-400,
+.h\\:bg-theme-primary-400:hover,
+.f\\:bg-theme-primary-400:focus,
+.f\\:bg-theme-primary-400:focus-within {
+  background-color: var(--theme-primary-400) !important;
+}
+.bc-theme-primary-400,
+.h\\:bc-theme-primary-400:hover,
+.f\\:bc-theme-primary-400:focus,
+.f\\:bc-theme-primary-400:focus-within {
+  border-color: var(--theme-primary-400) !important;
+}
+.fc-theme-primary-400,
+.h\\:fc-theme-primary-400:hover,
+.f\\:fc-theme-primary-400:focus,
+.f\\:fc-theme-primary-400:focus-within {
+  color: var(--theme-primary-400) !important;
+}
+.bg-theme-primary-500,
+.h\\:bg-theme-primary-500:hover,
+.f\\:bg-theme-primary-500:focus,
+.f\\:bg-theme-primary-500:focus-within {
+  background-color: var(--theme-primary-500) !important;
+}
+.bc-theme-primary-500,
+.h\\:bc-theme-primary-500:hover,
+.f\\:bc-theme-primary-500:focus,
+.f\\:bc-theme-primary-500:focus-within {
+  border-color: var(--theme-primary-500) !important;
+}
+.fc-theme-primary-500,
+.h\\:fc-theme-primary-500:hover,
+.f\\:fc-theme-primary-500:focus,
+.f\\:fc-theme-primary-500:focus-within {
+  color: var(--theme-primary-500) !important;
+}
+.bg-theme-primary-600,
+.h\\:bg-theme-primary-600:hover,
+.f\\:bg-theme-primary-600:focus,
+.f\\:bg-theme-primary-600:focus-within {
+  background-color: var(--theme-primary-600) !important;
+}
+.bc-theme-primary-600,
+.h\\:bc-theme-primary-600:hover,
+.f\\:bc-theme-primary-600:focus,
+.f\\:bc-theme-primary-600:focus-within {
+  border-color: var(--theme-primary-600) !important;
+}
+.fc-theme-primary-600,
+.h\\:fc-theme-primary-600:hover,
+.f\\:fc-theme-primary-600:focus,
+.f\\:fc-theme-primary-600:focus-within {
+  color: var(--theme-primary-600) !important;
+}
+.bg-theme-secondary,
+.h\\:bg-theme-secondary:hover,
+.f\\:bg-theme-secondary:focus,
+.f\\:bg-theme-secondary:focus-within {
+  background-color: var(--theme-secondary) !important;
+}
+.bc-theme-secondary,
+.h\\:bc-theme-secondary:hover,
+.f\\:bc-theme-secondary:focus,
+.f\\:bc-theme-secondary:focus-within {
+  border-color: var(--theme-secondary) !important;
+}
+.fc-theme-secondary,
+.h\\:fc-theme-secondary:hover,
+.f\\:fc-theme-secondary:focus,
+.f\\:fc-theme-secondary:focus-within {
+  color: var(--theme-secondary) !important;
+}
+.bg-theme-secondary-100,
+.h\\:bg-theme-secondary-100:hover,
+.f\\:bg-theme-secondary-100:focus,
+.f\\:bg-theme-secondary-100:focus-within {
+  background-color: var(--theme-secondary-100) !important;
+}
+.bc-theme-secondary-100,
+.h\\:bc-theme-secondary-100:hover,
+.f\\:bc-theme-secondary-100:focus,
+.f\\:bc-theme-secondary-100:focus-within {
+  border-color: var(--theme-secondary-100) !important;
+}
+.fc-theme-secondary-100,
+.h\\:fc-theme-secondary-100:hover,
+.f\\:fc-theme-secondary-100:focus,
+.f\\:fc-theme-secondary-100:focus-within {
+  color: var(--theme-secondary-100) !important;
+}
+.bg-theme-secondary-200,
+.h\\:bg-theme-secondary-200:hover,
+.f\\:bg-theme-secondary-200:focus,
+.f\\:bg-theme-secondary-200:focus-within {
+  background-color: var(--theme-secondary-200) !important;
+}
+.bc-theme-secondary-200,
+.h\\:bc-theme-secondary-200:hover,
+.f\\:bc-theme-secondary-200:focus,
+.f\\:bc-theme-secondary-200:focus-within {
+  border-color: var(--theme-secondary-200) !important;
+}
+.fc-theme-secondary-200,
+.h\\:fc-theme-secondary-200:hover,
+.f\\:fc-theme-secondary-200:focus,
+.f\\:fc-theme-secondary-200:focus-within {
+  color: var(--theme-secondary-200) !important;
+}
+.bg-theme-secondary-300,
+.h\\:bg-theme-secondary-300:hover,
+.f\\:bg-theme-secondary-300:focus,
+.f\\:bg-theme-secondary-300:focus-within {
+  background-color: var(--theme-secondary-300) !important;
+}
+.bc-theme-secondary-300,
+.h\\:bc-theme-secondary-300:hover,
+.f\\:bc-theme-secondary-300:focus,
+.f\\:bc-theme-secondary-300:focus-within {
+  border-color: var(--theme-secondary-300) !important;
+}
+.fc-theme-secondary-300,
+.h\\:fc-theme-secondary-300:hover,
+.f\\:fc-theme-secondary-300:focus,
+.f\\:fc-theme-secondary-300:focus-within {
+  color: var(--theme-secondary-300) !important;
+}
+.bg-theme-secondary-400,
+.h\\:bg-theme-secondary-400:hover,
+.f\\:bg-theme-secondary-400:focus,
+.f\\:bg-theme-secondary-400:focus-within {
+  background-color: var(--theme-secondary-400) !important;
+}
+.bc-theme-secondary-400,
+.h\\:bc-theme-secondary-400:hover,
+.f\\:bc-theme-secondary-400:focus,
+.f\\:bc-theme-secondary-400:focus-within {
+  border-color: var(--theme-secondary-400) !important;
+}
+.fc-theme-secondary-400,
+.h\\:fc-theme-secondary-400:hover,
+.f\\:fc-theme-secondary-400:focus,
+.f\\:fc-theme-secondary-400:focus-within {
+  color: var(--theme-secondary-400) !important;
+}
+.bg-theme-secondary-500,
+.h\\:bg-theme-secondary-500:hover,
+.f\\:bg-theme-secondary-500:focus,
+.f\\:bg-theme-secondary-500:focus-within {
+  background-color: var(--theme-secondary-500) !important;
+}
+.bc-theme-secondary-500,
+.h\\:bc-theme-secondary-500:hover,
+.f\\:bc-theme-secondary-500:focus,
+.f\\:bc-theme-secondary-500:focus-within {
+  border-color: var(--theme-secondary-500) !important;
+}
+.fc-theme-secondary-500,
+.h\\:fc-theme-secondary-500:hover,
+.f\\:fc-theme-secondary-500:focus,
+.f\\:fc-theme-secondary-500:focus-within {
+  color: var(--theme-secondary-500) !important;
+}
+.bg-theme-secondary-600,
+.h\\:bg-theme-secondary-600:hover,
+.f\\:bg-theme-secondary-600:focus,
+.f\\:bg-theme-secondary-600:focus-within {
+  background-color: var(--theme-secondary-600) !important;
+}
+.bc-theme-secondary-600,
+.h\\:bc-theme-secondary-600:hover,
+.f\\:bc-theme-secondary-600:focus,
+.f\\:bc-theme-secondary-600:focus-within {
+  border-color: var(--theme-secondary-600) !important;
+}
+.fc-theme-secondary-600,
+.h\\:fc-theme-secondary-600:hover,
+.f\\:fc-theme-secondary-600:focus,
+.f\\:fc-theme-secondary-600:focus-within {
+  color: var(--theme-secondary-600) !important;
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-system  .d\\:bg-white {
+    background-color: var(--white) !important;
+  }
+  body.theme-system  .d\\:fc-white {
+    color: var(--white) !important;
+  }
+  body.theme-system  .d\\:bg-black-050 {
+    background-color: var(--black-050) !important;
+  }
+  body.theme-system  .d\\:fc-black-050 {
+    color: var(--black-050) !important;
+  }
+  body.theme-system  .d\\:bg-black-100 {
+    background-color: var(--black-100) !important;
+  }
+  body.theme-system  .d\\:fc-black-100 {
+    color: var(--black-100) !important;
+  }
+  body.theme-system  .d\\:bg-black-150 {
+    background-color: var(--black-150) !important;
+  }
+  body.theme-system  .d\\:fc-black-150 {
+    color: var(--black-150) !important;
+  }
+  body.theme-system  .d\\:bg-black-200 {
+    background-color: var(--black-200) !important;
+  }
+  body.theme-system  .d\\:fc-black-200 {
+    color: var(--black-200) !important;
+  }
+  body.theme-system  .d\\:bg-black-225 {
+    background-color: var(--black-225) !important;
+  }
+  body.theme-system  .d\\:fc-black-225 {
+    color: var(--black-225) !important;
+  }
+  body.theme-system  .d\\:bg-black-250 {
+    background-color: var(--black-250) !important;
+  }
+  body.theme-system  .d\\:fc-black-250 {
+    color: var(--black-250) !important;
+  }
+  body.theme-system  .d\\:bg-black-300 {
+    background-color: var(--black-300) !important;
+  }
+  body.theme-system  .d\\:fc-black-300 {
+    color: var(--black-300) !important;
+  }
+  body.theme-system  .d\\:bg-black-350 {
+    background-color: var(--black-350) !important;
+  }
+  body.theme-system  .d\\:fc-black-350 {
+    color: var(--black-350) !important;
+  }
+  body.theme-system  .d\\:bg-black-400 {
+    background-color: var(--black-400) !important;
+  }
+  body.theme-system  .d\\:fc-black-400 {
+    color: var(--black-400) !important;
+  }
+  body.theme-system  .d\\:bg-black-500 {
+    background-color: var(--black-500) !important;
+  }
+  body.theme-system  .d\\:fc-black-500 {
+    color: var(--black-500) !important;
+  }
+  body.theme-system  .d\\:bg-black-600 {
+    background-color: var(--black-600) !important;
+  }
+  body.theme-system  .d\\:fc-black-600 {
+    color: var(--black-600) !important;
+  }
+  body.theme-system  .d\\:bg-black {
+    background-color: var(--black) !important;
+  }
+  body.theme-system  .d\\:fc-black {
+    color: var(--black) !important;
+  }
+  body.theme-system  .d\\:bg-orange-100 {
+    background-color: var(--orange-100) !important;
+  }
+  body.theme-system  .d\\:fc-orange-100 {
+    color: var(--orange-100) !important;
+  }
+  body.theme-system  .d\\:bg-orange-200 {
+    background-color: var(--orange-200) !important;
+  }
+  body.theme-system  .d\\:fc-orange-200 {
+    color: var(--orange-200) !important;
+  }
+  body.theme-system  .d\\:bg-orange-300 {
+    background-color: var(--orange-300) !important;
+  }
+  body.theme-system  .d\\:fc-orange-300 {
+    color: var(--orange-300) !important;
+  }
+  body.theme-system  .d\\:bg-orange-400 {
+    background-color: var(--orange-400) !important;
+  }
+  body.theme-system  .d\\:fc-orange-400 {
+    color: var(--orange-400) !important;
+  }
+  body.theme-system  .d\\:bg-orange-500 {
+    background-color: var(--orange-500) !important;
+  }
+  body.theme-system  .d\\:fc-orange-500 {
+    color: var(--orange-500) !important;
+  }
+  body.theme-system  .d\\:bg-orange-600 {
+    background-color: var(--orange-600) !important;
+  }
+  body.theme-system  .d\\:fc-orange-600 {
+    color: var(--orange-600) !important;
+  }
+  body.theme-system  .d\\:bg-blue-100 {
+    background-color: var(--blue-100) !important;
+  }
+  body.theme-system  .d\\:fc-blue-100 {
+    color: var(--blue-100) !important;
+  }
+  body.theme-system  .d\\:bg-blue-200 {
+    background-color: var(--blue-200) !important;
+  }
+  body.theme-system  .d\\:fc-blue-200 {
+    color: var(--blue-200) !important;
+  }
+  body.theme-system  .d\\:bg-blue-300 {
+    background-color: var(--blue-300) !important;
+  }
+  body.theme-system  .d\\:fc-blue-300 {
+    color: var(--blue-300) !important;
+  }
+  body.theme-system  .d\\:bg-blue-400 {
+    background-color: var(--blue-400) !important;
+  }
+  body.theme-system  .d\\:fc-blue-400 {
+    color: var(--blue-400) !important;
+  }
+  body.theme-system  .d\\:bg-blue-500 {
+    background-color: var(--blue-500) !important;
+  }
+  body.theme-system  .d\\:fc-blue-500 {
+    color: var(--blue-500) !important;
+  }
+  body.theme-system  .d\\:bg-blue-600 {
+    background-color: var(--blue-600) !important;
+  }
+  body.theme-system  .d\\:fc-blue-600 {
+    color: var(--blue-600) !important;
+  }
+  body.theme-system  .d\\:bg-green-100 {
+    background-color: var(--green-100) !important;
+  }
+  body.theme-system  .d\\:fc-green-100 {
+    color: var(--green-100) !important;
+  }
+  body.theme-system  .d\\:bg-green-200 {
+    background-color: var(--green-200) !important;
+  }
+  body.theme-system  .d\\:fc-green-200 {
+    color: var(--green-200) !important;
+  }
+  body.theme-system  .d\\:bg-green-300 {
+    background-color: var(--green-300) !important;
+  }
+  body.theme-system  .d\\:fc-green-300 {
+    color: var(--green-300) !important;
+  }
+  body.theme-system  .d\\:bg-green-400 {
+    background-color: var(--green-400) !important;
+  }
+  body.theme-system  .d\\:fc-green-400 {
+    color: var(--green-400) !important;
+  }
+  body.theme-system  .d\\:bg-green-500 {
+    background-color: var(--green-500) !important;
+  }
+  body.theme-system  .d\\:fc-green-500 {
+    color: var(--green-500) !important;
+  }
+  body.theme-system  .d\\:bg-green-600 {
+    background-color: var(--green-600) !important;
+  }
+  body.theme-system  .d\\:fc-green-600 {
+    color: var(--green-600) !important;
+  }
+  body.theme-system  .d\\:bg-red-100 {
+    background-color: var(--red-100) !important;
+  }
+  body.theme-system  .d\\:fc-red-100 {
+    color: var(--red-100) !important;
+  }
+  body.theme-system  .d\\:bg-red-200 {
+    background-color: var(--red-200) !important;
+  }
+  body.theme-system  .d\\:fc-red-200 {
+    color: var(--red-200) !important;
+  }
+  body.theme-system  .d\\:bg-red-300 {
+    background-color: var(--red-300) !important;
+  }
+  body.theme-system  .d\\:fc-red-300 {
+    color: var(--red-300) !important;
+  }
+  body.theme-system  .d\\:bg-red-400 {
+    background-color: var(--red-400) !important;
+  }
+  body.theme-system  .d\\:fc-red-400 {
+    color: var(--red-400) !important;
+  }
+  body.theme-system  .d\\:bg-red-500 {
+    background-color: var(--red-500) !important;
+  }
+  body.theme-system  .d\\:fc-red-500 {
+    color: var(--red-500) !important;
+  }
+  body.theme-system  .d\\:bg-red-600 {
+    background-color: var(--red-600) !important;
+  }
+  body.theme-system  .d\\:fc-red-600 {
+    color: var(--red-600) !important;
+  }
+  body.theme-system  .d\\:bg-yellow-100 {
+    background-color: var(--yellow-100) !important;
+  }
+  body.theme-system  .d\\:fc-yellow-100 {
+    color: var(--yellow-100) !important;
+  }
+  body.theme-system  .d\\:bg-yellow-200 {
+    background-color: var(--yellow-200) !important;
+  }
+  body.theme-system  .d\\:fc-yellow-200 {
+    color: var(--yellow-200) !important;
+  }
+  body.theme-system  .d\\:bg-yellow-300 {
+    background-color: var(--yellow-300) !important;
+  }
+  body.theme-system  .d\\:fc-yellow-300 {
+    color: var(--yellow-300) !important;
+  }
+  body.theme-system  .d\\:bg-yellow-400 {
+    background-color: var(--yellow-400) !important;
+  }
+  body.theme-system  .d\\:fc-yellow-400 {
+    color: var(--yellow-400) !important;
+  }
+  body.theme-system  .d\\:bg-yellow-500 {
+    background-color: var(--yellow-500) !important;
+  }
+  body.theme-system  .d\\:fc-yellow-500 {
+    color: var(--yellow-500) !important;
+  }
+  body.theme-system  .d\\:bg-yellow-600 {
+    background-color: var(--yellow-600) !important;
+  }
+  body.theme-system  .d\\:fc-yellow-600 {
+    color: var(--yellow-600) !important;
+  }
+  body.theme-system  .d\\:bg-purple-100 {
+    background-color: var(--purple-100) !important;
+  }
+  body.theme-system  .d\\:fc-purple-100 {
+    color: var(--purple-100) !important;
+  }
+  body.theme-system  .d\\:bg-purple-200 {
+    background-color: var(--purple-200) !important;
+  }
+  body.theme-system  .d\\:fc-purple-200 {
+    color: var(--purple-200) !important;
+  }
+  body.theme-system  .d\\:bg-purple-300 {
+    background-color: var(--purple-300) !important;
+  }
+  body.theme-system  .d\\:fc-purple-300 {
+    color: var(--purple-300) !important;
+  }
+  body.theme-system  .d\\:bg-purple-400 {
+    background-color: var(--purple-400) !important;
+  }
+  body.theme-system  .d\\:fc-purple-400 {
+    color: var(--purple-400) !important;
+  }
+  body.theme-system  .d\\:bg-purple-500 {
+    background-color: var(--purple-500) !important;
+  }
+  body.theme-system  .d\\:fc-purple-500 {
+    color: var(--purple-500) !important;
+  }
+  body.theme-system  .d\\:bg-purple-600 {
+    background-color: var(--purple-600) !important;
+  }
+  body.theme-system  .d\\:fc-purple-600 {
+    color: var(--purple-600) !important;
+  }
+  body.theme-system  .d\\:bg-pink-100 {
+    background-color: var(--pink-100) !important;
+  }
+  body.theme-system  .d\\:fc-pink-100 {
+    color: var(--pink-100) !important;
+  }
+  body.theme-system  .d\\:bg-pink-200 {
+    background-color: var(--pink-200) !important;
+  }
+  body.theme-system  .d\\:fc-pink-200 {
+    color: var(--pink-200) !important;
+  }
+  body.theme-system  .d\\:bg-pink-300 {
+    background-color: var(--pink-300) !important;
+  }
+  body.theme-system  .d\\:fc-pink-300 {
+    color: var(--pink-300) !important;
+  }
+  body.theme-system  .d\\:bg-pink-400 {
+    background-color: var(--pink-400) !important;
+  }
+  body.theme-system  .d\\:fc-pink-400 {
+    color: var(--pink-400) !important;
+  }
+  body.theme-system  .d\\:bg-pink-500 {
+    background-color: var(--pink-500) !important;
+  }
+  body.theme-system  .d\\:fc-pink-500 {
+    color: var(--pink-500) !important;
+  }
+  body.theme-system  .d\\:bg-pink-600 {
+    background-color: var(--pink-600) !important;
+  }
+  body.theme-system  .d\\:fc-pink-600 {
+    color: var(--pink-600) !important;
+  }
+  body.theme-system  .d\\:bg-gold-100 {
+    background-color: var(--gold-100) !important;
+  }
+  body.theme-system  .d\\:fc-gold-100 {
+    color: var(--gold-100) !important;
+  }
+  body.theme-system  .d\\:bg-gold-200 {
+    background-color: var(--gold-200) !important;
+  }
+  body.theme-system  .d\\:fc-gold-200 {
+    color: var(--gold-200) !important;
+  }
+  body.theme-system  .d\\:bg-gold-300 {
+    background-color: var(--gold-300) !important;
+  }
+  body.theme-system  .d\\:fc-gold-300 {
+    color: var(--gold-300) !important;
+  }
+  body.theme-system  .d\\:bg-gold-400 {
+    background-color: var(--gold-400) !important;
+  }
+  body.theme-system  .d\\:fc-gold-400 {
+    color: var(--gold-400) !important;
+  }
+  body.theme-system  .d\\:bg-silver-100 {
+    background-color: var(--silver-100) !important;
+  }
+  body.theme-system  .d\\:fc-silver-100 {
+    color: var(--silver-100) !important;
+  }
+  body.theme-system  .d\\:bg-silver-200 {
+    background-color: var(--silver-200) !important;
+  }
+  body.theme-system  .d\\:fc-silver-200 {
+    color: var(--silver-200) !important;
+  }
+  body.theme-system  .d\\:bg-silver-300 {
+    background-color: var(--silver-300) !important;
+  }
+  body.theme-system  .d\\:fc-silver-300 {
+    color: var(--silver-300) !important;
+  }
+  body.theme-system  .d\\:bg-silver-400 {
+    background-color: var(--silver-400) !important;
+  }
+  body.theme-system  .d\\:fc-silver-400 {
+    color: var(--silver-400) !important;
+  }
+  body.theme-system  .d\\:bg-bronze-100 {
+    background-color: var(--bronze-100) !important;
+  }
+  body.theme-system  .d\\:fc-bronze-100 {
+    color: var(--bronze-100) !important;
+  }
+  body.theme-system  .d\\:bg-bronze-200 {
+    background-color: var(--bronze-200) !important;
+  }
+  body.theme-system  .d\\:fc-bronze-200 {
+    color: var(--bronze-200) !important;
+  }
+  body.theme-system  .d\\:bg-bronze-300 {
+    background-color: var(--bronze-300) !important;
+  }
+  body.theme-system  .d\\:fc-bronze-300 {
+    color: var(--bronze-300) !important;
+  }
+  body.theme-system  .d\\:bg-bronze-400 {
+    background-color: var(--bronze-400) !important;
+  }
+  body.theme-system  .d\\:fc-bronze-400 {
+    color: var(--bronze-400) !important;
+  }
+  body.theme-system  .d\\:bg-brand {
+    background-color: var(--brand) !important;
+  }
+  body.theme-system  .d\\:fc-brand {
+    color: var(--brand) !important;
+  }
+  body.theme-system  .d\\:bg-brand-black {
+    background-color: var(--brand-black) !important;
+  }
+  body.theme-system  .d\\:fc-brand-black {
+    color: var(--brand-black) !important;
+  }
+  body.theme-system  .d\\:bg-brand-off-white {
+    background-color: var(--brand-off-white) !important;
+  }
+  body.theme-system  .d\\:fc-brand-off-white {
+    color: var(--brand-off-white) !important;
+  }
+  body.theme-system  .d\\:bg-brand-blue-light {
+    background-color: var(--brand-blue-light) !important;
+  }
+  body.theme-system  .d\\:fc-brand-blue-light {
+    color: var(--brand-blue-light) !important;
+  }
+  body.theme-system  .d\\:bg-brand-blue {
+    background-color: var(--brand-blue) !important;
+  }
+  body.theme-system  .d\\:fc-brand-blue {
+    color: var(--brand-blue) !important;
+  }
+  body.theme-system  .d\\:bg-brand-blue-dark {
+    background-color: var(--brand-blue-dark) !important;
+  }
+  body.theme-system  .d\\:fc-brand-blue-dark {
+    color: var(--brand-blue-dark) !important;
+  }
+  body.theme-system  .d\\:bg-brand-brown-light {
+    background-color: var(--brand-brown-light) !important;
+  }
+  body.theme-system  .d\\:fc-brand-brown-light {
+    color: var(--brand-brown-light) !important;
+  }
+  body.theme-system  .d\\:bg-brand-green {
+    background-color: var(--brand-green) !important;
+  }
+  body.theme-system  .d\\:fc-brand-green {
+    color: var(--brand-green) !important;
+  }
+  body.theme-system  .d\\:bg-brand-green-dark {
+    background-color: var(--brand-green-dark) !important;
+  }
+  body.theme-system  .d\\:fc-brand-green-dark {
+    color: var(--brand-green-dark) !important;
+  }
+  body.theme-system  .d\\:bg-brand-orange-medium {
+    background-color: var(--brand-orange-medium) !important;
+  }
+  body.theme-system  .d\\:fc-brand-orange-medium {
+    color: var(--brand-orange-medium) !important;
+  }
+  body.theme-system  .d\\:bg-brand-orange-dark {
+    background-color: var(--brand-orange-dark) !important;
+  }
+  body.theme-system  .d\\:fc-brand-orange-dark {
+    color: var(--brand-orange-dark) !important;
+  }
+  body.theme-system  .d\\:bg-brand-pink {
+    background-color: var(--brand-pink) !important;
+  }
+  body.theme-system  .d\\:fc-brand-pink {
+    color: var(--brand-pink) !important;
+  }
+  body.theme-system  .d\\:bg-brand-pink-dark {
+    background-color: var(--brand-pink-dark) !important;
+  }
+  body.theme-system  .d\\:fc-brand-pink-dark {
+    color: var(--brand-pink-dark) !important;
+  }
+  body.theme-system  .d\\:bg-brand-purple {
+    background-color: var(--brand-purple) !important;
+  }
+  body.theme-system  .d\\:fc-brand-purple {
+    color: var(--brand-purple) !important;
+  }
+  body.theme-system  .d\\:bg-brand-purple-dark {
+    background-color: var(--brand-purple-dark) !important;
+  }
+  body.theme-system  .d\\:fc-brand-purple-dark {
+    color: var(--brand-purple-dark) !important;
+  }
+  body.theme-system  .d\\:bg-brand-yellow {
+    background-color: var(--brand-yellow) !important;
+  }
+  body.theme-system  .d\\:fc-brand-yellow {
+    color: var(--brand-yellow) !important;
+  }
+  body.theme-system  .d\\:bg-brand-yellow-dark {
+    background-color: var(--brand-yellow-dark) !important;
+  }
+  body.theme-system  .d\\:fc-brand-yellow-dark {
+    color: var(--brand-yellow-dark) !important;
+  }
+  body.theme-system  .d\\:fc-light {
+    color: var(--fc-light) !important;
+  }
+  body.theme-system  .d\\:fc-medium {
+    color: var(--fc-medium) !important;
+  }
+  body.theme-system  .d\\:fc-dark {
+    color: var(--fc-dark) !important;
+  }
+  body.theme-system  .d\\:fc-error {
+    color: var(--fc-error) !important;
+  }
+  body.theme-system  .d\\:fc-danger {
+    color: var(--fc-danger) !important;
+  }
+  body.theme-system  .d\\:fc-success {
+    color: var(--fc-success) !important;
+  }
+  body.theme-system  .d\\:fc-warning {
+    color: var(--fc-warning) !important;
+  }
+  body.theme-system  .d\\:bg-error {
+    background-color: var(--bg-error) !important;
+  }
+  body.theme-system  .d\\:bg-danger {
+    background-color: var(--bg-danger) !important;
+  }
+  body.theme-system  .d\\:bg-success {
+    background-color: var(--bg-success) !important;
+  }
+  body.theme-system  .d\\:bg-warning {
+    background-color: var(--bg-warning) !important;
+  }
+  body.theme-system  .bg-transparent,
+  body.theme-system  .h\\:bg-transparent:hover,
+  body.theme-system  .f\\:bg-transparent:focus,
+  body.theme-system  .f\\:bg-transparent:focus-within {
+    background-color: transparent !important;
+  }
+  body.theme-system  .bc-transparent,
+  body.theme-system  .h\\:bc-transparent:hover,
+  body.theme-system  .f\\:bc-transparent:focus,
+  body.theme-system  .f\\:bc-transparent:focus-within {
+    border-color: transparent !important;
+  }
+  body.theme-system  .bg-inherit,
+  body.theme-system  .h\\:bg-inherit:hover,
+  body.theme-system  .f\\:bg-inherit:focus,
+  body.theme-system  .f\\:bg-inherit:focus-within {
+    background-color: inherit !important;
+  }
+  body.theme-system  .bc-inherit,
+  body.theme-system  .h\\:bc-inherit:hover,
+  body.theme-system  .f\\:bc-inherit:focus,
+  body.theme-system  .f\\:bc-inherit:focus-within {
+    border-color: inherit !important;
+  }
+}
+body.theme-dark  .d\\:bg-white,
+.theme-dark__forced  .d\\:bg-white,
+body.theme-system .theme-dark__forced  .d\\:bg-white {
+  background-color: var(--white) !important;
+}
+body.theme-dark  .d\\:fc-white,
+.theme-dark__forced  .d\\:fc-white,
+body.theme-system .theme-dark__forced  .d\\:fc-white {
+  color: var(--white) !important;
+}
+body.theme-dark  .d\\:bg-black-050,
+.theme-dark__forced  .d\\:bg-black-050,
+body.theme-system .theme-dark__forced  .d\\:bg-black-050 {
+  background-color: var(--black-050) !important;
+}
+body.theme-dark  .d\\:fc-black-050,
+.theme-dark__forced  .d\\:fc-black-050,
+body.theme-system .theme-dark__forced  .d\\:fc-black-050 {
+  color: var(--black-050) !important;
+}
+body.theme-dark  .d\\:bg-black-100,
+.theme-dark__forced  .d\\:bg-black-100,
+body.theme-system .theme-dark__forced  .d\\:bg-black-100 {
+  background-color: var(--black-100) !important;
+}
+body.theme-dark  .d\\:fc-black-100,
+.theme-dark__forced  .d\\:fc-black-100,
+body.theme-system .theme-dark__forced  .d\\:fc-black-100 {
+  color: var(--black-100) !important;
+}
+body.theme-dark  .d\\:bg-black-150,
+.theme-dark__forced  .d\\:bg-black-150,
+body.theme-system .theme-dark__forced  .d\\:bg-black-150 {
+  background-color: var(--black-150) !important;
+}
+body.theme-dark  .d\\:fc-black-150,
+.theme-dark__forced  .d\\:fc-black-150,
+body.theme-system .theme-dark__forced  .d\\:fc-black-150 {
+  color: var(--black-150) !important;
+}
+body.theme-dark  .d\\:bg-black-200,
+.theme-dark__forced  .d\\:bg-black-200,
+body.theme-system .theme-dark__forced  .d\\:bg-black-200 {
+  background-color: var(--black-200) !important;
+}
+body.theme-dark  .d\\:fc-black-200,
+.theme-dark__forced  .d\\:fc-black-200,
+body.theme-system .theme-dark__forced  .d\\:fc-black-200 {
+  color: var(--black-200) !important;
+}
+body.theme-dark  .d\\:bg-black-225,
+.theme-dark__forced  .d\\:bg-black-225,
+body.theme-system .theme-dark__forced  .d\\:bg-black-225 {
+  background-color: var(--black-225) !important;
+}
+body.theme-dark  .d\\:fc-black-225,
+.theme-dark__forced  .d\\:fc-black-225,
+body.theme-system .theme-dark__forced  .d\\:fc-black-225 {
+  color: var(--black-225) !important;
+}
+body.theme-dark  .d\\:bg-black-250,
+.theme-dark__forced  .d\\:bg-black-250,
+body.theme-system .theme-dark__forced  .d\\:bg-black-250 {
+  background-color: var(--black-250) !important;
+}
+body.theme-dark  .d\\:fc-black-250,
+.theme-dark__forced  .d\\:fc-black-250,
+body.theme-system .theme-dark__forced  .d\\:fc-black-250 {
+  color: var(--black-250) !important;
+}
+body.theme-dark  .d\\:bg-black-300,
+.theme-dark__forced  .d\\:bg-black-300,
+body.theme-system .theme-dark__forced  .d\\:bg-black-300 {
+  background-color: var(--black-300) !important;
+}
+body.theme-dark  .d\\:fc-black-300,
+.theme-dark__forced  .d\\:fc-black-300,
+body.theme-system .theme-dark__forced  .d\\:fc-black-300 {
+  color: var(--black-300) !important;
+}
+body.theme-dark  .d\\:bg-black-350,
+.theme-dark__forced  .d\\:bg-black-350,
+body.theme-system .theme-dark__forced  .d\\:bg-black-350 {
+  background-color: var(--black-350) !important;
+}
+body.theme-dark  .d\\:fc-black-350,
+.theme-dark__forced  .d\\:fc-black-350,
+body.theme-system .theme-dark__forced  .d\\:fc-black-350 {
+  color: var(--black-350) !important;
+}
+body.theme-dark  .d\\:bg-black-400,
+.theme-dark__forced  .d\\:bg-black-400,
+body.theme-system .theme-dark__forced  .d\\:bg-black-400 {
+  background-color: var(--black-400) !important;
+}
+body.theme-dark  .d\\:fc-black-400,
+.theme-dark__forced  .d\\:fc-black-400,
+body.theme-system .theme-dark__forced  .d\\:fc-black-400 {
+  color: var(--black-400) !important;
+}
+body.theme-dark  .d\\:bg-black-500,
+.theme-dark__forced  .d\\:bg-black-500,
+body.theme-system .theme-dark__forced  .d\\:bg-black-500 {
+  background-color: var(--black-500) !important;
+}
+body.theme-dark  .d\\:fc-black-500,
+.theme-dark__forced  .d\\:fc-black-500,
+body.theme-system .theme-dark__forced  .d\\:fc-black-500 {
+  color: var(--black-500) !important;
+}
+body.theme-dark  .d\\:bg-black-600,
+.theme-dark__forced  .d\\:bg-black-600,
+body.theme-system .theme-dark__forced  .d\\:bg-black-600 {
+  background-color: var(--black-600) !important;
+}
+body.theme-dark  .d\\:fc-black-600,
+.theme-dark__forced  .d\\:fc-black-600,
+body.theme-system .theme-dark__forced  .d\\:fc-black-600 {
+  color: var(--black-600) !important;
+}
+body.theme-dark  .d\\:bg-black,
+.theme-dark__forced  .d\\:bg-black,
+body.theme-system .theme-dark__forced  .d\\:bg-black {
+  background-color: var(--black) !important;
+}
+body.theme-dark  .d\\:fc-black,
+.theme-dark__forced  .d\\:fc-black,
+body.theme-system .theme-dark__forced  .d\\:fc-black {
+  color: var(--black) !important;
+}
+body.theme-dark  .d\\:bg-orange-100,
+.theme-dark__forced  .d\\:bg-orange-100,
+body.theme-system .theme-dark__forced  .d\\:bg-orange-100 {
+  background-color: var(--orange-100) !important;
+}
+body.theme-dark  .d\\:fc-orange-100,
+.theme-dark__forced  .d\\:fc-orange-100,
+body.theme-system .theme-dark__forced  .d\\:fc-orange-100 {
+  color: var(--orange-100) !important;
+}
+body.theme-dark  .d\\:bg-orange-200,
+.theme-dark__forced  .d\\:bg-orange-200,
+body.theme-system .theme-dark__forced  .d\\:bg-orange-200 {
+  background-color: var(--orange-200) !important;
+}
+body.theme-dark  .d\\:fc-orange-200,
+.theme-dark__forced  .d\\:fc-orange-200,
+body.theme-system .theme-dark__forced  .d\\:fc-orange-200 {
+  color: var(--orange-200) !important;
+}
+body.theme-dark  .d\\:bg-orange-300,
+.theme-dark__forced  .d\\:bg-orange-300,
+body.theme-system .theme-dark__forced  .d\\:bg-orange-300 {
+  background-color: var(--orange-300) !important;
+}
+body.theme-dark  .d\\:fc-orange-300,
+.theme-dark__forced  .d\\:fc-orange-300,
+body.theme-system .theme-dark__forced  .d\\:fc-orange-300 {
+  color: var(--orange-300) !important;
+}
+body.theme-dark  .d\\:bg-orange-400,
+.theme-dark__forced  .d\\:bg-orange-400,
+body.theme-system .theme-dark__forced  .d\\:bg-orange-400 {
+  background-color: var(--orange-400) !important;
+}
+body.theme-dark  .d\\:fc-orange-400,
+.theme-dark__forced  .d\\:fc-orange-400,
+body.theme-system .theme-dark__forced  .d\\:fc-orange-400 {
+  color: var(--orange-400) !important;
+}
+body.theme-dark  .d\\:bg-orange-500,
+.theme-dark__forced  .d\\:bg-orange-500,
+body.theme-system .theme-dark__forced  .d\\:bg-orange-500 {
+  background-color: var(--orange-500) !important;
+}
+body.theme-dark  .d\\:fc-orange-500,
+.theme-dark__forced  .d\\:fc-orange-500,
+body.theme-system .theme-dark__forced  .d\\:fc-orange-500 {
+  color: var(--orange-500) !important;
+}
+body.theme-dark  .d\\:bg-orange-600,
+.theme-dark__forced  .d\\:bg-orange-600,
+body.theme-system .theme-dark__forced  .d\\:bg-orange-600 {
+  background-color: var(--orange-600) !important;
+}
+body.theme-dark  .d\\:fc-orange-600,
+.theme-dark__forced  .d\\:fc-orange-600,
+body.theme-system .theme-dark__forced  .d\\:fc-orange-600 {
+  color: var(--orange-600) !important;
+}
+body.theme-dark  .d\\:bg-blue-100,
+.theme-dark__forced  .d\\:bg-blue-100,
+body.theme-system .theme-dark__forced  .d\\:bg-blue-100 {
+  background-color: var(--blue-100) !important;
+}
+body.theme-dark  .d\\:fc-blue-100,
+.theme-dark__forced  .d\\:fc-blue-100,
+body.theme-system .theme-dark__forced  .d\\:fc-blue-100 {
+  color: var(--blue-100) !important;
+}
+body.theme-dark  .d\\:bg-blue-200,
+.theme-dark__forced  .d\\:bg-blue-200,
+body.theme-system .theme-dark__forced  .d\\:bg-blue-200 {
+  background-color: var(--blue-200) !important;
+}
+body.theme-dark  .d\\:fc-blue-200,
+.theme-dark__forced  .d\\:fc-blue-200,
+body.theme-system .theme-dark__forced  .d\\:fc-blue-200 {
+  color: var(--blue-200) !important;
+}
+body.theme-dark  .d\\:bg-blue-300,
+.theme-dark__forced  .d\\:bg-blue-300,
+body.theme-system .theme-dark__forced  .d\\:bg-blue-300 {
+  background-color: var(--blue-300) !important;
+}
+body.theme-dark  .d\\:fc-blue-300,
+.theme-dark__forced  .d\\:fc-blue-300,
+body.theme-system .theme-dark__forced  .d\\:fc-blue-300 {
+  color: var(--blue-300) !important;
+}
+body.theme-dark  .d\\:bg-blue-400,
+.theme-dark__forced  .d\\:bg-blue-400,
+body.theme-system .theme-dark__forced  .d\\:bg-blue-400 {
+  background-color: var(--blue-400) !important;
+}
+body.theme-dark  .d\\:fc-blue-400,
+.theme-dark__forced  .d\\:fc-blue-400,
+body.theme-system .theme-dark__forced  .d\\:fc-blue-400 {
+  color: var(--blue-400) !important;
+}
+body.theme-dark  .d\\:bg-blue-500,
+.theme-dark__forced  .d\\:bg-blue-500,
+body.theme-system .theme-dark__forced  .d\\:bg-blue-500 {
+  background-color: var(--blue-500) !important;
+}
+body.theme-dark  .d\\:fc-blue-500,
+.theme-dark__forced  .d\\:fc-blue-500,
+body.theme-system .theme-dark__forced  .d\\:fc-blue-500 {
+  color: var(--blue-500) !important;
+}
+body.theme-dark  .d\\:bg-blue-600,
+.theme-dark__forced  .d\\:bg-blue-600,
+body.theme-system .theme-dark__forced  .d\\:bg-blue-600 {
+  background-color: var(--blue-600) !important;
+}
+body.theme-dark  .d\\:fc-blue-600,
+.theme-dark__forced  .d\\:fc-blue-600,
+body.theme-system .theme-dark__forced  .d\\:fc-blue-600 {
+  color: var(--blue-600) !important;
+}
+body.theme-dark  .d\\:bg-green-100,
+.theme-dark__forced  .d\\:bg-green-100,
+body.theme-system .theme-dark__forced  .d\\:bg-green-100 {
+  background-color: var(--green-100) !important;
+}
+body.theme-dark  .d\\:fc-green-100,
+.theme-dark__forced  .d\\:fc-green-100,
+body.theme-system .theme-dark__forced  .d\\:fc-green-100 {
+  color: var(--green-100) !important;
+}
+body.theme-dark  .d\\:bg-green-200,
+.theme-dark__forced  .d\\:bg-green-200,
+body.theme-system .theme-dark__forced  .d\\:bg-green-200 {
+  background-color: var(--green-200) !important;
+}
+body.theme-dark  .d\\:fc-green-200,
+.theme-dark__forced  .d\\:fc-green-200,
+body.theme-system .theme-dark__forced  .d\\:fc-green-200 {
+  color: var(--green-200) !important;
+}
+body.theme-dark  .d\\:bg-green-300,
+.theme-dark__forced  .d\\:bg-green-300,
+body.theme-system .theme-dark__forced  .d\\:bg-green-300 {
+  background-color: var(--green-300) !important;
+}
+body.theme-dark  .d\\:fc-green-300,
+.theme-dark__forced  .d\\:fc-green-300,
+body.theme-system .theme-dark__forced  .d\\:fc-green-300 {
+  color: var(--green-300) !important;
+}
+body.theme-dark  .d\\:bg-green-400,
+.theme-dark__forced  .d\\:bg-green-400,
+body.theme-system .theme-dark__forced  .d\\:bg-green-400 {
+  background-color: var(--green-400) !important;
+}
+body.theme-dark  .d\\:fc-green-400,
+.theme-dark__forced  .d\\:fc-green-400,
+body.theme-system .theme-dark__forced  .d\\:fc-green-400 {
+  color: var(--green-400) !important;
+}
+body.theme-dark  .d\\:bg-green-500,
+.theme-dark__forced  .d\\:bg-green-500,
+body.theme-system .theme-dark__forced  .d\\:bg-green-500 {
+  background-color: var(--green-500) !important;
+}
+body.theme-dark  .d\\:fc-green-500,
+.theme-dark__forced  .d\\:fc-green-500,
+body.theme-system .theme-dark__forced  .d\\:fc-green-500 {
+  color: var(--green-500) !important;
+}
+body.theme-dark  .d\\:bg-green-600,
+.theme-dark__forced  .d\\:bg-green-600,
+body.theme-system .theme-dark__forced  .d\\:bg-green-600 {
+  background-color: var(--green-600) !important;
+}
+body.theme-dark  .d\\:fc-green-600,
+.theme-dark__forced  .d\\:fc-green-600,
+body.theme-system .theme-dark__forced  .d\\:fc-green-600 {
+  color: var(--green-600) !important;
+}
+body.theme-dark  .d\\:bg-red-100,
+.theme-dark__forced  .d\\:bg-red-100,
+body.theme-system .theme-dark__forced  .d\\:bg-red-100 {
+  background-color: var(--red-100) !important;
+}
+body.theme-dark  .d\\:fc-red-100,
+.theme-dark__forced  .d\\:fc-red-100,
+body.theme-system .theme-dark__forced  .d\\:fc-red-100 {
+  color: var(--red-100) !important;
+}
+body.theme-dark  .d\\:bg-red-200,
+.theme-dark__forced  .d\\:bg-red-200,
+body.theme-system .theme-dark__forced  .d\\:bg-red-200 {
+  background-color: var(--red-200) !important;
+}
+body.theme-dark  .d\\:fc-red-200,
+.theme-dark__forced  .d\\:fc-red-200,
+body.theme-system .theme-dark__forced  .d\\:fc-red-200 {
+  color: var(--red-200) !important;
+}
+body.theme-dark  .d\\:bg-red-300,
+.theme-dark__forced  .d\\:bg-red-300,
+body.theme-system .theme-dark__forced  .d\\:bg-red-300 {
+  background-color: var(--red-300) !important;
+}
+body.theme-dark  .d\\:fc-red-300,
+.theme-dark__forced  .d\\:fc-red-300,
+body.theme-system .theme-dark__forced  .d\\:fc-red-300 {
+  color: var(--red-300) !important;
+}
+body.theme-dark  .d\\:bg-red-400,
+.theme-dark__forced  .d\\:bg-red-400,
+body.theme-system .theme-dark__forced  .d\\:bg-red-400 {
+  background-color: var(--red-400) !important;
+}
+body.theme-dark  .d\\:fc-red-400,
+.theme-dark__forced  .d\\:fc-red-400,
+body.theme-system .theme-dark__forced  .d\\:fc-red-400 {
+  color: var(--red-400) !important;
+}
+body.theme-dark  .d\\:bg-red-500,
+.theme-dark__forced  .d\\:bg-red-500,
+body.theme-system .theme-dark__forced  .d\\:bg-red-500 {
+  background-color: var(--red-500) !important;
+}
+body.theme-dark  .d\\:fc-red-500,
+.theme-dark__forced  .d\\:fc-red-500,
+body.theme-system .theme-dark__forced  .d\\:fc-red-500 {
+  color: var(--red-500) !important;
+}
+body.theme-dark  .d\\:bg-red-600,
+.theme-dark__forced  .d\\:bg-red-600,
+body.theme-system .theme-dark__forced  .d\\:bg-red-600 {
+  background-color: var(--red-600) !important;
+}
+body.theme-dark  .d\\:fc-red-600,
+.theme-dark__forced  .d\\:fc-red-600,
+body.theme-system .theme-dark__forced  .d\\:fc-red-600 {
+  color: var(--red-600) !important;
+}
+body.theme-dark  .d\\:bg-yellow-100,
+.theme-dark__forced  .d\\:bg-yellow-100,
+body.theme-system .theme-dark__forced  .d\\:bg-yellow-100 {
+  background-color: var(--yellow-100) !important;
+}
+body.theme-dark  .d\\:fc-yellow-100,
+.theme-dark__forced  .d\\:fc-yellow-100,
+body.theme-system .theme-dark__forced  .d\\:fc-yellow-100 {
+  color: var(--yellow-100) !important;
+}
+body.theme-dark  .d\\:bg-yellow-200,
+.theme-dark__forced  .d\\:bg-yellow-200,
+body.theme-system .theme-dark__forced  .d\\:bg-yellow-200 {
+  background-color: var(--yellow-200) !important;
+}
+body.theme-dark  .d\\:fc-yellow-200,
+.theme-dark__forced  .d\\:fc-yellow-200,
+body.theme-system .theme-dark__forced  .d\\:fc-yellow-200 {
+  color: var(--yellow-200) !important;
+}
+body.theme-dark  .d\\:bg-yellow-300,
+.theme-dark__forced  .d\\:bg-yellow-300,
+body.theme-system .theme-dark__forced  .d\\:bg-yellow-300 {
+  background-color: var(--yellow-300) !important;
+}
+body.theme-dark  .d\\:fc-yellow-300,
+.theme-dark__forced  .d\\:fc-yellow-300,
+body.theme-system .theme-dark__forced  .d\\:fc-yellow-300 {
+  color: var(--yellow-300) !important;
+}
+body.theme-dark  .d\\:bg-yellow-400,
+.theme-dark__forced  .d\\:bg-yellow-400,
+body.theme-system .theme-dark__forced  .d\\:bg-yellow-400 {
+  background-color: var(--yellow-400) !important;
+}
+body.theme-dark  .d\\:fc-yellow-400,
+.theme-dark__forced  .d\\:fc-yellow-400,
+body.theme-system .theme-dark__forced  .d\\:fc-yellow-400 {
+  color: var(--yellow-400) !important;
+}
+body.theme-dark  .d\\:bg-yellow-500,
+.theme-dark__forced  .d\\:bg-yellow-500,
+body.theme-system .theme-dark__forced  .d\\:bg-yellow-500 {
+  background-color: var(--yellow-500) !important;
+}
+body.theme-dark  .d\\:fc-yellow-500,
+.theme-dark__forced  .d\\:fc-yellow-500,
+body.theme-system .theme-dark__forced  .d\\:fc-yellow-500 {
+  color: var(--yellow-500) !important;
+}
+body.theme-dark  .d\\:bg-yellow-600,
+.theme-dark__forced  .d\\:bg-yellow-600,
+body.theme-system .theme-dark__forced  .d\\:bg-yellow-600 {
+  background-color: var(--yellow-600) !important;
+}
+body.theme-dark  .d\\:fc-yellow-600,
+.theme-dark__forced  .d\\:fc-yellow-600,
+body.theme-system .theme-dark__forced  .d\\:fc-yellow-600 {
+  color: var(--yellow-600) !important;
+}
+body.theme-dark  .d\\:bg-purple-100,
+.theme-dark__forced  .d\\:bg-purple-100,
+body.theme-system .theme-dark__forced  .d\\:bg-purple-100 {
+  background-color: var(--purple-100) !important;
+}
+body.theme-dark  .d\\:fc-purple-100,
+.theme-dark__forced  .d\\:fc-purple-100,
+body.theme-system .theme-dark__forced  .d\\:fc-purple-100 {
+  color: var(--purple-100) !important;
+}
+body.theme-dark  .d\\:bg-purple-200,
+.theme-dark__forced  .d\\:bg-purple-200,
+body.theme-system .theme-dark__forced  .d\\:bg-purple-200 {
+  background-color: var(--purple-200) !important;
+}
+body.theme-dark  .d\\:fc-purple-200,
+.theme-dark__forced  .d\\:fc-purple-200,
+body.theme-system .theme-dark__forced  .d\\:fc-purple-200 {
+  color: var(--purple-200) !important;
+}
+body.theme-dark  .d\\:bg-purple-300,
+.theme-dark__forced  .d\\:bg-purple-300,
+body.theme-system .theme-dark__forced  .d\\:bg-purple-300 {
+  background-color: var(--purple-300) !important;
+}
+body.theme-dark  .d\\:fc-purple-300,
+.theme-dark__forced  .d\\:fc-purple-300,
+body.theme-system .theme-dark__forced  .d\\:fc-purple-300 {
+  color: var(--purple-300) !important;
+}
+body.theme-dark  .d\\:bg-purple-400,
+.theme-dark__forced  .d\\:bg-purple-400,
+body.theme-system .theme-dark__forced  .d\\:bg-purple-400 {
+  background-color: var(--purple-400) !important;
+}
+body.theme-dark  .d\\:fc-purple-400,
+.theme-dark__forced  .d\\:fc-purple-400,
+body.theme-system .theme-dark__forced  .d\\:fc-purple-400 {
+  color: var(--purple-400) !important;
+}
+body.theme-dark  .d\\:bg-purple-500,
+.theme-dark__forced  .d\\:bg-purple-500,
+body.theme-system .theme-dark__forced  .d\\:bg-purple-500 {
+  background-color: var(--purple-500) !important;
+}
+body.theme-dark  .d\\:fc-purple-500,
+.theme-dark__forced  .d\\:fc-purple-500,
+body.theme-system .theme-dark__forced  .d\\:fc-purple-500 {
+  color: var(--purple-500) !important;
+}
+body.theme-dark  .d\\:bg-purple-600,
+.theme-dark__forced  .d\\:bg-purple-600,
+body.theme-system .theme-dark__forced  .d\\:bg-purple-600 {
+  background-color: var(--purple-600) !important;
+}
+body.theme-dark  .d\\:fc-purple-600,
+.theme-dark__forced  .d\\:fc-purple-600,
+body.theme-system .theme-dark__forced  .d\\:fc-purple-600 {
+  color: var(--purple-600) !important;
+}
+body.theme-dark  .d\\:bg-pink-100,
+.theme-dark__forced  .d\\:bg-pink-100,
+body.theme-system .theme-dark__forced  .d\\:bg-pink-100 {
+  background-color: var(--pink-100) !important;
+}
+body.theme-dark  .d\\:fc-pink-100,
+.theme-dark__forced  .d\\:fc-pink-100,
+body.theme-system .theme-dark__forced  .d\\:fc-pink-100 {
+  color: var(--pink-100) !important;
+}
+body.theme-dark  .d\\:bg-pink-200,
+.theme-dark__forced  .d\\:bg-pink-200,
+body.theme-system .theme-dark__forced  .d\\:bg-pink-200 {
+  background-color: var(--pink-200) !important;
+}
+body.theme-dark  .d\\:fc-pink-200,
+.theme-dark__forced  .d\\:fc-pink-200,
+body.theme-system .theme-dark__forced  .d\\:fc-pink-200 {
+  color: var(--pink-200) !important;
+}
+body.theme-dark  .d\\:bg-pink-300,
+.theme-dark__forced  .d\\:bg-pink-300,
+body.theme-system .theme-dark__forced  .d\\:bg-pink-300 {
+  background-color: var(--pink-300) !important;
+}
+body.theme-dark  .d\\:fc-pink-300,
+.theme-dark__forced  .d\\:fc-pink-300,
+body.theme-system .theme-dark__forced  .d\\:fc-pink-300 {
+  color: var(--pink-300) !important;
+}
+body.theme-dark  .d\\:bg-pink-400,
+.theme-dark__forced  .d\\:bg-pink-400,
+body.theme-system .theme-dark__forced  .d\\:bg-pink-400 {
+  background-color: var(--pink-400) !important;
+}
+body.theme-dark  .d\\:fc-pink-400,
+.theme-dark__forced  .d\\:fc-pink-400,
+body.theme-system .theme-dark__forced  .d\\:fc-pink-400 {
+  color: var(--pink-400) !important;
+}
+body.theme-dark  .d\\:bg-pink-500,
+.theme-dark__forced  .d\\:bg-pink-500,
+body.theme-system .theme-dark__forced  .d\\:bg-pink-500 {
+  background-color: var(--pink-500) !important;
+}
+body.theme-dark  .d\\:fc-pink-500,
+.theme-dark__forced  .d\\:fc-pink-500,
+body.theme-system .theme-dark__forced  .d\\:fc-pink-500 {
+  color: var(--pink-500) !important;
+}
+body.theme-dark  .d\\:bg-pink-600,
+.theme-dark__forced  .d\\:bg-pink-600,
+body.theme-system .theme-dark__forced  .d\\:bg-pink-600 {
+  background-color: var(--pink-600) !important;
+}
+body.theme-dark  .d\\:fc-pink-600,
+.theme-dark__forced  .d\\:fc-pink-600,
+body.theme-system .theme-dark__forced  .d\\:fc-pink-600 {
+  color: var(--pink-600) !important;
+}
+body.theme-dark  .d\\:bg-gold-100,
+.theme-dark__forced  .d\\:bg-gold-100,
+body.theme-system .theme-dark__forced  .d\\:bg-gold-100 {
+  background-color: var(--gold-100) !important;
+}
+body.theme-dark  .d\\:fc-gold-100,
+.theme-dark__forced  .d\\:fc-gold-100,
+body.theme-system .theme-dark__forced  .d\\:fc-gold-100 {
+  color: var(--gold-100) !important;
+}
+body.theme-dark  .d\\:bg-gold-200,
+.theme-dark__forced  .d\\:bg-gold-200,
+body.theme-system .theme-dark__forced  .d\\:bg-gold-200 {
+  background-color: var(--gold-200) !important;
+}
+body.theme-dark  .d\\:fc-gold-200,
+.theme-dark__forced  .d\\:fc-gold-200,
+body.theme-system .theme-dark__forced  .d\\:fc-gold-200 {
+  color: var(--gold-200) !important;
+}
+body.theme-dark  .d\\:bg-gold-300,
+.theme-dark__forced  .d\\:bg-gold-300,
+body.theme-system .theme-dark__forced  .d\\:bg-gold-300 {
+  background-color: var(--gold-300) !important;
+}
+body.theme-dark  .d\\:fc-gold-300,
+.theme-dark__forced  .d\\:fc-gold-300,
+body.theme-system .theme-dark__forced  .d\\:fc-gold-300 {
+  color: var(--gold-300) !important;
+}
+body.theme-dark  .d\\:bg-gold-400,
+.theme-dark__forced  .d\\:bg-gold-400,
+body.theme-system .theme-dark__forced  .d\\:bg-gold-400 {
+  background-color: var(--gold-400) !important;
+}
+body.theme-dark  .d\\:fc-gold-400,
+.theme-dark__forced  .d\\:fc-gold-400,
+body.theme-system .theme-dark__forced  .d\\:fc-gold-400 {
+  color: var(--gold-400) !important;
+}
+body.theme-dark  .d\\:bg-silver-100,
+.theme-dark__forced  .d\\:bg-silver-100,
+body.theme-system .theme-dark__forced  .d\\:bg-silver-100 {
+  background-color: var(--silver-100) !important;
+}
+body.theme-dark  .d\\:fc-silver-100,
+.theme-dark__forced  .d\\:fc-silver-100,
+body.theme-system .theme-dark__forced  .d\\:fc-silver-100 {
+  color: var(--silver-100) !important;
+}
+body.theme-dark  .d\\:bg-silver-200,
+.theme-dark__forced  .d\\:bg-silver-200,
+body.theme-system .theme-dark__forced  .d\\:bg-silver-200 {
+  background-color: var(--silver-200) !important;
+}
+body.theme-dark  .d\\:fc-silver-200,
+.theme-dark__forced  .d\\:fc-silver-200,
+body.theme-system .theme-dark__forced  .d\\:fc-silver-200 {
+  color: var(--silver-200) !important;
+}
+body.theme-dark  .d\\:bg-silver-300,
+.theme-dark__forced  .d\\:bg-silver-300,
+body.theme-system .theme-dark__forced  .d\\:bg-silver-300 {
+  background-color: var(--silver-300) !important;
+}
+body.theme-dark  .d\\:fc-silver-300,
+.theme-dark__forced  .d\\:fc-silver-300,
+body.theme-system .theme-dark__forced  .d\\:fc-silver-300 {
+  color: var(--silver-300) !important;
+}
+body.theme-dark  .d\\:bg-silver-400,
+.theme-dark__forced  .d\\:bg-silver-400,
+body.theme-system .theme-dark__forced  .d\\:bg-silver-400 {
+  background-color: var(--silver-400) !important;
+}
+body.theme-dark  .d\\:fc-silver-400,
+.theme-dark__forced  .d\\:fc-silver-400,
+body.theme-system .theme-dark__forced  .d\\:fc-silver-400 {
+  color: var(--silver-400) !important;
+}
+body.theme-dark  .d\\:bg-bronze-100,
+.theme-dark__forced  .d\\:bg-bronze-100,
+body.theme-system .theme-dark__forced  .d\\:bg-bronze-100 {
+  background-color: var(--bronze-100) !important;
+}
+body.theme-dark  .d\\:fc-bronze-100,
+.theme-dark__forced  .d\\:fc-bronze-100,
+body.theme-system .theme-dark__forced  .d\\:fc-bronze-100 {
+  color: var(--bronze-100) !important;
+}
+body.theme-dark  .d\\:bg-bronze-200,
+.theme-dark__forced  .d\\:bg-bronze-200,
+body.theme-system .theme-dark__forced  .d\\:bg-bronze-200 {
+  background-color: var(--bronze-200) !important;
+}
+body.theme-dark  .d\\:fc-bronze-200,
+.theme-dark__forced  .d\\:fc-bronze-200,
+body.theme-system .theme-dark__forced  .d\\:fc-bronze-200 {
+  color: var(--bronze-200) !important;
+}
+body.theme-dark  .d\\:bg-bronze-300,
+.theme-dark__forced  .d\\:bg-bronze-300,
+body.theme-system .theme-dark__forced  .d\\:bg-bronze-300 {
+  background-color: var(--bronze-300) !important;
+}
+body.theme-dark  .d\\:fc-bronze-300,
+.theme-dark__forced  .d\\:fc-bronze-300,
+body.theme-system .theme-dark__forced  .d\\:fc-bronze-300 {
+  color: var(--bronze-300) !important;
+}
+body.theme-dark  .d\\:bg-bronze-400,
+.theme-dark__forced  .d\\:bg-bronze-400,
+body.theme-system .theme-dark__forced  .d\\:bg-bronze-400 {
+  background-color: var(--bronze-400) !important;
+}
+body.theme-dark  .d\\:fc-bronze-400,
+.theme-dark__forced  .d\\:fc-bronze-400,
+body.theme-system .theme-dark__forced  .d\\:fc-bronze-400 {
+  color: var(--bronze-400) !important;
+}
+body.theme-dark  .d\\:bg-brand,
+.theme-dark__forced  .d\\:bg-brand,
+body.theme-system .theme-dark__forced  .d\\:bg-brand {
+  background-color: var(--brand) !important;
+}
+body.theme-dark  .d\\:fc-brand,
+.theme-dark__forced  .d\\:fc-brand,
+body.theme-system .theme-dark__forced  .d\\:fc-brand {
+  color: var(--brand) !important;
+}
+body.theme-dark  .d\\:bg-brand-black,
+.theme-dark__forced  .d\\:bg-brand-black,
+body.theme-system .theme-dark__forced  .d\\:bg-brand-black {
+  background-color: var(--brand-black) !important;
+}
+body.theme-dark  .d\\:fc-brand-black,
+.theme-dark__forced  .d\\:fc-brand-black,
+body.theme-system .theme-dark__forced  .d\\:fc-brand-black {
+  color: var(--brand-black) !important;
+}
+body.theme-dark  .d\\:bg-brand-off-white,
+.theme-dark__forced  .d\\:bg-brand-off-white,
+body.theme-system .theme-dark__forced  .d\\:bg-brand-off-white {
+  background-color: var(--brand-off-white) !important;
+}
+body.theme-dark  .d\\:fc-brand-off-white,
+.theme-dark__forced  .d\\:fc-brand-off-white,
+body.theme-system .theme-dark__forced  .d\\:fc-brand-off-white {
+  color: var(--brand-off-white) !important;
+}
+body.theme-dark  .d\\:bg-brand-blue-light,
+.theme-dark__forced  .d\\:bg-brand-blue-light,
+body.theme-system .theme-dark__forced  .d\\:bg-brand-blue-light {
+  background-color: var(--brand-blue-light) !important;
+}
+body.theme-dark  .d\\:fc-brand-blue-light,
+.theme-dark__forced  .d\\:fc-brand-blue-light,
+body.theme-system .theme-dark__forced  .d\\:fc-brand-blue-light {
+  color: var(--brand-blue-light) !important;
+}
+body.theme-dark  .d\\:bg-brand-blue,
+.theme-dark__forced  .d\\:bg-brand-blue,
+body.theme-system .theme-dark__forced  .d\\:bg-brand-blue {
+  background-color: var(--brand-blue) !important;
+}
+body.theme-dark  .d\\:fc-brand-blue,
+.theme-dark__forced  .d\\:fc-brand-blue,
+body.theme-system .theme-dark__forced  .d\\:fc-brand-blue {
+  color: var(--brand-blue) !important;
+}
+body.theme-dark  .d\\:bg-brand-blue-dark,
+.theme-dark__forced  .d\\:bg-brand-blue-dark,
+body.theme-system .theme-dark__forced  .d\\:bg-brand-blue-dark {
+  background-color: var(--brand-blue-dark) !important;
+}
+body.theme-dark  .d\\:fc-brand-blue-dark,
+.theme-dark__forced  .d\\:fc-brand-blue-dark,
+body.theme-system .theme-dark__forced  .d\\:fc-brand-blue-dark {
+  color: var(--brand-blue-dark) !important;
+}
+body.theme-dark  .d\\:bg-brand-brown-light,
+.theme-dark__forced  .d\\:bg-brand-brown-light,
+body.theme-system .theme-dark__forced  .d\\:bg-brand-brown-light {
+  background-color: var(--brand-brown-light) !important;
+}
+body.theme-dark  .d\\:fc-brand-brown-light,
+.theme-dark__forced  .d\\:fc-brand-brown-light,
+body.theme-system .theme-dark__forced  .d\\:fc-brand-brown-light {
+  color: var(--brand-brown-light) !important;
+}
+body.theme-dark  .d\\:bg-brand-green,
+.theme-dark__forced  .d\\:bg-brand-green,
+body.theme-system .theme-dark__forced  .d\\:bg-brand-green {
+  background-color: var(--brand-green) !important;
+}
+body.theme-dark  .d\\:fc-brand-green,
+.theme-dark__forced  .d\\:fc-brand-green,
+body.theme-system .theme-dark__forced  .d\\:fc-brand-green {
+  color: var(--brand-green) !important;
+}
+body.theme-dark  .d\\:bg-brand-green-dark,
+.theme-dark__forced  .d\\:bg-brand-green-dark,
+body.theme-system .theme-dark__forced  .d\\:bg-brand-green-dark {
+  background-color: var(--brand-green-dark) !important;
+}
+body.theme-dark  .d\\:fc-brand-green-dark,
+.theme-dark__forced  .d\\:fc-brand-green-dark,
+body.theme-system .theme-dark__forced  .d\\:fc-brand-green-dark {
+  color: var(--brand-green-dark) !important;
+}
+body.theme-dark  .d\\:bg-brand-orange-medium,
+.theme-dark__forced  .d\\:bg-brand-orange-medium,
+body.theme-system .theme-dark__forced  .d\\:bg-brand-orange-medium {
+  background-color: var(--brand-orange-medium) !important;
+}
+body.theme-dark  .d\\:fc-brand-orange-medium,
+.theme-dark__forced  .d\\:fc-brand-orange-medium,
+body.theme-system .theme-dark__forced  .d\\:fc-brand-orange-medium {
+  color: var(--brand-orange-medium) !important;
+}
+body.theme-dark  .d\\:bg-brand-orange-dark,
+.theme-dark__forced  .d\\:bg-brand-orange-dark,
+body.theme-system .theme-dark__forced  .d\\:bg-brand-orange-dark {
+  background-color: var(--brand-orange-dark) !important;
+}
+body.theme-dark  .d\\:fc-brand-orange-dark,
+.theme-dark__forced  .d\\:fc-brand-orange-dark,
+body.theme-system .theme-dark__forced  .d\\:fc-brand-orange-dark {
+  color: var(--brand-orange-dark) !important;
+}
+body.theme-dark  .d\\:bg-brand-pink,
+.theme-dark__forced  .d\\:bg-brand-pink,
+body.theme-system .theme-dark__forced  .d\\:bg-brand-pink {
+  background-color: var(--brand-pink) !important;
+}
+body.theme-dark  .d\\:fc-brand-pink,
+.theme-dark__forced  .d\\:fc-brand-pink,
+body.theme-system .theme-dark__forced  .d\\:fc-brand-pink {
+  color: var(--brand-pink) !important;
+}
+body.theme-dark  .d\\:bg-brand-pink-dark,
+.theme-dark__forced  .d\\:bg-brand-pink-dark,
+body.theme-system .theme-dark__forced  .d\\:bg-brand-pink-dark {
+  background-color: var(--brand-pink-dark) !important;
+}
+body.theme-dark  .d\\:fc-brand-pink-dark,
+.theme-dark__forced  .d\\:fc-brand-pink-dark,
+body.theme-system .theme-dark__forced  .d\\:fc-brand-pink-dark {
+  color: var(--brand-pink-dark) !important;
+}
+body.theme-dark  .d\\:bg-brand-purple,
+.theme-dark__forced  .d\\:bg-brand-purple,
+body.theme-system .theme-dark__forced  .d\\:bg-brand-purple {
+  background-color: var(--brand-purple) !important;
+}
+body.theme-dark  .d\\:fc-brand-purple,
+.theme-dark__forced  .d\\:fc-brand-purple,
+body.theme-system .theme-dark__forced  .d\\:fc-brand-purple {
+  color: var(--brand-purple) !important;
+}
+body.theme-dark  .d\\:bg-brand-purple-dark,
+.theme-dark__forced  .d\\:bg-brand-purple-dark,
+body.theme-system .theme-dark__forced  .d\\:bg-brand-purple-dark {
+  background-color: var(--brand-purple-dark) !important;
+}
+body.theme-dark  .d\\:fc-brand-purple-dark,
+.theme-dark__forced  .d\\:fc-brand-purple-dark,
+body.theme-system .theme-dark__forced  .d\\:fc-brand-purple-dark {
+  color: var(--brand-purple-dark) !important;
+}
+body.theme-dark  .d\\:bg-brand-yellow,
+.theme-dark__forced  .d\\:bg-brand-yellow,
+body.theme-system .theme-dark__forced  .d\\:bg-brand-yellow {
+  background-color: var(--brand-yellow) !important;
+}
+body.theme-dark  .d\\:fc-brand-yellow,
+.theme-dark__forced  .d\\:fc-brand-yellow,
+body.theme-system .theme-dark__forced  .d\\:fc-brand-yellow {
+  color: var(--brand-yellow) !important;
+}
+body.theme-dark  .d\\:bg-brand-yellow-dark,
+.theme-dark__forced  .d\\:bg-brand-yellow-dark,
+body.theme-system .theme-dark__forced  .d\\:bg-brand-yellow-dark {
+  background-color: var(--brand-yellow-dark) !important;
+}
+body.theme-dark  .d\\:fc-brand-yellow-dark,
+.theme-dark__forced  .d\\:fc-brand-yellow-dark,
+body.theme-system .theme-dark__forced  .d\\:fc-brand-yellow-dark {
+  color: var(--brand-yellow-dark) !important;
+}
+body.theme-dark  .d\\:fc-light,
+.theme-dark__forced  .d\\:fc-light,
+body.theme-system .theme-dark__forced  .d\\:fc-light {
+  color: var(--fc-light) !important;
+}
+body.theme-dark  .d\\:fc-medium,
+.theme-dark__forced  .d\\:fc-medium,
+body.theme-system .theme-dark__forced  .d\\:fc-medium {
+  color: var(--fc-medium) !important;
+}
+body.theme-dark  .d\\:fc-dark,
+.theme-dark__forced  .d\\:fc-dark,
+body.theme-system .theme-dark__forced  .d\\:fc-dark {
+  color: var(--fc-dark) !important;
+}
+body.theme-dark  .d\\:fc-error,
+.theme-dark__forced  .d\\:fc-error,
+body.theme-system .theme-dark__forced  .d\\:fc-error {
+  color: var(--fc-error) !important;
+}
+body.theme-dark  .d\\:fc-danger,
+.theme-dark__forced  .d\\:fc-danger,
+body.theme-system .theme-dark__forced  .d\\:fc-danger {
+  color: var(--fc-danger) !important;
+}
+body.theme-dark  .d\\:fc-success,
+.theme-dark__forced  .d\\:fc-success,
+body.theme-system .theme-dark__forced  .d\\:fc-success {
+  color: var(--fc-success) !important;
+}
+body.theme-dark  .d\\:fc-warning,
+.theme-dark__forced  .d\\:fc-warning,
+body.theme-system .theme-dark__forced  .d\\:fc-warning {
+  color: var(--fc-warning) !important;
+}
+body.theme-dark  .d\\:bg-error,
+.theme-dark__forced  .d\\:bg-error,
+body.theme-system .theme-dark__forced  .d\\:bg-error {
+  background-color: var(--bg-error) !important;
+}
+body.theme-dark  .d\\:bg-danger,
+.theme-dark__forced  .d\\:bg-danger,
+body.theme-system .theme-dark__forced  .d\\:bg-danger {
+  background-color: var(--bg-danger) !important;
+}
+body.theme-dark  .d\\:bg-success,
+.theme-dark__forced  .d\\:bg-success,
+body.theme-system .theme-dark__forced  .d\\:bg-success {
+  background-color: var(--bg-success) !important;
+}
+body.theme-dark  .d\\:bg-warning,
+.theme-dark__forced  .d\\:bg-warning,
+body.theme-system .theme-dark__forced  .d\\:bg-warning {
+  background-color: var(--bg-warning) !important;
+}
+body.theme-dark  .bg-transparent,
+.theme-dark__forced  .bg-transparent,
+body.theme-system .theme-dark__forced  .bg-transparent,
+body.theme-dark  .h\\:bg-transparent:hover,
+.theme-dark__forced  .h\\:bg-transparent:hover,
+body.theme-system .theme-dark__forced  .h\\:bg-transparent:hover,
+body.theme-dark  .f\\:bg-transparent:focus,
+.theme-dark__forced  .f\\:bg-transparent:focus,
+body.theme-system .theme-dark__forced  .f\\:bg-transparent:focus,
+body.theme-dark  .f\\:bg-transparent:focus-within,
+.theme-dark__forced  .f\\:bg-transparent:focus-within,
+body.theme-system .theme-dark__forced  .f\\:bg-transparent:focus-within {
+  background-color: transparent !important;
+}
+body.theme-dark  .bc-transparent,
+.theme-dark__forced  .bc-transparent,
+body.theme-system .theme-dark__forced  .bc-transparent,
+body.theme-dark  .h\\:bc-transparent:hover,
+.theme-dark__forced  .h\\:bc-transparent:hover,
+body.theme-system .theme-dark__forced  .h\\:bc-transparent:hover,
+body.theme-dark  .f\\:bc-transparent:focus,
+.theme-dark__forced  .f\\:bc-transparent:focus,
+body.theme-system .theme-dark__forced  .f\\:bc-transparent:focus,
+body.theme-dark  .f\\:bc-transparent:focus-within,
+.theme-dark__forced  .f\\:bc-transparent:focus-within,
+body.theme-system .theme-dark__forced  .f\\:bc-transparent:focus-within {
+  border-color: transparent !important;
+}
+body.theme-dark  .bg-inherit,
+.theme-dark__forced  .bg-inherit,
+body.theme-system .theme-dark__forced  .bg-inherit,
+body.theme-dark  .h\\:bg-inherit:hover,
+.theme-dark__forced  .h\\:bg-inherit:hover,
+body.theme-system .theme-dark__forced  .h\\:bg-inherit:hover,
+body.theme-dark  .f\\:bg-inherit:focus,
+.theme-dark__forced  .f\\:bg-inherit:focus,
+body.theme-system .theme-dark__forced  .f\\:bg-inherit:focus,
+body.theme-dark  .f\\:bg-inherit:focus-within,
+.theme-dark__forced  .f\\:bg-inherit:focus-within,
+body.theme-system .theme-dark__forced  .f\\:bg-inherit:focus-within {
+  background-color: inherit !important;
+}
+body.theme-dark  .bc-inherit,
+.theme-dark__forced  .bc-inherit,
+body.theme-system .theme-dark__forced  .bc-inherit,
+body.theme-dark  .h\\:bc-inherit:hover,
+.theme-dark__forced  .h\\:bc-inherit:hover,
+body.theme-system .theme-dark__forced  .h\\:bc-inherit:hover,
+body.theme-dark  .f\\:bc-inherit:focus,
+.theme-dark__forced  .f\\:bc-inherit:focus,
+body.theme-system .theme-dark__forced  .f\\:bc-inherit:focus,
+body.theme-dark  .f\\:bc-inherit:focus-within,
+.theme-dark__forced  .f\\:bc-inherit:focus-within,
+body.theme-system .theme-dark__forced  .f\\:bc-inherit:focus-within {
+  border-color: inherit !important;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  margin-top: 0;
+}
+.fs-display4 {
+  font-size: var(--fs-display4) !important;
+  line-height: 1.18;
+}
+.fs-display3 {
+  font-size: var(--fs-display3) !important;
+  line-height: 1.2;
+}
+.fs-display2 {
+  font-size: var(--fs-display2) !important;
+  line-height: 1.28;
+}
+.fs-display1 {
+  font-size: var(--fs-display1) !important;
+  line-height: 1.34;
+}
+.fs-headline2 {
+  font-size: var(--fs-headline2) !important;
+  line-height: 1.4;
+}
+.fs-headline1 {
+  font-size: var(--fs-headline1) !important;
+  line-height: 1.4;
+}
+.fs-title {
+  font-size: var(--fs-title) !important;
+  line-height: 1.4;
+}
+.fs-subheading {
+  font-size: var(--fs-subheading) !important;
+  line-height: 1.4;
+}
+.fs-body3 {
+  font-size: var(--fs-body3) !important;
+  line-height: 1.4;
+}
+.fs-body2 {
+  font-size: var(--fs-body2) !important;
+  line-height: 1.4;
+}
+.fs-body1 {
+  font-size: var(--fs-body1) !important;
+  line-height: 1.4;
+}
+.fs-caption {
+  font-size: var(--fs-caption) !important;
+  line-height: 1.4;
+}
+.fs-fine {
+  font-size: var(--fs-fine) !important;
+  line-height: 1.36;
+}
+@media (max-width: 48.75rem) {
+  html  .fs-display4 {
+    font-size: calc(var(--fs-display4) * 0.43) !important;
+  }
+  html  .fs-display3 {
+    font-size: calc(var(--fs-display3) * 0.5139) !important;
+  }
+  html  .fs-display2 {
+    font-size: calc(var(--fs-display2) * 0.5862) !important;
+  }
+  html  .fs-display1 {
+    font-size: calc(var(--fs-display1) * 0.6304) !important;
+  }
+  html  .fs-headline2 {
+    font-size: calc(var(--fs-headline2) * 0.7224) !important;
+  }
+  html  .fs-headline1 {
+    font-size: calc(var(--fs-headline1) * 0.8215) !important;
+  }
+  html  .fs-title {
+    font-size: calc(var(--fs-title) * 0.9094) !important;
+  }
+  html  .fs-subheading {
+    font-size: calc(var(--fs-subheading) * 0.8998) !important;
+  }
+  html  .fs-body3 {
+    font-size: calc(var(--fs-body3) * 0.8888) !important;
+  }
+  html  .fs-body2 {
+    font-size: calc(var(--fs-body2) * 0.9374) !important;
+  }
+}
+.lh-xs {
+  line-height: var(--lh-xs) !important;
+}
+.lh-sm {
+  line-height: var(--lh-sm) !important;
+}
+.lh-md {
+  line-height: var(--lh-md) !important;
+}
+.lh-lg {
+  line-height: var(--lh-lg) !important;
+}
+.lh-xl {
+  line-height: var(--lh-xl) !important;
+}
+.lh-xxl {
+  line-height: var(--lh-xxl) !important;
+}
+.lh-unset {
+  line-height: initial !important;
+}
+.ff-sans {
+  font-family: var(--ff-sans) !important;
+}
+.ff-serif {
+  font-family: var(--ff-serif) !important;
+}
+.ff-mono {
+  font-family: var(--ff-mono) !important;
+}
+.ff-inherit {
+  font-family: inherit !important;
+}
+.fw-normal {
+  font-weight: 400 !important;
+}
+.fw-medium {
+  font-weight: 500 !important;
+}
+.fw-bold {
+  font-weight: 600 !important;
+}
+.fs-normal {
+  font-style: normal !important;
+}
+.fs-italic {
+  font-style: italic !important;
+}
+.fs-unset {
+  font-style: unset !important;
+}
+.ta-left {
+  text-align: left !important;
+}
+.ta-center {
+  text-align: center !important;
+}
+.ta-right {
+  text-align: right !important;
+}
+.ta-justify {
+  text-align: justify !important;
+}
+.ta-unset {
+  text-align: unset !important;
+}
+.td-none {
+  text-decoration: none !important;
+}
+.td-underline {
+  text-decoration: underline !important;
+}
+.tt-capitalize {
+  text-transform: capitalize !important;
+}
+.tt-lowercase {
+  text-transform: lowercase !important;
+}
+.tt-uppercase {
+  text-transform: uppercase !important;
+}
+.tt-none {
+  text-transform: none !important;
+}
+.tt-unset {
+  text-transform: unset !important;
+}
+.ws-normal {
+  white-space: normal !important;
+}
+.ws-nowrap {
+  white-space: nowrap !important;
+}
+.ws-pre {
+  white-space: pre !important;
+}
+.ws-pre-wrap {
+  white-space: pre-wrap !important;
+}
+.ws-pre-line {
+  white-space: pre-line !important;
+}
+.ws-unset {
+  white-space: unset !important;
+}
+.wb-normal {
+  word-break: normal !important;
+}
+.wb-break-all {
+  word-break: break-all !important;
+}
+.wb-keep-all {
+  word-break: keep-all !important;
+}
+.wb-inherit {
+  word-break: inherit !important;
+}
+.wb-initial {
+  word-break: initial !important;
+}
+.wb-unset {
+  word-break: unset !important;
+}
+.ow-normal {
+  overflow-wrap: normal !important;
+}
+.ow-anywhere {
+  overflow-wrap: anywhere !important;
+}
+.ow-break-word {
+  overflow-wrap: break-word !important;
+}
+.ow-inherit {
+  overflow-wrap: inherit !important;
+}
+.ow-initial {
+  overflow-wrap: initial !important;
+}
+.ow-unset {
+  overflow-wrap: unset !important;
+}
+.hyphens-none {
+  hyphens: none !important;
+}
+.hyphens-auto {
+  -ms-hyphens: auto !important;
+  -webkit-hyphens: auto !important;
+  hyphens: auto !important;
+}
+.hyphens-unset {
+  hyphens: unset !important;
+}
+.break-word {
+  /* stylelint-disable-next-line declaration-property-value-keyword-no-deprecated */
+  word-break: break-word !important;
+  overflow-wrap: break-word !important;
+  -webkit-hyphens: auto !important;
+  -moz-hyphens: auto !important;
+  -ms-hyphens: auto !important;
+  hyphens: auto !important;
+}
+.bg-bottom {
+  background-position: bottom !important;
+}
+.bg-center {
+  background-position: center !important;
+}
+.bg-left {
+  background-position: left !important;
+}
+.bg-left-bottom {
+  background-position: left bottom !important;
+}
+.bg-left-top {
+  background-position: left top !important;
+}
+.bg-right {
+  background-position: right !important;
+}
+.bg-right-bottom {
+  background-position: right bottom !important;
+}
+.bg-right-top {
+  background-position: right top !important;
+}
+.bg-top {
+  background-position: top !important;
+}
+.bg-repeat {
+  background-repeat: repeat !important;
+}
+.bg-no-repeat {
+  background-repeat: no-repeat !important;
+}
+.bg-repeat-x {
+  background-repeat: repeat-x !important;
+}
+.bg-repeat-y {
+  background-repeat: repeat-y !important;
+}
+.bg-auto {
+  background-size: auto !important;
+}
+.bg-cover {
+  background-size: cover !important;
+}
+.bg-contain {
+  background-size: contain !important;
+}
+.bg-fixed {
+  background-attachment: fixed !important;
+}
+.bg-local {
+  background-attachment: local !important;
+}
+.bg-scroll {
+  background-attachment: scroll !important;
+}
+.bg-image-none {
+  background-image: none !important;
+}
+.bg-loading {
+  animation: loadingBgAnimation 1.5s ease-out infinite;
+  animation-delay: 1ms;
+}
+@keyframes loadingBgAnimation {
+  0% {
+    background-color: var(--black-150);
+    opacity: 1;
+  }
+  50% {
+    background-color: var(--black-100);
+    opacity: 0.7;
+  }
+  100% {
+    background-color: var(--black-150);
+    opacity: 1;
+  }
+}
+.bg-confetti-animated {
+  background-repeat: repeat-x;
+  background-position: top -10px center;
+  background-image: url("data:image/svg+xml;,%3Csvg width='600' height='90' viewBox='0 0 600 90' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='42' y='-10' width='6' height='10'/%3E%3Crect x='84' y='-10' width='6' height='10'/%3E%3Crect x='126' y='-13' width='5' height='13'/%3E%3Crect x='168' y='-13' width='5' height='13'/%3E%3Crect x='210' y='-10' width='6' height='10'/%3E%3Crect x='252' y='-13' width='5' height='13'/%3E%3Crect x='294' y='-10' width='6' height='10'/%3E%3Crect x='336' y='-13' width='5' height='13'/%3E%3Crect x='378' y='-13' width='5' height='13'/%3E%3Crect x='420' y='-10' width='6' height='10'/%3E%3Crect x='462' y='-10' width='6' height='10'/%3E%3Crect x='504' y='-13' width='5' height='13'/%3E%3Crect x='546' y='-10' width='6' height='10'/%3E%3Cstyle type='text/css'%3E rect %7B opacity: 0; %7D rect:nth-child(1) %7B transform-origin: 45px 5px; transform: rotate(-145deg); animation: blast 700ms infinite ease-out; animation-delay: 88ms; animation-duration: 631ms; %7D rect:nth-child(2) %7B transform-origin: 87px 5px; transform: rotate(164deg); animation: blast 700ms infinite ease-out; animation-delay: 131ms; animation-duration: 442ms; %7D rect:nth-child(3) %7B transform-origin: 128px 6px; transform: rotate(4deg); animation: blast 700ms infinite ease-out; animation-delay: 92ms; animation-duration: 662ms; %7D rect:nth-child(4) %7B transform-origin: 170px 6px; transform: rotate(-175deg); animation: blast 700ms infinite ease-out; animation-delay: 17ms; animation-duration: 593ms; %7D rect:nth-child(5) %7B transform-origin: 213px 5px; transform: rotate(-97deg); animation: blast 700ms infinite ease-out; animation-delay: 122ms; animation-duration: 476ms; %7D rect:nth-child(6) %7B transform-origin: 255px 6px; transform: rotate(57deg); animation: blast 700ms infinite ease-out; animation-delay: 271ms; animation-duration: 381ms; %7D rect:nth-child(7) %7B transform-origin: 297px 5px; transform: rotate(-46deg); animation: blast 700ms infinite ease-out; animation-delay: 131ms; animation-duration: 619ms; %7D rect:nth-child(8) %7B transform-origin: 338px 6px; transform: rotate(-65deg); animation: blast 700ms infinite ease-out; animation-delay: 85ms; animation-duration: 668ms; %7D rect:nth-child(9) %7B transform-origin: 380px 6px; transform: rotate(13deg); animation: blast 700ms infinite ease-out; animation-delay: 128ms; animation-duration: 377ms; %7D rect:nth-child(10) %7B transform-origin: 423px 5px; transform: rotate(176deg); animation: blast 700ms infinite ease-out; animation-delay: 311ms; animation-duration: 508ms; %7D rect:nth-child(11) %7B transform-origin: 465px 5px; transform: rotate(108deg); animation: blast 700ms infinite ease-out; animation-delay: 108ms; animation-duration: 595ms; %7D rect:nth-child(12) %7B transform-origin: 506px 6px; transform: rotate(62deg); animation: blast 700ms infinite ease-out; animation-delay: 105ms; animation-duration: 375ms; %7D rect:nth-child(13) %7B transform-origin: 549px 5px; transform: rotate(16deg); animation: blast 700ms infinite ease-out; animation-delay: 149ms; animation-duration: 491ms; %7D rect:nth-child(odd) %7B fill: %2365BB5C; %7D rect:nth-child(even) %7B z-index: 1; fill: %2333AAFF; %7D rect:nth-child(4n) %7B animation-duration: 1400ms; fill: %23F23B14; %7D rect:nth-child(3n) %7B animation-duration: 1750ms; animation-delay: 700ms; %7D rect:nth-child(4n-7) %7B fill: %232A2F6A; %7D rect:nth-child(6n) %7B fill: %23FBBA23; %7D @keyframes blast %7B from %7B opacity: 0; %7D 20%25 %7B opacity: 1; %7D to %7B transform: translateY(90px); %7D %7D %3C/style%3E%3C/svg%3E%0A");
+}
+@media (prefers-reduced-motion) {
+  .bg-confetti-animated {
+    background-image: url("data:image/svg+xml;,%3Csvg width='574' height='60' viewBox='0 0 574 60' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect opacity='0.8' x='27.1224' y='20.0458' width='5' height='13' transform='rotate(-139 27.1224 20.0458)' fill='%23F23B14'/%3E%3Crect opacity='0.8' x='118.478' y='7.00201' width='5' height='13' transform='rotate(-38.8114 118.478 7.00201)' fill='%23FBBA23'/%3E%3Crect opacity='0.8' x='504.616' y='25.4479' width='5' height='13' transform='rotate(-60.2734 504.616 25.4479)' fill='%23F23B14'/%3E%3Crect opacity='0.6' x='538.983' y='45.555' width='5' height='13' transform='rotate(16.7826 538.983 45.555)' fill='%232A2F6A'/%3E%3Crect opacity='0.3' x='470.322' y='2.63625' width='5' height='13' transform='rotate(11.295 470.322 2.63625)' fill='%2333AAFF'/%3E%3Crect opacity='0.3' x='190.295' y='4.58138' width='5' height='13' transform='rotate(27.5954 190.295 4.58138)' fill='%23F23B14'/%3E%3Crect opacity='0.8' x='234.303' y='16.3233' width='5' height='13' transform='rotate(-41.8233 234.303 16.3233)' fill='%2365BB5C'/%3E%3Crect opacity='0.6' x='369.702' y='40.9875' width='5' height='13' transform='rotate(-56.419 369.702 40.9875)' fill='%2333AAFF'/%3E%3Crect opacity='0.3' x='402.121' y='31.0848' width='5' height='13' transform='rotate(-17.9234 402.121 31.0848)' fill='%23F23B14'/%3E%3Crect opacity='0.6' x='200.316' y='31.9328' width='5' height='13' transform='rotate(-15.8896 200.316 31.9328)' fill='%232A2F6A'/%3E%3Crect opacity='0.6' x='69.6745' y='23.4725' width='6' height='10' transform='rotate(70.0266 69.6745 23.4725)' fill='%2365BB5C'/%3E%3Crect opacity='0.6' x='291.945' y='7.16931' width='6' height='10' transform='rotate(30.4258 291.945 7.16931)' fill='%23FBBA23'/%3E%3Crect opacity='0.3' x='33.7754' y='38.2208' width='6' height='10' transform='rotate(38.6056 33.7754 38.2208)' fill='%23FBBA23'/%3E%3Crect opacity='0.8' x='109.752' y='31.1743' width='6' height='10' transform='rotate(28.5296 109.752 31.1743)' fill='%2333AAFF'/%3E%3Crect opacity='0.3' x='278.081' y='37.8695' width='6' height='10' transform='rotate(-26.5651 278.081 37.8695)' fill='%23F23B14'/%3E%3Crect opacity='0.8' x='416.294' y='11.5573' width='6' height='10' transform='rotate(-22.8498 416.294 11.5573)' fill='%23FBBA23'/%3E%3Crect opacity='0.3' x='354.667' y='9.32341' width='6' height='10' transform='rotate(17.7506 354.667 9.32341)' fill='%232A2F6A'/%3E%3Crect opacity='0.8' x='532.404' y='16.6372' width='6' height='10' transform='rotate(-75.3432 532.404 16.6372)' fill='%23FBBA23'/%3E%3Crect opacity='0.6' x='460.463' y='39.3557' width='6' height='10' transform='rotate(45.4982 460.463 39.3557)' fill='%2365BB5C'/%3E%3C/svg%3E");
+  }
+}
+.bg-confetti-static {
+  background-repeat: repeat-x;
+  background-position: top -10px center;
+  background-image: url("data:image/svg+xml;,%3Csvg width='574' height='60' viewBox='0 0 574 60' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect opacity='0.8' x='27.1224' y='20.0458' width='5' height='13' transform='rotate(-139 27.1224 20.0458)' fill='%23F23B14'/%3E%3Crect opacity='0.8' x='118.478' y='7.00201' width='5' height='13' transform='rotate(-38.8114 118.478 7.00201)' fill='%23FBBA23'/%3E%3Crect opacity='0.8' x='504.616' y='25.4479' width='5' height='13' transform='rotate(-60.2734 504.616 25.4479)' fill='%23F23B14'/%3E%3Crect opacity='0.6' x='538.983' y='45.555' width='5' height='13' transform='rotate(16.7826 538.983 45.555)' fill='%232A2F6A'/%3E%3Crect opacity='0.3' x='470.322' y='2.63625' width='5' height='13' transform='rotate(11.295 470.322 2.63625)' fill='%2333AAFF'/%3E%3Crect opacity='0.3' x='190.295' y='4.58138' width='5' height='13' transform='rotate(27.5954 190.295 4.58138)' fill='%23F23B14'/%3E%3Crect opacity='0.8' x='234.303' y='16.3233' width='5' height='13' transform='rotate(-41.8233 234.303 16.3233)' fill='%2365BB5C'/%3E%3Crect opacity='0.6' x='369.702' y='40.9875' width='5' height='13' transform='rotate(-56.419 369.702 40.9875)' fill='%2333AAFF'/%3E%3Crect opacity='0.3' x='402.121' y='31.0848' width='5' height='13' transform='rotate(-17.9234 402.121 31.0848)' fill='%23F23B14'/%3E%3Crect opacity='0.6' x='200.316' y='31.9328' width='5' height='13' transform='rotate(-15.8896 200.316 31.9328)' fill='%232A2F6A'/%3E%3Crect opacity='0.6' x='69.6745' y='23.4725' width='6' height='10' transform='rotate(70.0266 69.6745 23.4725)' fill='%2365BB5C'/%3E%3Crect opacity='0.6' x='291.945' y='7.16931' width='6' height='10' transform='rotate(30.4258 291.945 7.16931)' fill='%23FBBA23'/%3E%3Crect opacity='0.3' x='33.7754' y='38.2208' width='6' height='10' transform='rotate(38.6056 33.7754 38.2208)' fill='%23FBBA23'/%3E%3Crect opacity='0.8' x='109.752' y='31.1743' width='6' height='10' transform='rotate(28.5296 109.752 31.1743)' fill='%2333AAFF'/%3E%3Crect opacity='0.3' x='278.081' y='37.8695' width='6' height='10' transform='rotate(-26.5651 278.081 37.8695)' fill='%23F23B14'/%3E%3Crect opacity='0.8' x='416.294' y='11.5573' width='6' height='10' transform='rotate(-22.8498 416.294 11.5573)' fill='%23FBBA23'/%3E%3Crect opacity='0.3' x='354.667' y='9.32341' width='6' height='10' transform='rotate(17.7506 354.667 9.32341)' fill='%232A2F6A'/%3E%3Crect opacity='0.8' x='532.404' y='16.6372' width='6' height='10' transform='rotate(-75.3432 532.404 16.6372)' fill='%23FBBA23'/%3E%3Crect opacity='0.6' x='460.463' y='39.3557' width='6' height='10' transform='rotate(45.4982 460.463 39.3557)' fill='%2365BB5C'/%3E%3C/svg%3E");
+}
+.ba {
+  border-style: solid !important;
+  border-width: var(--su1) !important;
+}
+.bt {
+  border-top-style: solid !important;
+  border-top-width: var(--su1) !important;
+}
+.br {
+  border-right-style: solid !important;
+  border-right-width: var(--su1) !important;
+}
+.bb {
+  border-bottom-style: solid !important;
+  border-bottom-width: var(--su1) !important;
+}
+.bl {
+  border-left-style: solid !important;
+  border-left-width: var(--su1) !important;
+}
+.bx {
+  border-left-style: solid !important;
+  border-right-style: solid !important;
+  border-right-width: var(--su1) !important;
+  border-left-width: var(--su1) !important;
+}
+.by {
+  border-top-style: solid !important;
+  border-bottom-style: solid !important;
+  border-top-width: var(--su1) !important;
+  border-bottom-width: var(--su1) !important;
+}
+.baw0 {
+  border-width: 0 !important;
+}
+.baw1 {
+  border-width: var(--su1) !important;
+}
+.baw2 {
+  border-width: var(--su2) !important;
+}
+.baw3 {
+  border-width: var(--su4) !important;
+}
+.btw0 {
+  border-top-width: 0 !important;
+}
+.btw1 {
+  border-top-width: var(--su1) !important;
+}
+.btw2 {
+  border-top-width: var(--su2) !important;
+}
+.btw3 {
+  border-top-width: var(--su4) !important;
+}
+.brw0 {
+  border-right-width: 0 !important;
+}
+.brw1 {
+  border-right-width: var(--su1) !important;
+}
+.brw2 {
+  border-right-width: var(--su2) !important;
+}
+.brw3 {
+  border-right-width: var(--su4) !important;
+}
+.bbw0 {
+  border-bottom-width: 0 !important;
+}
+.bbw1 {
+  border-bottom-width: var(--su1) !important;
+}
+.bbw2 {
+  border-bottom-width: var(--su2) !important;
+}
+.bbw3 {
+  border-bottom-width: var(--su4) !important;
+}
+.blw0 {
+  border-left-width: 0 !important;
+}
+.blw0 {
+  border-left-width: 0 !important;
+}
+.blw1 {
+  border-left-width: var(--su1) !important;
+}
+.blw2 {
+  border-left-width: var(--su2) !important;
+}
+.blw3 {
+  border-left-width: var(--su4) !important;
+}
+.byw0 {
+  border-top-width: 0 !important;
+  border-bottom-width: 0 !important;
+}
+.byw1 {
+  border-top-width: var(--su1) !important;
+  border-bottom-width: var(--su1) !important;
+}
+.byw2 {
+  border-top-width: var(--su2) !important;
+  border-bottom-width: var(--su2) !important;
+}
+.byw3 {
+  border-top-width: var(--su4) !important;
+  border-bottom-width: var(--su4) !important;
+}
+.bxw0 {
+  border-right-width: 0 !important;
+  border-left-width: 0 !important;
+}
+.bxw1 {
+  border-right-width: var(--su1) !important;
+  border-left-width: var(--su1) !important;
+}
+.bxw2 {
+  border-right-width: var(--su2) !important;
+  border-left-width: var(--su2) !important;
+}
+.bxw3 {
+  border-right-width: var(--su4) !important;
+  border-left-width: var(--su4) !important;
+}
+.bas-solid {
+  border-style: solid !important;
+}
+.bas-dashed {
+  border-style: dashed !important;
+}
+.bts-solid {
+  border-top-style: solid !important;
+}
+.bts-dashed {
+  border-top-style: dashed !important;
+}
+.brs-solid {
+  border-right-style: solid !important;
+}
+.brs-dashed {
+  border-right-style: dashed !important;
+}
+.bbs-solid {
+  border-bottom-style: solid !important;
+}
+.bbs-dashed {
+  border-bottom-style: dashed !important;
+}
+.bls-solid {
+  border-left-style: solid !important;
+}
+.bls-dashed {
+  border-left-style: dashed !important;
+}
+.bar0 {
+  border-radius: 0 !important;
+}
+.bar-md {
+  border-radius: var(--br-md) !important;
+}
+.bar-circle {
+  border-radius: var(--br-circle) !important;
+}
+.bar-pill {
+  border-radius: var(--br-pill) !important;
+}
+.btlr0 {
+  border-top-left-radius: 0 !important;
+}
+.btlr-md {
+  border-top-left-radius: var(--br-md) !important;
+}
+.btrr0 {
+  border-top-right-radius: 0 !important;
+}
+.btrr-md {
+  border-top-right-radius: var(--br-md) !important;
+}
+.bblr0 {
+  border-bottom-left-radius: 0 !important;
+}
+.bblr-md {
+  border-bottom-left-radius: var(--br-md) !important;
+}
+.bbrr0 {
+  border-bottom-right-radius: 0 !important;
+}
+.bbrr-md {
+  border-bottom-right-radius: var(--br-md) !important;
+}
+.btr0 {
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+}
+.btr-md {
+  border-top-left-radius: var(--br-md) !important;
+  border-top-right-radius: var(--br-md) !important;
+}
+.brr0 {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+.brr-md {
+  border-top-right-radius: var(--br-md) !important;
+  border-bottom-right-radius: var(--br-md) !important;
+}
+.bbr0 {
+  border-bottom-left-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+.bbr-md {
+  border-bottom-left-radius: var(--br-md) !important;
+  border-bottom-right-radius: var(--br-md) !important;
+}
+.blr0 {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+}
+.blr-md {
+  border-top-left-radius: var(--br-md) !important;
+  border-bottom-left-radius: var(--br-md) !important;
+}
+.bs-none {
+  box-shadow: none !important;
+}
+.bs-sm,
+.h\\:bs-sm:hover {
+  box-shadow: var(--bs-sm) !important;
+}
+.bs-md,
+.h\\:bs-md:hover {
+  box-shadow: var(--bs-md) !important;
+}
+.bs-lg,
+.h\\:bs-lg:hover {
+  box-shadow: var(--bs-lg) !important;
+}
+.bs-xl,
+.h\\:bs-xl:hover {
+  box-shadow: var(--bs-xl) !important;
+}
+.bs-ring,
+.h\\:bs-ring:hover,
+.f\\:bs-ring:focus,
+.f\\:bs-ring:focus-within {
+  box-shadow: 0 0 0 var(--su4) var(--focus-ring);
+}
+.box-content {
+  box-sizing: content-box !important;
+}
+.box-border {
+  box-sizing: border-box !important;
+}
+.box-unset {
+  box-sizing: unset !important;
+}
+.fill-current {
+  fill: currentColor !important;
+}
+.stroke-current {
+  stroke: currentColor !important;
+}
+.c-auto {
+  cursor: auto !important;
+}
+.c-default {
+  cursor: default !important;
+}
+.c-pointer {
+  cursor: pointer !important;
+}
+.c-text {
+  cursor: text !important;
+}
+.c-wait {
+  cursor: wait !important;
+}
+.c-move {
+  cursor: move !important;
+}
+.c-not-allowed {
+  cursor: not-allowed !important;
+}
+.c-help {
+  cursor: help !important;
+}
+.d-block {
+  display: block !important;
+}
+.d-flex {
+  display: flex !important;
+}
+.d-inline-flex {
+  display: inline-flex !important;
+}
+.d-grid {
+  display: grid !important;
+}
+.d-inline-grid {
+  display: inline-grid !important;
+}
+.d-inline {
+  display: inline !important;
+}
+.d-inline-block {
+  display: inline-block !important;
+}
+.d-table {
+  display: table !important;
+}
+.d-table-cell {
+  display: table-cell !important;
+}
+.d-none {
+  display: none !important;
+}
+.d-unset {
+  display: unset !important;
+}
+.flex__fl-shrink0,
+.flex__fl-shrink0 > .d-flex,
+.flex__fl-shrink0 > .flex--item {
+  flex: 0 auto;
+}
+.flex__fl-equal,
+.flex__fl-equal > .d-flex,
+.flex__fl-equal > .flex--item {
+  flex: 1 1 0%;
+}
+.flex__fl-grow1,
+.flex__fl-grow1 > .d-flex,
+.flex__fl-grow1 > .flex--item {
+  flex: 1 auto;
+}
+.flex--item1 {
+  flex-basis: 8.33333333%;
+}
+.flex--item2 {
+  flex-basis: 16.66666667%;
+}
+.flex--item3 {
+  flex-basis: 25%;
+}
+.flex--item4 {
+  flex-basis: 33.33333333%;
+}
+.flex--item5 {
+  flex-basis: 41.66666667%;
+}
+.flex--item6 {
+  flex-basis: 50%;
+}
+.flex--item7 {
+  flex-basis: 58.33333333%;
+}
+.flex--item8 {
+  flex-basis: 66.66666667%;
+}
+.flex--item9 {
+  flex-basis: 75%;
+}
+.flex--item10 {
+  flex-basis: 83.33333333%;
+}
+.flex--item11 {
+  flex-basis: 91.66666667%;
+}
+.flex--item12 {
+  flex-basis: 100%;
+}
+.flex__allitems1 > .d-flex,
+.flex__allitems1 > .flex--item {
+  flex-basis: 8.33333333%;
+}
+.flex__allitems2 > .d-flex,
+.flex__allitems2 > .flex--item {
+  flex-basis: 16.66666667%;
+}
+.flex__allitems3 > .d-flex,
+.flex__allitems3 > .flex--item {
+  flex-basis: 25%;
+}
+.flex__allitems4 > .d-flex,
+.flex__allitems4 > .flex--item {
+  flex-basis: 33.33333333%;
+}
+.flex__allitems5 > .d-flex,
+.flex__allitems5 > .flex--item {
+  flex-basis: 41.66666667%;
+}
+.flex__allitems6 > .d-flex,
+.flex__allitems6 > .flex--item {
+  flex-basis: 50%;
+}
+.flex__allitems7 > .d-flex,
+.flex__allitems7 > .flex--item {
+  flex-basis: 58.33333333%;
+}
+.flex__allitems8 > .d-flex,
+.flex__allitems8 > .flex--item {
+  flex-basis: 66.66666667%;
+}
+.flex__allitems9 > .d-flex,
+.flex__allitems9 > .flex--item {
+  flex-basis: 75%;
+}
+.flex__allitems10 > .d-flex,
+.flex__allitems10 > .flex--item {
+  flex-basis: 83.33333333%;
+}
+.flex__allitems11 > .d-flex,
+.flex__allitems11 > .flex--item {
+  flex-basis: 91.66666667%;
+}
+.flex__allitems12 > .d-flex,
+.flex__allitems12 > .flex--item {
+  flex-basis: 100%;
+}
+.g0 > .flex--item1,
+.gx0 > .flex--item1,
+.gy0 > .flex--item1,
+.g0.flex__allitems1 > .d-flex,
+.gx0.flex__allitems1 > .d-flex,
+.gy0.flex__allitems1 > .d-flex,
+.g0.flex__allitems1 > .flex--item,
+.gx0.flex__allitems1 > .flex--item,
+.gy0.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - (var(--su0) * 0.9166666666666666));
+}
+.g0 > .flex--item2,
+.gx0 > .flex--item2,
+.gy0 > .flex--item2,
+.g0.flex__allitems2 > .d-flex,
+.gx0.flex__allitems2 > .d-flex,
+.gy0.flex__allitems2 > .d-flex,
+.g0.flex__allitems2 > .flex--item,
+.gx0.flex__allitems2 > .flex--item,
+.gy0.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - (var(--su0) * 0.8333333333333334));
+}
+.g0 > .flex--item3,
+.gx0 > .flex--item3,
+.gy0 > .flex--item3,
+.g0.flex__allitems3 > .d-flex,
+.gx0.flex__allitems3 > .d-flex,
+.gy0.flex__allitems3 > .d-flex,
+.g0.flex__allitems3 > .flex--item,
+.gx0.flex__allitems3 > .flex--item,
+.gy0.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - (var(--su0) * 0.75));
+}
+.g0 > .flex--item4,
+.gx0 > .flex--item4,
+.gy0 > .flex--item4,
+.g0.flex__allitems4 > .d-flex,
+.gx0.flex__allitems4 > .d-flex,
+.gy0.flex__allitems4 > .d-flex,
+.g0.flex__allitems4 > .flex--item,
+.gx0.flex__allitems4 > .flex--item,
+.gy0.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - (var(--su0) * 0.6666666666666666));
+}
+.g0 > .flex--item5,
+.gx0 > .flex--item5,
+.gy0 > .flex--item5,
+.g0.flex__allitems5 > .d-flex,
+.gx0.flex__allitems5 > .d-flex,
+.gy0.flex__allitems5 > .d-flex,
+.g0.flex__allitems5 > .flex--item,
+.gx0.flex__allitems5 > .flex--item,
+.gy0.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - (var(--su0) * 0.5833333333333334));
+}
+.g0 > .flex--item6,
+.gx0 > .flex--item6,
+.gy0 > .flex--item6,
+.g0.flex__allitems6 > .d-flex,
+.gx0.flex__allitems6 > .d-flex,
+.gy0.flex__allitems6 > .d-flex,
+.g0.flex__allitems6 > .flex--item,
+.gx0.flex__allitems6 > .flex--item,
+.gy0.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - (var(--su0) * 0.5));
+}
+.g0 > .flex--item7,
+.gx0 > .flex--item7,
+.gy0 > .flex--item7,
+.g0.flex__allitems7 > .d-flex,
+.gx0.flex__allitems7 > .d-flex,
+.gy0.flex__allitems7 > .d-flex,
+.g0.flex__allitems7 > .flex--item,
+.gx0.flex__allitems7 > .flex--item,
+.gy0.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - (var(--su0) * 0.4166666666666667));
+}
+.g0 > .flex--item8,
+.gx0 > .flex--item8,
+.gy0 > .flex--item8,
+.g0.flex__allitems8 > .d-flex,
+.gx0.flex__allitems8 > .d-flex,
+.gy0.flex__allitems8 > .d-flex,
+.g0.flex__allitems8 > .flex--item,
+.gx0.flex__allitems8 > .flex--item,
+.gy0.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - (var(--su0) * 0.3333333333333333));
+}
+.g0 > .flex--item9,
+.gx0 > .flex--item9,
+.gy0 > .flex--item9,
+.g0.flex__allitems9 > .d-flex,
+.gx0.flex__allitems9 > .d-flex,
+.gy0.flex__allitems9 > .d-flex,
+.g0.flex__allitems9 > .flex--item,
+.gx0.flex__allitems9 > .flex--item,
+.gy0.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - (var(--su0) * 0.25));
+}
+.g0 > .flex--item10,
+.gx0 > .flex--item10,
+.gy0 > .flex--item10,
+.g0.flex__allitems10 > .d-flex,
+.gx0.flex__allitems10 > .d-flex,
+.gy0.flex__allitems10 > .d-flex,
+.g0.flex__allitems10 > .flex--item,
+.gx0.flex__allitems10 > .flex--item,
+.gy0.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - (var(--su0) * 0.16666666666666666));
+}
+.g0 > .flex--item11,
+.gx0 > .flex--item11,
+.gy0 > .flex--item11,
+.g0.flex__allitems11 > .d-flex,
+.gx0.flex__allitems11 > .d-flex,
+.gy0.flex__allitems11 > .d-flex,
+.g0.flex__allitems11 > .flex--item,
+.gx0.flex__allitems11 > .flex--item,
+.gy0.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - (var(--su0) * 0.08333333333333333));
+}
+.g0 > .flex--item12,
+.gx0 > .flex--item12,
+.gy0 > .flex--item12,
+.g0.flex__allitems12 > .d-flex,
+.gx0.flex__allitems12 > .d-flex,
+.gy0.flex__allitems12 > .d-flex,
+.g0.flex__allitems12 > .flex--item,
+.gx0.flex__allitems12 > .flex--item,
+.gy0.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - (var(--su0) * 0));
+}
+.g1 > .flex--item1,
+.gx1 > .flex--item1,
+.gy1 > .flex--item1,
+.g1.flex__allitems1 > .d-flex,
+.gx1.flex__allitems1 > .d-flex,
+.gy1.flex__allitems1 > .d-flex,
+.g1.flex__allitems1 > .flex--item,
+.gx1.flex__allitems1 > .flex--item,
+.gy1.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - (var(--su1) * 0.9166666666666666));
+}
+.g1 > .flex--item2,
+.gx1 > .flex--item2,
+.gy1 > .flex--item2,
+.g1.flex__allitems2 > .d-flex,
+.gx1.flex__allitems2 > .d-flex,
+.gy1.flex__allitems2 > .d-flex,
+.g1.flex__allitems2 > .flex--item,
+.gx1.flex__allitems2 > .flex--item,
+.gy1.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - (var(--su1) * 0.8333333333333334));
+}
+.g1 > .flex--item3,
+.gx1 > .flex--item3,
+.gy1 > .flex--item3,
+.g1.flex__allitems3 > .d-flex,
+.gx1.flex__allitems3 > .d-flex,
+.gy1.flex__allitems3 > .d-flex,
+.g1.flex__allitems3 > .flex--item,
+.gx1.flex__allitems3 > .flex--item,
+.gy1.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - (var(--su1) * 0.75));
+}
+.g1 > .flex--item4,
+.gx1 > .flex--item4,
+.gy1 > .flex--item4,
+.g1.flex__allitems4 > .d-flex,
+.gx1.flex__allitems4 > .d-flex,
+.gy1.flex__allitems4 > .d-flex,
+.g1.flex__allitems4 > .flex--item,
+.gx1.flex__allitems4 > .flex--item,
+.gy1.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - (var(--su1) * 0.6666666666666666));
+}
+.g1 > .flex--item5,
+.gx1 > .flex--item5,
+.gy1 > .flex--item5,
+.g1.flex__allitems5 > .d-flex,
+.gx1.flex__allitems5 > .d-flex,
+.gy1.flex__allitems5 > .d-flex,
+.g1.flex__allitems5 > .flex--item,
+.gx1.flex__allitems5 > .flex--item,
+.gy1.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - (var(--su1) * 0.5833333333333334));
+}
+.g1 > .flex--item6,
+.gx1 > .flex--item6,
+.gy1 > .flex--item6,
+.g1.flex__allitems6 > .d-flex,
+.gx1.flex__allitems6 > .d-flex,
+.gy1.flex__allitems6 > .d-flex,
+.g1.flex__allitems6 > .flex--item,
+.gx1.flex__allitems6 > .flex--item,
+.gy1.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - (var(--su1) * 0.5));
+}
+.g1 > .flex--item7,
+.gx1 > .flex--item7,
+.gy1 > .flex--item7,
+.g1.flex__allitems7 > .d-flex,
+.gx1.flex__allitems7 > .d-flex,
+.gy1.flex__allitems7 > .d-flex,
+.g1.flex__allitems7 > .flex--item,
+.gx1.flex__allitems7 > .flex--item,
+.gy1.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - (var(--su1) * 0.4166666666666667));
+}
+.g1 > .flex--item8,
+.gx1 > .flex--item8,
+.gy1 > .flex--item8,
+.g1.flex__allitems8 > .d-flex,
+.gx1.flex__allitems8 > .d-flex,
+.gy1.flex__allitems8 > .d-flex,
+.g1.flex__allitems8 > .flex--item,
+.gx1.flex__allitems8 > .flex--item,
+.gy1.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - (var(--su1) * 0.3333333333333333));
+}
+.g1 > .flex--item9,
+.gx1 > .flex--item9,
+.gy1 > .flex--item9,
+.g1.flex__allitems9 > .d-flex,
+.gx1.flex__allitems9 > .d-flex,
+.gy1.flex__allitems9 > .d-flex,
+.g1.flex__allitems9 > .flex--item,
+.gx1.flex__allitems9 > .flex--item,
+.gy1.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - (var(--su1) * 0.25));
+}
+.g1 > .flex--item10,
+.gx1 > .flex--item10,
+.gy1 > .flex--item10,
+.g1.flex__allitems10 > .d-flex,
+.gx1.flex__allitems10 > .d-flex,
+.gy1.flex__allitems10 > .d-flex,
+.g1.flex__allitems10 > .flex--item,
+.gx1.flex__allitems10 > .flex--item,
+.gy1.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - (var(--su1) * 0.16666666666666666));
+}
+.g1 > .flex--item11,
+.gx1 > .flex--item11,
+.gy1 > .flex--item11,
+.g1.flex__allitems11 > .d-flex,
+.gx1.flex__allitems11 > .d-flex,
+.gy1.flex__allitems11 > .d-flex,
+.g1.flex__allitems11 > .flex--item,
+.gx1.flex__allitems11 > .flex--item,
+.gy1.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - (var(--su1) * 0.08333333333333333));
+}
+.g1 > .flex--item12,
+.gx1 > .flex--item12,
+.gy1 > .flex--item12,
+.g1.flex__allitems12 > .d-flex,
+.gx1.flex__allitems12 > .d-flex,
+.gy1.flex__allitems12 > .d-flex,
+.g1.flex__allitems12 > .flex--item,
+.gx1.flex__allitems12 > .flex--item,
+.gy1.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - (var(--su1) * 0));
+}
+.g2 > .flex--item1,
+.gx2 > .flex--item1,
+.gy2 > .flex--item1,
+.g2.flex__allitems1 > .d-flex,
+.gx2.flex__allitems1 > .d-flex,
+.gy2.flex__allitems1 > .d-flex,
+.g2.flex__allitems1 > .flex--item,
+.gx2.flex__allitems1 > .flex--item,
+.gy2.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - (var(--su2) * 0.9166666666666666));
+}
+.g2 > .flex--item2,
+.gx2 > .flex--item2,
+.gy2 > .flex--item2,
+.g2.flex__allitems2 > .d-flex,
+.gx2.flex__allitems2 > .d-flex,
+.gy2.flex__allitems2 > .d-flex,
+.g2.flex__allitems2 > .flex--item,
+.gx2.flex__allitems2 > .flex--item,
+.gy2.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - (var(--su2) * 0.8333333333333334));
+}
+.g2 > .flex--item3,
+.gx2 > .flex--item3,
+.gy2 > .flex--item3,
+.g2.flex__allitems3 > .d-flex,
+.gx2.flex__allitems3 > .d-flex,
+.gy2.flex__allitems3 > .d-flex,
+.g2.flex__allitems3 > .flex--item,
+.gx2.flex__allitems3 > .flex--item,
+.gy2.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - (var(--su2) * 0.75));
+}
+.g2 > .flex--item4,
+.gx2 > .flex--item4,
+.gy2 > .flex--item4,
+.g2.flex__allitems4 > .d-flex,
+.gx2.flex__allitems4 > .d-flex,
+.gy2.flex__allitems4 > .d-flex,
+.g2.flex__allitems4 > .flex--item,
+.gx2.flex__allitems4 > .flex--item,
+.gy2.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - (var(--su2) * 0.6666666666666666));
+}
+.g2 > .flex--item5,
+.gx2 > .flex--item5,
+.gy2 > .flex--item5,
+.g2.flex__allitems5 > .d-flex,
+.gx2.flex__allitems5 > .d-flex,
+.gy2.flex__allitems5 > .d-flex,
+.g2.flex__allitems5 > .flex--item,
+.gx2.flex__allitems5 > .flex--item,
+.gy2.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - (var(--su2) * 0.5833333333333334));
+}
+.g2 > .flex--item6,
+.gx2 > .flex--item6,
+.gy2 > .flex--item6,
+.g2.flex__allitems6 > .d-flex,
+.gx2.flex__allitems6 > .d-flex,
+.gy2.flex__allitems6 > .d-flex,
+.g2.flex__allitems6 > .flex--item,
+.gx2.flex__allitems6 > .flex--item,
+.gy2.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - (var(--su2) * 0.5));
+}
+.g2 > .flex--item7,
+.gx2 > .flex--item7,
+.gy2 > .flex--item7,
+.g2.flex__allitems7 > .d-flex,
+.gx2.flex__allitems7 > .d-flex,
+.gy2.flex__allitems7 > .d-flex,
+.g2.flex__allitems7 > .flex--item,
+.gx2.flex__allitems7 > .flex--item,
+.gy2.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - (var(--su2) * 0.4166666666666667));
+}
+.g2 > .flex--item8,
+.gx2 > .flex--item8,
+.gy2 > .flex--item8,
+.g2.flex__allitems8 > .d-flex,
+.gx2.flex__allitems8 > .d-flex,
+.gy2.flex__allitems8 > .d-flex,
+.g2.flex__allitems8 > .flex--item,
+.gx2.flex__allitems8 > .flex--item,
+.gy2.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - (var(--su2) * 0.3333333333333333));
+}
+.g2 > .flex--item9,
+.gx2 > .flex--item9,
+.gy2 > .flex--item9,
+.g2.flex__allitems9 > .d-flex,
+.gx2.flex__allitems9 > .d-flex,
+.gy2.flex__allitems9 > .d-flex,
+.g2.flex__allitems9 > .flex--item,
+.gx2.flex__allitems9 > .flex--item,
+.gy2.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - (var(--su2) * 0.25));
+}
+.g2 > .flex--item10,
+.gx2 > .flex--item10,
+.gy2 > .flex--item10,
+.g2.flex__allitems10 > .d-flex,
+.gx2.flex__allitems10 > .d-flex,
+.gy2.flex__allitems10 > .d-flex,
+.g2.flex__allitems10 > .flex--item,
+.gx2.flex__allitems10 > .flex--item,
+.gy2.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - (var(--su2) * 0.16666666666666666));
+}
+.g2 > .flex--item11,
+.gx2 > .flex--item11,
+.gy2 > .flex--item11,
+.g2.flex__allitems11 > .d-flex,
+.gx2.flex__allitems11 > .d-flex,
+.gy2.flex__allitems11 > .d-flex,
+.g2.flex__allitems11 > .flex--item,
+.gx2.flex__allitems11 > .flex--item,
+.gy2.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - (var(--su2) * 0.08333333333333333));
+}
+.g2 > .flex--item12,
+.gx2 > .flex--item12,
+.gy2 > .flex--item12,
+.g2.flex__allitems12 > .d-flex,
+.gx2.flex__allitems12 > .d-flex,
+.gy2.flex__allitems12 > .d-flex,
+.g2.flex__allitems12 > .flex--item,
+.gx2.flex__allitems12 > .flex--item,
+.gy2.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - (var(--su2) * 0));
+}
+.g4 > .flex--item1,
+.gx4 > .flex--item1,
+.gy4 > .flex--item1,
+.g4.flex__allitems1 > .d-flex,
+.gx4.flex__allitems1 > .d-flex,
+.gy4.flex__allitems1 > .d-flex,
+.g4.flex__allitems1 > .flex--item,
+.gx4.flex__allitems1 > .flex--item,
+.gy4.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - (var(--su4) * 0.9166666666666666));
+}
+.g4 > .flex--item2,
+.gx4 > .flex--item2,
+.gy4 > .flex--item2,
+.g4.flex__allitems2 > .d-flex,
+.gx4.flex__allitems2 > .d-flex,
+.gy4.flex__allitems2 > .d-flex,
+.g4.flex__allitems2 > .flex--item,
+.gx4.flex__allitems2 > .flex--item,
+.gy4.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - (var(--su4) * 0.8333333333333334));
+}
+.g4 > .flex--item3,
+.gx4 > .flex--item3,
+.gy4 > .flex--item3,
+.g4.flex__allitems3 > .d-flex,
+.gx4.flex__allitems3 > .d-flex,
+.gy4.flex__allitems3 > .d-flex,
+.g4.flex__allitems3 > .flex--item,
+.gx4.flex__allitems3 > .flex--item,
+.gy4.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - (var(--su4) * 0.75));
+}
+.g4 > .flex--item4,
+.gx4 > .flex--item4,
+.gy4 > .flex--item4,
+.g4.flex__allitems4 > .d-flex,
+.gx4.flex__allitems4 > .d-flex,
+.gy4.flex__allitems4 > .d-flex,
+.g4.flex__allitems4 > .flex--item,
+.gx4.flex__allitems4 > .flex--item,
+.gy4.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - (var(--su4) * 0.6666666666666666));
+}
+.g4 > .flex--item5,
+.gx4 > .flex--item5,
+.gy4 > .flex--item5,
+.g4.flex__allitems5 > .d-flex,
+.gx4.flex__allitems5 > .d-flex,
+.gy4.flex__allitems5 > .d-flex,
+.g4.flex__allitems5 > .flex--item,
+.gx4.flex__allitems5 > .flex--item,
+.gy4.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - (var(--su4) * 0.5833333333333334));
+}
+.g4 > .flex--item6,
+.gx4 > .flex--item6,
+.gy4 > .flex--item6,
+.g4.flex__allitems6 > .d-flex,
+.gx4.flex__allitems6 > .d-flex,
+.gy4.flex__allitems6 > .d-flex,
+.g4.flex__allitems6 > .flex--item,
+.gx4.flex__allitems6 > .flex--item,
+.gy4.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - (var(--su4) * 0.5));
+}
+.g4 > .flex--item7,
+.gx4 > .flex--item7,
+.gy4 > .flex--item7,
+.g4.flex__allitems7 > .d-flex,
+.gx4.flex__allitems7 > .d-flex,
+.gy4.flex__allitems7 > .d-flex,
+.g4.flex__allitems7 > .flex--item,
+.gx4.flex__allitems7 > .flex--item,
+.gy4.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - (var(--su4) * 0.4166666666666667));
+}
+.g4 > .flex--item8,
+.gx4 > .flex--item8,
+.gy4 > .flex--item8,
+.g4.flex__allitems8 > .d-flex,
+.gx4.flex__allitems8 > .d-flex,
+.gy4.flex__allitems8 > .d-flex,
+.g4.flex__allitems8 > .flex--item,
+.gx4.flex__allitems8 > .flex--item,
+.gy4.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - (var(--su4) * 0.3333333333333333));
+}
+.g4 > .flex--item9,
+.gx4 > .flex--item9,
+.gy4 > .flex--item9,
+.g4.flex__allitems9 > .d-flex,
+.gx4.flex__allitems9 > .d-flex,
+.gy4.flex__allitems9 > .d-flex,
+.g4.flex__allitems9 > .flex--item,
+.gx4.flex__allitems9 > .flex--item,
+.gy4.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - (var(--su4) * 0.25));
+}
+.g4 > .flex--item10,
+.gx4 > .flex--item10,
+.gy4 > .flex--item10,
+.g4.flex__allitems10 > .d-flex,
+.gx4.flex__allitems10 > .d-flex,
+.gy4.flex__allitems10 > .d-flex,
+.g4.flex__allitems10 > .flex--item,
+.gx4.flex__allitems10 > .flex--item,
+.gy4.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - (var(--su4) * 0.16666666666666666));
+}
+.g4 > .flex--item11,
+.gx4 > .flex--item11,
+.gy4 > .flex--item11,
+.g4.flex__allitems11 > .d-flex,
+.gx4.flex__allitems11 > .d-flex,
+.gy4.flex__allitems11 > .d-flex,
+.g4.flex__allitems11 > .flex--item,
+.gx4.flex__allitems11 > .flex--item,
+.gy4.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - (var(--su4) * 0.08333333333333333));
+}
+.g4 > .flex--item12,
+.gx4 > .flex--item12,
+.gy4 > .flex--item12,
+.g4.flex__allitems12 > .d-flex,
+.gx4.flex__allitems12 > .d-flex,
+.gy4.flex__allitems12 > .d-flex,
+.g4.flex__allitems12 > .flex--item,
+.gx4.flex__allitems12 > .flex--item,
+.gy4.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - (var(--su4) * 0));
+}
+.g6 > .flex--item1,
+.gx6 > .flex--item1,
+.gy6 > .flex--item1,
+.g6.flex__allitems1 > .d-flex,
+.gx6.flex__allitems1 > .d-flex,
+.gy6.flex__allitems1 > .d-flex,
+.g6.flex__allitems1 > .flex--item,
+.gx6.flex__allitems1 > .flex--item,
+.gy6.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - (var(--su6) * 0.9166666666666666));
+}
+.g6 > .flex--item2,
+.gx6 > .flex--item2,
+.gy6 > .flex--item2,
+.g6.flex__allitems2 > .d-flex,
+.gx6.flex__allitems2 > .d-flex,
+.gy6.flex__allitems2 > .d-flex,
+.g6.flex__allitems2 > .flex--item,
+.gx6.flex__allitems2 > .flex--item,
+.gy6.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - (var(--su6) * 0.8333333333333334));
+}
+.g6 > .flex--item3,
+.gx6 > .flex--item3,
+.gy6 > .flex--item3,
+.g6.flex__allitems3 > .d-flex,
+.gx6.flex__allitems3 > .d-flex,
+.gy6.flex__allitems3 > .d-flex,
+.g6.flex__allitems3 > .flex--item,
+.gx6.flex__allitems3 > .flex--item,
+.gy6.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - (var(--su6) * 0.75));
+}
+.g6 > .flex--item4,
+.gx6 > .flex--item4,
+.gy6 > .flex--item4,
+.g6.flex__allitems4 > .d-flex,
+.gx6.flex__allitems4 > .d-flex,
+.gy6.flex__allitems4 > .d-flex,
+.g6.flex__allitems4 > .flex--item,
+.gx6.flex__allitems4 > .flex--item,
+.gy6.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - (var(--su6) * 0.6666666666666666));
+}
+.g6 > .flex--item5,
+.gx6 > .flex--item5,
+.gy6 > .flex--item5,
+.g6.flex__allitems5 > .d-flex,
+.gx6.flex__allitems5 > .d-flex,
+.gy6.flex__allitems5 > .d-flex,
+.g6.flex__allitems5 > .flex--item,
+.gx6.flex__allitems5 > .flex--item,
+.gy6.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - (var(--su6) * 0.5833333333333334));
+}
+.g6 > .flex--item6,
+.gx6 > .flex--item6,
+.gy6 > .flex--item6,
+.g6.flex__allitems6 > .d-flex,
+.gx6.flex__allitems6 > .d-flex,
+.gy6.flex__allitems6 > .d-flex,
+.g6.flex__allitems6 > .flex--item,
+.gx6.flex__allitems6 > .flex--item,
+.gy6.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - (var(--su6) * 0.5));
+}
+.g6 > .flex--item7,
+.gx6 > .flex--item7,
+.gy6 > .flex--item7,
+.g6.flex__allitems7 > .d-flex,
+.gx6.flex__allitems7 > .d-flex,
+.gy6.flex__allitems7 > .d-flex,
+.g6.flex__allitems7 > .flex--item,
+.gx6.flex__allitems7 > .flex--item,
+.gy6.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - (var(--su6) * 0.4166666666666667));
+}
+.g6 > .flex--item8,
+.gx6 > .flex--item8,
+.gy6 > .flex--item8,
+.g6.flex__allitems8 > .d-flex,
+.gx6.flex__allitems8 > .d-flex,
+.gy6.flex__allitems8 > .d-flex,
+.g6.flex__allitems8 > .flex--item,
+.gx6.flex__allitems8 > .flex--item,
+.gy6.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - (var(--su6) * 0.3333333333333333));
+}
+.g6 > .flex--item9,
+.gx6 > .flex--item9,
+.gy6 > .flex--item9,
+.g6.flex__allitems9 > .d-flex,
+.gx6.flex__allitems9 > .d-flex,
+.gy6.flex__allitems9 > .d-flex,
+.g6.flex__allitems9 > .flex--item,
+.gx6.flex__allitems9 > .flex--item,
+.gy6.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - (var(--su6) * 0.25));
+}
+.g6 > .flex--item10,
+.gx6 > .flex--item10,
+.gy6 > .flex--item10,
+.g6.flex__allitems10 > .d-flex,
+.gx6.flex__allitems10 > .d-flex,
+.gy6.flex__allitems10 > .d-flex,
+.g6.flex__allitems10 > .flex--item,
+.gx6.flex__allitems10 > .flex--item,
+.gy6.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - (var(--su6) * 0.16666666666666666));
+}
+.g6 > .flex--item11,
+.gx6 > .flex--item11,
+.gy6 > .flex--item11,
+.g6.flex__allitems11 > .d-flex,
+.gx6.flex__allitems11 > .d-flex,
+.gy6.flex__allitems11 > .d-flex,
+.g6.flex__allitems11 > .flex--item,
+.gx6.flex__allitems11 > .flex--item,
+.gy6.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - (var(--su6) * 0.08333333333333333));
+}
+.g6 > .flex--item12,
+.gx6 > .flex--item12,
+.gy6 > .flex--item12,
+.g6.flex__allitems12 > .d-flex,
+.gx6.flex__allitems12 > .d-flex,
+.gy6.flex__allitems12 > .d-flex,
+.g6.flex__allitems12 > .flex--item,
+.gx6.flex__allitems12 > .flex--item,
+.gy6.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - (var(--su6) * 0));
+}
+.g8 > .flex--item1,
+.gx8 > .flex--item1,
+.gy8 > .flex--item1,
+.g8.flex__allitems1 > .d-flex,
+.gx8.flex__allitems1 > .d-flex,
+.gy8.flex__allitems1 > .d-flex,
+.g8.flex__allitems1 > .flex--item,
+.gx8.flex__allitems1 > .flex--item,
+.gy8.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - (var(--su8) * 0.9166666666666666));
+}
+.g8 > .flex--item2,
+.gx8 > .flex--item2,
+.gy8 > .flex--item2,
+.g8.flex__allitems2 > .d-flex,
+.gx8.flex__allitems2 > .d-flex,
+.gy8.flex__allitems2 > .d-flex,
+.g8.flex__allitems2 > .flex--item,
+.gx8.flex__allitems2 > .flex--item,
+.gy8.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - (var(--su8) * 0.8333333333333334));
+}
+.g8 > .flex--item3,
+.gx8 > .flex--item3,
+.gy8 > .flex--item3,
+.g8.flex__allitems3 > .d-flex,
+.gx8.flex__allitems3 > .d-flex,
+.gy8.flex__allitems3 > .d-flex,
+.g8.flex__allitems3 > .flex--item,
+.gx8.flex__allitems3 > .flex--item,
+.gy8.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - (var(--su8) * 0.75));
+}
+.g8 > .flex--item4,
+.gx8 > .flex--item4,
+.gy8 > .flex--item4,
+.g8.flex__allitems4 > .d-flex,
+.gx8.flex__allitems4 > .d-flex,
+.gy8.flex__allitems4 > .d-flex,
+.g8.flex__allitems4 > .flex--item,
+.gx8.flex__allitems4 > .flex--item,
+.gy8.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - (var(--su8) * 0.6666666666666666));
+}
+.g8 > .flex--item5,
+.gx8 > .flex--item5,
+.gy8 > .flex--item5,
+.g8.flex__allitems5 > .d-flex,
+.gx8.flex__allitems5 > .d-flex,
+.gy8.flex__allitems5 > .d-flex,
+.g8.flex__allitems5 > .flex--item,
+.gx8.flex__allitems5 > .flex--item,
+.gy8.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - (var(--su8) * 0.5833333333333334));
+}
+.g8 > .flex--item6,
+.gx8 > .flex--item6,
+.gy8 > .flex--item6,
+.g8.flex__allitems6 > .d-flex,
+.gx8.flex__allitems6 > .d-flex,
+.gy8.flex__allitems6 > .d-flex,
+.g8.flex__allitems6 > .flex--item,
+.gx8.flex__allitems6 > .flex--item,
+.gy8.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - (var(--su8) * 0.5));
+}
+.g8 > .flex--item7,
+.gx8 > .flex--item7,
+.gy8 > .flex--item7,
+.g8.flex__allitems7 > .d-flex,
+.gx8.flex__allitems7 > .d-flex,
+.gy8.flex__allitems7 > .d-flex,
+.g8.flex__allitems7 > .flex--item,
+.gx8.flex__allitems7 > .flex--item,
+.gy8.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - (var(--su8) * 0.4166666666666667));
+}
+.g8 > .flex--item8,
+.gx8 > .flex--item8,
+.gy8 > .flex--item8,
+.g8.flex__allitems8 > .d-flex,
+.gx8.flex__allitems8 > .d-flex,
+.gy8.flex__allitems8 > .d-flex,
+.g8.flex__allitems8 > .flex--item,
+.gx8.flex__allitems8 > .flex--item,
+.gy8.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - (var(--su8) * 0.3333333333333333));
+}
+.g8 > .flex--item9,
+.gx8 > .flex--item9,
+.gy8 > .flex--item9,
+.g8.flex__allitems9 > .d-flex,
+.gx8.flex__allitems9 > .d-flex,
+.gy8.flex__allitems9 > .d-flex,
+.g8.flex__allitems9 > .flex--item,
+.gx8.flex__allitems9 > .flex--item,
+.gy8.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - (var(--su8) * 0.25));
+}
+.g8 > .flex--item10,
+.gx8 > .flex--item10,
+.gy8 > .flex--item10,
+.g8.flex__allitems10 > .d-flex,
+.gx8.flex__allitems10 > .d-flex,
+.gy8.flex__allitems10 > .d-flex,
+.g8.flex__allitems10 > .flex--item,
+.gx8.flex__allitems10 > .flex--item,
+.gy8.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - (var(--su8) * 0.16666666666666666));
+}
+.g8 > .flex--item11,
+.gx8 > .flex--item11,
+.gy8 > .flex--item11,
+.g8.flex__allitems11 > .d-flex,
+.gx8.flex__allitems11 > .d-flex,
+.gy8.flex__allitems11 > .d-flex,
+.g8.flex__allitems11 > .flex--item,
+.gx8.flex__allitems11 > .flex--item,
+.gy8.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - (var(--su8) * 0.08333333333333333));
+}
+.g8 > .flex--item12,
+.gx8 > .flex--item12,
+.gy8 > .flex--item12,
+.g8.flex__allitems12 > .d-flex,
+.gx8.flex__allitems12 > .d-flex,
+.gy8.flex__allitems12 > .d-flex,
+.g8.flex__allitems12 > .flex--item,
+.gx8.flex__allitems12 > .flex--item,
+.gy8.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - (var(--su8) * 0));
+}
+.g12 > .flex--item1,
+.gx12 > .flex--item1,
+.gy12 > .flex--item1,
+.g12.flex__allitems1 > .d-flex,
+.gx12.flex__allitems1 > .d-flex,
+.gy12.flex__allitems1 > .d-flex,
+.g12.flex__allitems1 > .flex--item,
+.gx12.flex__allitems1 > .flex--item,
+.gy12.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - (var(--su12) * 0.9166666666666666));
+}
+.g12 > .flex--item2,
+.gx12 > .flex--item2,
+.gy12 > .flex--item2,
+.g12.flex__allitems2 > .d-flex,
+.gx12.flex__allitems2 > .d-flex,
+.gy12.flex__allitems2 > .d-flex,
+.g12.flex__allitems2 > .flex--item,
+.gx12.flex__allitems2 > .flex--item,
+.gy12.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - (var(--su12) * 0.8333333333333334));
+}
+.g12 > .flex--item3,
+.gx12 > .flex--item3,
+.gy12 > .flex--item3,
+.g12.flex__allitems3 > .d-flex,
+.gx12.flex__allitems3 > .d-flex,
+.gy12.flex__allitems3 > .d-flex,
+.g12.flex__allitems3 > .flex--item,
+.gx12.flex__allitems3 > .flex--item,
+.gy12.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - (var(--su12) * 0.75));
+}
+.g12 > .flex--item4,
+.gx12 > .flex--item4,
+.gy12 > .flex--item4,
+.g12.flex__allitems4 > .d-flex,
+.gx12.flex__allitems4 > .d-flex,
+.gy12.flex__allitems4 > .d-flex,
+.g12.flex__allitems4 > .flex--item,
+.gx12.flex__allitems4 > .flex--item,
+.gy12.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - (var(--su12) * 0.6666666666666666));
+}
+.g12 > .flex--item5,
+.gx12 > .flex--item5,
+.gy12 > .flex--item5,
+.g12.flex__allitems5 > .d-flex,
+.gx12.flex__allitems5 > .d-flex,
+.gy12.flex__allitems5 > .d-flex,
+.g12.flex__allitems5 > .flex--item,
+.gx12.flex__allitems5 > .flex--item,
+.gy12.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - (var(--su12) * 0.5833333333333334));
+}
+.g12 > .flex--item6,
+.gx12 > .flex--item6,
+.gy12 > .flex--item6,
+.g12.flex__allitems6 > .d-flex,
+.gx12.flex__allitems6 > .d-flex,
+.gy12.flex__allitems6 > .d-flex,
+.g12.flex__allitems6 > .flex--item,
+.gx12.flex__allitems6 > .flex--item,
+.gy12.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - (var(--su12) * 0.5));
+}
+.g12 > .flex--item7,
+.gx12 > .flex--item7,
+.gy12 > .flex--item7,
+.g12.flex__allitems7 > .d-flex,
+.gx12.flex__allitems7 > .d-flex,
+.gy12.flex__allitems7 > .d-flex,
+.g12.flex__allitems7 > .flex--item,
+.gx12.flex__allitems7 > .flex--item,
+.gy12.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - (var(--su12) * 0.4166666666666667));
+}
+.g12 > .flex--item8,
+.gx12 > .flex--item8,
+.gy12 > .flex--item8,
+.g12.flex__allitems8 > .d-flex,
+.gx12.flex__allitems8 > .d-flex,
+.gy12.flex__allitems8 > .d-flex,
+.g12.flex__allitems8 > .flex--item,
+.gx12.flex__allitems8 > .flex--item,
+.gy12.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - (var(--su12) * 0.3333333333333333));
+}
+.g12 > .flex--item9,
+.gx12 > .flex--item9,
+.gy12 > .flex--item9,
+.g12.flex__allitems9 > .d-flex,
+.gx12.flex__allitems9 > .d-flex,
+.gy12.flex__allitems9 > .d-flex,
+.g12.flex__allitems9 > .flex--item,
+.gx12.flex__allitems9 > .flex--item,
+.gy12.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - (var(--su12) * 0.25));
+}
+.g12 > .flex--item10,
+.gx12 > .flex--item10,
+.gy12 > .flex--item10,
+.g12.flex__allitems10 > .d-flex,
+.gx12.flex__allitems10 > .d-flex,
+.gy12.flex__allitems10 > .d-flex,
+.g12.flex__allitems10 > .flex--item,
+.gx12.flex__allitems10 > .flex--item,
+.gy12.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - (var(--su12) * 0.16666666666666666));
+}
+.g12 > .flex--item11,
+.gx12 > .flex--item11,
+.gy12 > .flex--item11,
+.g12.flex__allitems11 > .d-flex,
+.gx12.flex__allitems11 > .d-flex,
+.gy12.flex__allitems11 > .d-flex,
+.g12.flex__allitems11 > .flex--item,
+.gx12.flex__allitems11 > .flex--item,
+.gy12.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - (var(--su12) * 0.08333333333333333));
+}
+.g12 > .flex--item12,
+.gx12 > .flex--item12,
+.gy12 > .flex--item12,
+.g12.flex__allitems12 > .d-flex,
+.gx12.flex__allitems12 > .d-flex,
+.gy12.flex__allitems12 > .d-flex,
+.g12.flex__allitems12 > .flex--item,
+.gx12.flex__allitems12 > .flex--item,
+.gy12.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - (var(--su12) * 0));
+}
+.g16 > .flex--item1,
+.gx16 > .flex--item1,
+.gy16 > .flex--item1,
+.g16.flex__allitems1 > .d-flex,
+.gx16.flex__allitems1 > .d-flex,
+.gy16.flex__allitems1 > .d-flex,
+.g16.flex__allitems1 > .flex--item,
+.gx16.flex__allitems1 > .flex--item,
+.gy16.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - (var(--su16) * 0.9166666666666666));
+}
+.g16 > .flex--item2,
+.gx16 > .flex--item2,
+.gy16 > .flex--item2,
+.g16.flex__allitems2 > .d-flex,
+.gx16.flex__allitems2 > .d-flex,
+.gy16.flex__allitems2 > .d-flex,
+.g16.flex__allitems2 > .flex--item,
+.gx16.flex__allitems2 > .flex--item,
+.gy16.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - (var(--su16) * 0.8333333333333334));
+}
+.g16 > .flex--item3,
+.gx16 > .flex--item3,
+.gy16 > .flex--item3,
+.g16.flex__allitems3 > .d-flex,
+.gx16.flex__allitems3 > .d-flex,
+.gy16.flex__allitems3 > .d-flex,
+.g16.flex__allitems3 > .flex--item,
+.gx16.flex__allitems3 > .flex--item,
+.gy16.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - (var(--su16) * 0.75));
+}
+.g16 > .flex--item4,
+.gx16 > .flex--item4,
+.gy16 > .flex--item4,
+.g16.flex__allitems4 > .d-flex,
+.gx16.flex__allitems4 > .d-flex,
+.gy16.flex__allitems4 > .d-flex,
+.g16.flex__allitems4 > .flex--item,
+.gx16.flex__allitems4 > .flex--item,
+.gy16.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - (var(--su16) * 0.6666666666666666));
+}
+.g16 > .flex--item5,
+.gx16 > .flex--item5,
+.gy16 > .flex--item5,
+.g16.flex__allitems5 > .d-flex,
+.gx16.flex__allitems5 > .d-flex,
+.gy16.flex__allitems5 > .d-flex,
+.g16.flex__allitems5 > .flex--item,
+.gx16.flex__allitems5 > .flex--item,
+.gy16.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - (var(--su16) * 0.5833333333333334));
+}
+.g16 > .flex--item6,
+.gx16 > .flex--item6,
+.gy16 > .flex--item6,
+.g16.flex__allitems6 > .d-flex,
+.gx16.flex__allitems6 > .d-flex,
+.gy16.flex__allitems6 > .d-flex,
+.g16.flex__allitems6 > .flex--item,
+.gx16.flex__allitems6 > .flex--item,
+.gy16.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - (var(--su16) * 0.5));
+}
+.g16 > .flex--item7,
+.gx16 > .flex--item7,
+.gy16 > .flex--item7,
+.g16.flex__allitems7 > .d-flex,
+.gx16.flex__allitems7 > .d-flex,
+.gy16.flex__allitems7 > .d-flex,
+.g16.flex__allitems7 > .flex--item,
+.gx16.flex__allitems7 > .flex--item,
+.gy16.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - (var(--su16) * 0.4166666666666667));
+}
+.g16 > .flex--item8,
+.gx16 > .flex--item8,
+.gy16 > .flex--item8,
+.g16.flex__allitems8 > .d-flex,
+.gx16.flex__allitems8 > .d-flex,
+.gy16.flex__allitems8 > .d-flex,
+.g16.flex__allitems8 > .flex--item,
+.gx16.flex__allitems8 > .flex--item,
+.gy16.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - (var(--su16) * 0.3333333333333333));
+}
+.g16 > .flex--item9,
+.gx16 > .flex--item9,
+.gy16 > .flex--item9,
+.g16.flex__allitems9 > .d-flex,
+.gx16.flex__allitems9 > .d-flex,
+.gy16.flex__allitems9 > .d-flex,
+.g16.flex__allitems9 > .flex--item,
+.gx16.flex__allitems9 > .flex--item,
+.gy16.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - (var(--su16) * 0.25));
+}
+.g16 > .flex--item10,
+.gx16 > .flex--item10,
+.gy16 > .flex--item10,
+.g16.flex__allitems10 > .d-flex,
+.gx16.flex__allitems10 > .d-flex,
+.gy16.flex__allitems10 > .d-flex,
+.g16.flex__allitems10 > .flex--item,
+.gx16.flex__allitems10 > .flex--item,
+.gy16.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - (var(--su16) * 0.16666666666666666));
+}
+.g16 > .flex--item11,
+.gx16 > .flex--item11,
+.gy16 > .flex--item11,
+.g16.flex__allitems11 > .d-flex,
+.gx16.flex__allitems11 > .d-flex,
+.gy16.flex__allitems11 > .d-flex,
+.g16.flex__allitems11 > .flex--item,
+.gx16.flex__allitems11 > .flex--item,
+.gy16.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - (var(--su16) * 0.08333333333333333));
+}
+.g16 > .flex--item12,
+.gx16 > .flex--item12,
+.gy16 > .flex--item12,
+.g16.flex__allitems12 > .d-flex,
+.gx16.flex__allitems12 > .d-flex,
+.gy16.flex__allitems12 > .d-flex,
+.g16.flex__allitems12 > .flex--item,
+.gx16.flex__allitems12 > .flex--item,
+.gy16.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - (var(--su16) * 0));
+}
+.g24 > .flex--item1,
+.gx24 > .flex--item1,
+.gy24 > .flex--item1,
+.g24.flex__allitems1 > .d-flex,
+.gx24.flex__allitems1 > .d-flex,
+.gy24.flex__allitems1 > .d-flex,
+.g24.flex__allitems1 > .flex--item,
+.gx24.flex__allitems1 > .flex--item,
+.gy24.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - (var(--su24) * 0.9166666666666666));
+}
+.g24 > .flex--item2,
+.gx24 > .flex--item2,
+.gy24 > .flex--item2,
+.g24.flex__allitems2 > .d-flex,
+.gx24.flex__allitems2 > .d-flex,
+.gy24.flex__allitems2 > .d-flex,
+.g24.flex__allitems2 > .flex--item,
+.gx24.flex__allitems2 > .flex--item,
+.gy24.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - (var(--su24) * 0.8333333333333334));
+}
+.g24 > .flex--item3,
+.gx24 > .flex--item3,
+.gy24 > .flex--item3,
+.g24.flex__allitems3 > .d-flex,
+.gx24.flex__allitems3 > .d-flex,
+.gy24.flex__allitems3 > .d-flex,
+.g24.flex__allitems3 > .flex--item,
+.gx24.flex__allitems3 > .flex--item,
+.gy24.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - (var(--su24) * 0.75));
+}
+.g24 > .flex--item4,
+.gx24 > .flex--item4,
+.gy24 > .flex--item4,
+.g24.flex__allitems4 > .d-flex,
+.gx24.flex__allitems4 > .d-flex,
+.gy24.flex__allitems4 > .d-flex,
+.g24.flex__allitems4 > .flex--item,
+.gx24.flex__allitems4 > .flex--item,
+.gy24.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - (var(--su24) * 0.6666666666666666));
+}
+.g24 > .flex--item5,
+.gx24 > .flex--item5,
+.gy24 > .flex--item5,
+.g24.flex__allitems5 > .d-flex,
+.gx24.flex__allitems5 > .d-flex,
+.gy24.flex__allitems5 > .d-flex,
+.g24.flex__allitems5 > .flex--item,
+.gx24.flex__allitems5 > .flex--item,
+.gy24.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - (var(--su24) * 0.5833333333333334));
+}
+.g24 > .flex--item6,
+.gx24 > .flex--item6,
+.gy24 > .flex--item6,
+.g24.flex__allitems6 > .d-flex,
+.gx24.flex__allitems6 > .d-flex,
+.gy24.flex__allitems6 > .d-flex,
+.g24.flex__allitems6 > .flex--item,
+.gx24.flex__allitems6 > .flex--item,
+.gy24.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - (var(--su24) * 0.5));
+}
+.g24 > .flex--item7,
+.gx24 > .flex--item7,
+.gy24 > .flex--item7,
+.g24.flex__allitems7 > .d-flex,
+.gx24.flex__allitems7 > .d-flex,
+.gy24.flex__allitems7 > .d-flex,
+.g24.flex__allitems7 > .flex--item,
+.gx24.flex__allitems7 > .flex--item,
+.gy24.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - (var(--su24) * 0.4166666666666667));
+}
+.g24 > .flex--item8,
+.gx24 > .flex--item8,
+.gy24 > .flex--item8,
+.g24.flex__allitems8 > .d-flex,
+.gx24.flex__allitems8 > .d-flex,
+.gy24.flex__allitems8 > .d-flex,
+.g24.flex__allitems8 > .flex--item,
+.gx24.flex__allitems8 > .flex--item,
+.gy24.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - (var(--su24) * 0.3333333333333333));
+}
+.g24 > .flex--item9,
+.gx24 > .flex--item9,
+.gy24 > .flex--item9,
+.g24.flex__allitems9 > .d-flex,
+.gx24.flex__allitems9 > .d-flex,
+.gy24.flex__allitems9 > .d-flex,
+.g24.flex__allitems9 > .flex--item,
+.gx24.flex__allitems9 > .flex--item,
+.gy24.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - (var(--su24) * 0.25));
+}
+.g24 > .flex--item10,
+.gx24 > .flex--item10,
+.gy24 > .flex--item10,
+.g24.flex__allitems10 > .d-flex,
+.gx24.flex__allitems10 > .d-flex,
+.gy24.flex__allitems10 > .d-flex,
+.g24.flex__allitems10 > .flex--item,
+.gx24.flex__allitems10 > .flex--item,
+.gy24.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - (var(--su24) * 0.16666666666666666));
+}
+.g24 > .flex--item11,
+.gx24 > .flex--item11,
+.gy24 > .flex--item11,
+.g24.flex__allitems11 > .d-flex,
+.gx24.flex__allitems11 > .d-flex,
+.gy24.flex__allitems11 > .d-flex,
+.g24.flex__allitems11 > .flex--item,
+.gx24.flex__allitems11 > .flex--item,
+.gy24.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - (var(--su24) * 0.08333333333333333));
+}
+.g24 > .flex--item12,
+.gx24 > .flex--item12,
+.gy24 > .flex--item12,
+.g24.flex__allitems12 > .d-flex,
+.gx24.flex__allitems12 > .d-flex,
+.gy24.flex__allitems12 > .d-flex,
+.g24.flex__allitems12 > .flex--item,
+.gx24.flex__allitems12 > .flex--item,
+.gy24.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - (var(--su24) * 0));
+}
+.g32 > .flex--item1,
+.gx32 > .flex--item1,
+.gy32 > .flex--item1,
+.g32.flex__allitems1 > .d-flex,
+.gx32.flex__allitems1 > .d-flex,
+.gy32.flex__allitems1 > .d-flex,
+.g32.flex__allitems1 > .flex--item,
+.gx32.flex__allitems1 > .flex--item,
+.gy32.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - (var(--su32) * 0.9166666666666666));
+}
+.g32 > .flex--item2,
+.gx32 > .flex--item2,
+.gy32 > .flex--item2,
+.g32.flex__allitems2 > .d-flex,
+.gx32.flex__allitems2 > .d-flex,
+.gy32.flex__allitems2 > .d-flex,
+.g32.flex__allitems2 > .flex--item,
+.gx32.flex__allitems2 > .flex--item,
+.gy32.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - (var(--su32) * 0.8333333333333334));
+}
+.g32 > .flex--item3,
+.gx32 > .flex--item3,
+.gy32 > .flex--item3,
+.g32.flex__allitems3 > .d-flex,
+.gx32.flex__allitems3 > .d-flex,
+.gy32.flex__allitems3 > .d-flex,
+.g32.flex__allitems3 > .flex--item,
+.gx32.flex__allitems3 > .flex--item,
+.gy32.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - (var(--su32) * 0.75));
+}
+.g32 > .flex--item4,
+.gx32 > .flex--item4,
+.gy32 > .flex--item4,
+.g32.flex__allitems4 > .d-flex,
+.gx32.flex__allitems4 > .d-flex,
+.gy32.flex__allitems4 > .d-flex,
+.g32.flex__allitems4 > .flex--item,
+.gx32.flex__allitems4 > .flex--item,
+.gy32.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - (var(--su32) * 0.6666666666666666));
+}
+.g32 > .flex--item5,
+.gx32 > .flex--item5,
+.gy32 > .flex--item5,
+.g32.flex__allitems5 > .d-flex,
+.gx32.flex__allitems5 > .d-flex,
+.gy32.flex__allitems5 > .d-flex,
+.g32.flex__allitems5 > .flex--item,
+.gx32.flex__allitems5 > .flex--item,
+.gy32.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - (var(--su32) * 0.5833333333333334));
+}
+.g32 > .flex--item6,
+.gx32 > .flex--item6,
+.gy32 > .flex--item6,
+.g32.flex__allitems6 > .d-flex,
+.gx32.flex__allitems6 > .d-flex,
+.gy32.flex__allitems6 > .d-flex,
+.g32.flex__allitems6 > .flex--item,
+.gx32.flex__allitems6 > .flex--item,
+.gy32.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - (var(--su32) * 0.5));
+}
+.g32 > .flex--item7,
+.gx32 > .flex--item7,
+.gy32 > .flex--item7,
+.g32.flex__allitems7 > .d-flex,
+.gx32.flex__allitems7 > .d-flex,
+.gy32.flex__allitems7 > .d-flex,
+.g32.flex__allitems7 > .flex--item,
+.gx32.flex__allitems7 > .flex--item,
+.gy32.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - (var(--su32) * 0.4166666666666667));
+}
+.g32 > .flex--item8,
+.gx32 > .flex--item8,
+.gy32 > .flex--item8,
+.g32.flex__allitems8 > .d-flex,
+.gx32.flex__allitems8 > .d-flex,
+.gy32.flex__allitems8 > .d-flex,
+.g32.flex__allitems8 > .flex--item,
+.gx32.flex__allitems8 > .flex--item,
+.gy32.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - (var(--su32) * 0.3333333333333333));
+}
+.g32 > .flex--item9,
+.gx32 > .flex--item9,
+.gy32 > .flex--item9,
+.g32.flex__allitems9 > .d-flex,
+.gx32.flex__allitems9 > .d-flex,
+.gy32.flex__allitems9 > .d-flex,
+.g32.flex__allitems9 > .flex--item,
+.gx32.flex__allitems9 > .flex--item,
+.gy32.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - (var(--su32) * 0.25));
+}
+.g32 > .flex--item10,
+.gx32 > .flex--item10,
+.gy32 > .flex--item10,
+.g32.flex__allitems10 > .d-flex,
+.gx32.flex__allitems10 > .d-flex,
+.gy32.flex__allitems10 > .d-flex,
+.g32.flex__allitems10 > .flex--item,
+.gx32.flex__allitems10 > .flex--item,
+.gy32.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - (var(--su32) * 0.16666666666666666));
+}
+.g32 > .flex--item11,
+.gx32 > .flex--item11,
+.gy32 > .flex--item11,
+.g32.flex__allitems11 > .d-flex,
+.gx32.flex__allitems11 > .d-flex,
+.gy32.flex__allitems11 > .d-flex,
+.g32.flex__allitems11 > .flex--item,
+.gx32.flex__allitems11 > .flex--item,
+.gy32.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - (var(--su32) * 0.08333333333333333));
+}
+.g32 > .flex--item12,
+.gx32 > .flex--item12,
+.gy32 > .flex--item12,
+.g32.flex__allitems12 > .d-flex,
+.gx32.flex__allitems12 > .d-flex,
+.gy32.flex__allitems12 > .d-flex,
+.g32.flex__allitems12 > .flex--item,
+.gx32.flex__allitems12 > .flex--item,
+.gy32.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - (var(--su32) * 0));
+}
+.g48 > .flex--item1,
+.gx48 > .flex--item1,
+.gy48 > .flex--item1,
+.g48.flex__allitems1 > .d-flex,
+.gx48.flex__allitems1 > .d-flex,
+.gy48.flex__allitems1 > .d-flex,
+.g48.flex__allitems1 > .flex--item,
+.gx48.flex__allitems1 > .flex--item,
+.gy48.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - (var(--su48) * 0.9166666666666666));
+}
+.g48 > .flex--item2,
+.gx48 > .flex--item2,
+.gy48 > .flex--item2,
+.g48.flex__allitems2 > .d-flex,
+.gx48.flex__allitems2 > .d-flex,
+.gy48.flex__allitems2 > .d-flex,
+.g48.flex__allitems2 > .flex--item,
+.gx48.flex__allitems2 > .flex--item,
+.gy48.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - (var(--su48) * 0.8333333333333334));
+}
+.g48 > .flex--item3,
+.gx48 > .flex--item3,
+.gy48 > .flex--item3,
+.g48.flex__allitems3 > .d-flex,
+.gx48.flex__allitems3 > .d-flex,
+.gy48.flex__allitems3 > .d-flex,
+.g48.flex__allitems3 > .flex--item,
+.gx48.flex__allitems3 > .flex--item,
+.gy48.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - (var(--su48) * 0.75));
+}
+.g48 > .flex--item4,
+.gx48 > .flex--item4,
+.gy48 > .flex--item4,
+.g48.flex__allitems4 > .d-flex,
+.gx48.flex__allitems4 > .d-flex,
+.gy48.flex__allitems4 > .d-flex,
+.g48.flex__allitems4 > .flex--item,
+.gx48.flex__allitems4 > .flex--item,
+.gy48.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - (var(--su48) * 0.6666666666666666));
+}
+.g48 > .flex--item5,
+.gx48 > .flex--item5,
+.gy48 > .flex--item5,
+.g48.flex__allitems5 > .d-flex,
+.gx48.flex__allitems5 > .d-flex,
+.gy48.flex__allitems5 > .d-flex,
+.g48.flex__allitems5 > .flex--item,
+.gx48.flex__allitems5 > .flex--item,
+.gy48.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - (var(--su48) * 0.5833333333333334));
+}
+.g48 > .flex--item6,
+.gx48 > .flex--item6,
+.gy48 > .flex--item6,
+.g48.flex__allitems6 > .d-flex,
+.gx48.flex__allitems6 > .d-flex,
+.gy48.flex__allitems6 > .d-flex,
+.g48.flex__allitems6 > .flex--item,
+.gx48.flex__allitems6 > .flex--item,
+.gy48.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - (var(--su48) * 0.5));
+}
+.g48 > .flex--item7,
+.gx48 > .flex--item7,
+.gy48 > .flex--item7,
+.g48.flex__allitems7 > .d-flex,
+.gx48.flex__allitems7 > .d-flex,
+.gy48.flex__allitems7 > .d-flex,
+.g48.flex__allitems7 > .flex--item,
+.gx48.flex__allitems7 > .flex--item,
+.gy48.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - (var(--su48) * 0.4166666666666667));
+}
+.g48 > .flex--item8,
+.gx48 > .flex--item8,
+.gy48 > .flex--item8,
+.g48.flex__allitems8 > .d-flex,
+.gx48.flex__allitems8 > .d-flex,
+.gy48.flex__allitems8 > .d-flex,
+.g48.flex__allitems8 > .flex--item,
+.gx48.flex__allitems8 > .flex--item,
+.gy48.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - (var(--su48) * 0.3333333333333333));
+}
+.g48 > .flex--item9,
+.gx48 > .flex--item9,
+.gy48 > .flex--item9,
+.g48.flex__allitems9 > .d-flex,
+.gx48.flex__allitems9 > .d-flex,
+.gy48.flex__allitems9 > .d-flex,
+.g48.flex__allitems9 > .flex--item,
+.gx48.flex__allitems9 > .flex--item,
+.gy48.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - (var(--su48) * 0.25));
+}
+.g48 > .flex--item10,
+.gx48 > .flex--item10,
+.gy48 > .flex--item10,
+.g48.flex__allitems10 > .d-flex,
+.gx48.flex__allitems10 > .d-flex,
+.gy48.flex__allitems10 > .d-flex,
+.g48.flex__allitems10 > .flex--item,
+.gx48.flex__allitems10 > .flex--item,
+.gy48.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - (var(--su48) * 0.16666666666666666));
+}
+.g48 > .flex--item11,
+.gx48 > .flex--item11,
+.gy48 > .flex--item11,
+.g48.flex__allitems11 > .d-flex,
+.gx48.flex__allitems11 > .d-flex,
+.gy48.flex__allitems11 > .d-flex,
+.g48.flex__allitems11 > .flex--item,
+.gx48.flex__allitems11 > .flex--item,
+.gy48.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - (var(--su48) * 0.08333333333333333));
+}
+.g48 > .flex--item12,
+.gx48 > .flex--item12,
+.gy48 > .flex--item12,
+.g48.flex__allitems12 > .d-flex,
+.gx48.flex__allitems12 > .d-flex,
+.gy48.flex__allitems12 > .d-flex,
+.g48.flex__allitems12 > .flex--item,
+.gx48.flex__allitems12 > .flex--item,
+.gy48.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - (var(--su48) * 0));
+}
+.g64 > .flex--item1,
+.gx64 > .flex--item1,
+.gy64 > .flex--item1,
+.g64.flex__allitems1 > .d-flex,
+.gx64.flex__allitems1 > .d-flex,
+.gy64.flex__allitems1 > .d-flex,
+.g64.flex__allitems1 > .flex--item,
+.gx64.flex__allitems1 > .flex--item,
+.gy64.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - (var(--su64) * 0.9166666666666666));
+}
+.g64 > .flex--item2,
+.gx64 > .flex--item2,
+.gy64 > .flex--item2,
+.g64.flex__allitems2 > .d-flex,
+.gx64.flex__allitems2 > .d-flex,
+.gy64.flex__allitems2 > .d-flex,
+.g64.flex__allitems2 > .flex--item,
+.gx64.flex__allitems2 > .flex--item,
+.gy64.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - (var(--su64) * 0.8333333333333334));
+}
+.g64 > .flex--item3,
+.gx64 > .flex--item3,
+.gy64 > .flex--item3,
+.g64.flex__allitems3 > .d-flex,
+.gx64.flex__allitems3 > .d-flex,
+.gy64.flex__allitems3 > .d-flex,
+.g64.flex__allitems3 > .flex--item,
+.gx64.flex__allitems3 > .flex--item,
+.gy64.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - (var(--su64) * 0.75));
+}
+.g64 > .flex--item4,
+.gx64 > .flex--item4,
+.gy64 > .flex--item4,
+.g64.flex__allitems4 > .d-flex,
+.gx64.flex__allitems4 > .d-flex,
+.gy64.flex__allitems4 > .d-flex,
+.g64.flex__allitems4 > .flex--item,
+.gx64.flex__allitems4 > .flex--item,
+.gy64.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - (var(--su64) * 0.6666666666666666));
+}
+.g64 > .flex--item5,
+.gx64 > .flex--item5,
+.gy64 > .flex--item5,
+.g64.flex__allitems5 > .d-flex,
+.gx64.flex__allitems5 > .d-flex,
+.gy64.flex__allitems5 > .d-flex,
+.g64.flex__allitems5 > .flex--item,
+.gx64.flex__allitems5 > .flex--item,
+.gy64.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - (var(--su64) * 0.5833333333333334));
+}
+.g64 > .flex--item6,
+.gx64 > .flex--item6,
+.gy64 > .flex--item6,
+.g64.flex__allitems6 > .d-flex,
+.gx64.flex__allitems6 > .d-flex,
+.gy64.flex__allitems6 > .d-flex,
+.g64.flex__allitems6 > .flex--item,
+.gx64.flex__allitems6 > .flex--item,
+.gy64.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - (var(--su64) * 0.5));
+}
+.g64 > .flex--item7,
+.gx64 > .flex--item7,
+.gy64 > .flex--item7,
+.g64.flex__allitems7 > .d-flex,
+.gx64.flex__allitems7 > .d-flex,
+.gy64.flex__allitems7 > .d-flex,
+.g64.flex__allitems7 > .flex--item,
+.gx64.flex__allitems7 > .flex--item,
+.gy64.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - (var(--su64) * 0.4166666666666667));
+}
+.g64 > .flex--item8,
+.gx64 > .flex--item8,
+.gy64 > .flex--item8,
+.g64.flex__allitems8 > .d-flex,
+.gx64.flex__allitems8 > .d-flex,
+.gy64.flex__allitems8 > .d-flex,
+.g64.flex__allitems8 > .flex--item,
+.gx64.flex__allitems8 > .flex--item,
+.gy64.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - (var(--su64) * 0.3333333333333333));
+}
+.g64 > .flex--item9,
+.gx64 > .flex--item9,
+.gy64 > .flex--item9,
+.g64.flex__allitems9 > .d-flex,
+.gx64.flex__allitems9 > .d-flex,
+.gy64.flex__allitems9 > .d-flex,
+.g64.flex__allitems9 > .flex--item,
+.gx64.flex__allitems9 > .flex--item,
+.gy64.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - (var(--su64) * 0.25));
+}
+.g64 > .flex--item10,
+.gx64 > .flex--item10,
+.gy64 > .flex--item10,
+.g64.flex__allitems10 > .d-flex,
+.gx64.flex__allitems10 > .d-flex,
+.gy64.flex__allitems10 > .d-flex,
+.g64.flex__allitems10 > .flex--item,
+.gx64.flex__allitems10 > .flex--item,
+.gy64.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - (var(--su64) * 0.16666666666666666));
+}
+.g64 > .flex--item11,
+.gx64 > .flex--item11,
+.gy64 > .flex--item11,
+.g64.flex__allitems11 > .d-flex,
+.gx64.flex__allitems11 > .d-flex,
+.gy64.flex__allitems11 > .d-flex,
+.g64.flex__allitems11 > .flex--item,
+.gx64.flex__allitems11 > .flex--item,
+.gy64.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - (var(--su64) * 0.08333333333333333));
+}
+.g64 > .flex--item12,
+.gx64 > .flex--item12,
+.gy64 > .flex--item12,
+.g64.flex__allitems12 > .d-flex,
+.gx64.flex__allitems12 > .d-flex,
+.gy64.flex__allitems12 > .d-flex,
+.g64.flex__allitems12 > .flex--item,
+.gx64.flex__allitems12 > .flex--item,
+.gy64.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - (var(--su64) * 0));
+}
+.gs2 {
+  margin: calc(var(--su2) / 2 * -1);
+}
+.gs2 > .d-flex,
+.gs2 > .flex--item {
+  margin: calc(var(--su2) / 2);
+}
+.gs2 > .flex--item1 {
+  margin: calc(var(--su2) / 2);
+}
+.gs2 > .flex--item1,
+.gs2.flex__allitems1 > .d-flex,
+.gs2.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - var(--su2));
+}
+.gs2 > .flex--item2 {
+  margin: calc(var(--su2) / 2);
+}
+.gs2 > .flex--item2,
+.gs2.flex__allitems2 > .d-flex,
+.gs2.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - var(--su2));
+}
+.gs2 > .flex--item3 {
+  margin: calc(var(--su2) / 2);
+}
+.gs2 > .flex--item3,
+.gs2.flex__allitems3 > .d-flex,
+.gs2.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - var(--su2));
+}
+.gs2 > .flex--item4 {
+  margin: calc(var(--su2) / 2);
+}
+.gs2 > .flex--item4,
+.gs2.flex__allitems4 > .d-flex,
+.gs2.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - var(--su2));
+}
+.gs2 > .flex--item5 {
+  margin: calc(var(--su2) / 2);
+}
+.gs2 > .flex--item5,
+.gs2.flex__allitems5 > .d-flex,
+.gs2.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - var(--su2));
+}
+.gs2 > .flex--item6 {
+  margin: calc(var(--su2) / 2);
+}
+.gs2 > .flex--item6,
+.gs2.flex__allitems6 > .d-flex,
+.gs2.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - var(--su2));
+}
+.gs2 > .flex--item7 {
+  margin: calc(var(--su2) / 2);
+}
+.gs2 > .flex--item7,
+.gs2.flex__allitems7 > .d-flex,
+.gs2.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - var(--su2));
+}
+.gs2 > .flex--item8 {
+  margin: calc(var(--su2) / 2);
+}
+.gs2 > .flex--item8,
+.gs2.flex__allitems8 > .d-flex,
+.gs2.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - var(--su2));
+}
+.gs2 > .flex--item9 {
+  margin: calc(var(--su2) / 2);
+}
+.gs2 > .flex--item9,
+.gs2.flex__allitems9 > .d-flex,
+.gs2.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - var(--su2));
+}
+.gs2 > .flex--item10 {
+  margin: calc(var(--su2) / 2);
+}
+.gs2 > .flex--item10,
+.gs2.flex__allitems10 > .d-flex,
+.gs2.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - var(--su2));
+}
+.gs2 > .flex--item11 {
+  margin: calc(var(--su2) / 2);
+}
+.gs2 > .flex--item11,
+.gs2.flex__allitems11 > .d-flex,
+.gs2.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - var(--su2));
+}
+.gs2 > .flex--item12 {
+  margin: calc(var(--su2) / 2);
+}
+.gs2 > .flex--item12,
+.gs2.flex__allitems12 > .d-flex,
+.gs2.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - var(--su2));
+}
+.gs4 {
+  margin: calc(var(--su4) / 2 * -1);
+}
+.gs4 > .d-flex,
+.gs4 > .flex--item {
+  margin: calc(var(--su4) / 2);
+}
+.gs4 > .flex--item1 {
+  margin: calc(var(--su4) / 2);
+}
+.gs4 > .flex--item1,
+.gs4.flex__allitems1 > .d-flex,
+.gs4.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - var(--su4));
+}
+.gs4 > .flex--item2 {
+  margin: calc(var(--su4) / 2);
+}
+.gs4 > .flex--item2,
+.gs4.flex__allitems2 > .d-flex,
+.gs4.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - var(--su4));
+}
+.gs4 > .flex--item3 {
+  margin: calc(var(--su4) / 2);
+}
+.gs4 > .flex--item3,
+.gs4.flex__allitems3 > .d-flex,
+.gs4.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - var(--su4));
+}
+.gs4 > .flex--item4 {
+  margin: calc(var(--su4) / 2);
+}
+.gs4 > .flex--item4,
+.gs4.flex__allitems4 > .d-flex,
+.gs4.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - var(--su4));
+}
+.gs4 > .flex--item5 {
+  margin: calc(var(--su4) / 2);
+}
+.gs4 > .flex--item5,
+.gs4.flex__allitems5 > .d-flex,
+.gs4.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - var(--su4));
+}
+.gs4 > .flex--item6 {
+  margin: calc(var(--su4) / 2);
+}
+.gs4 > .flex--item6,
+.gs4.flex__allitems6 > .d-flex,
+.gs4.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - var(--su4));
+}
+.gs4 > .flex--item7 {
+  margin: calc(var(--su4) / 2);
+}
+.gs4 > .flex--item7,
+.gs4.flex__allitems7 > .d-flex,
+.gs4.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - var(--su4));
+}
+.gs4 > .flex--item8 {
+  margin: calc(var(--su4) / 2);
+}
+.gs4 > .flex--item8,
+.gs4.flex__allitems8 > .d-flex,
+.gs4.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - var(--su4));
+}
+.gs4 > .flex--item9 {
+  margin: calc(var(--su4) / 2);
+}
+.gs4 > .flex--item9,
+.gs4.flex__allitems9 > .d-flex,
+.gs4.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - var(--su4));
+}
+.gs4 > .flex--item10 {
+  margin: calc(var(--su4) / 2);
+}
+.gs4 > .flex--item10,
+.gs4.flex__allitems10 > .d-flex,
+.gs4.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - var(--su4));
+}
+.gs4 > .flex--item11 {
+  margin: calc(var(--su4) / 2);
+}
+.gs4 > .flex--item11,
+.gs4.flex__allitems11 > .d-flex,
+.gs4.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - var(--su4));
+}
+.gs4 > .flex--item12 {
+  margin: calc(var(--su4) / 2);
+}
+.gs4 > .flex--item12,
+.gs4.flex__allitems12 > .d-flex,
+.gs4.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - var(--su4));
+}
+.gs6 {
+  margin: calc(var(--su6) / 2 * -1);
+}
+.gs6 > .d-flex,
+.gs6 > .flex--item {
+  margin: calc(var(--su6) / 2);
+}
+.gs6 > .flex--item1 {
+  margin: calc(var(--su6) / 2);
+}
+.gs6 > .flex--item1,
+.gs6.flex__allitems1 > .d-flex,
+.gs6.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - var(--su6));
+}
+.gs6 > .flex--item2 {
+  margin: calc(var(--su6) / 2);
+}
+.gs6 > .flex--item2,
+.gs6.flex__allitems2 > .d-flex,
+.gs6.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - var(--su6));
+}
+.gs6 > .flex--item3 {
+  margin: calc(var(--su6) / 2);
+}
+.gs6 > .flex--item3,
+.gs6.flex__allitems3 > .d-flex,
+.gs6.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - var(--su6));
+}
+.gs6 > .flex--item4 {
+  margin: calc(var(--su6) / 2);
+}
+.gs6 > .flex--item4,
+.gs6.flex__allitems4 > .d-flex,
+.gs6.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - var(--su6));
+}
+.gs6 > .flex--item5 {
+  margin: calc(var(--su6) / 2);
+}
+.gs6 > .flex--item5,
+.gs6.flex__allitems5 > .d-flex,
+.gs6.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - var(--su6));
+}
+.gs6 > .flex--item6 {
+  margin: calc(var(--su6) / 2);
+}
+.gs6 > .flex--item6,
+.gs6.flex__allitems6 > .d-flex,
+.gs6.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - var(--su6));
+}
+.gs6 > .flex--item7 {
+  margin: calc(var(--su6) / 2);
+}
+.gs6 > .flex--item7,
+.gs6.flex__allitems7 > .d-flex,
+.gs6.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - var(--su6));
+}
+.gs6 > .flex--item8 {
+  margin: calc(var(--su6) / 2);
+}
+.gs6 > .flex--item8,
+.gs6.flex__allitems8 > .d-flex,
+.gs6.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - var(--su6));
+}
+.gs6 > .flex--item9 {
+  margin: calc(var(--su6) / 2);
+}
+.gs6 > .flex--item9,
+.gs6.flex__allitems9 > .d-flex,
+.gs6.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - var(--su6));
+}
+.gs6 > .flex--item10 {
+  margin: calc(var(--su6) / 2);
+}
+.gs6 > .flex--item10,
+.gs6.flex__allitems10 > .d-flex,
+.gs6.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - var(--su6));
+}
+.gs6 > .flex--item11 {
+  margin: calc(var(--su6) / 2);
+}
+.gs6 > .flex--item11,
+.gs6.flex__allitems11 > .d-flex,
+.gs6.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - var(--su6));
+}
+.gs6 > .flex--item12 {
+  margin: calc(var(--su6) / 2);
+}
+.gs6 > .flex--item12,
+.gs6.flex__allitems12 > .d-flex,
+.gs6.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - var(--su6));
+}
+.gs8 {
+  margin: calc(var(--su8) / 2 * -1);
+}
+.gs8 > .d-flex,
+.gs8 > .flex--item {
+  margin: calc(var(--su8) / 2);
+}
+.gs8 > .flex--item1 {
+  margin: calc(var(--su8) / 2);
+}
+.gs8 > .flex--item1,
+.gs8.flex__allitems1 > .d-flex,
+.gs8.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - var(--su8));
+}
+.gs8 > .flex--item2 {
+  margin: calc(var(--su8) / 2);
+}
+.gs8 > .flex--item2,
+.gs8.flex__allitems2 > .d-flex,
+.gs8.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - var(--su8));
+}
+.gs8 > .flex--item3 {
+  margin: calc(var(--su8) / 2);
+}
+.gs8 > .flex--item3,
+.gs8.flex__allitems3 > .d-flex,
+.gs8.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - var(--su8));
+}
+.gs8 > .flex--item4 {
+  margin: calc(var(--su8) / 2);
+}
+.gs8 > .flex--item4,
+.gs8.flex__allitems4 > .d-flex,
+.gs8.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - var(--su8));
+}
+.gs8 > .flex--item5 {
+  margin: calc(var(--su8) / 2);
+}
+.gs8 > .flex--item5,
+.gs8.flex__allitems5 > .d-flex,
+.gs8.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - var(--su8));
+}
+.gs8 > .flex--item6 {
+  margin: calc(var(--su8) / 2);
+}
+.gs8 > .flex--item6,
+.gs8.flex__allitems6 > .d-flex,
+.gs8.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - var(--su8));
+}
+.gs8 > .flex--item7 {
+  margin: calc(var(--su8) / 2);
+}
+.gs8 > .flex--item7,
+.gs8.flex__allitems7 > .d-flex,
+.gs8.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - var(--su8));
+}
+.gs8 > .flex--item8 {
+  margin: calc(var(--su8) / 2);
+}
+.gs8 > .flex--item8,
+.gs8.flex__allitems8 > .d-flex,
+.gs8.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - var(--su8));
+}
+.gs8 > .flex--item9 {
+  margin: calc(var(--su8) / 2);
+}
+.gs8 > .flex--item9,
+.gs8.flex__allitems9 > .d-flex,
+.gs8.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - var(--su8));
+}
+.gs8 > .flex--item10 {
+  margin: calc(var(--su8) / 2);
+}
+.gs8 > .flex--item10,
+.gs8.flex__allitems10 > .d-flex,
+.gs8.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - var(--su8));
+}
+.gs8 > .flex--item11 {
+  margin: calc(var(--su8) / 2);
+}
+.gs8 > .flex--item11,
+.gs8.flex__allitems11 > .d-flex,
+.gs8.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - var(--su8));
+}
+.gs8 > .flex--item12 {
+  margin: calc(var(--su8) / 2);
+}
+.gs8 > .flex--item12,
+.gs8.flex__allitems12 > .d-flex,
+.gs8.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - var(--su8));
+}
+.gs12 {
+  margin: calc(var(--su12) / 2 * -1);
+}
+.gs12 > .d-flex,
+.gs12 > .flex--item {
+  margin: calc(var(--su12) / 2);
+}
+.gs12 > .flex--item1 {
+  margin: calc(var(--su12) / 2);
+}
+.gs12 > .flex--item1,
+.gs12.flex__allitems1 > .d-flex,
+.gs12.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - var(--su12));
+}
+.gs12 > .flex--item2 {
+  margin: calc(var(--su12) / 2);
+}
+.gs12 > .flex--item2,
+.gs12.flex__allitems2 > .d-flex,
+.gs12.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - var(--su12));
+}
+.gs12 > .flex--item3 {
+  margin: calc(var(--su12) / 2);
+}
+.gs12 > .flex--item3,
+.gs12.flex__allitems3 > .d-flex,
+.gs12.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - var(--su12));
+}
+.gs12 > .flex--item4 {
+  margin: calc(var(--su12) / 2);
+}
+.gs12 > .flex--item4,
+.gs12.flex__allitems4 > .d-flex,
+.gs12.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - var(--su12));
+}
+.gs12 > .flex--item5 {
+  margin: calc(var(--su12) / 2);
+}
+.gs12 > .flex--item5,
+.gs12.flex__allitems5 > .d-flex,
+.gs12.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - var(--su12));
+}
+.gs12 > .flex--item6 {
+  margin: calc(var(--su12) / 2);
+}
+.gs12 > .flex--item6,
+.gs12.flex__allitems6 > .d-flex,
+.gs12.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - var(--su12));
+}
+.gs12 > .flex--item7 {
+  margin: calc(var(--su12) / 2);
+}
+.gs12 > .flex--item7,
+.gs12.flex__allitems7 > .d-flex,
+.gs12.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - var(--su12));
+}
+.gs12 > .flex--item8 {
+  margin: calc(var(--su12) / 2);
+}
+.gs12 > .flex--item8,
+.gs12.flex__allitems8 > .d-flex,
+.gs12.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - var(--su12));
+}
+.gs12 > .flex--item9 {
+  margin: calc(var(--su12) / 2);
+}
+.gs12 > .flex--item9,
+.gs12.flex__allitems9 > .d-flex,
+.gs12.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - var(--su12));
+}
+.gs12 > .flex--item10 {
+  margin: calc(var(--su12) / 2);
+}
+.gs12 > .flex--item10,
+.gs12.flex__allitems10 > .d-flex,
+.gs12.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - var(--su12));
+}
+.gs12 > .flex--item11 {
+  margin: calc(var(--su12) / 2);
+}
+.gs12 > .flex--item11,
+.gs12.flex__allitems11 > .d-flex,
+.gs12.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - var(--su12));
+}
+.gs12 > .flex--item12 {
+  margin: calc(var(--su12) / 2);
+}
+.gs12 > .flex--item12,
+.gs12.flex__allitems12 > .d-flex,
+.gs12.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - var(--su12));
+}
+.gs16 {
+  margin: calc(var(--su16) / 2 * -1);
+}
+.gs16 > .d-flex,
+.gs16 > .flex--item {
+  margin: calc(var(--su16) / 2);
+}
+.gs16 > .flex--item1 {
+  margin: calc(var(--su16) / 2);
+}
+.gs16 > .flex--item1,
+.gs16.flex__allitems1 > .d-flex,
+.gs16.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - var(--su16));
+}
+.gs16 > .flex--item2 {
+  margin: calc(var(--su16) / 2);
+}
+.gs16 > .flex--item2,
+.gs16.flex__allitems2 > .d-flex,
+.gs16.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - var(--su16));
+}
+.gs16 > .flex--item3 {
+  margin: calc(var(--su16) / 2);
+}
+.gs16 > .flex--item3,
+.gs16.flex__allitems3 > .d-flex,
+.gs16.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - var(--su16));
+}
+.gs16 > .flex--item4 {
+  margin: calc(var(--su16) / 2);
+}
+.gs16 > .flex--item4,
+.gs16.flex__allitems4 > .d-flex,
+.gs16.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - var(--su16));
+}
+.gs16 > .flex--item5 {
+  margin: calc(var(--su16) / 2);
+}
+.gs16 > .flex--item5,
+.gs16.flex__allitems5 > .d-flex,
+.gs16.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - var(--su16));
+}
+.gs16 > .flex--item6 {
+  margin: calc(var(--su16) / 2);
+}
+.gs16 > .flex--item6,
+.gs16.flex__allitems6 > .d-flex,
+.gs16.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - var(--su16));
+}
+.gs16 > .flex--item7 {
+  margin: calc(var(--su16) / 2);
+}
+.gs16 > .flex--item7,
+.gs16.flex__allitems7 > .d-flex,
+.gs16.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - var(--su16));
+}
+.gs16 > .flex--item8 {
+  margin: calc(var(--su16) / 2);
+}
+.gs16 > .flex--item8,
+.gs16.flex__allitems8 > .d-flex,
+.gs16.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - var(--su16));
+}
+.gs16 > .flex--item9 {
+  margin: calc(var(--su16) / 2);
+}
+.gs16 > .flex--item9,
+.gs16.flex__allitems9 > .d-flex,
+.gs16.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - var(--su16));
+}
+.gs16 > .flex--item10 {
+  margin: calc(var(--su16) / 2);
+}
+.gs16 > .flex--item10,
+.gs16.flex__allitems10 > .d-flex,
+.gs16.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - var(--su16));
+}
+.gs16 > .flex--item11 {
+  margin: calc(var(--su16) / 2);
+}
+.gs16 > .flex--item11,
+.gs16.flex__allitems11 > .d-flex,
+.gs16.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - var(--su16));
+}
+.gs16 > .flex--item12 {
+  margin: calc(var(--su16) / 2);
+}
+.gs16 > .flex--item12,
+.gs16.flex__allitems12 > .d-flex,
+.gs16.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - var(--su16));
+}
+.gs24 {
+  margin: calc(var(--su24) / 2 * -1);
+}
+.gs24 > .d-flex,
+.gs24 > .flex--item {
+  margin: calc(var(--su24) / 2);
+}
+.gs24 > .flex--item1 {
+  margin: calc(var(--su24) / 2);
+}
+.gs24 > .flex--item1,
+.gs24.flex__allitems1 > .d-flex,
+.gs24.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - var(--su24));
+}
+.gs24 > .flex--item2 {
+  margin: calc(var(--su24) / 2);
+}
+.gs24 > .flex--item2,
+.gs24.flex__allitems2 > .d-flex,
+.gs24.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - var(--su24));
+}
+.gs24 > .flex--item3 {
+  margin: calc(var(--su24) / 2);
+}
+.gs24 > .flex--item3,
+.gs24.flex__allitems3 > .d-flex,
+.gs24.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - var(--su24));
+}
+.gs24 > .flex--item4 {
+  margin: calc(var(--su24) / 2);
+}
+.gs24 > .flex--item4,
+.gs24.flex__allitems4 > .d-flex,
+.gs24.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - var(--su24));
+}
+.gs24 > .flex--item5 {
+  margin: calc(var(--su24) / 2);
+}
+.gs24 > .flex--item5,
+.gs24.flex__allitems5 > .d-flex,
+.gs24.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - var(--su24));
+}
+.gs24 > .flex--item6 {
+  margin: calc(var(--su24) / 2);
+}
+.gs24 > .flex--item6,
+.gs24.flex__allitems6 > .d-flex,
+.gs24.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - var(--su24));
+}
+.gs24 > .flex--item7 {
+  margin: calc(var(--su24) / 2);
+}
+.gs24 > .flex--item7,
+.gs24.flex__allitems7 > .d-flex,
+.gs24.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - var(--su24));
+}
+.gs24 > .flex--item8 {
+  margin: calc(var(--su24) / 2);
+}
+.gs24 > .flex--item8,
+.gs24.flex__allitems8 > .d-flex,
+.gs24.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - var(--su24));
+}
+.gs24 > .flex--item9 {
+  margin: calc(var(--su24) / 2);
+}
+.gs24 > .flex--item9,
+.gs24.flex__allitems9 > .d-flex,
+.gs24.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - var(--su24));
+}
+.gs24 > .flex--item10 {
+  margin: calc(var(--su24) / 2);
+}
+.gs24 > .flex--item10,
+.gs24.flex__allitems10 > .d-flex,
+.gs24.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - var(--su24));
+}
+.gs24 > .flex--item11 {
+  margin: calc(var(--su24) / 2);
+}
+.gs24 > .flex--item11,
+.gs24.flex__allitems11 > .d-flex,
+.gs24.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - var(--su24));
+}
+.gs24 > .flex--item12 {
+  margin: calc(var(--su24) / 2);
+}
+.gs24 > .flex--item12,
+.gs24.flex__allitems12 > .d-flex,
+.gs24.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - var(--su24));
+}
+.gs32 {
+  margin: calc(var(--su32) / 2 * -1);
+}
+.gs32 > .d-flex,
+.gs32 > .flex--item {
+  margin: calc(var(--su32) / 2);
+}
+.gs32 > .flex--item1 {
+  margin: calc(var(--su32) / 2);
+}
+.gs32 > .flex--item1,
+.gs32.flex__allitems1 > .d-flex,
+.gs32.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - var(--su32));
+}
+.gs32 > .flex--item2 {
+  margin: calc(var(--su32) / 2);
+}
+.gs32 > .flex--item2,
+.gs32.flex__allitems2 > .d-flex,
+.gs32.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - var(--su32));
+}
+.gs32 > .flex--item3 {
+  margin: calc(var(--su32) / 2);
+}
+.gs32 > .flex--item3,
+.gs32.flex__allitems3 > .d-flex,
+.gs32.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - var(--su32));
+}
+.gs32 > .flex--item4 {
+  margin: calc(var(--su32) / 2);
+}
+.gs32 > .flex--item4,
+.gs32.flex__allitems4 > .d-flex,
+.gs32.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - var(--su32));
+}
+.gs32 > .flex--item5 {
+  margin: calc(var(--su32) / 2);
+}
+.gs32 > .flex--item5,
+.gs32.flex__allitems5 > .d-flex,
+.gs32.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - var(--su32));
+}
+.gs32 > .flex--item6 {
+  margin: calc(var(--su32) / 2);
+}
+.gs32 > .flex--item6,
+.gs32.flex__allitems6 > .d-flex,
+.gs32.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - var(--su32));
+}
+.gs32 > .flex--item7 {
+  margin: calc(var(--su32) / 2);
+}
+.gs32 > .flex--item7,
+.gs32.flex__allitems7 > .d-flex,
+.gs32.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - var(--su32));
+}
+.gs32 > .flex--item8 {
+  margin: calc(var(--su32) / 2);
+}
+.gs32 > .flex--item8,
+.gs32.flex__allitems8 > .d-flex,
+.gs32.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - var(--su32));
+}
+.gs32 > .flex--item9 {
+  margin: calc(var(--su32) / 2);
+}
+.gs32 > .flex--item9,
+.gs32.flex__allitems9 > .d-flex,
+.gs32.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - var(--su32));
+}
+.gs32 > .flex--item10 {
+  margin: calc(var(--su32) / 2);
+}
+.gs32 > .flex--item10,
+.gs32.flex__allitems10 > .d-flex,
+.gs32.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - var(--su32));
+}
+.gs32 > .flex--item11 {
+  margin: calc(var(--su32) / 2);
+}
+.gs32 > .flex--item11,
+.gs32.flex__allitems11 > .d-flex,
+.gs32.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - var(--su32));
+}
+.gs32 > .flex--item12 {
+  margin: calc(var(--su32) / 2);
+}
+.gs32 > .flex--item12,
+.gs32.flex__allitems12 > .d-flex,
+.gs32.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - var(--su32));
+}
+.gs48 {
+  margin: calc(var(--su48) / 2 * -1);
+}
+.gs48 > .d-flex,
+.gs48 > .flex--item {
+  margin: calc(var(--su48) / 2);
+}
+.gs48 > .flex--item1 {
+  margin: calc(var(--su48) / 2);
+}
+.gs48 > .flex--item1,
+.gs48.flex__allitems1 > .d-flex,
+.gs48.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - var(--su48));
+}
+.gs48 > .flex--item2 {
+  margin: calc(var(--su48) / 2);
+}
+.gs48 > .flex--item2,
+.gs48.flex__allitems2 > .d-flex,
+.gs48.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - var(--su48));
+}
+.gs48 > .flex--item3 {
+  margin: calc(var(--su48) / 2);
+}
+.gs48 > .flex--item3,
+.gs48.flex__allitems3 > .d-flex,
+.gs48.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - var(--su48));
+}
+.gs48 > .flex--item4 {
+  margin: calc(var(--su48) / 2);
+}
+.gs48 > .flex--item4,
+.gs48.flex__allitems4 > .d-flex,
+.gs48.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - var(--su48));
+}
+.gs48 > .flex--item5 {
+  margin: calc(var(--su48) / 2);
+}
+.gs48 > .flex--item5,
+.gs48.flex__allitems5 > .d-flex,
+.gs48.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - var(--su48));
+}
+.gs48 > .flex--item6 {
+  margin: calc(var(--su48) / 2);
+}
+.gs48 > .flex--item6,
+.gs48.flex__allitems6 > .d-flex,
+.gs48.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - var(--su48));
+}
+.gs48 > .flex--item7 {
+  margin: calc(var(--su48) / 2);
+}
+.gs48 > .flex--item7,
+.gs48.flex__allitems7 > .d-flex,
+.gs48.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - var(--su48));
+}
+.gs48 > .flex--item8 {
+  margin: calc(var(--su48) / 2);
+}
+.gs48 > .flex--item8,
+.gs48.flex__allitems8 > .d-flex,
+.gs48.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - var(--su48));
+}
+.gs48 > .flex--item9 {
+  margin: calc(var(--su48) / 2);
+}
+.gs48 > .flex--item9,
+.gs48.flex__allitems9 > .d-flex,
+.gs48.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - var(--su48));
+}
+.gs48 > .flex--item10 {
+  margin: calc(var(--su48) / 2);
+}
+.gs48 > .flex--item10,
+.gs48.flex__allitems10 > .d-flex,
+.gs48.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - var(--su48));
+}
+.gs48 > .flex--item11 {
+  margin: calc(var(--su48) / 2);
+}
+.gs48 > .flex--item11,
+.gs48.flex__allitems11 > .d-flex,
+.gs48.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - var(--su48));
+}
+.gs48 > .flex--item12 {
+  margin: calc(var(--su48) / 2);
+}
+.gs48 > .flex--item12,
+.gs48.flex__allitems12 > .d-flex,
+.gs48.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - var(--su48));
+}
+.gs64 {
+  margin: calc(var(--su64) / 2 * -1);
+}
+.gs64 > .d-flex,
+.gs64 > .flex--item {
+  margin: calc(var(--su64) / 2);
+}
+.gs64 > .flex--item1 {
+  margin: calc(var(--su64) / 2);
+}
+.gs64 > .flex--item1,
+.gs64.flex__allitems1 > .d-flex,
+.gs64.flex__allitems1 > .flex--item {
+  flex-basis: calc(8.333333333333334% - var(--su64));
+}
+.gs64 > .flex--item2 {
+  margin: calc(var(--su64) / 2);
+}
+.gs64 > .flex--item2,
+.gs64.flex__allitems2 > .d-flex,
+.gs64.flex__allitems2 > .flex--item {
+  flex-basis: calc(16.666666666666668% - var(--su64));
+}
+.gs64 > .flex--item3 {
+  margin: calc(var(--su64) / 2);
+}
+.gs64 > .flex--item3,
+.gs64.flex__allitems3 > .d-flex,
+.gs64.flex__allitems3 > .flex--item {
+  flex-basis: calc(25% - var(--su64));
+}
+.gs64 > .flex--item4 {
+  margin: calc(var(--su64) / 2);
+}
+.gs64 > .flex--item4,
+.gs64.flex__allitems4 > .d-flex,
+.gs64.flex__allitems4 > .flex--item {
+  flex-basis: calc(33.333333333333336% - var(--su64));
+}
+.gs64 > .flex--item5 {
+  margin: calc(var(--su64) / 2);
+}
+.gs64 > .flex--item5,
+.gs64.flex__allitems5 > .d-flex,
+.gs64.flex__allitems5 > .flex--item {
+  flex-basis: calc(41.666666666666664% - var(--su64));
+}
+.gs64 > .flex--item6 {
+  margin: calc(var(--su64) / 2);
+}
+.gs64 > .flex--item6,
+.gs64.flex__allitems6 > .d-flex,
+.gs64.flex__allitems6 > .flex--item {
+  flex-basis: calc(50% - var(--su64));
+}
+.gs64 > .flex--item7 {
+  margin: calc(var(--su64) / 2);
+}
+.gs64 > .flex--item7,
+.gs64.flex__allitems7 > .d-flex,
+.gs64.flex__allitems7 > .flex--item {
+  flex-basis: calc(58.333333333333336% - var(--su64));
+}
+.gs64 > .flex--item8 {
+  margin: calc(var(--su64) / 2);
+}
+.gs64 > .flex--item8,
+.gs64.flex__allitems8 > .d-flex,
+.gs64.flex__allitems8 > .flex--item {
+  flex-basis: calc(66.66666666666667% - var(--su64));
+}
+.gs64 > .flex--item9 {
+  margin: calc(var(--su64) / 2);
+}
+.gs64 > .flex--item9,
+.gs64.flex__allitems9 > .d-flex,
+.gs64.flex__allitems9 > .flex--item {
+  flex-basis: calc(75% - var(--su64));
+}
+.gs64 > .flex--item10 {
+  margin: calc(var(--su64) / 2);
+}
+.gs64 > .flex--item10,
+.gs64.flex__allitems10 > .d-flex,
+.gs64.flex__allitems10 > .flex--item {
+  flex-basis: calc(83.33333333333333% - var(--su64));
+}
+.gs64 > .flex--item11 {
+  margin: calc(var(--su64) / 2);
+}
+.gs64 > .flex--item11,
+.gs64.flex__allitems11 > .d-flex,
+.gs64.flex__allitems11 > .flex--item {
+  flex-basis: calc(91.66666666666667% - var(--su64));
+}
+.gs64 > .flex--item12 {
+  margin: calc(var(--su64) / 2);
+}
+.gs64 > .flex--item12,
+.gs64.flex__allitems12 > .d-flex,
+.gs64.flex__allitems12 > .flex--item {
+  flex-basis: calc(100% - var(--su64));
+}
+.gsx,
+.gsx > .d-flex,
+.gsx > [class*="flex--item"] {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+.gsy,
+.gsy > .d-flex,
+.gsy > [class*="flex--item"] {
+  margin-right: 0;
+  margin-left: 0;
+}
+.fd-row {
+  flex-direction: row !important;
+}
+.fd-row-reverse {
+  flex-direction: row-reverse !important;
+}
+.fd-column {
+  flex-direction: column !important;
+}
+.fd-column-reverse {
+  flex-direction: column-reverse !important;
+}
+.fw-wrap {
+  flex-wrap: wrap !important;
+}
+.fw-reverse {
+  flex-wrap: wrap-reverse !important;
+}
+.fw-nowrap {
+  flex-wrap: nowrap !important;
+}
+.jc-center {
+  justify-content: center !important;
+}
+.jc-end {
+  justify-content: flex-end !important;
+}
+.jc-space-around {
+  justify-content: space-around !important;
+}
+.jc-space-between {
+  justify-content: space-between !important;
+}
+.jc-space-evenly {
+  justify-content: space-evenly !important;
+}
+.jc-start {
+  justify-content: flex-start !important;
+}
+.ac-center {
+  align-content: center !important;
+}
+.ac-end {
+  align-content: flex-end !important;
+}
+.ac-space-around {
+  align-content: space-around !important;
+}
+.ac-space-between {
+  align-content: space-between !important;
+}
+.ac-start {
+  align-content: flex-start !important;
+}
+.ac-stretch {
+  align-content: stretch !important;
+}
+.ai-baseline {
+  align-items: baseline !important;
+}
+.ai-center {
+  align-items: center !important;
+}
+.ai-end {
+  align-items: flex-end !important;
+}
+.ai-start {
+  align-items: flex-start !important;
+}
+.ai-stretch {
+  align-items: stretch !important;
+}
+.flex__center {
+  justify-content: center !important;
+  align-items: center !important;
+}
+.as-auto {
+  align-self: auto !important;
+}
+.as-baseline {
+  align-self: baseline !important;
+}
+.as-center {
+  align-self: center !important;
+}
+.as-end {
+  align-self: flex-end !important;
+}
+.as-start {
+  align-self: flex-start !important;
+}
+.as-stretch {
+  align-self: stretch !important;
+}
+.as-true {
+  align-self: true !important;
+}
+.fl-grow1 {
+  flex-grow: 1 !important;
+}
+.fl-grow0 {
+  flex-grow: 0 !important;
+}
+.fl-shrink1 {
+  flex-shrink: 1 !important;
+}
+.fl-shrink0 {
+  flex-shrink: 0 !important;
+}
+.fl-none {
+  flex: none !important;
+}
+.fl-initial {
+  flex: 0 1 auto !important;
+}
+.fl-auto {
+  flex: 1 1 auto !important;
+}
+.fl-equal {
+  flex: 1 1 0% !important;
+}
+.order-first {
+  order: -1 !important;
+}
+.order-last {
+  order: 1 !important;
+}
+.ff-row-wrap {
+  flex-flow: row wrap !important;
+}
+.ff-row-nowrap {
+  flex-flow: row nowrap !important;
+}
+.ff-row-reverse-wrap {
+  flex-flow: row-reverse wrap !important;
+}
+.ff-row-reverse-nowrap {
+  flex-flow: row-reverse nowrap !important;
+}
+.ff-column-wrap {
+  flex-flow: column wrap !important;
+}
+.ff-column-nowrap {
+  flex-flow: column nowrap !important;
+}
+.ff-column-reverse-wrap {
+  flex-flow: column-reverse wrap !important;
+}
+.ff-column-reverse-nowrap {
+  flex-flow: column-reverse nowrap !important;
+}
+.fl0 {
+  flex: 0 auto !important;
+}
+.fl1 {
+  flex: 1 auto !important;
+}
+.fl2 {
+  flex: 2 auto !important;
+}
+.fl3 {
+  flex: 3 auto !important;
+}
+.fl4 {
+  flex: 4 auto !important;
+}
+.fl5 {
+  flex: 5 auto !important;
+}
+.fl-shrink2 {
+  flex-shrink: 2;
+}
+.fl-shrink3 {
+  flex-shrink: 3;
+}
+.fl-shrink4 {
+  flex-shrink: 4;
+}
+.fl-shrink5 {
+  flex-shrink: 5;
+}
+.fl-grow2 {
+  flex-grow: 2;
+}
+.fl-grow3 {
+  flex-grow: 3;
+}
+.fl-grow4 {
+  flex-grow: 4;
+}
+.fl-grow5 {
+  flex-grow: 5;
+}
+.float-left {
+  float: left !important;
+}
+.float-right {
+  float: right !important;
+}
+.float-none {
+  float: none !important;
+}
+.clearfix:before,
+.clearfix:after {
+  content: "";
+  display: table;
+}
+.clearfix:after {
+  clear: both;
+}
+.clear-left {
+  clear: left !important;
+}
+.clear-right {
+  clear: right !important;
+}
+.clear-both {
+  clear: both !important;
+}
+.clear-none {
+  clear: none !important;
+}
+.g0 {
+  --_gap-y: 0;
+  --_gap-x: 0;
+}
+.g1 {
+  --_gap-y: var(--su1);
+  --_gap-x: var(--su1);
+}
+.g2 {
+  --_gap-y: var(--su2);
+  --_gap-x: var(--su2);
+}
+.g4 {
+  --_gap-y: var(--su4);
+  --_gap-x: var(--su4);
+}
+.g6 {
+  --_gap-y: var(--su6);
+  --_gap-x: var(--su6);
+}
+.g8 {
+  --_gap-y: var(--su8);
+  --_gap-x: var(--su8);
+}
+.g12 {
+  --_gap-y: var(--su12);
+  --_gap-x: var(--su12);
+}
+.g16 {
+  --_gap-y: var(--su16);
+  --_gap-x: var(--su16);
+}
+.g24 {
+  --_gap-y: var(--su24);
+  --_gap-x: var(--su24);
+}
+.g32 {
+  --_gap-y: var(--su32);
+  --_gap-x: var(--su32);
+}
+.g48 {
+  --_gap-y: var(--su48);
+  --_gap-x: var(--su48);
+}
+.g64 {
+  --_gap-y: var(--su64);
+  --_gap-x: var(--su64);
+}
+.gx0 {
+  --_gap-x: 0;
+}
+.gx1 {
+  --_gap-x: var(--su1);
+}
+.gx2 {
+  --_gap-x: var(--su2);
+}
+.gx4 {
+  --_gap-x: var(--su4);
+}
+.gx6 {
+  --_gap-x: var(--su6);
+}
+.gx8 {
+  --_gap-x: var(--su8);
+}
+.gx12 {
+  --_gap-x: var(--su12);
+}
+.gx16 {
+  --_gap-x: var(--su16);
+}
+.gx24 {
+  --_gap-x: var(--su24);
+}
+.gx32 {
+  --_gap-x: var(--su32);
+}
+.gx48 {
+  --_gap-x: var(--su48);
+}
+.gx64 {
+  --_gap-x: var(--su64);
+}
+.gy0 {
+  --_gap-y: 0;
+}
+.gy1 {
+  --_gap-y: var(--su1);
+}
+.gy2 {
+  --_gap-y: var(--su2);
+}
+.gy4 {
+  --_gap-y: var(--su4);
+}
+.gy6 {
+  --_gap-y: var(--su6);
+}
+.gy8 {
+  --_gap-y: var(--su8);
+}
+.gy12 {
+  --_gap-y: var(--su12);
+}
+.gy16 {
+  --_gap-y: var(--su16);
+}
+.gy24 {
+  --_gap-y: var(--su24);
+}
+.gy32 {
+  --_gap-y: var(--su32);
+}
+.gy48 {
+  --_gap-y: var(--su48);
+}
+.gy64 {
+  --_gap-y: var(--su64);
+}
+.gx0,
+.gx1,
+.gx2,
+.gx4,
+.gx6,
+.gx8,
+.gx12,
+.gx16,
+.gx24,
+.gx32,
+.gx48,
+.gx64,
+.gy0,
+.gy1,
+.gy2,
+.gy4,
+.gy6,
+.gy8,
+.gy12,
+.gy16,
+.gy24,
+.gy32,
+.gy48,
+.gy64,
+.g0,
+.g1,
+.g2,
+.g4,
+.g6,
+.g8,
+.g12,
+.g16,
+.g24,
+.g32,
+.g48,
+.g64 {
+  gap: var(--_gap-y, 0) var(--_gap-x, 0);
+}
+.g-af-dense {
+  grid-auto-flow: dense;
+}
+.g-af-row {
+  grid-auto-flow: row;
+}
+.g-af-column {
+  grid-auto-flow: column;
+}
+.grid__1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+.grid__2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.grid__3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.grid__4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+.grid__5 {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+.grid__6 {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+.grid__7 {
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+.grid__8 {
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+}
+.grid__9 {
+  grid-template-columns: repeat(9, minmax(0, 1fr));
+}
+.grid__10 {
+  grid-template-columns: repeat(10, minmax(0, 1fr));
+}
+.grid__11 {
+  grid-template-columns: repeat(11, minmax(0, 1fr));
+}
+.grid__12 {
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+}
+.grid__auto {
+  grid-template-columns: auto 1fr;
+}
+.grid--col-all {
+  grid-column: 1 / -1;
+}
+.grid--row-all {
+  grid-row: 1 / -1;
+}
+.grid--col1 {
+  grid-column: span 1;
+}
+.grid--col2 {
+  grid-column: span 2;
+}
+.grid--col3 {
+  grid-column: span 3;
+}
+.grid--col4 {
+  grid-column: span 4;
+}
+.grid--col5 {
+  grid-column: span 5;
+}
+.grid--col6 {
+  grid-column: span 6;
+}
+.grid--col7 {
+  grid-column: span 7;
+}
+.grid--col8 {
+  grid-column: span 8;
+}
+.grid--col9 {
+  grid-column: span 9;
+}
+.grid--col10 {
+  grid-column: span 10;
+}
+.grid--col11 {
+  grid-column: span 11;
+}
+.grid--col12 {
+  grid-column: span 12;
+}
+.grid--row1 {
+  grid-row: span 1;
+}
+.grid--row2 {
+  grid-row: span 2;
+}
+.grid--row3 {
+  grid-row: span 3;
+}
+.grid--row4 {
+  grid-row: span 4;
+}
+.grid--row5 {
+  grid-row: span 5;
+}
+.grid--row6 {
+  grid-row: span 6;
+}
+.grid--row7 {
+  grid-row: span 7;
+}
+.grid--row8 {
+  grid-row: span 8;
+}
+.grid--row9 {
+  grid-row: span 9;
+}
+.grid--row10 {
+  grid-row: span 10;
+}
+.grid--row11 {
+  grid-row: span 11;
+}
+.grid--row12 {
+  grid-row: span 12;
+}
+.grid--col-start1 {
+  grid-column-start: 1;
+}
+.grid--col-start2 {
+  grid-column-start: 2;
+}
+.grid--col-start3 {
+  grid-column-start: 3;
+}
+.grid--col-start4 {
+  grid-column-start: 4;
+}
+.grid--col-start5 {
+  grid-column-start: 5;
+}
+.grid--col-start6 {
+  grid-column-start: 6;
+}
+.grid--col-start7 {
+  grid-column-start: 7;
+}
+.grid--col-start8 {
+  grid-column-start: 8;
+}
+.grid--col-start9 {
+  grid-column-start: 9;
+}
+.grid--col-start10 {
+  grid-column-start: 10;
+}
+.grid--col-start11 {
+  grid-column-start: 11;
+}
+.grid--col-start12 {
+  grid-column-start: 12;
+}
+.grid--col-end2 {
+  grid-column-end: 2;
+}
+.grid--col-end3 {
+  grid-column-end: 3;
+}
+.grid--col-end4 {
+  grid-column-end: 4;
+}
+.grid--col-end5 {
+  grid-column-end: 5;
+}
+.grid--col-end6 {
+  grid-column-end: 6;
+}
+.grid--col-end7 {
+  grid-column-end: 7;
+}
+.grid--col-end8 {
+  grid-column-end: 8;
+}
+.grid--col-end9 {
+  grid-column-end: 9;
+}
+.grid--col-end10 {
+  grid-column-end: 10;
+}
+.grid--col-end11 {
+  grid-column-end: 11;
+}
+.grid--col-end12 {
+  grid-column-end: 12;
+}
+.grid--col-end13 {
+  grid-column-end: 13;
+}
+.grid--row-start1 {
+  grid-row-start: 1;
+}
+.grid--row-start2 {
+  grid-row-start: 2;
+}
+.grid--row-start3 {
+  grid-row-start: 3;
+}
+.grid--row-start4 {
+  grid-row-start: 4;
+}
+.grid--row-start5 {
+  grid-row-start: 5;
+}
+.grid--row-start6 {
+  grid-row-start: 6;
+}
+.grid--row-start7 {
+  grid-row-start: 7;
+}
+.grid--row-start8 {
+  grid-row-start: 8;
+}
+.grid--row-start9 {
+  grid-row-start: 9;
+}
+.grid--row-start10 {
+  grid-row-start: 10;
+}
+.grid--row-start11 {
+  grid-row-start: 11;
+}
+.grid--row-start12 {
+  grid-row-start: 12;
+}
+.grid--row-end2 {
+  grid-row-end: 2;
+}
+.grid--row-end3 {
+  grid-row-end: 3;
+}
+.grid--row-end4 {
+  grid-row-end: 4;
+}
+.grid--row-end5 {
+  grid-row-end: 5;
+}
+.grid--row-end6 {
+  grid-row-end: 6;
+}
+.grid--row-end7 {
+  grid-row-end: 7;
+}
+.grid--row-end8 {
+  grid-row-end: 8;
+}
+.grid--row-end9 {
+  grid-row-end: 9;
+}
+.grid--row-end10 {
+  grid-row-end: 10;
+}
+.grid--row-end11 {
+  grid-row-end: 11;
+}
+.grid--row-end12 {
+  grid-row-end: 12;
+}
+.grid--row-end13 {
+  grid-row-end: 13;
+}
+.ji-auto {
+  justify-items: auto !important;
+}
+.ji-center {
+  justify-items: center !important;
+}
+.ji-start {
+  justify-items: start !important;
+}
+.ji-end {
+  justify-items: end !important;
+}
+.ji-stretch {
+  justify-items: stretch !important;
+}
+.ji-unset {
+  justify-items: unset !important;
+}
+.js-auto {
+  justify-self: auto !important;
+}
+.js-center {
+  justify-self: center !important;
+}
+.js-start {
+  justify-self: start !important;
+}
+.js-end {
+  justify-self: end !important;
+}
+.js-stretch {
+  justify-self: stretch !important;
+}
+.js-unset {
+  justify-self: unset !important;
+}
+.h0 {
+  height: var(--su0) !important;
+}
+.h1 {
+  height: var(--su1) !important;
+}
+.h2 {
+  height: var(--su2) !important;
+}
+.h4 {
+  height: var(--su4) !important;
+}
+.h6 {
+  height: var(--su6) !important;
+}
+.h8 {
+  height: var(--su8) !important;
+}
+.h12 {
+  height: var(--su12) !important;
+}
+.h16 {
+  height: var(--su16) !important;
+}
+.h24 {
+  height: var(--su24) !important;
+}
+.h32 {
+  height: var(--su32) !important;
+}
+.h48 {
+  height: var(--su48) !important;
+}
+.h64 {
+  height: var(--su64) !important;
+}
+.h96 {
+  height: var(--su96) !important;
+}
+.h128 {
+  height: var(--su128) !important;
+}
+.hs1 {
+  height: var(--su128) !important;
+}
+.hs2 {
+  height: var(--su256) !important;
+}
+.hs3 {
+  height: var(--su344) !important;
+}
+.hs4 {
+  height: var(--su448) !important;
+}
+.hs5 {
+  height: var(--su512) !important;
+}
+.hs6 {
+  height: var(--su640) !important;
+}
+.hs7 {
+  height: var(--su768) !important;
+}
+.hs8 {
+  height: var(--su848) !important;
+}
+.hs9 {
+  height: var(--su960) !important;
+}
+.hs10 {
+  height: var(--su1024) !important;
+}
+.hs11 {
+  height: var(--su1120) !important;
+}
+.hs12 {
+  height: var(--su1280) !important;
+}
+.h100 {
+  height: 100% !important;
+}
+.h-auto {
+  height: auto !important;
+}
+.h-screen {
+  height: 100vh !important;
+}
+.hmn0 {
+  min-height: var(--sun0) !important;
+}
+.hmn1 {
+  min-height: var(--su128) !important;
+}
+.hmn2 {
+  min-height: var(--su256) !important;
+}
+.hmn3 {
+  min-height: var(--su344) !important;
+}
+.hmn4 {
+  min-height: var(--su448) !important;
+}
+.hmn5 {
+  min-height: var(--su512) !important;
+}
+.hmn6 {
+  min-height: var(--su640) !important;
+}
+.hmn7 {
+  min-height: var(--su768) !important;
+}
+.hmn8 {
+  min-height: var(--su848) !important;
+}
+.hmn9 {
+  min-height: var(--su960) !important;
+}
+.hmn10 {
+  min-height: var(--su1024) !important;
+}
+.hmn11 {
+  min-height: var(--su1120) !important;
+}
+.hmn12 {
+  min-height: var(--su1280) !important;
+}
+.hmn100 {
+  min-height: 100% !important;
+}
+.hmn-initial {
+  min-height: initial !important;
+}
+.hmn-screen {
+  min-height: 100vh !important;
+}
+.hmx1 {
+  max-height: var(--su128) !important;
+}
+.hmx2 {
+  max-height: var(--su256) !important;
+}
+.hmx3 {
+  max-height: var(--su344) !important;
+}
+.hmx4 {
+  max-height: var(--su448) !important;
+}
+.hmx5 {
+  max-height: var(--su512) !important;
+}
+.hmx6 {
+  max-height: var(--su640) !important;
+}
+.hmx7 {
+  max-height: var(--su768) !important;
+}
+.hmx8 {
+  max-height: var(--su848) !important;
+}
+.hmx9 {
+  max-height: var(--su960) !important;
+}
+.hmx10 {
+  max-height: var(--su1024) !important;
+}
+.hmx11 {
+  max-height: var(--su1120) !important;
+}
+.hmx12 {
+  max-height: var(--su1280) !important;
+}
+.hmx100 {
+  max-height: 100% !important;
+}
+.hmx-initial {
+  max-height: initial !important;
+}
+.hmx-screen {
+  max-height: 100vh !important;
+}
+.focus,
+.f\\:focus:focus,
+.f\\:focus:focus-within {
+  box-shadow: 0 0 0 var(--su2) var(--focus-neutral), 0 0 0 var(--su4) var(--focus-theme);
+  outline: var(--su2) solid transparent !important;
+}
+.focus-inset,
+.f\\:focus-inset:focus,
+.f\\:focus-inset:focus-within {
+  box-shadow: inset 0 0 0 var(--su2) var(--focus-theme), inset 0 0 0 var(--su4) var(--focus-neutral);
+  outline: var(--su2) solid transparent !important;
+}
+.focus-bordered,
+.f\\:focus-bordered:focus,
+.f\\:focus-bordered:focus-within {
+  border-color: var(--focus-neutral) !important;
+  box-shadow: 0 0 0 var(--su1) var(--focus-neutral), 0 0 0 var(--su3) var(--focus-theme);
+  outline: var(--su2) solid transparent !important;
+}
+.focus-inset-bordered,
+.f\\:focus-inset-bordered:focus,
+.f\\:focus-inset-bordered:focus-within {
+  border-color: var(--focus-theme) !important;
+  box-shadow: inset 0 0 0 var(--su1) var(--focus-theme), inset 0 0 0 var(--su3) var(--focus-neutral);
+  outline: var(--su2) solid transparent !important;
+}
+.pe-auto {
+  pointer-events: auto !important;
+}
+.pe-none {
+  pointer-events: none !important;
+}
+.us-auto {
+  -webkit-user-select: auto !important;
+  -moz-user-select: auto !important;
+  -ms-user-select: auto !important;
+  user-select: auto !important;
+}
+.us-none {
+  -webkit-user-select: none !important;
+  -moz-user-select: none !important;
+  -ms-user-select: none !important;
+  user-select: none !important;
+}
+ul,
+ol {
+  padding: 0;
+  margin-left: 2.8em;
+}
+ul ul,
+ol ul,
+ul ol,
+ol ol {
+  margin-bottom: 0;
+}
+ul {
+  list-style-type: disc;
+}
+ol {
+  list-style-type: decimal;
+}
+.list-reset {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.list-ls-none {
+  list-style: none !important;
+}
+.list-ls-disc {
+  list-style-type: disc !important;
+}
+.list-ls-decimal {
+  list-style-type: decimal !important;
+}
+.list-ls-unset {
+  list-style-type: unset !important;
+}
+.list-inside {
+  list-style-position: inside !important;
+}
+.list-outside {
+  list-style-position: outside !important;
+}
+.m-auto {
+  margin: auto !important;
+}
+.m0 {
+  margin: var(--su0) !important;
+}
+.m1 {
+  margin: var(--su1) !important;
+}
+.m2 {
+  margin: var(--su2) !important;
+}
+.m4 {
+  margin: var(--su4) !important;
+}
+.m6 {
+  margin: var(--su6) !important;
+}
+.m8 {
+  margin: var(--su8) !important;
+}
+.m12 {
+  margin: var(--su12) !important;
+}
+.m16 {
+  margin: var(--su16) !important;
+}
+.m24 {
+  margin: var(--su24) !important;
+}
+.m32 {
+  margin: var(--su32) !important;
+}
+.m48 {
+  margin: var(--su48) !important;
+}
+.m64 {
+  margin: var(--su64) !important;
+}
+.m96 {
+  margin: var(--su96) !important;
+}
+.m128 {
+  margin: var(--su128) !important;
+}
+.mn1 {
+  margin: var(--sun1) !important;
+}
+.mn2 {
+  margin: var(--sun2) !important;
+}
+.mn4 {
+  margin: var(--sun4) !important;
+}
+.mn6 {
+  margin: var(--sun6) !important;
+}
+.mn8 {
+  margin: var(--sun8) !important;
+}
+.mn12 {
+  margin: var(--sun12) !important;
+}
+.mn16 {
+  margin: var(--sun16) !important;
+}
+.mn24 {
+  margin: var(--sun24) !important;
+}
+.mn32 {
+  margin: var(--sun32) !important;
+}
+.mn48 {
+  margin: var(--sun48) !important;
+}
+.mn64 {
+  margin: var(--sun64) !important;
+}
+.mn96 {
+  margin: var(--sun96) !important;
+}
+.mn128 {
+  margin: var(--sun128) !important;
+}
+.m50 {
+  margin: 50% !important;
+}
+.m100 {
+  margin: 100% !important;
+}
+.mn50 {
+  margin: -50% !important;
+}
+.mn100 {
+  margin: -100% !important;
+}
+.mt-auto {
+  margin-top: auto !important;
+}
+.mt0 {
+  margin-top: var(--su0) !important;
+}
+.mt1 {
+  margin-top: var(--su1) !important;
+}
+.mt2 {
+  margin-top: var(--su2) !important;
+}
+.mt4 {
+  margin-top: var(--su4) !important;
+}
+.mt6 {
+  margin-top: var(--su6) !important;
+}
+.mt8 {
+  margin-top: var(--su8) !important;
+}
+.mt12 {
+  margin-top: var(--su12) !important;
+}
+.mt16 {
+  margin-top: var(--su16) !important;
+}
+.mt24 {
+  margin-top: var(--su24) !important;
+}
+.mt32 {
+  margin-top: var(--su32) !important;
+}
+.mt48 {
+  margin-top: var(--su48) !important;
+}
+.mt64 {
+  margin-top: var(--su64) !important;
+}
+.mt96 {
+  margin-top: var(--su96) !important;
+}
+.mt128 {
+  margin-top: var(--su128) !important;
+}
+.mtn1 {
+  margin-top: var(--sun1) !important;
+}
+.mtn2 {
+  margin-top: var(--sun2) !important;
+}
+.mtn4 {
+  margin-top: var(--sun4) !important;
+}
+.mtn6 {
+  margin-top: var(--sun6) !important;
+}
+.mtn8 {
+  margin-top: var(--sun8) !important;
+}
+.mtn12 {
+  margin-top: var(--sun12) !important;
+}
+.mtn16 {
+  margin-top: var(--sun16) !important;
+}
+.mtn24 {
+  margin-top: var(--sun24) !important;
+}
+.mtn32 {
+  margin-top: var(--sun32) !important;
+}
+.mtn48 {
+  margin-top: var(--sun48) !important;
+}
+.mtn64 {
+  margin-top: var(--sun64) !important;
+}
+.mtn96 {
+  margin-top: var(--sun96) !important;
+}
+.mtn128 {
+  margin-top: var(--sun128) !important;
+}
+.mt50 {
+  margin-top: 50% !important;
+}
+.mt100 {
+  margin-top: 100% !important;
+}
+.mtn50 {
+  margin-top: -50% !important;
+}
+.mtn100 {
+  margin-top: -100% !important;
+}
+.mr-auto {
+  margin-right: auto !important;
+}
+.mr0 {
+  margin-right: var(--su0) !important;
+}
+.mr1 {
+  margin-right: var(--su1) !important;
+}
+.mr2 {
+  margin-right: var(--su2) !important;
+}
+.mr4 {
+  margin-right: var(--su4) !important;
+}
+.mr6 {
+  margin-right: var(--su6) !important;
+}
+.mr8 {
+  margin-right: var(--su8) !important;
+}
+.mr12 {
+  margin-right: var(--su12) !important;
+}
+.mr16 {
+  margin-right: var(--su16) !important;
+}
+.mr24 {
+  margin-right: var(--su24) !important;
+}
+.mr32 {
+  margin-right: var(--su32) !important;
+}
+.mr48 {
+  margin-right: var(--su48) !important;
+}
+.mr64 {
+  margin-right: var(--su64) !important;
+}
+.mr96 {
+  margin-right: var(--su96) !important;
+}
+.mr128 {
+  margin-right: var(--su128) !important;
+}
+.mrn1 {
+  margin-right: var(--sun1) !important;
+}
+.mrn2 {
+  margin-right: var(--sun2) !important;
+}
+.mrn4 {
+  margin-right: var(--sun4) !important;
+}
+.mrn6 {
+  margin-right: var(--sun6) !important;
+}
+.mrn8 {
+  margin-right: var(--sun8) !important;
+}
+.mrn12 {
+  margin-right: var(--sun12) !important;
+}
+.mrn16 {
+  margin-right: var(--sun16) !important;
+}
+.mrn24 {
+  margin-right: var(--sun24) !important;
+}
+.mrn32 {
+  margin-right: var(--sun32) !important;
+}
+.mrn48 {
+  margin-right: var(--sun48) !important;
+}
+.mrn64 {
+  margin-right: var(--sun64) !important;
+}
+.mrn96 {
+  margin-right: var(--sun96) !important;
+}
+.mrn128 {
+  margin-right: var(--sun128) !important;
+}
+.mr50 {
+  margin-right: 50% !important;
+}
+.mr100 {
+  margin-right: 100% !important;
+}
+.mrn50 {
+  margin-right: -50% !important;
+}
+.mrn100 {
+  margin-right: -100% !important;
+}
+.mb-auto {
+  margin-bottom: auto !important;
+}
+.mb0 {
+  margin-bottom: var(--su0) !important;
+}
+.mb1 {
+  margin-bottom: var(--su1) !important;
+}
+.mb2 {
+  margin-bottom: var(--su2) !important;
+}
+.mb4 {
+  margin-bottom: var(--su4) !important;
+}
+.mb6 {
+  margin-bottom: var(--su6) !important;
+}
+.mb8 {
+  margin-bottom: var(--su8) !important;
+}
+.mb12 {
+  margin-bottom: var(--su12) !important;
+}
+.mb16 {
+  margin-bottom: var(--su16) !important;
+}
+.mb24 {
+  margin-bottom: var(--su24) !important;
+}
+.mb32 {
+  margin-bottom: var(--su32) !important;
+}
+.mb48 {
+  margin-bottom: var(--su48) !important;
+}
+.mb64 {
+  margin-bottom: var(--su64) !important;
+}
+.mb96 {
+  margin-bottom: var(--su96) !important;
+}
+.mb128 {
+  margin-bottom: var(--su128) !important;
+}
+.mbn1 {
+  margin-bottom: var(--sun1) !important;
+}
+.mbn2 {
+  margin-bottom: var(--sun2) !important;
+}
+.mbn4 {
+  margin-bottom: var(--sun4) !important;
+}
+.mbn6 {
+  margin-bottom: var(--sun6) !important;
+}
+.mbn8 {
+  margin-bottom: var(--sun8) !important;
+}
+.mbn12 {
+  margin-bottom: var(--sun12) !important;
+}
+.mbn16 {
+  margin-bottom: var(--sun16) !important;
+}
+.mbn24 {
+  margin-bottom: var(--sun24) !important;
+}
+.mbn32 {
+  margin-bottom: var(--sun32) !important;
+}
+.mbn48 {
+  margin-bottom: var(--sun48) !important;
+}
+.mbn64 {
+  margin-bottom: var(--sun64) !important;
+}
+.mbn96 {
+  margin-bottom: var(--sun96) !important;
+}
+.mbn128 {
+  margin-bottom: var(--sun128) !important;
+}
+.mb50 {
+  margin-bottom: 50% !important;
+}
+.mb100 {
+  margin-bottom: 100% !important;
+}
+.mbn50 {
+  margin-bottom: -50% !important;
+}
+.mbn100 {
+  margin-bottom: -100% !important;
+}
+.ml-auto {
+  margin-left: auto !important;
+}
+.ml0 {
+  margin-left: var(--su0) !important;
+}
+.ml1 {
+  margin-left: var(--su1) !important;
+}
+.ml2 {
+  margin-left: var(--su2) !important;
+}
+.ml4 {
+  margin-left: var(--su4) !important;
+}
+.ml6 {
+  margin-left: var(--su6) !important;
+}
+.ml8 {
+  margin-left: var(--su8) !important;
+}
+.ml12 {
+  margin-left: var(--su12) !important;
+}
+.ml16 {
+  margin-left: var(--su16) !important;
+}
+.ml24 {
+  margin-left: var(--su24) !important;
+}
+.ml32 {
+  margin-left: var(--su32) !important;
+}
+.ml48 {
+  margin-left: var(--su48) !important;
+}
+.ml64 {
+  margin-left: var(--su64) !important;
+}
+.ml96 {
+  margin-left: var(--su96) !important;
+}
+.ml128 {
+  margin-left: var(--su128) !important;
+}
+.mln1 {
+  margin-left: var(--sun1) !important;
+}
+.mln2 {
+  margin-left: var(--sun2) !important;
+}
+.mln4 {
+  margin-left: var(--sun4) !important;
+}
+.mln6 {
+  margin-left: var(--sun6) !important;
+}
+.mln8 {
+  margin-left: var(--sun8) !important;
+}
+.mln12 {
+  margin-left: var(--sun12) !important;
+}
+.mln16 {
+  margin-left: var(--sun16) !important;
+}
+.mln24 {
+  margin-left: var(--sun24) !important;
+}
+.mln32 {
+  margin-left: var(--sun32) !important;
+}
+.mln48 {
+  margin-left: var(--sun48) !important;
+}
+.mln64 {
+  margin-left: var(--sun64) !important;
+}
+.mln96 {
+  margin-left: var(--sun96) !important;
+}
+.mln128 {
+  margin-left: var(--sun128) !important;
+}
+.ml50 {
+  margin-left: 50% !important;
+}
+.ml100 {
+  margin-left: 100% !important;
+}
+.mln50 {
+  margin-left: -50% !important;
+}
+.mln100 {
+  margin-left: -100% !important;
+}
+.mx-auto {
+  margin-left: auto !important;
+  margin-right: auto !important;
+}
+.my-auto {
+  margin-top: auto !important;
+  margin-bottom: auto !important;
+}
+.mx0 {
+  margin-left: var(--su0) !important;
+  margin-right: var(--su0) !important;
+}
+.mx1 {
+  margin-left: var(--su1) !important;
+  margin-right: var(--su1) !important;
+}
+.mx2 {
+  margin-left: var(--su2) !important;
+  margin-right: var(--su2) !important;
+}
+.mx4 {
+  margin-left: var(--su4) !important;
+  margin-right: var(--su4) !important;
+}
+.mx6 {
+  margin-left: var(--su6) !important;
+  margin-right: var(--su6) !important;
+}
+.mx8 {
+  margin-left: var(--su8) !important;
+  margin-right: var(--su8) !important;
+}
+.mx12 {
+  margin-left: var(--su12) !important;
+  margin-right: var(--su12) !important;
+}
+.mx16 {
+  margin-left: var(--su16) !important;
+  margin-right: var(--su16) !important;
+}
+.mx24 {
+  margin-left: var(--su24) !important;
+  margin-right: var(--su24) !important;
+}
+.mx32 {
+  margin-left: var(--su32) !important;
+  margin-right: var(--su32) !important;
+}
+.mx48 {
+  margin-left: var(--su48) !important;
+  margin-right: var(--su48) !important;
+}
+.mx64 {
+  margin-left: var(--su64) !important;
+  margin-right: var(--su64) !important;
+}
+.mx96 {
+  margin-left: var(--su96) !important;
+  margin-right: var(--su96) !important;
+}
+.mx128 {
+  margin-left: var(--su128) !important;
+  margin-right: var(--su128) !important;
+}
+.mxn1 {
+  margin-left: var(--sun1) !important;
+  margin-right: var(--sun1) !important;
+}
+.mxn2 {
+  margin-left: var(--sun2) !important;
+  margin-right: var(--sun2) !important;
+}
+.mxn4 {
+  margin-left: var(--sun4) !important;
+  margin-right: var(--sun4) !important;
+}
+.mxn6 {
+  margin-left: var(--sun6) !important;
+  margin-right: var(--sun6) !important;
+}
+.mxn8 {
+  margin-left: var(--sun8) !important;
+  margin-right: var(--sun8) !important;
+}
+.mxn12 {
+  margin-left: var(--sun12) !important;
+  margin-right: var(--sun12) !important;
+}
+.mxn16 {
+  margin-left: var(--sun16) !important;
+  margin-right: var(--sun16) !important;
+}
+.mxn24 {
+  margin-left: var(--sun24) !important;
+  margin-right: var(--sun24) !important;
+}
+.mxn32 {
+  margin-left: var(--sun32) !important;
+  margin-right: var(--sun32) !important;
+}
+.mxn48 {
+  margin-left: var(--sun48) !important;
+  margin-right: var(--sun48) !important;
+}
+.mxn64 {
+  margin-left: var(--sun64) !important;
+  margin-right: var(--sun64) !important;
+}
+.mxn96 {
+  margin-left: var(--sun96) !important;
+  margin-right: var(--sun96) !important;
+}
+.mxn128 {
+  margin-left: var(--sun128) !important;
+  margin-right: var(--sun128) !important;
+}
+.my0 {
+  margin-top: var(--su0) !important;
+  margin-bottom: var(--su0) !important;
+}
+.my1 {
+  margin-top: var(--su1) !important;
+  margin-bottom: var(--su1) !important;
+}
+.my2 {
+  margin-top: var(--su2) !important;
+  margin-bottom: var(--su2) !important;
+}
+.my4 {
+  margin-top: var(--su4) !important;
+  margin-bottom: var(--su4) !important;
+}
+.my6 {
+  margin-top: var(--su6) !important;
+  margin-bottom: var(--su6) !important;
+}
+.my8 {
+  margin-top: var(--su8) !important;
+  margin-bottom: var(--su8) !important;
+}
+.my12 {
+  margin-top: var(--su12) !important;
+  margin-bottom: var(--su12) !important;
+}
+.my16 {
+  margin-top: var(--su16) !important;
+  margin-bottom: var(--su16) !important;
+}
+.my24 {
+  margin-top: var(--su24) !important;
+  margin-bottom: var(--su24) !important;
+}
+.my32 {
+  margin-top: var(--su32) !important;
+  margin-bottom: var(--su32) !important;
+}
+.my48 {
+  margin-top: var(--su48) !important;
+  margin-bottom: var(--su48) !important;
+}
+.my64 {
+  margin-top: var(--su64) !important;
+  margin-bottom: var(--su64) !important;
+}
+.my96 {
+  margin-top: var(--su96) !important;
+  margin-bottom: var(--su96) !important;
+}
+.my128 {
+  margin-top: var(--su128) !important;
+  margin-bottom: var(--su128) !important;
+}
+.myn1 {
+  margin-top: var(--sun1) !important;
+  margin-bottom: var(--sun1) !important;
+}
+.myn2 {
+  margin-top: var(--sun2) !important;
+  margin-bottom: var(--sun2) !important;
+}
+.myn4 {
+  margin-top: var(--sun4) !important;
+  margin-bottom: var(--sun4) !important;
+}
+.myn6 {
+  margin-top: var(--sun6) !important;
+  margin-bottom: var(--sun6) !important;
+}
+.myn8 {
+  margin-top: var(--sun8) !important;
+  margin-bottom: var(--sun8) !important;
+}
+.myn12 {
+  margin-top: var(--sun12) !important;
+  margin-bottom: var(--sun12) !important;
+}
+.myn16 {
+  margin-top: var(--sun16) !important;
+  margin-bottom: var(--sun16) !important;
+}
+.myn24 {
+  margin-top: var(--sun24) !important;
+  margin-bottom: var(--sun24) !important;
+}
+.myn32 {
+  margin-top: var(--sun32) !important;
+  margin-bottom: var(--sun32) !important;
+}
+.myn48 {
+  margin-top: var(--sun48) !important;
+  margin-bottom: var(--sun48) !important;
+}
+.myn64 {
+  margin-top: var(--sun64) !important;
+  margin-bottom: var(--sun64) !important;
+}
+.myn96 {
+  margin-top: var(--sun96) !important;
+  margin-bottom: var(--sun96) !important;
+}
+.myn128 {
+  margin-top: var(--sun128) !important;
+  margin-bottom: var(--sun128) !important;
+}
+.of-contain {
+  object-fit: contain !important;
+}
+.of-cover {
+  object-fit: cover !important;
+}
+.of-fill {
+  object-fit: fill !important;
+}
+.of-none {
+  object-fit: none !important;
+}
+.of-scale-down {
+  object-fit: scale-down !important;
+}
+.op-center {
+  object-position: center !important;
+}
+.o0,
+.h\\:o0:hover {
+  opacity: 0 !important;
+}
+.o5,
+.h\\:o5:hover {
+  opacity: 0.05 !important;
+}
+.o10 {
+  opacity: 0.1 !important;
+}
+.o20 {
+  opacity: 0.2 !important;
+}
+.o30 {
+  opacity: 0.3 !important;
+}
+.o40 {
+  opacity: 0.4 !important;
+}
+.o50,
+.h\\:o50:hover {
+  opacity: 0.5 !important;
+}
+.o60 {
+  opacity: 0.6 !important;
+}
+.o70 {
+  opacity: 0.7 !important;
+}
+.o80,
+.h\\:o80:hover {
+  opacity: 0.8 !important;
+}
+.o90 {
+  opacity: 0.9 !important;
+}
+.o100,
+.h\\:o100:hover,
+.f\\:o100:focus,
+.f\\:o100:focus-within {
+  opacity: 1 !important;
+}
+.outline-none {
+  outline: 0 !important;
+}
+.outline-ring {
+  border-color: var(--focus-neutral) !important;
+  box-shadow: 0 0 0 var(--su1) var(--focus-neutral), 0 0 0 var(--su3) var(--focus-theme);
+  outline: var(--su2) solid transparent !important;
+}
+.f\\:outline-ring:focus,
+.f\\:outline-ring:focus-within {
+  border-color: var(--focus-neutral) !important;
+  box-shadow: 0 0 0 var(--su1) var(--focus-neutral), 0 0 0 var(--su3) var(--focus-theme);
+  outline: var(--su2) solid transparent !important;
+}
+.overflow-auto {
+  overflow: auto !important;
+  scrollbar-color: var(--scrollbar) transparent;
+}
+.overflow-auto::-webkit-scrollbar {
+  width: calc(var(--su12) - var(--su2));
+  height: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-auto::-webkit-scrollbar-track {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-auto::-webkit-scrollbar-thumb {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: var(--scrollbar);
+}
+.overflow-auto::-webkit-scrollbar-corner {
+  background-color: transparent;
+  border-color: transparent;
+}
+.overflow-hidden {
+  overflow: hidden !important;
+  scrollbar-color: var(--scrollbar) transparent;
+}
+.overflow-hidden::-webkit-scrollbar {
+  width: calc(var(--su12) - var(--su2));
+  height: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-hidden::-webkit-scrollbar-track {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-hidden::-webkit-scrollbar-thumb {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: var(--scrollbar);
+}
+.overflow-hidden::-webkit-scrollbar-corner {
+  background-color: transparent;
+  border-color: transparent;
+}
+.overflow-scroll {
+  overflow: scroll !important;
+  scrollbar-color: var(--scrollbar) transparent;
+}
+.overflow-scroll::-webkit-scrollbar {
+  width: calc(var(--su12) - var(--su2));
+  height: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-scroll::-webkit-scrollbar-track {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-scroll::-webkit-scrollbar-thumb {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: var(--scrollbar);
+}
+.overflow-scroll::-webkit-scrollbar-corner {
+  background-color: transparent;
+  border-color: transparent;
+}
+.overflow-visible {
+  overflow: visible !important;
+}
+.overflow-x-auto {
+  overflow-x: auto !important;
+  scrollbar-color: var(--scrollbar) transparent;
+}
+.overflow-x-auto::-webkit-scrollbar {
+  width: calc(var(--su12) - var(--su2));
+  height: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-x-auto::-webkit-scrollbar-track {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-x-auto::-webkit-scrollbar-thumb {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: var(--scrollbar);
+}
+.overflow-x-auto::-webkit-scrollbar-corner {
+  background-color: transparent;
+  border-color: transparent;
+}
+.overflow-x-hidden {
+  overflow-x: hidden !important;
+  scrollbar-color: var(--scrollbar) transparent;
+}
+.overflow-x-hidden::-webkit-scrollbar {
+  width: calc(var(--su12) - var(--su2));
+  height: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-x-hidden::-webkit-scrollbar-track {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-x-hidden::-webkit-scrollbar-thumb {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: var(--scrollbar);
+}
+.overflow-x-hidden::-webkit-scrollbar-corner {
+  background-color: transparent;
+  border-color: transparent;
+}
+.overflow-x-scroll {
+  overflow-x: scroll !important;
+  scrollbar-color: var(--scrollbar) transparent;
+}
+.overflow-x-scroll::-webkit-scrollbar {
+  width: calc(var(--su12) - var(--su2));
+  height: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-x-scroll::-webkit-scrollbar-track {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-x-scroll::-webkit-scrollbar-thumb {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: var(--scrollbar);
+}
+.overflow-x-scroll::-webkit-scrollbar-corner {
+  background-color: transparent;
+  border-color: transparent;
+}
+.overflow-y-auto {
+  overflow-y: auto !important;
+  scrollbar-color: var(--scrollbar) transparent;
+}
+.overflow-y-auto::-webkit-scrollbar {
+  width: calc(var(--su12) - var(--su2));
+  height: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-y-auto::-webkit-scrollbar-track {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-y-auto::-webkit-scrollbar-thumb {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: var(--scrollbar);
+}
+.overflow-y-auto::-webkit-scrollbar-corner {
+  background-color: transparent;
+  border-color: transparent;
+}
+.overflow-y-hidden {
+  overflow-y: hidden !important;
+  scrollbar-color: var(--scrollbar) transparent;
+}
+.overflow-y-hidden::-webkit-scrollbar {
+  width: calc(var(--su12) - var(--su2));
+  height: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-y-hidden::-webkit-scrollbar-track {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-y-hidden::-webkit-scrollbar-thumb {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: var(--scrollbar);
+}
+.overflow-y-hidden::-webkit-scrollbar-corner {
+  background-color: transparent;
+  border-color: transparent;
+}
+.overflow-y-scroll {
+  overflow-y: scroll !important;
+  scrollbar-color: var(--scrollbar) transparent;
+}
+.overflow-y-scroll::-webkit-scrollbar {
+  width: calc(var(--su12) - var(--su2));
+  height: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-y-scroll::-webkit-scrollbar-track {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.overflow-y-scroll::-webkit-scrollbar-thumb {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: var(--scrollbar);
+}
+.overflow-y-scroll::-webkit-scrollbar-corner {
+  background-color: transparent;
+  border-color: transparent;
+}
+.p0 {
+  padding: var(--su0) !important;
+}
+.p1 {
+  padding: var(--su1) !important;
+}
+.p2 {
+  padding: var(--su2) !important;
+}
+.p4 {
+  padding: var(--su4) !important;
+}
+.p6 {
+  padding: var(--su6) !important;
+}
+.p8 {
+  padding: var(--su8) !important;
+}
+.p12 {
+  padding: var(--su12) !important;
+}
+.p16 {
+  padding: var(--su16) !important;
+}
+.p24 {
+  padding: var(--su24) !important;
+}
+.p32 {
+  padding: var(--su32) !important;
+}
+.p48 {
+  padding: var(--su48) !important;
+}
+.p64 {
+  padding: var(--su64) !important;
+}
+.p96 {
+  padding: var(--su96) !important;
+}
+.p128 {
+  padding: var(--su128) !important;
+}
+.pt0 {
+  padding-top: var(--su0) !important;
+}
+.pt1 {
+  padding-top: var(--su1) !important;
+}
+.pt2 {
+  padding-top: var(--su2) !important;
+}
+.pt4 {
+  padding-top: var(--su4) !important;
+}
+.pt6 {
+  padding-top: var(--su6) !important;
+}
+.pt8 {
+  padding-top: var(--su8) !important;
+}
+.pt12 {
+  padding-top: var(--su12) !important;
+}
+.pt16 {
+  padding-top: var(--su16) !important;
+}
+.pt24 {
+  padding-top: var(--su24) !important;
+}
+.pt32 {
+  padding-top: var(--su32) !important;
+}
+.pt48 {
+  padding-top: var(--su48) !important;
+}
+.pt64 {
+  padding-top: var(--su64) !important;
+}
+.pt96 {
+  padding-top: var(--su96) !important;
+}
+.pt128 {
+  padding-top: var(--su128) !important;
+}
+.pr0 {
+  padding-right: var(--su0) !important;
+}
+.pr1 {
+  padding-right: var(--su1) !important;
+}
+.pr2 {
+  padding-right: var(--su2) !important;
+}
+.pr4 {
+  padding-right: var(--su4) !important;
+}
+.pr6 {
+  padding-right: var(--su6) !important;
+}
+.pr8 {
+  padding-right: var(--su8) !important;
+}
+.pr12 {
+  padding-right: var(--su12) !important;
+}
+.pr16 {
+  padding-right: var(--su16) !important;
+}
+.pr24 {
+  padding-right: var(--su24) !important;
+}
+.pr32 {
+  padding-right: var(--su32) !important;
+}
+.pr48 {
+  padding-right: var(--su48) !important;
+}
+.pr64 {
+  padding-right: var(--su64) !important;
+}
+.pr96 {
+  padding-right: var(--su96) !important;
+}
+.pr128 {
+  padding-right: var(--su128) !important;
+}
+.pb0 {
+  padding-bottom: var(--su0) !important;
+}
+.pb1 {
+  padding-bottom: var(--su1) !important;
+}
+.pb2 {
+  padding-bottom: var(--su2) !important;
+}
+.pb4 {
+  padding-bottom: var(--su4) !important;
+}
+.pb6 {
+  padding-bottom: var(--su6) !important;
+}
+.pb8 {
+  padding-bottom: var(--su8) !important;
+}
+.pb12 {
+  padding-bottom: var(--su12) !important;
+}
+.pb16 {
+  padding-bottom: var(--su16) !important;
+}
+.pb24 {
+  padding-bottom: var(--su24) !important;
+}
+.pb32 {
+  padding-bottom: var(--su32) !important;
+}
+.pb48 {
+  padding-bottom: var(--su48) !important;
+}
+.pb64 {
+  padding-bottom: var(--su64) !important;
+}
+.pb96 {
+  padding-bottom: var(--su96) !important;
+}
+.pb128 {
+  padding-bottom: var(--su128) !important;
+}
+.pl0 {
+  padding-left: var(--su0) !important;
+}
+.pl1 {
+  padding-left: var(--su1) !important;
+}
+.pl2 {
+  padding-left: var(--su2) !important;
+}
+.pl4 {
+  padding-left: var(--su4) !important;
+}
+.pl6 {
+  padding-left: var(--su6) !important;
+}
+.pl8 {
+  padding-left: var(--su8) !important;
+}
+.pl12 {
+  padding-left: var(--su12) !important;
+}
+.pl16 {
+  padding-left: var(--su16) !important;
+}
+.pl24 {
+  padding-left: var(--su24) !important;
+}
+.pl32 {
+  padding-left: var(--su32) !important;
+}
+.pl48 {
+  padding-left: var(--su48) !important;
+}
+.pl64 {
+  padding-left: var(--su64) !important;
+}
+.pl96 {
+  padding-left: var(--su96) !important;
+}
+.pl128 {
+  padding-left: var(--su128) !important;
+}
+.px0 {
+  padding-left: var(--su0) !important;
+  padding-right: var(--su0) !important;
+}
+.px1 {
+  padding-left: var(--su1) !important;
+  padding-right: var(--su1) !important;
+}
+.px2 {
+  padding-left: var(--su2) !important;
+  padding-right: var(--su2) !important;
+}
+.px4 {
+  padding-left: var(--su4) !important;
+  padding-right: var(--su4) !important;
+}
+.px6 {
+  padding-left: var(--su6) !important;
+  padding-right: var(--su6) !important;
+}
+.px8 {
+  padding-left: var(--su8) !important;
+  padding-right: var(--su8) !important;
+}
+.px12 {
+  padding-left: var(--su12) !important;
+  padding-right: var(--su12) !important;
+}
+.px16 {
+  padding-left: var(--su16) !important;
+  padding-right: var(--su16) !important;
+}
+.px24 {
+  padding-left: var(--su24) !important;
+  padding-right: var(--su24) !important;
+}
+.px32 {
+  padding-left: var(--su32) !important;
+  padding-right: var(--su32) !important;
+}
+.px48 {
+  padding-left: var(--su48) !important;
+  padding-right: var(--su48) !important;
+}
+.px64 {
+  padding-left: var(--su64) !important;
+  padding-right: var(--su64) !important;
+}
+.px96 {
+  padding-left: var(--su96) !important;
+  padding-right: var(--su96) !important;
+}
+.px128 {
+  padding-left: var(--su128) !important;
+  padding-right: var(--su128) !important;
+}
+.py0 {
+  padding-top: var(--su0) !important;
+  padding-bottom: var(--su0) !important;
+}
+.py1 {
+  padding-top: var(--su1) !important;
+  padding-bottom: var(--su1) !important;
+}
+.py2 {
+  padding-top: var(--su2) !important;
+  padding-bottom: var(--su2) !important;
+}
+.py4 {
+  padding-top: var(--su4) !important;
+  padding-bottom: var(--su4) !important;
+}
+.py6 {
+  padding-top: var(--su6) !important;
+  padding-bottom: var(--su6) !important;
+}
+.py8 {
+  padding-top: var(--su8) !important;
+  padding-bottom: var(--su8) !important;
+}
+.py12 {
+  padding-top: var(--su12) !important;
+  padding-bottom: var(--su12) !important;
+}
+.py16 {
+  padding-top: var(--su16) !important;
+  padding-bottom: var(--su16) !important;
+}
+.py24 {
+  padding-top: var(--su24) !important;
+  padding-bottom: var(--su24) !important;
+}
+.py32 {
+  padding-top: var(--su32) !important;
+  padding-bottom: var(--su32) !important;
+}
+.py48 {
+  padding-top: var(--su48) !important;
+  padding-bottom: var(--su48) !important;
+}
+.py64 {
+  padding-top: var(--su64) !important;
+  padding-bottom: var(--su64) !important;
+}
+.py96 {
+  padding-top: var(--su96) !important;
+  padding-bottom: var(--su96) !important;
+}
+.py128 {
+  padding-top: var(--su128) !important;
+  padding-bottom: var(--su128) !important;
+}
+.ps-absolute {
+  position: absolute !important;
+}
+.ps-fixed {
+  position: fixed !important;
+}
+.ps-relative {
+  position: relative !important;
+}
+.ps-static {
+  position: static !important;
+}
+.ps-sticky {
+  position: sticky !important;
+}
+.ps-unset {
+  position: unset !important;
+}
+.i0 {
+  inset: var(--su0) !important;
+}
+.i1 {
+  inset: var(--su1) !important;
+}
+.i2 {
+  inset: var(--su2) !important;
+}
+.i4 {
+  inset: var(--su4) !important;
+}
+.i6 {
+  inset: var(--su6) !important;
+}
+.i8 {
+  inset: var(--su8) !important;
+}
+.i12 {
+  inset: var(--su12) !important;
+}
+.i16 {
+  inset: var(--su16) !important;
+}
+.i24 {
+  inset: var(--su24) !important;
+}
+.i32 {
+  inset: var(--su32) !important;
+}
+.i48 {
+  inset: var(--su48) !important;
+}
+.i64 {
+  inset: var(--su64) !important;
+}
+.i96 {
+  inset: var(--su96) !important;
+}
+.i128 {
+  inset: var(--su128) !important;
+}
+.t0 {
+  top: var(--su0) !important;
+}
+.t1 {
+  top: var(--su1) !important;
+}
+.t2 {
+  top: var(--su2) !important;
+}
+.t4 {
+  top: var(--su4) !important;
+}
+.t6 {
+  top: var(--su6) !important;
+}
+.t8 {
+  top: var(--su8) !important;
+}
+.t12 {
+  top: var(--su12) !important;
+}
+.t16 {
+  top: var(--su16) !important;
+}
+.t24 {
+  top: var(--su24) !important;
+}
+.t32 {
+  top: var(--su32) !important;
+}
+.t48 {
+  top: var(--su48) !important;
+}
+.t64 {
+  top: var(--su64) !important;
+}
+.t96 {
+  top: var(--su96) !important;
+}
+.t128 {
+  top: var(--su128) !important;
+}
+.tn1 {
+  top: var(--sun1) !important;
+}
+.tn2 {
+  top: var(--sun2) !important;
+}
+.tn4 {
+  top: var(--sun4) !important;
+}
+.tn6 {
+  top: var(--sun6) !important;
+}
+.tn8 {
+  top: var(--sun8) !important;
+}
+.tn12 {
+  top: var(--sun12) !important;
+}
+.tn16 {
+  top: var(--sun16) !important;
+}
+.tn24 {
+  top: var(--sun24) !important;
+}
+.tn32 {
+  top: var(--sun32) !important;
+}
+.tn48 {
+  top: var(--sun48) !important;
+}
+.tn64 {
+  top: var(--sun64) !important;
+}
+.tn96 {
+  top: var(--sun96) !important;
+}
+.tn128 {
+  top: var(--sun128) !important;
+}
+.t50 {
+  top: 50% !important;
+}
+.t100 {
+  top: 100% !important;
+}
+.tn50 {
+  top: -50% !important;
+}
+.tn100 {
+  top: -100% !important;
+}
+.r0 {
+  right: var(--su0) !important;
+}
+.r1 {
+  right: var(--su1) !important;
+}
+.r2 {
+  right: var(--su2) !important;
+}
+.r4 {
+  right: var(--su4) !important;
+}
+.r6 {
+  right: var(--su6) !important;
+}
+.r8 {
+  right: var(--su8) !important;
+}
+.r12 {
+  right: var(--su12) !important;
+}
+.r16 {
+  right: var(--su16) !important;
+}
+.r24 {
+  right: var(--su24) !important;
+}
+.r32 {
+  right: var(--su32) !important;
+}
+.r48 {
+  right: var(--su48) !important;
+}
+.r64 {
+  right: var(--su64) !important;
+}
+.r96 {
+  right: var(--su96) !important;
+}
+.r128 {
+  right: var(--su128) !important;
+}
+.rn1 {
+  right: var(--sun1) !important;
+}
+.rn2 {
+  right: var(--sun2) !important;
+}
+.rn4 {
+  right: var(--sun4) !important;
+}
+.rn6 {
+  right: var(--sun6) !important;
+}
+.rn8 {
+  right: var(--sun8) !important;
+}
+.rn12 {
+  right: var(--sun12) !important;
+}
+.rn16 {
+  right: var(--sun16) !important;
+}
+.rn24 {
+  right: var(--sun24) !important;
+}
+.rn32 {
+  right: var(--sun32) !important;
+}
+.rn48 {
+  right: var(--sun48) !important;
+}
+.rn64 {
+  right: var(--sun64) !important;
+}
+.rn96 {
+  right: var(--sun96) !important;
+}
+.rn128 {
+  right: var(--sun128) !important;
+}
+.r50 {
+  right: 50% !important;
+}
+.r100 {
+  right: 100% !important;
+}
+.rn50 {
+  right: -50% !important;
+}
+.rn100 {
+  right: -100% !important;
+}
+.b0 {
+  bottom: var(--su0) !important;
+}
+.b1 {
+  bottom: var(--su1) !important;
+}
+.b2 {
+  bottom: var(--su2) !important;
+}
+.b4 {
+  bottom: var(--su4) !important;
+}
+.b6 {
+  bottom: var(--su6) !important;
+}
+.b8 {
+  bottom: var(--su8) !important;
+}
+.b12 {
+  bottom: var(--su12) !important;
+}
+.b16 {
+  bottom: var(--su16) !important;
+}
+.b24 {
+  bottom: var(--su24) !important;
+}
+.b32 {
+  bottom: var(--su32) !important;
+}
+.b48 {
+  bottom: var(--su48) !important;
+}
+.b64 {
+  bottom: var(--su64) !important;
+}
+.b96 {
+  bottom: var(--su96) !important;
+}
+.b128 {
+  bottom: var(--su128) !important;
+}
+.bn1 {
+  bottom: var(--sun1) !important;
+}
+.bn2 {
+  bottom: var(--sun2) !important;
+}
+.bn4 {
+  bottom: var(--sun4) !important;
+}
+.bn6 {
+  bottom: var(--sun6) !important;
+}
+.bn8 {
+  bottom: var(--sun8) !important;
+}
+.bn12 {
+  bottom: var(--sun12) !important;
+}
+.bn16 {
+  bottom: var(--sun16) !important;
+}
+.bn24 {
+  bottom: var(--sun24) !important;
+}
+.bn32 {
+  bottom: var(--sun32) !important;
+}
+.bn48 {
+  bottom: var(--sun48) !important;
+}
+.bn64 {
+  bottom: var(--sun64) !important;
+}
+.bn96 {
+  bottom: var(--sun96) !important;
+}
+.bn128 {
+  bottom: var(--sun128) !important;
+}
+.b50 {
+  bottom: 50% !important;
+}
+.b100 {
+  bottom: 100% !important;
+}
+.bn50 {
+  bottom: -50% !important;
+}
+.bn100 {
+  bottom: -100% !important;
+}
+.l0 {
+  left: var(--su0) !important;
+}
+.l1 {
+  left: var(--su1) !important;
+}
+.l2 {
+  left: var(--su2) !important;
+}
+.l4 {
+  left: var(--su4) !important;
+}
+.l6 {
+  left: var(--su6) !important;
+}
+.l8 {
+  left: var(--su8) !important;
+}
+.l12 {
+  left: var(--su12) !important;
+}
+.l16 {
+  left: var(--su16) !important;
+}
+.l24 {
+  left: var(--su24) !important;
+}
+.l32 {
+  left: var(--su32) !important;
+}
+.l48 {
+  left: var(--su48) !important;
+}
+.l64 {
+  left: var(--su64) !important;
+}
+.l96 {
+  left: var(--su96) !important;
+}
+.l128 {
+  left: var(--su128) !important;
+}
+.ln1 {
+  left: var(--sun1) !important;
+}
+.ln2 {
+  left: var(--sun2) !important;
+}
+.ln4 {
+  left: var(--sun4) !important;
+}
+.ln6 {
+  left: var(--sun6) !important;
+}
+.ln8 {
+  left: var(--sun8) !important;
+}
+.ln12 {
+  left: var(--sun12) !important;
+}
+.ln16 {
+  left: var(--sun16) !important;
+}
+.ln24 {
+  left: var(--sun24) !important;
+}
+.ln32 {
+  left: var(--sun32) !important;
+}
+.ln48 {
+  left: var(--sun48) !important;
+}
+.ln64 {
+  left: var(--sun64) !important;
+}
+.ln96 {
+  left: var(--sun96) !important;
+}
+.ln128 {
+  left: var(--sun128) !important;
+}
+.l50 {
+  left: 50% !important;
+}
+.l100 {
+  left: 100% !important;
+}
+.ln50 {
+  left: -50% !important;
+}
+.ln100 {
+  left: -100% !important;
+}
+.truncate {
+  overflow: hidden;
+  max-width: 100%;
+  text-overflow: ellipsis !important;
+  white-space: nowrap;
+}
+.v-truncate1 {
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.v-truncate2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.v-truncate3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.v-truncate4 {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.v-truncate5 {
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.v-truncate-fade {
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(180deg, #000 calc(var(--lh-md) * 9em), transparent);
+  mask-image: linear-gradient(180deg, #000 calc(var(--lh-md) * 9em), transparent);
+  max-height: calc(var(--lh-md) * 12em);
+}
+.v-truncate-fade.v-truncate-fade__sm {
+  -webkit-mask-image: linear-gradient(180deg, #000 calc(var(--lh-md) * 3em), transparent);
+  mask-image: linear-gradient(180deg, #000 calc(var(--lh-md) * 3em), transparent);
+  max-height: calc(var(--lh-md) * 6em);
+}
+.v-truncate-fade.v-truncate-fade__lg {
+  -webkit-mask-image: linear-gradient(180deg, #000 calc(var(--lh-md) * 21em), transparent);
+  mask-image: linear-gradient(180deg, #000 calc(var(--lh-md) * 21em), transparent);
+  max-height: calc(var(--lh-md) * 24em);
+}
+.va-baseline {
+  vertical-align: baseline !important;
+}
+.va-bottom {
+  vertical-align: bottom !important;
+}
+.va-middle {
+  vertical-align: middle !important;
+}
+.va-sub {
+  vertical-align: sub !important;
+}
+.va-super {
+  vertical-align: super !important;
+}
+.va-text-bottom {
+  vertical-align: text-bottom !important;
+}
+.va-text-top {
+  vertical-align: text-top !important;
+}
+.va-top {
+  vertical-align: top !important;
+}
+.va-unset {
+  vertical-align: unset !important;
+}
+.v-visible {
+  visibility: visible !important;
+}
+.v-hidden {
+  visibility: hidden !important;
+}
+.v-visible-sr {
+  border: 0;
+  /* stylelint-disable-next-line property-no-deprecated -- clip is kept for older browser compatibility alongside clip-path */
+  clip: rect(var(--su1), var(--su1), var(--su1), var(--su1));
+  clip-path: inset(50%);
+  height: var(--su1);
+  margin: var(--sun1);
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: var(--su1);
+  overflow-wrap: normal;
+}
+.w0 {
+  width: var(--su0) !important;
+}
+.w1 {
+  width: var(--su1) !important;
+}
+.w2 {
+  width: var(--su2) !important;
+}
+.w4 {
+  width: var(--su4) !important;
+}
+.w6 {
+  width: var(--su6) !important;
+}
+.w8 {
+  width: var(--su8) !important;
+}
+.w12 {
+  width: var(--su12) !important;
+}
+.w16 {
+  width: var(--su16) !important;
+}
+.w24 {
+  width: var(--su24) !important;
+}
+.w32 {
+  width: var(--su32) !important;
+}
+.w48 {
+  width: var(--su48) !important;
+}
+.w64 {
+  width: var(--su64) !important;
+}
+.w96 {
+  width: var(--su96) !important;
+}
+.w128 {
+  width: var(--su128) !important;
+}
+.ws1 {
+  width: var(--su128) !important;
+}
+.ws2 {
+  width: var(--su256) !important;
+}
+.ws3 {
+  width: var(--su344) !important;
+}
+.ws4 {
+  width: var(--su448) !important;
+}
+.ws5 {
+  width: var(--su512) !important;
+}
+.ws6 {
+  width: var(--su640) !important;
+}
+.ws7 {
+  width: var(--su768) !important;
+}
+.ws8 {
+  width: var(--su848) !important;
+}
+.ws9 {
+  width: var(--su960) !important;
+}
+.ws10 {
+  width: var(--su1024) !important;
+}
+.ws11 {
+  width: var(--su1120) !important;
+}
+.ws12 {
+  width: var(--su1280) !important;
+}
+.w10 {
+  width: 10% !important;
+}
+.w20 {
+  width: 20% !important;
+}
+.w30 {
+  width: 30% !important;
+}
+.w40 {
+  width: 40% !important;
+}
+.w60 {
+  width: 60% !important;
+}
+.w70 {
+  width: 70% !important;
+}
+.w80 {
+  width: 80% !important;
+}
+.w90 {
+  width: 90% !important;
+}
+.w25 {
+  width: 25% !important;
+}
+.w50 {
+  width: 50% !important;
+}
+.w75 {
+  width: 75% !important;
+}
+.w100 {
+  width: 100% !important;
+}
+.w33 {
+  width: calc(100% / 3) !important;
+}
+.w66 {
+  width: calc(100% / 3 * 2) !important;
+}
+.w-auto {
+  width: auto !important;
+}
+.w-screen {
+  width: 100vw !important;
+}
+.wmn0 {
+  min-width: var(--su0) !important;
+}
+.wmn1 {
+  min-width: var(--su128) !important;
+}
+.wmn2 {
+  min-width: var(--su256) !important;
+}
+.wmn3 {
+  min-width: var(--su344) !important;
+}
+.wmn4 {
+  min-width: var(--su448) !important;
+}
+.wmn5 {
+  min-width: var(--su512) !important;
+}
+.wmn6 {
+  min-width: var(--su640) !important;
+}
+.wmn7 {
+  min-width: var(--su768) !important;
+}
+.wmn8 {
+  min-width: var(--su848) !important;
+}
+.wmn9 {
+  min-width: var(--su960) !important;
+}
+.wmn10 {
+  min-width: var(--su1024) !important;
+}
+.wmn11 {
+  min-width: var(--su1120) !important;
+}
+.wmn12 {
+  min-width: var(--su1280) !important;
+}
+.wmn25 {
+  min-width: 25% !important;
+}
+.wmn50 {
+  min-width: 50% !important;
+}
+.wmn75 {
+  min-width: 75% !important;
+}
+.wmn100 {
+  min-width: 100% !important;
+}
+.wmn-initial {
+  min-width: initial !important;
+}
+.wmn-screen {
+  min-width: 100vw !important;
+}
+.wmx1 {
+  max-width: var(--su128) !important;
+}
+.wmx2 {
+  max-width: var(--su256) !important;
+}
+.wmx3 {
+  max-width: var(--su344) !important;
+}
+.wmx4 {
+  max-width: var(--su448) !important;
+}
+.wmx5 {
+  max-width: var(--su512) !important;
+}
+.wmx6 {
+  max-width: var(--su640) !important;
+}
+.wmx7 {
+  max-width: var(--su768) !important;
+}
+.wmx8 {
+  max-width: var(--su848) !important;
+}
+.wmx9 {
+  max-width: var(--su960) !important;
+}
+.wmx10 {
+  max-width: var(--su1024) !important;
+}
+.wmx11 {
+  max-width: var(--su1120) !important;
+}
+.wmx12 {
+  max-width: var(--su1280) !important;
+}
+.wmx25 {
+  max-width: 25% !important;
+}
+.wmx50 {
+  max-width: 50% !important;
+}
+.wmx75 {
+  max-width: 75% !important;
+}
+.wmx100 {
+  max-width: 100% !important;
+}
+.wmx-initial {
+  max-width: initial !important;
+}
+.wmx-screen {
+  max-width: 100vw !important;
+}
+.z-hide {
+  z-index: var(--zi-hide) !important;
+}
+.z-base {
+  z-index: var(--zi-base) !important;
+}
+.z-active {
+  z-index: var(--zi-active) !important;
+}
+.z-selected {
+  z-index: var(--zi-selected) !important;
+}
+.z-dropdown {
+  z-index: var(--zi-dropdown) !important;
+}
+.z-popover {
+  z-index: var(--zi-popovers) !important;
+}
+.z-tooltip {
+  z-index: var(--zi-tooltips) !important;
+}
+.z-banner {
+  z-index: var(--zi-banners) !important;
+}
+.z-nav {
+  z-index: var(--zi-navigation) !important;
+}
+.z-nav-fixed {
+  z-index: var(--zi-navigation-fixed) !important;
+}
+.z-modal {
+  z-index: var(--zi-modals) !important;
+}
+.z-modal-bg {
+  z-index: var(--zi-modals-background) !important;
+}
+.s-activity-indicator {
+  --_ai-bg: var(--pink-400);
+  --_ai-fc: var(--white);
+  --_ai-min-size: var(--su16);
+  --_ai-p: 0 var(--su3);
+  background-color: var(--_ai-bg);
+  color: var(--_ai-fc);
+  min-width: var(--_ai-min-size);
+  min-height: var(--_ai-min-size);
+  padding: var(--_ai-p);
+  border-radius: var(--br-pill);
+  display: inline-flex;
+  font-size: var(--fs-fine);
+  font-weight: 600;
+  line-height: 1.1;
+  text-align: center;
+  align-items: center;
+  justify-content: center;
+  text-transform: uppercase;
+}
+.s-activity-indicator.s-activity-indicator__danger {
+  --_ai-bg: var(--red-400);
+}
+.s-activity-indicator.s-activity-indicator__success {
+  --_ai-bg: var(--green-400);
+}
+.s-activity-indicator.s-activity-indicator__warning {
+  --_ai-bg: var(--yellow-400);
+}
+.s-activity-indicator.s-activity-indicator__sm {
+  --_ai-min-size: calc(var(--su8) + var(--su2));
+  --_ai-p: 0;
+}
+.s-anchors {
+  --_an-a-fc: var(--theme-link-color, var(--black-600));
+  --_an-a-fc-hover: var(--theme-link-color-hover, var(--blue-400));
+  --_an-a-fc-visited: var(--theme-link-color-visited, var(--black-400));
+}
+body.theme-highcontrast .s-anchors a[href] {
+  text-decoration: underline;
+}
+.s-anchors.s-anchors__underlined a:not(.s-link),
+.s-anchors.s-anchors__underlined .s-btn.s-btn__link {
+  text-decoration: underline;
+}
+.s-anchors.s-anchors__danger {
+  --_an-a-fc: var(--red-400);
+  --_an-a-fc-hover: var(--red-500);
+  --_an-a-fc-visited: var(--red-600);
+}
+.s-anchors.s-anchors__grayscale {
+  --_an-a-fc: var(--black-500);
+  --_an-a-fc-hover: var(--black-600);
+}
+.s-anchors.s-anchors__inherit {
+  --_an-a-fc: inherit;
+  --_an-a-fc-hover: inherit;
+  --_an-a-fc-visited: inherit;
+}
+.s-anchors.s-anchors__inherit a:not(.s-link):not(.s-btn),
+.s-anchors.s-anchors__inherit .s-btn.s-btn__link {
+  color: var(--_an-a-fc) !important;
+}
+.s-anchors.s-anchors__muted {
+  --_an-a-fc: var(--black-400);
+}
+p.s-anchors > a[href],
+.s-anchors p > a[href] {
+  text-decoration: underline;
+}
+.s-anchors a:not(.s-link),
+.s-anchors .s-btn.s-btn__link {
+  color: var(--_an-a-fc, inherit);
+  text-decoration: none;
+}
+.s-anchors a:not(.s-link):active,
+.s-anchors .s-btn.s-btn__link:active,
+.s-anchors a:not(.s-link):hover,
+.s-anchors .s-btn.s-btn__link:hover {
+  color: var(--_an-a-fc-hover);
+  text-decoration: underline;
+}
+.s-anchors a:not(.s-link):visited {
+  color: var(--_an-a-fc-visited, inherit);
+}
+.s-anchors a:not(.s-link):visited:hover {
+  color: var(--_an-a-fc-hover, inherit);
+}
+.s-avatar {
+  --_av-size: var(--su16);
+  --_av-bg: var(--white);
+  --_av-fs-letter: calc(var(--su12) - var(--su1));
+  --_av-scale-badge: 1;
+  background-color: var(--_av-bg);
+  height: var(--_av-size);
+  width: var(--_av-size);
+  background-repeat: no-repeat;
+  background-size: 100%;
+  display: inline-block;
+  position: relative;
+  text-decoration: none;
+  vertical-align: bottom;
+}
+body.theme-highcontrast .s-avatar {
+  background-color: var(--black);
+  box-shadow: 0 0 0 var(--su1) var(--black);
+  color: var(--white);
+}
+body.theme-highcontrast .s-avatar .s-avatar--letter {
+  color: var(--white);
+}
+.s-avatar.s-avatar__96,
+.s-avatar.s-avatar__128 {
+  --_av-scale-badge: 3;
+}
+.s-avatar.s-avatar__24 {
+  --_av-size: var(--su24);
+  --_av-fs-letter: var(--su16);
+  --_av-scale-badge: 1.1;
+}
+.s-avatar.s-avatar__32 {
+  --_av-size: var(--su32);
+  --_av-fs-letter: calc(var(--su24) - var(--su2));
+  --_av-scale-badge: 1.3;
+}
+.s-avatar.s-avatar__48 {
+  --_av-size: var(--su48);
+  --_av-fs-letter: calc(var(--su32) + var(--su2));
+  --_av-scale-badge: 1.6;
+}
+.s-avatar.s-avatar__64 {
+  --_av-size: var(--su64);
+  --_av-fs-letter: calc(var(--su48) - var(--su4));
+  --_av-scale-badge: 2.4;
+}
+.s-avatar.s-avatar__96 {
+  --_av-size: var(--su96);
+  --_av-fs-letter: calc(var(--su64) + var(--su2));
+}
+.s-avatar.s-avatar__128 {
+  --_av-size: var(--su128);
+  --_av-fs-letter: calc(var(--su96) - var(--su8));
+}
+.s-avatar .s-avatar--badge {
+  bottom: var(--sun4);
+  position: absolute;
+  right: var(--sun4);
+  -webkit-transform: scale(var(--_av-scale-badge));
+  transform: scale(var(--_av-scale-badge));
+}
+.s-avatar .s-avatar--image {
+  display: block;
+  height: var(--_av-size);
+  width: var(--_av-size);
+}
+.s-avatar .s-avatar--letter {
+  color: var(--_white-static);
+  display: block;
+  font-size: var(--_av-fs-letter);
+  font-weight: bold;
+  line-height: 1.4;
+  text-align: center;
+  text-transform: uppercase;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.s-avatar .s-avatar--indicator {
+  box-shadow: 0 0 0 var(--su2) var(--white);
+  bottom: 100%;
+  left: 100%;
+  position: absolute;
+  transform: translate(-50%, 60%);
+}
+.s-badge {
+  --_ba-bc: transparent;
+  --_ba-bg: var(--black-100);
+  --_ba-fc: var(--black-500);
+  --_ba-fs: var(--fs-caption);
+  --_ba-px: var(--su6);
+  --_ba-py: var(--su4);
+  --_ba-tt: unset;
+  --_ba-wmn: 0;
+  --_ba-bl: 0;
+  --_ba-fw: unset;
+  --_ba-g: unset;
+  --_ba-svg-p: var(--su2);
+  --_ba-sq-bg: var(--black-200);
+  background-color: var(--_ba-bg);
+  border-left: var(--_ba-bl) solid var(--_ba-bc);
+  color: var(--_ba-fc);
+  font-size: var(--_ba-fs);
+  font-weight: var(--_ba-fw);
+  gap: var(--_ba-g, var(--_ba-px));
+  padding: var(--_ba-py) var(--_ba-pr, var(--_ba-px)) var(--_ba-py) var(--_ba-px);
+  min-width: var(--_ba-wmn);
+  text-transform: var(--_ba-tt);
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  line-height: var(--lh-md);
+  text-decoration: none;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+body.theme-highcontrast .s-badge {
+  --_ba-bx-sh-w: var(--su1);
+}
+body.theme-highcontrast .s-badge.s-badge__sm {
+  --_ba-bx-sh-w: 0;
+}
+body.theme-highcontrast .s-badge.s-badge__lg {
+  --_ba-bx-sh-w: var(--su4);
+}
+body.theme-highcontrast .s-badge:not(.s-badge__important) > svg {
+  box-shadow: 0 0 0 calc(var(--_ba-bx-sh-w) - var(--su1)) var(--_ba-sq-bg), 0 0 0 max(var(--su1), var(--_ba-bx-sh-w)) currentcolor inset;
+}
+body.theme-highcontrast .s-badge a[href],
+body.theme-highcontrast .s-badge a[href]:hover {
+  text-decoration: underline !important;
+}
+.s-badge:has(> .s-bling__filled),
+.s-badge.s-badge__squared,
+.s-badge:has(> svg) {
+  --_ba-pr: var(--su6);
+}
+.s-badge:has(> .s-bling__filled),
+.s-badge.s-badge__squared,
+.s-badge:has(> svg),
+.s-badge:has(> .s-bling__filled).s-badge__lg,
+.s-badge.s-badge__squared.s-badge__lg,
+.s-badge:has(> svg).s-badge__lg,
+.s-badge:has(> .s-bling__filled).s-badge__sm,
+.s-badge.s-badge__squared.s-badge__sm,
+.s-badge:has(> svg).s-badge__sm {
+  --_ba-px: 0;
+  --_ba-py: 0;
+}
+.s-badge:has(> .s-bling__filled).s-badge__lg,
+.s-badge.s-badge__squared.s-badge__lg,
+.s-badge:has(> svg).s-badge__lg {
+  --_ba-pr: var(--su8);
+}
+.s-badge:has(> .s-bling__filled).s-badge__sm,
+.s-badge.s-badge__squared.s-badge__sm,
+.s-badge:has(> svg).s-badge__sm {
+  --_ba-pr: var(--su4);
+}
+.s-badge:has(> .s-bling__filled),
+.s-badge.s-badge__squared {
+  --_ba-g: var(--su6);
+}
+.s-badge:has(> .s-bling__filled).s-badge__lg,
+.s-badge.s-badge__squared.s-badge__lg {
+  --_ba-g: var(--su8);
+}
+.s-badge:has(> .s-bling__filled).s-badge__sm,
+.s-badge.s-badge__squared.s-badge__sm {
+  --_ba-g: var(--su4);
+}
+.s-badge:not(.s-badge__squared):has(> svg) {
+  --_ba-g: var(--su2);
+}
+.s-badge:has(.s-bling__rep) {
+  --_ba-fw: 600;
+  --_ba-fc: var(--black-600);
+}
+.s-badge:has(.s-bling) {
+  --_ba-bg: var(--black-150);
+}
+.s-badge.s-badge__sm {
+  --_ba-fs: var(--fs-fine);
+  --_ba-px: var(--su4);
+  --_ba-py: var(--su1);
+  --_ba-wmn: calc(var(--su16) + var(--su2));
+  --_ba-svg-p: var(--_ba-py);
+}
+.s-badge.s-badge__lg {
+  --_ba-fs: var(--fs-body1);
+  --_ba-px: var(--su8);
+  --_ba-py: calc(var(--su4) + var(--su1));
+  --_ba-svg-p: var(--_ba-py);
+}
+.s-badge.s-badge__gold,
+.s-badge.s-badge__silver,
+.s-badge.s-badge__bronze {
+  --_ba-bl: var(--su4);
+}
+.s-badge.s-badge__gold .s-bling__gold,
+.s-badge.s-badge__silver .s-bling__gold,
+.s-badge.s-badge__bronze .s-bling__gold,
+.s-badge.s-badge__gold .s-bling__silver,
+.s-badge.s-badge__silver .s-bling__silver,
+.s-badge.s-badge__bronze .s-bling__silver,
+.s-badge.s-badge__gold .s-bling__bronze,
+.s-badge.s-badge__silver .s-bling__bronze,
+.s-badge.s-badge__bronze .s-bling__bronze {
+  margin-left: -2px;
+}
+.s-badge.s-badge__gold {
+  --_ba-bc: var(--yellow-300);
+}
+.s-badge.s-badge__silver {
+  --_ba-bc: var(--blue-300);
+}
+.s-badge.s-badge__bronze {
+  --_ba-bc: var(--orange-300);
+}
+.s-badge.s-badge__admin,
+.s-badge.s-badge__moderator,
+.s-badge.s-badge__staff,
+.s-badge.s-badge__ai,
+.s-badge.s-badge__bot,
+.s-badge.s-badge__new {
+  --_ba-bl: var(--su4);
+  --_ba-bg: var(--black-150);
+  --_ba-fc: var(--black-600);
+}
+.s-badge.s-badge__moderator:before,
+.s-badge.s-badge__new:before {
+  background-color: var(--_ba-bc);
+  height: var(--_ba-before-h);
+  width: var(--_ba-before-w);
+  -webkit-mask: var(--_ba-before-icon) no-repeat center;
+  mask: var(--_ba-before-icon) no-repeat center;
+  content: "";
+  display: inline-block;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+}
+.s-badge.s-badge__moderator {
+  --_ba-bc: var(--blue-500);
+  --_ba-before-h: calc(var(--su12) + var(--su1));
+  --_ba-before-w: calc(var(--su12) - var(--su1));
+  --_ba-before-icon: url("data:image/svg+xml;,%3Csvg width='11' height='13' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.528.746c.257-.329.675-.327.93 0l4.42 5.66c.258.329.257.864 0 1.192l-4.42 5.66c-.256.328-.674.327-.93 0l-4.42-5.66c-.257-.329-.256-.865 0-1.192l4.42-5.66z' fill='%23fff'/%3E%3C/svg%3E");
+}
+.s-badge.s-badge__moderator.s-badge__sm {
+  --_ba-before-h: calc(var(--su12) - var(--su1));
+  --_ba-before-w: calc(var(--su8) + var(--su1));
+  --_ba-before-icon: url("data:image/svg+xml;,%3Csvg width='9' height='11' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3.55.246c.257-.329.647-.327.903 0l3.36 4.66c.256.329.256.864 0 1.192L4.45 10.75c-.257.329-.644.327-.9 0L.192 6.098c-.256-.329-.256-.865 0-1.192L3.55.246z' fill='%23fff'/%3E%3C/svg%3E");
+}
+.s-badge.s-badge__moderator:before {
+  margin-top: var(--sun1);
+}
+.s-badge.s-badge__staff {
+  --_ba-bc: var(--orange-400);
+}
+.s-badge.s-badge__admin {
+  --_ba-bc: var(--theme-primary-500, var(--orange-500));
+}
+.s-badge.s-badge__ai {
+  --_ba-bc: var(--purple-400);
+}
+.s-badge.s-badge__bot {
+  --_ba-bc: var(--black-400);
+}
+.s-badge.s-badge__new {
+  --_ba-bg: var(--purple-100);
+  --_ba-fc: var(--purple-500);
+  --_ba-sq-bg: var(--purple-200);
+  --_ba-bc: var(--purple-400);
+  --_ba-gap: var(--su2);
+  --_ba-before-h: calc(var(--su12) + var(--su2));
+  --_ba-before-w: calc(var(--su12) + var(--su2));
+  --_ba-before-icon: url("data:image/svg+xml;,%3Csvg width='14' height='14' viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8 1a7 7 0 1 1 0 14A7 7 0 0 1 8 1m0 1.25a5.75 5.75 0 1 0 0 11.5 5.75 5.75 0 0 0 0-11.5m1 10.06H7V10.6h2zM8.14 4c1.78 0 2.77.96 2.77 2.5 0 1.79-2.1 2.2-2.1 3.25h-1.6c0-2 2-2.08 2-3.26 0-.54-.27-.96-1.02-.96-.7 0-1.03.46-1.1 1.23H5.4A2.75 2.75 0 0 1 8.13 4' fill='%23fff'/%3E%3C/svg%3E");
+}
+.s-badge.s-badge__new:before {
+  margin-left: var(--sun2);
+  margin-top: 0;
+}
+.s-badge.s-badge__info {
+  --_ba-bg: var(--blue-100);
+  --_ba-fc: var(--blue-500);
+  --_ba-sq-bg: var(--blue-200);
+}
+.s-badge.s-badge__info.s-badge__important {
+  --_ba-bg: var(--blue-400);
+  --_ba-sq-bg: var(--blue-500);
+}
+.s-badge.s-badge__warning {
+  --_ba-bg: var(--yellow-100);
+  --_ba-fc: var(--yellow-500);
+  --_ba-sq-bg: var(--yellow-200);
+}
+.s-badge.s-badge__warning.s-badge__important {
+  --_ba-bg: var(--yellow-400);
+  --_ba-sq-bg: var(--yellow-500);
+}
+.s-badge.s-badge__danger {
+  --_ba-bg: var(--red-100);
+  --_ba-fc: var(--red-500);
+  --_ba-sq-bg: var(--red-200);
+}
+.s-badge.s-badge__danger.s-badge__important {
+  --_ba-bg: var(--red-400);
+  --_ba-sq-bg: var(--red-500);
+}
+.s-badge.s-badge__critical {
+  --_ba-bg: var(--red-200);
+  --_ba-fc: var(--red-600);
+  --_ba-sq-bg: var(--red-300);
+}
+.s-badge.s-badge__critical.s-badge__important {
+  --_ba-bg: var(--red-500);
+  --_ba-sq-bg: var(--red-600);
+}
+.s-badge.s-badge__tonal {
+  --_ba-bg: var(--black-200);
+  --_ba-fc: var(--black-600);
+  --_ba-sq-bg: var(--black-300);
+}
+.s-badge.s-badge__tonal.s-badge__important {
+  --_ba-bg: var(--black-500);
+  --_ba-sq-bg: var(--black-600);
+}
+.s-badge.s-badge__success {
+  --_ba-bg: var(--green-100);
+  --_ba-fc: var(--green-600);
+  --_ba-sq-bg: var(--green-200);
+}
+.s-badge.s-badge__success.s-badge__important {
+  --_ba-bg: var(--green-500);
+  --_ba-sq-bg: var(--green-600);
+}
+.s-badge.s-badge__featured {
+  --_ba-bg: var(--purple-100);
+  --_ba-fc: var(--purple-500);
+  --_ba-sq-bg: var(--purple-200);
+}
+.s-badge.s-badge__featured.s-badge__important {
+  --_ba-bg: var(--purple-400);
+  --_ba-sq-bg: var(--purple-500);
+}
+.s-badge.s-badge__squared svg {
+  background-color: var(--_ba-sq-bg);
+}
+.s-badge.s-badge__important {
+  --_ba-bg: var(--black-400);
+  --_ba-fc: var(--black-050);
+  --_ba-fw: 600;
+  --_ba-sq-bg: var(--black-500);
+}
+.s-badge svg {
+  aspect-ratio: 1 / 1;
+  box-sizing: content-box;
+  display: block;
+  height: calc(var(--su16) + var(--su4));
+  padding: var(--_ba-svg-p);
+}
+a.s-badge:hover {
+  text-decoration: none;
+}
+.s-banner {
+  --_no-ty-offset: 0;
+  --_no-ty: var(--theme-topbar-height, calc(var(--su48) + var(--su8)));
+  --_no-bg: var(--black-150);
+  --_no-icon-bg: var(--black-200);
+  --_no-fc: var(--black-600);
+  --_no-code-bc: var(--black-300);
+  --_no-code-bg: var(--black-200);
+  --_no-code-fc: var(--_no-fc);
+  background: var(--_no-bg);
+  color: var(--_no-fc);
+  display: flex;
+  align-items: center;
+  padding: var(--su16);
+  inset: 0 0 auto 0;
+  position: fixed;
+  transform: translate3d(0, calc(var(--_no-ty) * var(--_no-ty-offset)), 0);
+  width: 100%;
+  z-index: calc(var(--zi-navigation-fixed) - 1);
+}
+body.theme-highcontrast .s-banner:not(body.theme-highcontrast .s-banner__important) {
+  --_no-icon-bc: var(--_no-code-bc);
+}
+.s-banner__important {
+  --_no-bg: var(--black-400);
+  --_no-icon-bg: var(--black-500);
+  --_no-fc: var(--white);
+  --_no-code-bc: var(--black-300);
+  --_no-code-bg: var(--black-500);
+}
+.s-banner__danger:not(.s-banner__important) {
+  --_no-bg: var(--red-100);
+  --_no-icon-bg: var(--red-200);
+  --_no-code-bc: var(--red-300);
+  --_no-code-bg: var(--red-200);
+}
+.s-banner__danger.s-banner__important {
+  --_no-bg: var(--red-400);
+  --_no-icon-bg: var(--red-500);
+  --_no-fc: var(--white);
+  --_no-code-bc: var(--red-300);
+  --_no-code-bg: var(--red-500);
+}
+.s-banner__info:not(.s-banner__important) {
+  --_no-bg: var(--blue-100);
+  --_no-icon-bg: var(--blue-200);
+  --_no-code-bc: var(--blue-300);
+  --_no-code-bg: var(--blue-200);
+}
+.s-banner__info.s-banner__important {
+  --_no-bg: var(--blue-400);
+  --_no-icon-bg: var(--blue-500);
+  --_no-fc: var(--white);
+  --_no-code-bc: var(--blue-300);
+  --_no-code-bg: var(--blue-500);
+}
+.s-banner__success:not(.s-banner__important) {
+  --_no-bg: var(--green-100);
+  --_no-icon-bg: var(--green-200);
+  --_no-code-bc: var(--green-300);
+  --_no-code-bg: var(--green-200);
+}
+.s-banner__success.s-banner__important {
+  --_no-bg: var(--green-400);
+  --_no-icon-bg: var(--green-500);
+  --_no-fc: var(--white);
+  --_no-code-bc: var(--green-300);
+  --_no-code-bg: var(--green-500);
+}
+.s-banner__featured:not(.s-banner__important) {
+  --_no-bg: var(--purple-100);
+  --_no-icon-bg: var(--purple-200);
+  --_no-code-bc: var(--purple-300);
+  --_no-code-bg: var(--purple-200);
+}
+.s-banner__featured.s-banner__important {
+  --_no-bg: var(--purple-400);
+  --_no-icon-bg: var(--purple-500);
+  --_no-fc: var(--white);
+  --_no-code-bc: var(--purple-300);
+  --_no-code-bg: var(--purple-500);
+}
+.s-banner__activity:not(.s-banner__important) {
+  --_no-bg: var(--pink-100);
+  --_no-icon-bg: var(--pink-200);
+  --_no-code-bc: var(--pink-300);
+  --_no-code-bg: var(--pink-200);
+}
+.s-banner__activity.s-banner__important {
+  --_no-bg: var(--pink-400);
+  --_no-icon-bg: var(--pink-500);
+  --_no-fc: var(--white);
+  --_no-code-bc: var(--pink-300);
+  --_no-code-bg: var(--pink-500);
+}
+.s-banner__warning:not(.s-banner__important) {
+  --_no-bg: var(--yellow-100);
+  --_no-icon-bg: var(--yellow-200);
+  --_no-code-bc: var(--yellow-300);
+  --_no-code-bg: var(--yellow-200);
+}
+.s-banner__warning.s-banner__important {
+  --_no-bg: var(--yellow-300);
+  --_no-icon-bg: var(--yellow-400);
+  --_no-fc: var(--black);
+  --_no-code-bc: var(--yellow-400);
+  --_no-code-bg: var(--yellow-200);
+}
+.s-banner__warning.s-banner__important .s-notice--icon {
+  color: var(--white);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-system .s-banner__warning.s-banner__important {
+    --_no-fc: var(--white);
+    --_no-code-bc: var(--yellow-300);
+    --_no-code-bg: var(--yellow-500);
+    --_no-bg: var(--yellow-400);
+    --_no-icon-bg: var(--yellow-500);
+  }
+}
+body.theme-dark .s-banner__warning.s-banner__important,
+.theme-dark__forced .s-banner__warning.s-banner__important,
+body.theme-system .theme-dark__forced .s-banner__warning.s-banner__important {
+  --_no-fc: var(--white);
+  --_no-code-bc: var(--yellow-300);
+  --_no-code-bg: var(--yellow-500);
+  --_no-bg: var(--yellow-400);
+  --_no-icon-bg: var(--yellow-500);
+}
+body.theme-highcontrast .s-banner__warning.s-banner__important {
+  --_no-bg: var(--yellow-400);
+  --_no-icon-bg: var(--yellow-500);
+  --_no-code-bc: var(--yellow-300);
+  --_no-code-bg: var(--yellow-500);
+  --_no-fc: var(--white);
+}
+.s-banner code {
+  background-color: var(--_no-code-bg);
+  color: var(--_no-code-fc);
+  outline: var(--su1) solid var(--_no-code-bc);
+  padding-left: var(--su2);
+  padding-right: var(--su2);
+  white-space: nowrap;
+}
+button.s-banner--dismiss {
+  color: var(--_no-fc);
+}
+button.s-banner--dismiss:active {
+  background-color: var(--_no-fc);
+  color: var(--_no-bg);
+}
+button.s-banner--dismiss:focus-visible,
+button.s-banner--dismiss:hover,
+button.s-banner--dismiss.focus-inset-bordered {
+  background-color: var(--_no-fc);
+  color: var(--_no-bg);
+}
+.s-banner--actions {
+  display: flex;
+  margin-left: auto;
+  align-self: flex-start;
+  padding-left: var(--su24);
+  color: var(--_no-fc);
+  gap: calc(var(--su24) - var(--su2));
+  overflow-wrap: initial !important;
+}
+.s-banner--actions > .s-link:not(.s-banner--dismiss) {
+  color: var(--_no-fc);
+}
+.s-banner--icon {
+  --_no-icon-bg: transparent;
+  margin-right: var(--su8);
+  align-self: flex-start;
+}
+.s-banner[aria-hidden="true"] {
+  --_no-ty-offset: -1;
+  opacity: 0;
+  visibility: hidden;
+}
+.s-banner[aria-hidden="false"] {
+  --_no-ty-offset: 1;
+  opacity: 1;
+  visibility: visible;
+}
+.s-banner[aria-hidden="false"].is-pinned {
+  --_no-ty-offset: 0;
+  z-index: calc(var(--zi-navigation-fixed) + 1);
+}
+.s-banner__body-pt {
+  padding-top: 93px;
+}
+.s-bling {
+  --_bl-bg: unset;
+  --_bl-size: calc(var(--su8) + var(--su2));
+  --_bl-icon: url("data:image/svg+xml;utf8,<svg viewBox='0 0 8 8' xmlns='http://www.w3.org/2000/svg'><circle cx='4' cy='4' r='4'/></svg>");
+  --_bl-icon-bg: var(--black-500);
+  --_bl-icon-size: var(--su8);
+  background-color: var(--_bl-bg);
+  height: var(--_bl-size);
+  width: var(--_bl-size);
+  align-items: center;
+  color: inherit;
+  display: inline-flex;
+  justify-content: center;
+}
+.s-bling.s-bling__activity {
+  --_bl-icon-bg: var(--pink-400);
+}
+.s-bling.s-bling__gold {
+  --_bl-icon-bg: var(--yellow-400);
+  --_bl-icon: url("data:image/svg+xml;,<svg viewBox='0 0 8 9' xmlns='http://www.w3.org/2000/svg'><path d='M3.89709 0L7.79421 2.25V6.75L3.89709 9L-1.95503e-05 6.75V2.25L3.89709 0Z'/></svg>");
+}
+.s-bling.s-bling__silver {
+  --_bl-icon-bg: var(--blue-400);
+  --_bl-icon: url("data:image/svg+xml;,<svg viewBox='0 0 9 9' xmlns='http://www.w3.org/2000/svg'><path d='M4.27979 0L8.55954 3.10942L6.92482 8.14058H1.63475L3.09944e-05 3.10942L4.27979 0Z'/></svg>");
+}
+.s-bling.s-bling__bronze {
+  --_bl-icon-bg: var(--orange-400);
+  --_bl-icon: url("data:image/svg+xml;,<svg viewBox='0 0 8 8' xmlns='http://www.w3.org/2000/svg'><rect width='8' height='8'/></svg>");
+}
+.s-bling.s-bling__filled {
+  --_bl-bg: var(--black-225);
+  --_bl-icon-bg: var(--black-600);
+  --_bl-size: var(--su24);
+}
+.s-bling.s-bling__filled.s-bling__rep {
+  --_bl-bg: var(--black-300);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-highcontrast.theme-system .s-bling.s-bling__filled.s-bling__rep {
+    --_bl-icon-bg: var(--black-050);
+  }
+}
+body.theme-highcontrast.theme-dark .s-bling.s-bling__filled.s-bling__rep {
+  --_bl-icon-bg: var(--black-050);
+}
+.s-bling.s-bling__filled.s-bling__activity {
+  --_bl-bg: var(--pink-300);
+  --_bl-icon-bg: var(--pink-600);
+}
+body.theme-highcontrast .s-bling.s-bling__filled.s-bling__activity {
+  --_bl-icon-bg: var(--black-050);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-highcontrast.theme-system .s-bling.s-bling__filled.s-bling__activity {
+    --_bl-bg: var(--pink-400);
+  }
+}
+body.theme-highcontrast.theme-dark .s-bling.s-bling__filled.s-bling__activity {
+  --_bl-bg: var(--pink-400);
+}
+.s-bling.s-bling__filled.s-bling__gold {
+  --_bl-bg: var(--yellow-300);
+  --_bl-icon-bg: var(--yellow-600);
+}
+body.theme-highcontrast .s-bling.s-bling__filled.s-bling__gold {
+  --_bl-icon-bg: var(--black-050);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-highcontrast.theme-system .s-bling.s-bling__filled.s-bling__gold {
+    --_bl-bg: var(--yellow-400);
+  }
+}
+body.theme-highcontrast.theme-dark .s-bling.s-bling__filled.s-bling__gold {
+  --_bl-bg: var(--yellow-400);
+}
+.s-bling.s-bling__filled.s-bling__silver {
+  --_bl-bg: var(--blue-300);
+  --_bl-icon-bg: var(--blue-600);
+}
+body.theme-highcontrast .s-bling.s-bling__filled.s-bling__silver {
+  --_bl-icon-bg: var(--black-050);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-highcontrast.theme-system .s-bling.s-bling__filled.s-bling__silver {
+    --_bl-bg: var(--blue-400);
+  }
+}
+body.theme-highcontrast.theme-dark .s-bling.s-bling__filled.s-bling__silver {
+  --_bl-bg: var(--blue-400);
+}
+.s-bling.s-bling__filled.s-bling__bronze {
+  --_bl-bg: var(--orange-300);
+  --_bl-icon-bg: var(--orange-600);
+}
+body.theme-highcontrast .s-bling.s-bling__filled.s-bling__bronze {
+  --_bl-icon-bg: var(--black-050);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-highcontrast.theme-system .s-bling.s-bling__filled.s-bling__bronze {
+    --_bl-bg: var(--orange-400);
+  }
+}
+body.theme-highcontrast.theme-dark .s-bling.s-bling__filled.s-bling__bronze {
+  --_bl-bg: var(--orange-400);
+}
+.s-bling.s-bling__sm:not(.s-bling__filled) {
+  --_bl-size: var(--su8);
+}
+.s-bling.s-bling__sm.s-bling__filled {
+  --_bl-size: var(--su16);
+}
+.s-bling.s-bling__lg.s-bling__filled {
+  --_bl-size: calc(var(--su24) + var(--su4));
+}
+.s-bling.s-bling__sm {
+  --_bl-icon-size: var(--su6);
+}
+.s-bling.s-bling__sm.s-bling__gold,
+.s-bling.s-bling__sm.s-bling__silver {
+  --_bl-icon-size: calc(var(--su6) + var(--su1));
+}
+.s-bling.s-bling__gold:not(.s-bling__sm),
+.s-bling.s-bling__silver:not(.s-bling__sm) {
+  --_bl-icon-size: calc(var(--su8) + var(--su1));
+}
+.s-bling:before {
+  -webkit-mask: var(--_bl-icon) no-repeat center;
+  mask: var(--_bl-icon) no-repeat center;
+  background-color: var(--_bl-icon-bg);
+  content: "";
+  height: var(--_bl-icon-size);
+  width: var(--_bl-icon-size);
+}
+.s-btn {
+  --_bu-baw: var(--su1);
+  --_bu-br: var(--br-pill);
+  --_bu-fs: var(--fs-body1);
+  --_bu-lh: var(--lh-base);
+  --_bu-g: var(--su8);
+  --_bu-px: var(--su16);
+  --_bu-py: calc(var(--su8) + var(--su2));
+  --_bu-badge-fs: var(--fs-caption);
+  --_bu-badge-px: var(--su6);
+  --_bu-badge-py: var(--su2);
+  --_bu-dropdown-bw: var(--su4);
+  background: linear-gradient(0deg, var(--_bu-bg-selected-overlay, var(--_bu-bg)) 50%, var(--_bu-bg) 50%) padding-box, linear-gradient(0deg, var(--_bu-bg-selected-overlay, var(--_bu-bg)) 50%, var(--_bu-bg) 50%) border-box;
+  border: var(--_bu-baw) solid var(--_bu-bc, transparent);
+  color: var(--_bu-fc);
+  font-size: var(--_bu-fs);
+  gap: var(--_bu-g);
+  padding: var(--_bu-py) var(--_bu-px);
+  align-items: center;
+  align-self: center;
+  border-radius: var(--_bu-br);
+  border-style: solid;
+  cursor: pointer;
+  display: inline-flex;
+  font-family: inherit;
+  font-weight: 600;
+  justify-content: center;
+  line-height: var(--_bu-lh);
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  user-select: none;
+}
+.s-btn:not(.s-btn__danger):not(.s-btn__featured):not(.s-btn__tonal):not(.s-btn__link):not(.s-btn__unset):not(.s-btn__facebook):not(.s-btn__github):not(.s-btn__google) {
+  --_bu-bg: var(--theme-button-color, var(--theme-secondary));
+  --_bu-bg-disabled: var(--theme-secondary-300);
+  --_bu-bg-hover: var(--theme-button-hover-background-color, var(--theme-secondary-500));
+  --_bu-fc: var(--white);
+  --_bu-fc-disabled: var(--theme-secondary-100);
+  --_bu-fc-hover: var(--theme-button-hover-color, var(--white));
+  --_bu-badge-bg: var(--theme-secondary-500);
+  --_bu-badge-fc: var(--white);
+  --_bu-badge-bg-disabled: var(--theme-secondary-300);
+  --_bu-badge-fc-disabled: var(--theme-secondary-100);
+}
+body.theme-highcontrast .s-btn:not(.s-btn__danger):not(.s-btn__featured):not(.s-btn__tonal):not(.s-btn__link):not(.s-btn__unset):not(.s-btn__facebook):not(.s-btn__github):not(.s-btn__google) {
+  --_bu-bg-disabled: var(--theme-secondary-300);
+}
+.s-btn:not(.s-btn__danger):not(.s-btn__featured):not(.s-btn__tonal):not(.s-btn__link):not(.s-btn__unset):not(.s-btn__facebook):not(.s-btn__github):not(.s-btn__google).s-btn__clear {
+  --_bu-bg: transparent;
+  --_bu-bg-disabled: var(--_bu-bg);
+  --_bu-bg-hover: var(--theme-secondary-100);
+  --_bu-bg-selected: var(--theme-secondary-100);
+  --_bu-fc: var(--theme-secondary-600);
+  --_bu-fc-disabled: var(--theme-secondary-300);
+  --_bu-fc-hover: var(--_bu-fc);
+  --_bu-badge-bg: var(--theme-secondary-100);
+  --_bu-badge-fc: var(--theme-secondary-500);
+  --_bu-badge-bg-disabled: var(--theme-secondary-100);
+  --_bu-badge-fc-disabled: var(--theme-secondary-300);
+}
+body.theme-highcontrast .s-btn:not(.s-btn__danger):not(.s-btn__featured):not(.s-btn__tonal):not(.s-btn__link):not(.s-btn__unset):not(.s-btn__facebook):not(.s-btn__github):not(.s-btn__google).s-btn__clear {
+  --_bu-bc: var(--theme-secondary-400);
+  --_bu-bc-disabled: var(--theme-secondary-300);
+  --_bu-bg-disabled: var(--white);
+  --_bu-badge-bg-disabled: var(--theme-secondary-100);
+  --_bu-badge-fc-disabled: var(--theme-secondary-300);
+}
+.s-btn.s-btn__danger {
+  --_bu-bg: var(--red-400);
+  --_bu-fc: var(--white);
+  --_bu-bg-disabled: var(--red-200);
+  --_bu-fc-disabled: var(--black-050);
+  --_bu-bg-hover: var(--red-500);
+  --_bu-bg-selected: var(--red-500);
+  --_bu-fc-selected: var(--_bu-fc);
+  --_bu-badge-bg: var(--red-500);
+  --_bu-badge-fc: var(--black-050);
+  --_bu-badge-bg-disabled: var(--red-300);
+  --_bu-badge-fc-disabled: var(--black-100);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-system .s-btn.s-btn__danger {
+    --_bu-bg-disabled: var(--red-300);
+    --_bu-badge-fc-disabled: var(--black-050);
+    --_bu-badge-bg-disabled: var(--red-400);
+  }
+}
+body.theme-dark .s-btn.s-btn__danger,
+.theme-dark__forced .s-btn.s-btn__danger,
+body.theme-system .theme-dark__forced .s-btn.s-btn__danger {
+  --_bu-bg-disabled: var(--red-300);
+  --_bu-badge-fc-disabled: var(--black-050);
+  --_bu-badge-bg-disabled: var(--red-400);
+}
+body.theme-highcontrast .s-btn.s-btn__danger {
+  --_bu-fc-disabled: var(--black-300);
+  --_bu-badge-bg-disabled: var(--red-100);
+  --_bu-badge-fc-disabled: var(--black-300);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-highcontrast.theme-system .s-btn.s-btn__danger {
+    --_bu-bg-disabled: var(--red-300);
+    --_bu-fc-disabled: var(--black-050);
+    --_bu-badge-fc-disabled: var(--black-050);
+    --_bu-badge-bg-disabled: var(--red-400);
+  }
+}
+body.theme-highcontrast.theme-dark .s-btn.s-btn__danger {
+  --_bu-bg-disabled: var(--red-300);
+  --_bu-fc-disabled: var(--black-050);
+  --_bu-badge-fc-disabled: var(--black-050);
+  --_bu-badge-bg-disabled: var(--red-400);
+}
+.s-btn.s-btn__danger.s-btn__clear {
+  --_bu-bg: transparent;
+  --_bu-bg-disabled: var(--_bu-bg);
+  --_bu-bg-hover: var(--red-100);
+  --_bu-bg-selected: var(--red-100);
+  --_bu-fc: var(--red-400);
+  --_bu-fc-disabled: var(--red-200);
+  --_bu-fc-hover: var(--red-500);
+  --_bu-fc-selected: var(--red-500);
+  --_bu-badge-bg: var(--red-100);
+  --_bu-badge-fc: var(--red-500);
+  --_bu-badge-bg-disabled: var(--red-100);
+  --_bu-badge-fc-disabled: var(--red-300);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-system .s-btn.s-btn__danger.s-btn__clear {
+    --_bu-bg-disabled: var(--_bu-bg);
+    --_bu-fc-disabled: var(--red-300);
+    --_bu-badge-bg-disabled: var(--red-100);
+    --_bu-badge-fc-disabled: var(--red-400);
+  }
+}
+body.theme-dark .s-btn.s-btn__danger.s-btn__clear,
+.theme-dark__forced .s-btn.s-btn__danger.s-btn__clear,
+body.theme-system .theme-dark__forced .s-btn.s-btn__danger.s-btn__clear {
+  --_bu-bg-disabled: var(--_bu-bg);
+  --_bu-fc-disabled: var(--red-300);
+  --_bu-badge-bg-disabled: var(--red-100);
+  --_bu-badge-fc-disabled: var(--red-400);
+}
+body.theme-highcontrast .s-btn.s-btn__danger.s-btn__clear {
+  --_bu-bc: var(--red-600);
+  --_bu-bc-disabled: var(--black-300);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-highcontrast.theme-system .s-btn.s-btn__danger.s-btn__clear {
+    --_bu-bg-disabled: var(--black-050);
+    --_bu-fc-disabled: var(--red-300);
+    --_bu-badge-bg-disabled: var(--red-100);
+    --_bu-badge-fc-disabled: var(--red-300);
+  }
+}
+body.theme-highcontrast.theme-dark .s-btn.s-btn__danger.s-btn__clear {
+  --_bu-bg-disabled: var(--black-050);
+  --_bu-fc-disabled: var(--red-300);
+  --_bu-badge-bg-disabled: var(--red-100);
+  --_bu-badge-fc-disabled: var(--red-300);
+}
+.s-btn.s-btn__featured {
+  --_bu-bg: var(--purple-400);
+  --_bu-bg-disabled: var(--purple-200);
+  --_bu-bg-hover: var(--purple-500);
+  --_bu-bg-selected: var(--purple-500);
+  --_bu-fc: var(--white);
+  --_bu-fc-selected: var(--_bu-fc);
+  --_bu-badge-bg: var(--purple-500);
+  --_bu-badge-fc: var(--black-050);
+  --_bu-badge-bg-disabled: var(--purple-300);
+  --_bu-badge-fc-disabled: var(--black-100);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-system .s-btn.s-btn__featured {
+    --_bu-bg-disabled: var(--purple-100);
+    --_bu-fc-disabled: var(--purple-400);
+    --_bu-badge-fc-disabled: var(--purple-400);
+    --_bu-badge-bg-disabled: var(--purple-200);
+  }
+}
+body.theme-dark .s-btn.s-btn__featured,
+.theme-dark__forced .s-btn.s-btn__featured,
+body.theme-system .theme-dark__forced .s-btn.s-btn__featured {
+  --_bu-bg-disabled: var(--purple-100);
+  --_bu-fc-disabled: var(--purple-400);
+  --_bu-badge-fc-disabled: var(--purple-400);
+  --_bu-badge-bg-disabled: var(--purple-200);
+}
+body.theme-highcontrast .s-btn.s-btn__featured {
+  --_bu-fc-disabled: var(--black-300);
+  --_bu-badge-fc-disabled: var(--black-300);
+  --_bu-badge-bg-disabled: var(--purple-200);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-highcontrast.theme-system .s-btn.s-btn__featured {
+    --_bu-fc-disabled: var(--purple-400);
+    --_bu-badge-bg-disabled: var(--purple-200);
+    --_bu-badge-fc-disabled: var(--purple-400);
+  }
+}
+body.theme-highcontrast.theme-dark .s-btn.s-btn__featured {
+  --_bu-fc-disabled: var(--purple-400);
+  --_bu-badge-bg-disabled: var(--purple-200);
+  --_bu-badge-fc-disabled: var(--purple-400);
+}
+.s-btn.s-btn__tonal {
+  --_bu-bg: var(--black-150);
+  --_bu-bg-disabled: var(--black-100);
+  --_bu-bg-hover: var(--black-200);
+  --_bu-bg-selected: var(--black-200);
+  --_bu-fc: var(--black);
+  --_bu-fc-disabled: var(--black-300);
+  --_bu-fc-selected: var(--_bu-fc);
+  --_bu-badge-bg: var(--black-200);
+  --_bu-badge-fc: var(--black-600);
+  --_bu-badge-bg-disabled: var(--black-100);
+  --_bu-badge-fc-disabled: var(--black-300);
+}
+body.theme-highcontrast .s-btn.s-btn__tonal {
+  --_bu-bc: var(--black-400);
+  --_bu-bc-disabled: var(--black-300);
+}
+.s-btn.s-btn__facebook {
+  --_bu-bg: #1877F2;
+  --_bu-bg-hover: #0d6ae4;
+  --_bu-fc: #fff;
+  --_bu-fc-hover: var(--_bu-fc);
+}
+.s-btn.s-btn__google {
+  --_bu-bg: var(--black-150);
+  --_bu-bg-hover: var(--black-200);
+  --_bu-fc: var(--black-600);
+}
+.s-btn.s-btn__github {
+  --_bu-bg: var(--black-600);
+  --_bu-bg-hover: var(--black-500);
+  --_bu-fc: var(--white);
+}
+.s-btn.s-btn__link,
+.s-btn.s-btn__unset {
+  --_bu-baw: 0;
+  --_bu-br: 0;
+  --_bu-px: 0;
+  --_bu-py: 0;
+}
+.s-btn.s-btn__link:focus,
+.s-btn.s-btn__unset:focus,
+.s-btn.s-btn__link:focus-visible,
+.s-btn.s-btn__unset:focus-visible {
+  outline-style: auto;
+}
+.s-btn.s-btn__link {
+  --_li-fc: var(--theme-link-color, var(--black-600));
+  --_li-fc-hover: var(--theme-link-color-hover, var(--blue-400));
+  --_li-fc-visited: var(--theme-link-color-visited, var(--black-400));
+  color: var(--_li-fc);
+  cursor: pointer;
+  text-decoration: none;
+  user-select: auto;
+  display: inline;
+  font: inherit;
+  outline: revert;
+  text-align: inherit;
+}
+.s-btn.s-btn__link,
+.s-btn.s-btn__link:hover,
+.s-btn.s-btn__link:active,
+.s-btn.s-btn__link:focus,
+.s-btn.s-btn__link[disabled],
+.s-btn.s-btn__link[aria-disabled="true"] {
+  --_bu-bg: none;
+}
+.s-btn.s-btn__link.s-btn__dropdown {
+  padding-right: 0.9em;
+}
+body.theme-highcontrast .s-btn.s-btn__link {
+  text-decoration: underline;
+}
+.s-btn.s-btn__link__dropdown {
+  align-items: center;
+  display: inline-flex;
+  gap: var(--su4);
+}
+.s-btn.s-btn__link__dropdown:after {
+  border-color: currentColor transparent;
+  border-style: solid;
+  border-width: var(--su4) var(--su4) 0 var(--su4);
+  content: "";
+}
+.s-btn.s-btn__link__underlined {
+  text-decoration: underline !important;
+}
+.s-btn.s-btn__link__danger {
+  --_li-fc: var(--red-400);
+  --_li-fc-hover: var(--red-500);
+  --_li-fc-visited: var(--red-600);
+}
+.s-btn.s-btn__link__grayscale {
+  --_li-fc: var(--black-500);
+  --_li-fc-hover: var(--black-600);
+}
+.s-btn.s-btn__link__inherit {
+  --_li-fc: inherit !important;
+  --_li-fc-hover: inherit !important;
+  --_li-fc-visited: inherit !important;
+}
+.s-btn.s-btn__link__muted {
+  --_li-fc: var(--black-400);
+}
+fieldset[disabled] .s-btn.s-btn__link {
+  box-shadow: none !important;
+  opacity: var(--_o-disabled-static);
+  pointer-events: none;
+}
+button.s-btn.s-btn__link {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  font-family: inherit;
+  line-height: inherit;
+  padding: 0;
+  user-select: auto;
+}
+button.s-btn.s-btn__link:focus {
+  outline: revert;
+}
+p .s-btn.s-btn__link {
+  text-decoration: underline;
+}
+.s-btn.s-btn__link:active,
+.s-btn.s-btn__link:hover {
+  --_li-fc: var(--_li-fc-hover);
+  text-decoration: underline;
+}
+.s-btn.s-btn__link:visited {
+  color: var(--_li-fc-visited);
+}
+.s-btn.s-btn__link:visited:hover {
+  color: var(--_li-fc-hover);
+}
+.s-btn.s-btn__unset {
+  outline: initial;
+}
+.s-btn.s-btn__unset,
+.s-btn.s-btn__unset:hover,
+.s-btn.s-btn__unset:active,
+.s-btn.s-btn__unset:focus {
+  --_bu-baw: 0;
+  --_bu-bg: none;
+  --_bu-br: unset;
+  --_bu-fc: unset;
+  --_bu-fs: inherit;
+  --_bu-g: unset;
+  --_bu-lh: inherit;
+  cursor: default;
+  font: unset;
+  user-select: auto;
+}
+.s-btn.s-btn__dropdown:after {
+  border-color: currentColor transparent;
+  border-style: solid;
+  border-width: var(--_bu-dropdown-bw);
+  border-bottom-width: 0;
+  content: "";
+}
+.s-btn.is-selected,
+.s-btn--radio:checked + .s-btn {
+  --_bu-bg-selected-overlay-o: 20%;
+  --_bu-bg-selected-overlay: color-mix(in srgb, var(--_bu-bg-selected, var(--_bu-bg)), var(--white) var(--_bu-bg-selected-overlay-o));
+  --_bu-bg-gradient-top: var(--_bu-bg-selected-overlay, var(--_bu-bg));
+  --_bu-bg-gradient-bottom: var(--_bu-bg-selected, var(--_bu-bg));
+  background: linear-gradient(0deg, var(--_bu-bg-gradient-top) 50%, var(--_bu-bg-gradient-bottom) 50%) padding-box, linear-gradient(0deg, var(--_bu-bg-gradient-top) 50%, var(--_bu-bg-gradient-bottom) 50%) border-box;
+  color: var(--_bu-fc-selected, var(--_bu-fc));
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-system .s-btn.is-selected,
+  body.theme-system .s-btn--radio:checked + .s-btn {
+    --_bu-bg-selected-overlay-o: 13%;
+    --_bu-bg-gradient-top: var(--_bu-bg-selected-overlay, var(--_bu-bg));
+    --_bu-bg-gradient-bottom: var(--_bu-bg-selected, var(--_bu-bg));
+  }
+}
+body.theme-dark .s-btn.is-selected,
+body.theme-dark .s-btn--radio:checked + .s-btn,
+.theme-dark__forced .s-btn.is-selected,
+.theme-dark__forced .s-btn--radio:checked + .s-btn,
+body.theme-system .theme-dark__forced .s-btn.is-selected,
+body.theme-system .theme-dark__forced .s-btn--radio:checked + .s-btn {
+  --_bu-bg-selected-overlay-o: 13%;
+  --_bu-bg-gradient-top: var(--_bu-bg-selected-overlay, var(--_bu-bg));
+  --_bu-bg-gradient-bottom: var(--_bu-bg-selected, var(--_bu-bg));
+}
+.s-btn.is-selected .s-btn--badge,
+.s-btn--radio:checked + .s-btn .s-btn--badge {
+  background-color: var(--_bu-badge-bg);
+}
+.s-btn.is-selected .s-btn--badge .s-btn--number,
+.s-btn--radio:checked + .s-btn .s-btn--badge .s-btn--number {
+  color: var(--_bu-badge-fc, var(--_bu-fc));
+}
+.s-btn .s-btn--badge {
+  background-color: var(--_bu-badge-bg);
+  border-radius: var(--br-pill);
+  display: inline-block;
+  font-size: var(--_bu-badge-fs);
+  line-height: inherit;
+  opacity: var(--_bu-badge-o);
+  padding: var(--_bu-badge-py) var(--_bu-badge-px);
+  margin-block: calc(var(--_bu-badge-py) * -1);
+}
+.s-btn .s-btn--number {
+  color: var(--_bu-badge-fc, var(--_bu-fc));
+}
+.s-btn--radio {
+  border: 0;
+  clip-path: inset(50%);
+  /* stylelint-disable-next-line property-no-deprecated -- clip is kept for older browser compatibility alongside clip-path */
+  clip: rect(var(--su1), var(--su1), var(--su1), var(--su1));
+  height: var(--su1);
+  margin: var(--sun1);
+  overflow-wrap: normal;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: var(--su1);
+}
+.s-btn.s-btn__xs,
+.s-btn.s-btn__sm {
+  --_bu-lh: var(--lh-sm);
+  --_bu-px: var(--su12);
+  --_bu-badge-fs: var(--fs-fine);
+  --_bu-badge-py: var(--su1);
+  --_bu-badge-px: var(--su3);
+}
+.s-btn.s-btn__xs {
+  --_bu-g: var(--su4);
+  --_bu-fs: var(--fs-fine);
+  --_bu-py: var(--su6);
+}
+.s-btn.s-btn__sm {
+  --_bu-g: var(--su6);
+  --_bu-fs: var(--fs-caption);
+  --_bu-py: var(--su8);
+}
+.s-btn.s-btn__lg {
+  --_bu-fs: var(--fs-body2);
+  --_bu-px: var(--su24);
+  --_bu-py: calc(var(--su12) + var(--su1));
+  --_bu-badge-py: var(--su3);
+}
+.s-btn:not(.s-btn__link):not(.s-btn__unset):focus-visible,
+.s-btn--radio:focus-visible + .s-btn {
+  border-color: var(--focus-neutral) !important;
+  box-shadow: 0 0 0 var(--su1) var(--focus-neutral), 0 0 0 var(--su3) var(--focus-theme);
+  outline: var(--su2) solid transparent !important;
+}
+.s-btn:not(.is-selected):hover {
+  background: linear-gradient(0deg, var(--_bu-bg-selected-overlay, var(--_bu-bg-hover, var(--_bu-bg))) 50%, var(--_bu-bg-hover, var(--_bu-bg-selected, var(--_bu-bg))) 50%) padding-box, linear-gradient(0deg, var(--_bu-bg-selected-overlay, var(--_bu-bg-hover, var(--_bu-bg))) 50%, var(--_bu-bg-hover, var(--_bu-bg-selected, var(--_bu-bg))) 50%) border-box;
+  color: var(--_bu-fc-hover, var(--_bu-fc));
+}
+fieldset[disabled] .s-btn,
+.s-btn[disabled],
+.s-btn[aria-disabled="true"] {
+  cursor: auto;
+}
+fieldset[disabled] .s-btn,
+.s-btn[disabled],
+.s-btn[aria-disabled="true"],
+fieldset[disabled] .s-btn:hover,
+.s-btn[disabled]:hover,
+.s-btn[aria-disabled="true"]:hover {
+  background: var(--_bu-bg-disabled, var(--theme-secondary-400));
+  border-color: var(--_bu-bc-disabled, var(--_bu-bc, transparent));
+  color: var(--_bu-fc-disabled, var(--_bu-fc));
+}
+fieldset[disabled] .s-btn .s-btn--badge,
+.s-btn[disabled] .s-btn--badge,
+.s-btn[aria-disabled="true"] .s-btn--badge,
+fieldset[disabled] .s-btn:hover .s-btn--badge,
+.s-btn[disabled]:hover .s-btn--badge,
+.s-btn[aria-disabled="true"]:hover .s-btn--badge {
+  background-color: var(--_bu-badge-bg-disabled);
+}
+fieldset[disabled] .s-btn .s-btn--badge .s-btn--number,
+.s-btn[disabled] .s-btn--badge .s-btn--number,
+.s-btn[aria-disabled="true"] .s-btn--badge .s-btn--number,
+fieldset[disabled] .s-btn:hover .s-btn--badge .s-btn--number,
+.s-btn[disabled]:hover .s-btn--badge .s-btn--number,
+.s-btn[aria-disabled="true"]:hover .s-btn--badge .s-btn--number {
+  color: var(--_bu-badge-fc-disabled);
+}
+.s-checkbox,
+.s-radio {
+  --_ch-ai: center;
+  --_ch-fc: unset;
+  --_ch-after-fc: unset;
+  --_ch-cursor: pointer;
+  --_ch-label-fc: var(--_ch-fc);
+  --_ch-gap: var(--su8);
+  --_ch-input-baw: var(--su1);
+  --_ch-input-bc: var(--black-350);
+  --_ch-input-bg: var(--white);
+  --_ch-input-bg-image: unset;
+  --_ch-input-br: var(--su1);
+  --_ch-input-cursor: pointer;
+  --_ch-input-h: calc(var(--su12) + var(--su2));
+  align-items: var(--_ch-ai);
+  display: flex;
+  gap: var(--_ch-gap);
+}
+@media (forced-colors: active) {
+  .s-checkbox:checked,
+  .s-radio:checked,
+  .s-checkbox:indeterminate,
+  .s-radio:indeterminate {
+    --_ch-input-bg: ButtonText !important;
+  }
+}
+fieldset[disabled] .s-checkbox,
+fieldset[disabled] .s-radio,
+.s-checkbox:has(> input[disabled]),
+.s-radio:has(> input[disabled]) {
+  --_ch-fc: var(--black-300);
+  --_ch-input-bc: var(--black-300);
+  --_ch-input-cursor: not-allowed;
+}
+.s-checkbox:has(> input[disabled]:checked),
+.s-radio:has(> input[disabled]:checked) {
+  --_ch-input-bc: var(--theme-secondary-300);
+}
+.s-checkbox.s-checkbox__checkmark,
+.s-checkbox.s-radio__checkmark,
+.s-radio.s-checkbox__checkmark,
+.s-radio.s-radio__checkmark {
+  --_ch-fc: var(--theme-secondary);
+  --_ch-gap: var(--su4);
+  --_ch-after-fc: unset;
+  border-radius: var(--br-md);
+  color: var(--_ch-fc);
+  cursor: var(--_ch-cursor);
+  width: 100%;
+}
+.s-checkbox.s-checkbox__checkmark:has(> input:focus-visible),
+.s-checkbox.s-radio__checkmark:has(> input:focus-visible),
+.s-radio.s-checkbox__checkmark:has(> input:focus-visible),
+.s-radio.s-radio__checkmark:has(> input:focus-visible) {
+  box-shadow: inset 0 0 0 var(--su2) var(--focus-theme), inset 0 0 0 var(--su4) var(--focus-neutral);
+  outline: var(--su2) solid transparent !important;
+}
+.s-checkbox.s-checkbox__checkmark:has(> input:checked),
+.s-checkbox.s-radio__checkmark:has(> input:checked),
+.s-radio.s-checkbox__checkmark:has(> input:checked),
+.s-radio.s-radio__checkmark:has(> input:checked) {
+  --_ch-after-fc: var(--_ch-fc);
+}
+.s-checkbox.s-checkbox__checkmark:has(> input[disabled]),
+.s-checkbox.s-radio__checkmark:has(> input[disabled]),
+.s-radio.s-checkbox__checkmark:has(> input[disabled]),
+.s-radio.s-radio__checkmark:has(> input[disabled]) {
+  --_ch-cursor: not-allowed;
+}
+.s-checkbox.s-checkbox__checkmark:has(> input:checked[disabled]),
+.s-checkbox.s-radio__checkmark:has(> input:checked[disabled]),
+.s-radio.s-checkbox__checkmark:has(> input:checked[disabled]),
+.s-radio.s-radio__checkmark:has(> input:checked[disabled]) {
+  --_ch-fc: var(--theme-secondary-300);
+}
+.s-checkbox.s-checkbox__checkmark input,
+.s-checkbox.s-radio__checkmark input,
+.s-radio.s-checkbox__checkmark input,
+.s-radio.s-radio__checkmark input,
+.s-checkbox.s-checkbox__checkmark:after,
+.s-checkbox.s-radio__checkmark:after,
+.s-radio.s-checkbox__checkmark:after,
+.s-radio.s-radio__checkmark:after {
+  height: var(--su16);
+  margin-left: 100%;
+  width: var(--su16);
+}
+.s-checkbox.s-checkbox__checkmark:after,
+.s-checkbox.s-radio__checkmark:after,
+.s-radio.s-checkbox__checkmark:after,
+.s-radio.s-radio__checkmark:after {
+  background-color: var(--_ch-after-fc);
+  content: "";
+  flex-shrink: 0;
+  margin-left: auto;
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='m14 3.88-.44.44-7.34 7.35-.44.44-.44-.44-2.9-2.9L2 8.34l.89-.88.44.44 2.45 2.45 6.9-6.9.44-.44z'/%3E%3C/svg%3E");
+  mask-size: contain;
+  mask-repeat: no-repeat;
+}
+.s-checkbox.s-checkbox__checkmark input,
+.s-checkbox.s-radio__checkmark input,
+.s-radio.s-checkbox__checkmark input,
+.s-radio.s-radio__checkmark input {
+  appearance: none;
+  opacity: 0;
+  position: absolute;
+  right: 0;
+  z-index: -1;
+}
+.s-checkbox.s-checkbox__checkmark .s-description,
+.s-checkbox.s-radio__checkmark .s-description,
+.s-radio.s-checkbox__checkmark .s-description,
+.s-radio.s-radio__checkmark .s-description {
+  margin: var(--su2) 0 0;
+  padding: 0;
+}
+.s-checkbox.s-checkbox__checkmark .s-label,
+.s-checkbox.s-radio__checkmark .s-label,
+.s-radio.s-checkbox__checkmark .s-label,
+.s-radio.s-radio__checkmark .s-label {
+  flex-grow: 1;
+}
+.s-checkbox:has(> input[disabled]) .s-label,
+.s-radio:has(> input[disabled]) .s-label {
+  --_ch-label-fc: var(--black-300);
+}
+.s-checkbox:not(> input[disabled]):has(input:checked) .s-label,
+.s-radio:not(> input[disabled]):has(input:checked) .s-label,
+.s-checkbox:not(> input[disabled]):has(input:indeterminate) .s-label,
+.s-radio:not(> input[disabled]):has(input:indeterminate) .s-label {
+  --_ch-label-fc: var(--black-600);
+}
+.s-checkbox:has(> .s-label .s-description),
+.s-radio:has(> .s-label .s-description),
+.s-checkbox:has(> .s-label .s-input-message),
+.s-radio:has(> .s-label .s-input-message) {
+  --_ch-ai: flex-start;
+}
+.s-checkbox:has(> .s-label .s-description) input,
+.s-radio:has(> .s-label .s-description) input,
+.s-checkbox:has(> .s-label .s-input-message) input,
+.s-radio:has(> .s-label .s-input-message) input {
+  margin-top: var(--su2);
+}
+.s-checkbox:has( > input:not(:checked)).has-error,
+.s-radio:has( > input:not(:checked)).has-error {
+  --_ch-input-bc: var(--red-400);
+}
+.s-checkbox:has( > input:not(:checked)).has-success,
+.s-radio:has( > input:not(:checked)).has-success {
+  --_ch-input-bc: var(--green-400);
+}
+.s-checkbox:has( > input:not(:checked)).has-warning,
+.s-radio:has( > input:not(:checked)).has-warning {
+  --_ch-input-bc: var(--yellow-400);
+}
+.s-checkbox input,
+.s-radio input {
+  appearance: none;
+  background-color: var(--_ch-input-bg);
+  border: var(--_ch-input-baw) solid var(--_ch-input-bc);
+  border-radius: var(--_ch-input-br);
+  cursor: var(--_ch-input-cursor);
+  height: var(--_ch-input-h);
+  aspect-ratio: 1 / 1;
+  flex-shrink: 0;
+  font-size: inherit;
+  margin: 0;
+  outline: 0;
+  vertical-align: middle;
+}
+.s-checkbox input:focus-visible,
+.s-radio input:focus-visible {
+  box-shadow: 0 0 0 var(--su2) var(--focus-neutral), 0 0 0 var(--su4) var(--focus-theme);
+  outline: var(--su2) solid transparent !important;
+}
+.has-error .s-checkbox input:not(:checked),
+.has-error .s-radio input:not(:checked),
+.has-success .s-checkbox input:not(:checked),
+.has-success .s-radio input:not(:checked),
+.has-warning .s-checkbox input:not(:checked),
+.has-warning .s-radio input:not(:checked) {
+  --_ch-input-bc-focus: var(--_ch-input-bc);
+}
+.has-error .s-checkbox input:not(:checked),
+.has-error .s-radio input:not(:checked) {
+  --_ch-input-bc: var(--red-400);
+}
+.has-success .s-checkbox input:not(:checked),
+.has-success .s-radio input:not(:checked) {
+  --_ch-input-bc: var(--green-400);
+}
+.has-warning .s-checkbox input:not(:checked),
+.has-warning .s-radio input:not(:checked) {
+  --_ch-input-bc: var(--yellow-500);
+}
+.s-checkbox .s-label,
+.s-radio .s-label {
+  color: var(--_ch-label-fc);
+  font-size: var(--fs-body1);
+  font-weight: normal;
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-system .s-checkbox input:checked {
+    --_ch-input-bg-image: url("data:image/svg+xml;,%3Csvg width='11' height='11' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M10 3.41L8.59 2 4 6.59 2.41 5 1 6.41l3 3z' fill='%23141414'/%3E%3C/svg%3E");
+  }
+  body.theme-system .s-checkbox input:indeterminate {
+    --_ch-input-bg-image: url("data:image/svg+xml;,%3Csvg width='11' height='11' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2 4.5 h7 v2 h-7 z' fill='%23141414'/%3E%3C/svg%3E");
+  }
+}
+body.theme-dark .s-checkbox input:checked,
+.theme-dark__forced .s-checkbox input:checked,
+body.theme-system .theme-dark__forced .s-checkbox input:checked {
+  --_ch-input-bg-image: url("data:image/svg+xml;,%3Csvg width='11' height='11' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M10 3.41L8.59 2 4 6.59 2.41 5 1 6.41l3 3z' fill='%23141414'/%3E%3C/svg%3E");
+}
+body.theme-dark .s-checkbox input:indeterminate,
+.theme-dark__forced .s-checkbox input:indeterminate,
+body.theme-system .theme-dark__forced .s-checkbox input:indeterminate {
+  --_ch-input-bg-image: url("data:image/svg+xml;,%3Csvg width='11' height='11' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2 4.5 h7 v2 h-7 z' fill='%23141414'/%3E%3C/svg%3E");
+}
+.s-checkbox input {
+  background-image: var(--_ch-input-bg-image);
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+fieldset[disabled] .s-checkbox input:checked,
+.s-checkbox input[disabled]:checked,
+fieldset[disabled] .s-checkbox input:indeterminate,
+.s-checkbox input[disabled]:indeterminate {
+  --_ch-input-bc: var(--theme-secondary-300);
+  --_ch-input-bg: var(--theme-secondary-300);
+}
+.s-checkbox input:checked,
+.s-checkbox input:indeterminate {
+  --_ch-input-bc: var(--theme-secondary);
+  --_ch-input-bg: var(--theme-secondary);
+}
+.s-checkbox input:checked {
+  --_ch-input-bg-image: url("data:image/svg+xml;,%3Csvg width='11' height='11' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M10 3.41L8.59 2 4 6.59 2.41 5 1 6.41l3 3z' fill='%23ffffff'/%3E%3C/svg%3E");
+}
+.s-checkbox input:indeterminate {
+  --_ch-input-bg-image: url("data:image/svg+xml;,%3Csvg width='11' height='11' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2 4.5 h7 v2 h-7 z' fill='%23ffffff'/%3E%3C/svg%3E");
+}
+.s-radio input {
+  --_ch-input-br: var(--br-circle);
+}
+fieldset[disabled] .s-radio input:checked,
+.s-radio input[disabled]:checked {
+  --_ch-input-bc: var(--theme-secondary-300);
+}
+.s-radio input:checked {
+  --_ch-input-baw: calc(var(--_ch-input-h) / 3);
+  --_ch-input-bc: var(--theme-secondary);
+  --_ch-input-bg: var(--white);
+}
+.s-form-group {
+  --_fg-fd: column;
+  --_fg-gap: var(--su8);
+  flex-direction: var(--_fg-fd);
+  display: flex;
+  gap: var(--_fg-gap);
+}
+.s-form-group.s-menu {
+  --_fg-gap: 0;
+}
+.s-form-group:has(.s-input__sm, .s-textarea__sm, .s-select__sm) {
+  --_fg-gap: var(--su6);
+}
+.s-form-group:has(.s-input__lg, .s-textarea__lg, .s-select__lg) {
+  --_fg-gap: calc(var(--su8) + var(--su2));
+}
+.s-form-group.s-form-group__horizontal {
+  --_fg-fd: row;
+}
+.s-form-group legend.s-label {
+  margin-bottom: var(--su8);
+}
+.s-form-group:has(.s-input, .s-textarea, .s-select) .s-label + .s-description {
+  margin-top: var(--sun4);
+}
+.s-code-block {
+  --_cb-line-numbers-bg: var(--black-150);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-system .s-code-block {
+    --_cb-line-numbers-bg: var(--black-100);
+  }
+}
+body.theme-dark .s-code-block,
+.theme-dark__forced .s-code-block,
+body.theme-system .theme-dark__forced .s-code-block {
+  --_cb-line-numbers-bg: var(--black-100);
+}
+code[class*="language-"] .s-code-block,
+pre.s-code-block > code {
+  font-family: inherit;
+}
+code[class*="language-"] .s-code-block .hljs-built_in,
+pre.s-code-block > code .hljs-built_in,
+code[class*="language-"] .s-code-block .hljs-literal,
+pre.s-code-block > code .hljs-literal,
+code[class*="language-"] .s-code-block .hljs-title,
+pre.s-code-block > code .hljs-title {
+  color: var(--highlight-literal);
+}
+code[class*="language-"] .s-code-block .hljs-bullet,
+pre.s-code-block > code .hljs-bullet,
+code[class*="language-"] .s-code-block .hljs-code,
+pre.s-code-block > code .hljs-code {
+  color: var(--highlight-punctuation);
+}
+code[class*="language-"] .s-code-block .hljs-doctag,
+pre.s-code-block > code .hljs-doctag,
+code[class*="language-"] .s-code-block .hljs-keyword,
+pre.s-code-block > code .hljs-keyword,
+code[class*="language-"] .s-code-block .hljs-meta-keyword,
+pre.s-code-block > code .hljs-meta-keyword,
+code[class*="language-"] .s-code-block .hljs-meta,
+pre.s-code-block > code .hljs-meta,
+code[class*="language-"] .s-code-block .hljs-section,
+pre.s-code-block > code .hljs-section,
+code[class*="language-"] .s-code-block .hljs-selector-class,
+pre.s-code-block > code .hljs-selector-class,
+code[class*="language-"] .s-code-block .hljs-selector-pseudo,
+pre.s-code-block > code .hljs-selector-pseudo,
+code[class*="language-"] .s-code-block .hljs-selector-tag,
+pre.s-code-block > code .hljs-selector-tag {
+  color: var(--highlight-keyword);
+}
+code[class*="language-"] .s-code-block .hljs-name,
+pre.s-code-block > code .hljs-name,
+code[class*="language-"] .s-code-block .hljs-number,
+pre.s-code-block > code .hljs-number,
+code[class*="language-"] .s-code-block .hljs-quote,
+pre.s-code-block > code .hljs-quote,
+code[class*="language-"] .s-code-block .hljs-selector-id,
+pre.s-code-block > code .hljs-selector-id,
+code[class*="language-"] .s-code-block .hljs-template-tag,
+pre.s-code-block > code .hljs-template-tag,
+code[class*="language-"] .s-code-block .hljs-type,
+pre.s-code-block > code .hljs-type {
+  color: var(--highlight-namespace);
+}
+code[class*="language-"] .s-code-block .hljs-link,
+pre.s-code-block > code .hljs-link,
+code[class*="language-"] .s-code-block .hljs-meta-string,
+pre.s-code-block > code .hljs-meta-string,
+code[class*="language-"] .s-code-block .hljs-regexp,
+pre.s-code-block > code .hljs-regexp,
+code[class*="language-"] .s-code-block .hljs-selector-attr,
+pre.s-code-block > code .hljs-selector-attr,
+code[class*="language-"] .s-code-block .hljs-string,
+pre.s-code-block > code .hljs-string,
+code[class*="language-"] .s-code-block .hljs-symbol,
+pre.s-code-block > code .hljs-symbol,
+code[class*="language-"] .s-code-block .hljs-template-variable,
+pre.s-code-block > code .hljs-template-variable,
+code[class*="language-"] .s-code-block .hljs-variable,
+pre.s-code-block > code .hljs-variable {
+  color: var(--highlight-variable);
+}
+code[class*="language-"] .s-code-block .hljs-addition,
+pre.s-code-block > code .hljs-addition {
+  color: var(--highlight-addition);
+}
+code[class*="language-"] .s-code-block .hljs-attr,
+pre.s-code-block > code .hljs-attr {
+  color: var(--highlight-attribute);
+}
+code[class*="language-"] .s-code-block .hljs-attribute,
+pre.s-code-block > code .hljs-attribute {
+  color: var(--highlight-symbol);
+}
+code[class*="language-"] .s-code-block .hljs-comment,
+pre.s-code-block > code .hljs-comment {
+  color: var(--highlight-comment);
+}
+code[class*="language-"] .s-code-block .hljs-deletion,
+pre.s-code-block > code .hljs-deletion {
+  color: var(--highlight-deletion);
+}
+code[class*="language-"] .s-code-block .hljs-emphasis,
+pre.s-code-block > code .hljs-emphasis {
+  font-style: italic;
+}
+code[class*="language-"] .s-code-block .hljs-strong,
+pre.s-code-block > code .hljs-strong {
+  font-weight: bold;
+}
+code[class*="language-"] .s-code-block .hljs-subst,
+pre.s-code-block > code .hljs-subst {
+  color: var(--highlight-color);
+}
+pre.s-code-block {
+  scrollbar-color: var(--scrollbar) transparent;
+  background-color: var(--highlight-bg);
+  color: var(--highlight-color);
+  font-family: var(--ff-mono);
+  font-size: var(--fs-body1);
+  line-height: var(--lh-md);
+  margin: 0;
+  overflow: auto;
+  padding: var(--su12);
+}
+pre.s-code-block .s-code-block--line-numbers {
+  background-color: var(--_cb-line-numbers-bg);
+  border-color: var(--bc-medium);
+  border-style: solid;
+  border-width: 0 var(--su1) 0 0;
+  color: var(--black-350);
+  float: left;
+  margin: var(--sun12);
+  margin-right: var(--su12);
+  padding: var(--su12);
+  padding-right: var(--su6);
+  text-align: right;
+}
+pre.s-code-block::-webkit-scrollbar {
+  width: calc(var(--su12) - var(--su2));
+  height: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+pre.s-code-block::-webkit-scrollbar-track {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+pre.s-code-block::-webkit-scrollbar-thumb {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: var(--scrollbar);
+}
+pre.s-code-block::-webkit-scrollbar-corner {
+  background-color: transparent;
+  border-color: transparent;
+}
+.s-description {
+  --_de-fc: var(--black-400);
+  color: var(--_de-fc);
+  font-size: var(--fs-body1);
+  margin-bottom: 0;
+  padding: 0 var(--su2);
+}
+.is-disabled .s-description {
+  opacity: var(--_o-disabled-static);
+}
+.has-error .s-description {
+  --_de-fc: var(--red-400);
+}
+.has-success .s-description {
+  --_de-fc: var(--green-400);
+}
+.has-warning .s-description {
+  --_de-fc: var(--yellow-400);
+}
+.s-empty-state {
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+}
+.s-empty-state p {
+  color: var(--black-400);
+  margin-bottom: var(--su32);
+}
+.s-empty-state--title {
+  font-weight: 600;
+  font-size: var(--fs-body3);
+  margin-bottom: var(--su8);
+  color: var(--black-400);
+}
+.s-empty-state .svg-spot {
+  margin-bottom: var(--su24);
+}
+.s-empty-state:last-child {
+  margin-bottom: 0;
+}
+.s-input,
+.s-textarea,
+:has(> .s-textarea) {
+  --_in-ai: unset;
+  --_in-bc: var(--black-300);
+  --_in-bg: var(--white);
+  --_in-br: var(--br-md);
+  --_in-bw: var(--su1);
+  --_in-c: unset;
+  --_in-d: unset;
+  --_in-fc: var(--black-600);
+  --_in-fs: var(--fs-body1);
+  --_in-fw: unset;
+  --_in-g: unset;
+  --_in-lh: var(--lh-base);
+  --_in-px: calc(var(--su12) - var(--su1));
+  --_in-py: var(--su8);
+  --_in-placeholder-fc: var(--black-300);
+}
+.s-input,
+.s-textarea {
+  scrollbar-color: var(--scrollbar) transparent;
+  align-items: var(--_in-ai);
+  background-color: var(--_in-bg);
+  border: var(--_in-bw) solid var(--_in-bc);
+  color: var(--_in-fc);
+  cursor: var(--_in-c);
+  display: var(--_in-d);
+  flex-wrap: var(--_in-fw);
+  font-size: var(--_in-fs);
+  gap: var(--_in-g);
+  line-height: var(--_in-lh);
+  padding: var(--_in-py) var(--_in-px) var(--_in-py) var(--_in-pl, var(--_in-px));
+  border-radius: var(--br-md);
+  font-family: inherit;
+  margin: 0;
+  width: 100%;
+}
+body.theme-highcontrast .s-input,
+body.theme-highcontrast .s-textarea {
+  --_in-bc: var(--black);
+  --_in-placeholder-fc: var(--black-400);
+}
+fieldset[disabled] .s-input,
+fieldset[disabled] .s-textarea,
+.s-input[disabled],
+.s-textarea[disabled] {
+  --_in-c: not-allowed;
+}
+.s-input[readonly],
+.s-textarea[readonly],
+.is-readonly .s-input,
+.is-readonly .s-textarea {
+  --_in-bg: var(--black-150);
+  --_in-bc: var(--black-200);
+  --_in-c: default;
+  --_in-fc: var(--black-400);
+}
+body.theme-highcontrast .s-input[readonly],
+body.theme-highcontrast .s-textarea[readonly],
+body.theme-highcontrast .is-readonly .s-input,
+body.theme-highcontrast .is-readonly .s-textarea {
+  --_in-fc: var(--black-500);
+}
+.has-error .s-input,
+.has-error .s-textarea,
+.has-success .s-input,
+.has-success .s-textarea,
+.has-warning .s-input,
+.has-warning .s-textarea {
+  --_in-bc-focus: var(--_in-bc);
+}
+.has-error .s-input,
+.has-error .s-textarea {
+  --_in-bc: var(--red-400);
+}
+body.theme-highcontrast .has-error .s-input,
+body.theme-highcontrast .has-error .s-textarea {
+  --_in-bc: var(--red-400);
+}
+.has-success .s-input,
+.has-success .s-textarea {
+  --_in-bc: var(--green-400);
+}
+body.theme-highcontrast .has-success .s-input,
+body.theme-highcontrast .has-success .s-textarea {
+  --_in-bc: var(--green-400);
+}
+.has-warning .s-input,
+.has-warning .s-textarea {
+  --_in-bc: var(--yellow-500);
+}
+body.theme-highcontrast .has-warning .s-input,
+body.theme-highcontrast .has-warning .s-textarea {
+  --_in-bc: var(--yellow-500);
+}
+.s-input.s-input__sm,
+.s-input.s-textarea__sm,
+.s-textarea.s-input__sm,
+.s-textarea.s-textarea__sm {
+  --_in-fs: var(--fs-caption);
+  --_in-lh: var(--lh-sm);
+  --_in-px: calc(var(--su12) - var(--su2));
+  --_in-py: calc(var(--su4) + var(--su1));
+}
+.s-input.s-input__lg,
+.s-input.s-textarea__lg,
+.s-textarea.s-input__lg,
+.s-textarea.s-textarea__lg {
+  --_in-fs: var(--fs-body3);
+  --_in-lh: var(--lh-lg);
+  --_in-px: calc(var(--su12) + var(--su1));
+}
+.s-input::placeholder,
+.s-textarea::placeholder {
+  color: var(--_in-placeholder-fc);
+  opacity: 1;
+}
+.s-input.s-input__creditcard,
+.s-input.s-textarea__creditcard,
+.s-textarea.s-input__creditcard,
+.s-textarea.s-textarea__creditcard,
+.s-input.s-input__search,
+.s-input.s-textarea__search,
+.s-textarea.s-input__search,
+.s-textarea.s-textarea__search {
+  --_in-pl: calc(var(--su32) + var(--su4));
+}
+.s-input:focus,
+.s-textarea:focus,
+.s-input:focus-within,
+.s-textarea:focus-within {
+  box-shadow: 0 0 0 var(--su2) var(--focus-neutral), 0 0 0 var(--su4) var(--focus-theme);
+  outline: var(--su2) solid transparent !important;
+}
+.s-input::-webkit-scrollbar,
+.s-textarea::-webkit-scrollbar {
+  width: calc(var(--su12) - var(--su2));
+  height: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.s-input::-webkit-scrollbar-track,
+.s-textarea::-webkit-scrollbar-track {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.s-input::-webkit-scrollbar-thumb,
+.s-textarea::-webkit-scrollbar-thumb {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: var(--scrollbar);
+}
+.s-input::-webkit-scrollbar-corner,
+.s-textarea::-webkit-scrollbar-corner {
+  background-color: transparent;
+  border-color: transparent;
+}
+.is-disabled .s-input,
+.is-readonly .s-input,
+.has-success .s-input,
+.has-error .s-input,
+.has-warning .s-input {
+  padding-right: var(--su32);
+}
+.s-input .s-input {
+  --_in-bg: transparent;
+  --_in-bw: 0;
+  --_in-px: 0;
+  box-shadow: none;
+  flex: 1 1 0;
+  margin: calc(var(--_in-py) * -1) 0;
+}
+.s-input:has(.s-input) {
+  --_in-ai: center;
+  --_in-d: flex;
+  --_in-fw: nowrap;
+  --_in-px: var(--_in-py);
+  --_in-g: var(--su8);
+}
+.s-textarea {
+  --_in-py: var(--su8);
+  --_te-hmn: calc(var(--su32) + var(--su4));
+  --_te-h: calc(var(--su64) + var(--su6));
+  min-height: var(--_te-hmn);
+  height: var(--_te-h);
+}
+.is-disabled .s-textarea,
+.is-readonly .s-textarea,
+.has-success .s-textarea,
+.has-error .s-textarea,
+.has-warning .s-textarea {
+  padding-right: var(--su48);
+}
+.s-textarea.s-textarea__sm {
+  --_te-hmn: calc(var(--su32) - var(--su4));
+  --_te-h: calc(var(--su48) + var(--su6));
+}
+.s-textarea.s-textarea__lg {
+  --_te-hmn: calc(var(--su48) - var(--su4));
+  --_te-h: calc(var(--su64) + var(--su32));
+}
+.s-textarea ~ .s-input-icon {
+  right: var(--_in-px);
+  top: var(--_in-py);
+  margin-top: 0;
+}
+.s-input-fill {
+  --_if-bc: var(--bc-dark);
+  --_if-bg: var(--black-150);
+  --_if-blw: 0;
+  --_if-blr: 0;
+  --_if-brr: 0;
+  --_if-brw: 0;
+  background-color: var(--_if-bg);
+  border: var(--su1) solid var(--_if-bc);
+  border-left-width: var(--_if-blw);
+  border-right-width: var(--_if-brw);
+  border-radius: var(--_if-blr) var(--_if-brr) var(--_if-brr) var(--_if-blr);
+  color: var(--fc-medium);
+  font-family: inherit;
+  line-height: var(--lh-sm);
+  padding: 0.6em 0.7em;
+  white-space: nowrap;
+}
+.s-input-fill.s-input-fill__clear {
+  --_if-bc: transparent;
+  --_if-bg: transparent;
+}
+.s-input-fill.order-first {
+  --_if-blw: var(--su1);
+  --_if-blr: var(--br-md);
+}
+.s-input-fill.order-last {
+  --_if-brw: var(--su1);
+  --_if-brr: var(--br-md);
+}
+.s-input-icon {
+  --_ii-fc: unset;
+  --_ii-r: calc(var(--su8) + var(--su2));
+  color: var(--_ii-fc);
+  right: var(--_ii-r);
+  margin-top: calc(var(--sun8) + var(--sun2));
+  pointer-events: none;
+  position: absolute;
+  top: 50%;
+}
+.has-error .s-input-icon {
+  --_ii-fc: var(--red-400);
+}
+.has-success .s-input-icon {
+  --_ii-fc: var(--green-400);
+}
+.has-warning .s-input-icon {
+  --_ii-fc: var(--yellow-400);
+}
+.is-disabled .s-input-icon {
+  --_ii-fc: var(--black-400);
+}
+.is-readonly .s-input-icon {
+  --_ii-fc: var(--black-300);
+}
+body.theme-highcontrast .is-readonly .s-input-icon {
+  --_ii-fc: var(--fc-light);
+}
+.s-input-icon.s-input-icon__creditcard,
+.s-input-icon.s-input-icon__search {
+  --_ii-r: auto;
+  color: var(--black-400);
+  left: calc(var(--su8) + var(--su2));
+}
+.s-input-message {
+  --_im-fc: unset;
+  --_im-a-fc: unset;
+  --_im-a-fc-hover: unset;
+  color: var(--_im-fc);
+  font-size: var(--fs-caption);
+  margin-bottom: 0;
+  padding: var(--su2);
+}
+.is-disabled .s-input-message a,
+.is-readonly .s-input-message a,
+.has-success .s-input-message a,
+.has-error .s-input-message a,
+.has-warning .s-input-message a {
+  text-decoration: underline;
+}
+fieldset[disabled] .s-input-message {
+  cursor: not-allowed;
+  opacity: var(--_o-disabled-static);
+}
+.has-error .s-input-message {
+  --_im-fc: var(--red-400);
+  --_im-a-fc: var(--red-600);
+  --_im-a-fc-hover: var(--red-500);
+}
+.has-success .s-input-message {
+  --_im-fc: var(--green-400);
+  --_im-a-fc: var(--green-600);
+  --_im-a-fc-hover: var(--green-500);
+}
+.has-warning .s-input-message {
+  --_im-fc: var(--yellow-500);
+  --_im-a-fc: var(--yellow-600);
+  --_im-a-fc-hover: var(--yellow-500);
+}
+.s-input-message a {
+  color: var(--_im-a-fc) !important;
+}
+.s-input-message a:hover {
+  color: var(--_im-a-fc-hover) !important;
+}
+.s-label {
+  --_la-c: unset;
+  --_la-fs: var(--fs-body2);
+  cursor: var(--_la-c);
+  font-size: var(--_la-fs);
+  color: var(--black-500);
+  font-family: inherit;
+  font-weight: 600;
+  padding: 0 var(--su2);
+}
+.s-label[for] {
+  --_la-c: pointer;
+}
+fieldset[disabled] .s-label,
+.is-disabled .s-label {
+  opacity: var(--_o-disabled-static);
+}
+fieldset[disabled] .s-label .s-description,
+.is-disabled .s-label .s-description {
+  opacity: unset;
+}
+fieldset[disabled] .s-label,
+.is-disabled .s-label,
+fieldset[disabled] .s-label[for],
+.is-disabled .s-label[for] {
+  --_la-c: not-allowed;
+}
+.is-readonly .s-label {
+  --_la-c: default;
+}
+.s-label.s-label__sm {
+  --_la-fs: var(--fs-body1);
+}
+.s-label.s-label__lg {
+  --_la-fs: calc(var(--su16) + var(--su6));
+}
+.s-label .s-badge {
+  font-weight: 400;
+  margin-left: var(--su6);
+}
+.s-label:has(.s-badge) {
+  display: flex;
+  align-items: center;
+}
+.s-label .s-description,
+.s-label .s-input-message {
+  font-size: var(--fs-caption);
+  font-weight: normal;
+  margin-bottom: 0;
+  margin-top: var(--su4);
+  padding: 0;
+}
+.s-required-symbol {
+  color: var(--red-400);
+  font-size: 125%;
+  font-weight: normal;
+  line-height: 0;
+  text-decoration: none !important;
+}
+.s-link {
+  --_li-fc: var(--theme-link-color, var(--black-600));
+  --_li-fc-hover: var(--theme-link-color-hover, var(--blue-400));
+  --_li-fc-visited: var(--theme-link-color-visited, var(--black-400));
+  color: var(--_li-fc);
+  cursor: pointer;
+  text-decoration: none;
+  user-select: auto;
+}
+body.theme-highcontrast .s-link {
+  text-decoration: underline;
+}
+.s-link__dropdown {
+  align-items: center;
+  display: inline-flex;
+  gap: var(--su4);
+}
+.s-link__dropdown:after {
+  border-color: currentColor transparent;
+  border-style: solid;
+  border-width: var(--su4) var(--su4) 0 var(--su4);
+  content: "";
+}
+.s-link__underlined {
+  text-decoration: underline !important;
+}
+.s-link__danger {
+  --_li-fc: var(--red-400);
+  --_li-fc-hover: var(--red-500);
+  --_li-fc-visited: var(--red-600);
+}
+.s-link__grayscale {
+  --_li-fc: var(--black-500);
+  --_li-fc-hover: var(--black-600);
+}
+.s-link__inherit {
+  --_li-fc: inherit !important;
+  --_li-fc-hover: inherit !important;
+  --_li-fc-visited: inherit !important;
+}
+.s-link__muted {
+  --_li-fc: var(--black-400);
+}
+fieldset[disabled] .s-link {
+  box-shadow: none !important;
+  opacity: var(--_o-disabled-static);
+  pointer-events: none;
+}
+button.s-link {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  font-family: inherit;
+  line-height: inherit;
+  padding: 0;
+  user-select: auto;
+}
+button.s-link:focus {
+  outline: revert;
+}
+p .s-link {
+  text-decoration: underline;
+}
+.s-link:active,
+.s-link:hover {
+  --_li-fc: var(--_li-fc-hover);
+  text-decoration: underline;
+}
+.s-link:visited {
+  color: var(--_li-fc-visited);
+}
+.s-link:visited:hover {
+  color: var(--_li-fc-hover);
+}
+.s-loader {
+  --_ld-color: var(--black-600);
+  --_ld-gap: calc(var(--_ld-size) / 2);
+  --_ld-size: calc(var(--su4) + var(--su1));
+  --_ld-offset: calc(calc(var(--_ld-size) / 8) * -5);
+  display: flex;
+  gap: var(--_ld-gap);
+  margin-top: var(--_ld-gap);
+}
+.s-loader__sm {
+  --_ld-size: calc(calc(var(--su8) - var(--su1)) / 2);
+  margin-left: var(--su1);
+  margin-right: var(--su1);
+}
+.s-loader__lg {
+  --_ld-size: var(--su8);
+}
+.s-loader:before,
+.s-loader .s-loader--sr-text:before,
+.s-loader:after {
+  background-color: currentColor;
+  content: "";
+  display: block;
+  height: var(--_ld-size);
+  width: var(--_ld-size);
+  animation: loader-animation 0.8s cubic-bezier(1, 1, 0, 1) infinite;
+}
+.s-loader .s-loader--sr-text {
+  display: block;
+  flex-shrink: 0;
+  height: var(--_ld-size);
+  width: var(--_ld-size);
+  font-size: 0;
+  overflow: visible;
+}
+.s-loader .s-loader--sr-text:before {
+  animation-delay: 0.25s;
+}
+.s-loader:after {
+  animation-delay: 0.5s;
+}
+@media (prefers-reduced-motion: reduce) {
+  .s-loader:before,
+  .s-loader .s-loader--sr-text:before,
+  .s-loader:after {
+    animation: loader-animation-reduced-motion 2s ease-in-out infinite;
+  }
+}
+@keyframes loader-animation {
+  0%,
+  1%,
+  99%,
+  to {
+    opacity: 0.2;
+    transform: translateY(0);
+  }
+  49%,
+  50% {
+    opacity: 1;
+    transform: translateY(var(--_ld-offset));
+  }
+  51% {
+    opacity: 0.2;
+    transform: translateY(var(--_ld-offset));
+  }
+}
+@keyframes loader-animation-reduced-motion {
+  0%,
+  to {
+    opacity: 0.3;
+    transform: none;
+  }
+  50% {
+    opacity: 1;
+    transform: none;
+  }
+}
+.s-menu {
+  --_me-action-bg: unset;
+  --_me-action-fc: var(--black-500);
+  --_me-item-p: var(--su8);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+body.theme-highcontrast .s-menu a[href] {
+  text-decoration: underline;
+}
+.s-menu .s-menu--divider {
+  background-color: var(--black-200);
+  height: var(--su1);
+  margin: var(--su8) 0;
+}
+.s-menu .s-menu--icon {
+  color: inherit;
+  margin-right: var(--su8);
+}
+.s-menu .s-menu--item {
+  color: var(--_me-action-fc);
+  padding: var(--_me-item-p);
+  align-items: center;
+  display: flex;
+  width: 100%;
+}
+.s-menu .s-menu--item:has(> .s-menu--action) {
+  --_me-item-p: 0;
+}
+.s-menu .s-menu--item.s-checkbox,
+.s-menu .s-menu--item.s-radio {
+  --_me-item-p: var(--su6) var(--su8);
+  align-items: flex-start;
+}
+.s-menu .s-menu--item.s-checkbox input,
+.s-menu .s-menu--item.s-radio input {
+  margin-top: var(--su4);
+}
+.s-menu .s-menu--item:not(.s-checkbox):not(.s-radio) input {
+  height: 0;
+  pointer-events: none;
+  position: absolute;
+  opacity: 0;
+  width: 0;
+}
+.s-menu .s-menu--action {
+  background-color: var(--_me-action-bg);
+  color: var(--_me-action-fc);
+  align-items: center;
+  border-radius: var(--br-md);
+  cursor: pointer;
+  display: flex;
+  padding: var(--su8);
+  text-decoration: none;
+  width: 100%;
+}
+.s-menu .s-menu--action:focus-visible,
+.s-menu .s-menu--action:has(> input:focus-visible) {
+  box-shadow: inset 0 0 0 var(--su2) var(--focus-theme), inset 0 0 0 var(--su4) var(--focus-neutral);
+  outline: var(--su2) solid transparent !important;
+}
+.s-menu .s-menu--action:focus-visible,
+.s-menu .s-menu--action:has(> input:focus-visible),
+.s-menu .s-menu--action:hover {
+  --_me-action-bg: var(--black-150);
+  --_me-action-fc: var(--black-600);
+}
+.s-menu .s-menu--action__danger {
+  --_me-action-fc: var(--red-400);
+}
+.s-menu .s-menu--action__danger:focus-visible,
+.s-menu .s-menu--action__danger:hover {
+  --_me-action-fc: var(--red-500);
+}
+.s-menu button.s-menu--action {
+  border: none;
+  font-family: inherit;
+  line-height: inherit;
+  text-align: left;
+}
+.s-menu .s-menu--title {
+  color: var(--black-600);
+  font-weight: 700;
+  padding: var(--su6) var(--su8);
+}
+.s-menu .s-menu--item + .s-menu--title {
+  margin-top: var(--su12);
+}
+.s-modal {
+  --_mo-bg: rgba(33, 29, 30, 0.5);
+  --_mo-hmx: unset;
+  --_mo-wmx: unset;
+  --_mo-dialog-bg: var(--white);
+  --_mo-dialog-pt: var(--su24);
+  --_mo-dialog-ou: 0;
+  background-color: var(--_mo-bg);
+  max-height: var(--_mo-hmx);
+  max-width: var(--_mo-wmx);
+  align-items: center;
+  backface-visibility: hidden;
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  opacity: 0;
+  position: fixed;
+  transition: opacity 100ms var(--te-smooth) 0s, z-index 0s 100ms, visibility 0s 100ms;
+  visibility: hidden;
+  z-index: var(--zi-hide);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-system .s-modal {
+    --_mo-dialog-bg: var(--black-100);
+  }
+}
+body.theme-dark .s-modal,
+.theme-dark__forced .s-modal,
+body.theme-system .theme-dark__forced .s-modal {
+  --_mo-dialog-bg: var(--black-100);
+}
+body.theme-highcontrast .s-modal {
+  --_mo-dialog-ou: var(--su2) solid var(--black-500);
+}
+.s-modal[aria-hidden="false"],
+.s-modal[aria-hidden="false"] .s-modal--dialog {
+  opacity: 1;
+  transform: translate3d(0, 0, 0) scale3d(1, 1, 1);
+  transition: opacity 100ms var(--te-smooth) 10ms, z-index 0s 0s, visibility 0s 0s, transform 100ms var(--te-smooth) 10ms, transform 100ms var(--te-smooth) 10ms;
+  visibility: visible;
+  z-index: var(--zi-modals);
+}
+.s-modal.s-modal__celebration {
+  --_mo-dialog-pt: var(--su64);
+}
+.s-modal.s-modal__celebration .s-modal--dialog {
+  background-repeat: repeat-x;
+  background-position: top -10px center;
+  background-image: url("data:image/svg+xml;,%3Csvg width='600' height='90' viewBox='0 0 600 90' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='42' y='-10' width='6' height='10'/%3E%3Crect x='84' y='-10' width='6' height='10'/%3E%3Crect x='126' y='-13' width='5' height='13'/%3E%3Crect x='168' y='-13' width='5' height='13'/%3E%3Crect x='210' y='-10' width='6' height='10'/%3E%3Crect x='252' y='-13' width='5' height='13'/%3E%3Crect x='294' y='-10' width='6' height='10'/%3E%3Crect x='336' y='-13' width='5' height='13'/%3E%3Crect x='378' y='-13' width='5' height='13'/%3E%3Crect x='420' y='-10' width='6' height='10'/%3E%3Crect x='462' y='-10' width='6' height='10'/%3E%3Crect x='504' y='-13' width='5' height='13'/%3E%3Crect x='546' y='-10' width='6' height='10'/%3E%3Cstyle type='text/css'%3E rect %7B opacity: 0; %7D rect:nth-child(1) %7B transform-origin: 45px 5px; transform: rotate(-145deg); animation: blast 700ms infinite ease-out; animation-delay: 88ms; animation-duration: 631ms; %7D rect:nth-child(2) %7B transform-origin: 87px 5px; transform: rotate(164deg); animation: blast 700ms infinite ease-out; animation-delay: 131ms; animation-duration: 442ms; %7D rect:nth-child(3) %7B transform-origin: 128px 6px; transform: rotate(4deg); animation: blast 700ms infinite ease-out; animation-delay: 92ms; animation-duration: 662ms; %7D rect:nth-child(4) %7B transform-origin: 170px 6px; transform: rotate(-175deg); animation: blast 700ms infinite ease-out; animation-delay: 17ms; animation-duration: 593ms; %7D rect:nth-child(5) %7B transform-origin: 213px 5px; transform: rotate(-97deg); animation: blast 700ms infinite ease-out; animation-delay: 122ms; animation-duration: 476ms; %7D rect:nth-child(6) %7B transform-origin: 255px 6px; transform: rotate(57deg); animation: blast 700ms infinite ease-out; animation-delay: 271ms; animation-duration: 381ms; %7D rect:nth-child(7) %7B transform-origin: 297px 5px; transform: rotate(-46deg); animation: blast 700ms infinite ease-out; animation-delay: 131ms; animation-duration: 619ms; %7D rect:nth-child(8) %7B transform-origin: 338px 6px; transform: rotate(-65deg); animation: blast 700ms infinite ease-out; animation-delay: 85ms; animation-duration: 668ms; %7D rect:nth-child(9) %7B transform-origin: 380px 6px; transform: rotate(13deg); animation: blast 700ms infinite ease-out; animation-delay: 128ms; animation-duration: 377ms; %7D rect:nth-child(10) %7B transform-origin: 423px 5px; transform: rotate(176deg); animation: blast 700ms infinite ease-out; animation-delay: 311ms; animation-duration: 508ms; %7D rect:nth-child(11) %7B transform-origin: 465px 5px; transform: rotate(108deg); animation: blast 700ms infinite ease-out; animation-delay: 108ms; animation-duration: 595ms; %7D rect:nth-child(12) %7B transform-origin: 506px 6px; transform: rotate(62deg); animation: blast 700ms infinite ease-out; animation-delay: 105ms; animation-duration: 375ms; %7D rect:nth-child(13) %7B transform-origin: 549px 5px; transform: rotate(16deg); animation: blast 700ms infinite ease-out; animation-delay: 149ms; animation-duration: 491ms; %7D rect:nth-child(odd) %7B fill: %2365BB5C; %7D rect:nth-child(even) %7B z-index: 1; fill: %2333AAFF; %7D rect:nth-child(4n) %7B animation-duration: 1400ms; fill: %23F23B14; %7D rect:nth-child(3n) %7B animation-duration: 1750ms; animation-delay: 700ms; %7D rect:nth-child(4n-7) %7B fill: %232A2F6A; %7D rect:nth-child(6n) %7B fill: %23FBBA23; %7D @keyframes blast %7B from %7B opacity: 0; %7D 20%25 %7B opacity: 1; %7D to %7B transform: translateY(90px); %7D %7D %3C/style%3E%3C/svg%3E%0A");
+}
+@media (prefers-reduced-motion) {
+  .s-modal.s-modal__celebration .s-modal--dialog {
+    background-image: url("data:image/svg+xml;,%3Csvg width='574' height='60' viewBox='0 0 574 60' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect opacity='0.8' x='27.1224' y='20.0458' width='5' height='13' transform='rotate(-139 27.1224 20.0458)' fill='%23F23B14'/%3E%3Crect opacity='0.8' x='118.478' y='7.00201' width='5' height='13' transform='rotate(-38.8114 118.478 7.00201)' fill='%23FBBA23'/%3E%3Crect opacity='0.8' x='504.616' y='25.4479' width='5' height='13' transform='rotate(-60.2734 504.616 25.4479)' fill='%23F23B14'/%3E%3Crect opacity='0.6' x='538.983' y='45.555' width='5' height='13' transform='rotate(16.7826 538.983 45.555)' fill='%232A2F6A'/%3E%3Crect opacity='0.3' x='470.322' y='2.63625' width='5' height='13' transform='rotate(11.295 470.322 2.63625)' fill='%2333AAFF'/%3E%3Crect opacity='0.3' x='190.295' y='4.58138' width='5' height='13' transform='rotate(27.5954 190.295 4.58138)' fill='%23F23B14'/%3E%3Crect opacity='0.8' x='234.303' y='16.3233' width='5' height='13' transform='rotate(-41.8233 234.303 16.3233)' fill='%2365BB5C'/%3E%3Crect opacity='0.6' x='369.702' y='40.9875' width='5' height='13' transform='rotate(-56.419 369.702 40.9875)' fill='%2333AAFF'/%3E%3Crect opacity='0.3' x='402.121' y='31.0848' width='5' height='13' transform='rotate(-17.9234 402.121 31.0848)' fill='%23F23B14'/%3E%3Crect opacity='0.6' x='200.316' y='31.9328' width='5' height='13' transform='rotate(-15.8896 200.316 31.9328)' fill='%232A2F6A'/%3E%3Crect opacity='0.6' x='69.6745' y='23.4725' width='6' height='10' transform='rotate(70.0266 69.6745 23.4725)' fill='%2365BB5C'/%3E%3Crect opacity='0.6' x='291.945' y='7.16931' width='6' height='10' transform='rotate(30.4258 291.945 7.16931)' fill='%23FBBA23'/%3E%3Crect opacity='0.3' x='33.7754' y='38.2208' width='6' height='10' transform='rotate(38.6056 33.7754 38.2208)' fill='%23FBBA23'/%3E%3Crect opacity='0.8' x='109.752' y='31.1743' width='6' height='10' transform='rotate(28.5296 109.752 31.1743)' fill='%2333AAFF'/%3E%3Crect opacity='0.3' x='278.081' y='37.8695' width='6' height='10' transform='rotate(-26.5651 278.081 37.8695)' fill='%23F23B14'/%3E%3Crect opacity='0.8' x='416.294' y='11.5573' width='6' height='10' transform='rotate(-22.8498 416.294 11.5573)' fill='%23FBBA23'/%3E%3Crect opacity='0.3' x='354.667' y='9.32341' width='6' height='10' transform='rotate(17.7506 354.667 9.32341)' fill='%232A2F6A'/%3E%3Crect opacity='0.8' x='532.404' y='16.6372' width='6' height='10' transform='rotate(-75.3432 532.404 16.6372)' fill='%23FBBA23'/%3E%3Crect opacity='0.6' x='460.463' y='39.3557' width='6' height='10' transform='rotate(45.4982 460.463 39.3557)' fill='%2365BB5C'/%3E%3C/svg%3E");
+  }
+}
+.s-modal.s-modal__full {
+  --_mo-hmx: calc(100% - var(--su48));
+  --_mo-wmx: calc(100% - var(--su48));
+}
+.s-modal.has-danger,
+.s-modal.s-modal__danger {
+  --_mo-bg: rgba(1, 0, 0, 0.5);
+}
+.s-modal .s-modal--body {
+  color: var(--fc-medium);
+  margin-bottom: var(--su24);
+}
+.s-modal .s-modal--close {
+  padding: var(--su6) !important;
+  position: absolute !important;
+  right: var(--su16);
+  top: var(--su16);
+}
+.s-modal .s-modal--close .svg-icon {
+  margin: 0 !important;
+}
+.s-modal .s-modal--dialog {
+  padding: var(--_mo-dialog-pt) var(--su24) var(--su24);
+  scrollbar-color: var(--scrollbar) transparent;
+  position: relative;
+  backface-visibility: hidden;
+  background-color: var(--_mo-dialog-bg);
+  border-radius: var(--br-md);
+  box-shadow: var(--bs-lg);
+  max-height: 100%;
+  max-width: 600px;
+  opacity: 0;
+  overflow-y: auto;
+  transform: translate3d(0, 30%, 0) scale3d(0.6, 0.6, 0.6);
+  transition: opacity 200ms var(--te-smooth) 0s, z-index 0s 100ms, visibility 0s 100ms, transform 100ms var(--te-smooth) 0s, transform 100ms var(--te-smooth) 0s;
+  visibility: hidden;
+  z-index: var(--zi-hide);
+  outline: var(--_mo-dialog-ou);
+}
+.s-modal .s-modal--dialog::-webkit-scrollbar {
+  width: calc(var(--su12) - var(--su2));
+  height: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.s-modal .s-modal--dialog::-webkit-scrollbar-track {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.s-modal .s-modal--dialog::-webkit-scrollbar-thumb {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: var(--scrollbar);
+}
+.s-modal .s-modal--dialog::-webkit-scrollbar-corner {
+  background-color: transparent;
+  border-color: transparent;
+}
+.s-modal .s-modal--footer {
+  margin-top: var(--su24);
+}
+.s-modal .s-modal--header {
+  color: var(--fc-dark);
+  font-size: var(--fs-headline1);
+  font-weight: normal;
+  line-height: var(--lh-sm);
+  margin-bottom: var(--su16);
+  margin-right: var(--su24);
+}
+.s-navigation,
+.s-navigation ul {
+  --_na-fd: row;
+  --_na-fw: wrap;
+  --_na-p: var(--su2) 0;
+  --_na-gap: var(--su4);
+  --_na-item-bg: none;
+  --_na-item-fc: var(--black-400);
+  --_na-item-fs: unset;
+  --_na-item-p: calc(var(--su12) - var(--su1)) var(--su16);
+  --_na-item-ws: nowrap;
+  --_na-item-bg-hover: var(--black-100);
+  --_na-item-fc-hover: var(--_na-item-fc);
+  --_na-item-selected-bg: none;
+  --_na-item-selected-fc: var(--black-600);
+  --_na-item-selected-bg-hover: var(--_na-item-bg-hover);
+  --_na-item-selected-h: var(--su2);
+  --_na-item-text-ta: center;
+  --_na-after-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'%3E%3Cpath d='M11.35 4.35 6 9.71.65 4.35l.7-.7L6 8.29l4.65-4.64z'/%3E%3C/svg%3E");
+  --_na-after-bg-color: var(--black-400);
+  flex-direction: var(--_na-fd);
+  flex-wrap: var(--_na-fw);
+  gap: var(--_na-gap);
+  padding: var(--_na-p);
+  display: flex;
+  list-style: none;
+  margin: 0;
+}
+body.theme-highcontrast .s-navigation,
+body.theme-highcontrast .s-navigation ul {
+  --_na-item-bg-hover: var(--black-500);
+  --_na-item-fc-hover: var(--black-225);
+}
+body.theme-highcontrast .s-navigation a[href].s-navigation--item,
+body.theme-highcontrast .s-navigation ul a[href].s-navigation--item {
+  text-decoration: underline;
+}
+.s-navigation.s-navigation__scroll,
+.s-navigation.s-navigation ul__scroll,
+.s-navigation ul.s-navigation__scroll,
+.s-navigation ul.s-navigation ul__scroll {
+  --_na-fw: nowrap;
+  overflow-x: auto;
+  scrollbar-color: var(--scrollbar) transparent;
+}
+.s-navigation.s-navigation__scroll::-webkit-scrollbar,
+.s-navigation.s-navigation ul__scroll::-webkit-scrollbar,
+.s-navigation ul.s-navigation__scroll::-webkit-scrollbar,
+.s-navigation ul.s-navigation ul__scroll::-webkit-scrollbar {
+  width: calc(var(--su12) - var(--su2));
+  height: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.s-navigation.s-navigation__scroll::-webkit-scrollbar-track,
+.s-navigation.s-navigation ul__scroll::-webkit-scrollbar-track,
+.s-navigation ul.s-navigation__scroll::-webkit-scrollbar-track,
+.s-navigation ul.s-navigation ul__scroll::-webkit-scrollbar-track {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.s-navigation.s-navigation__scroll::-webkit-scrollbar-thumb,
+.s-navigation.s-navigation ul__scroll::-webkit-scrollbar-thumb,
+.s-navigation ul.s-navigation__scroll::-webkit-scrollbar-thumb,
+.s-navigation ul.s-navigation ul__scroll::-webkit-scrollbar-thumb {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: var(--scrollbar);
+}
+.s-navigation.s-navigation__scroll::-webkit-scrollbar-corner,
+.s-navigation.s-navigation ul__scroll::-webkit-scrollbar-corner,
+.s-navigation ul.s-navigation__scroll::-webkit-scrollbar-corner,
+.s-navigation ul.s-navigation ul__scroll::-webkit-scrollbar-corner {
+  background-color: transparent;
+  border-color: transparent;
+}
+.s-navigation.s-navigation__sm,
+.s-navigation.s-navigation ul__sm,
+.s-navigation ul.s-navigation__sm,
+.s-navigation ul.s-navigation ul__sm {
+  --_na-item-fs: var(--fs-caption);
+  --_na-item-p: var(--su6) var(--su4);
+}
+.s-navigation.s-navigation__vertical,
+.s-navigation.s-navigation ul__vertical,
+.s-navigation ul.s-navigation__vertical,
+.s-navigation ul.s-navigation ul__vertical,
+.s-navigation.s-navigation__vertical ul,
+.s-navigation.s-navigation ul__vertical ul,
+.s-navigation ul.s-navigation__vertical ul,
+.s-navigation ul.s-navigation ul__vertical ul {
+  --_na-fd: column;
+  --_na-gap: 0;
+  --_na-p: 0;
+  --_na-item-text-ta: unset;
+  --_na-item-ws: normal;
+  --_na-item-selected-h: 0;
+  --_na-item-p: var(--su6) var(--su8);
+  --_na-item-fc: var(--black-600);
+}
+.s-navigation.s-navigation__vertical .s-navigation--item.is-selected,
+.s-navigation.s-navigation ul__vertical .s-navigation--item.is-selected,
+.s-navigation ul.s-navigation__vertical .s-navigation--item.is-selected,
+.s-navigation ul.s-navigation ul__vertical .s-navigation--item.is-selected,
+.s-navigation.s-navigation__vertical ul .s-navigation--item.is-selected,
+.s-navigation.s-navigation ul__vertical ul .s-navigation--item.is-selected,
+.s-navigation ul.s-navigation__vertical ul .s-navigation--item.is-selected,
+.s-navigation ul.s-navigation ul__vertical ul .s-navigation--item.is-selected {
+  --_na-item-bg: var(--black-150);
+}
+.s-navigation.s-navigation__vertical .s-navigation--item:has(.s-navigation--icon),
+.s-navigation.s-navigation ul__vertical .s-navigation--item:has(.s-navigation--icon),
+.s-navigation ul.s-navigation__vertical .s-navigation--item:has(.s-navigation--icon),
+.s-navigation ul.s-navigation ul__vertical .s-navigation--item:has(.s-navigation--icon),
+.s-navigation.s-navigation__vertical ul .s-navigation--item:has(.s-navigation--icon),
+.s-navigation.s-navigation ul__vertical ul .s-navigation--item:has(.s-navigation--icon),
+.s-navigation ul.s-navigation__vertical ul .s-navigation--item:has(.s-navigation--icon),
+.s-navigation ul.s-navigation ul__vertical ul .s-navigation--item:has(.s-navigation--icon) {
+  --_na-item-p: calc(var(--su12) - var(--su1)) var(--su8);
+}
+.s-navigation.s-navigation__vertical .s-navigation--item:has(.s-navigation--avatar),
+.s-navigation.s-navigation ul__vertical .s-navigation--item:has(.s-navigation--avatar),
+.s-navigation ul.s-navigation__vertical .s-navigation--item:has(.s-navigation--avatar),
+.s-navigation ul.s-navigation ul__vertical .s-navigation--item:has(.s-navigation--avatar),
+.s-navigation.s-navigation__vertical ul .s-navigation--item:has(.s-navigation--avatar),
+.s-navigation.s-navigation ul__vertical ul .s-navigation--item:has(.s-navigation--avatar),
+.s-navigation ul.s-navigation__vertical ul .s-navigation--item:has(.s-navigation--avatar),
+.s-navigation ul.s-navigation ul__vertical ul .s-navigation--item:has(.s-navigation--avatar) {
+  --_na-item-p: var(--su12) var(--su8);
+}
+.s-navigation .s-navigation--item,
+.s-navigation .s-navigation ul--item,
+.s-navigation ul .s-navigation--item,
+.s-navigation ul .s-navigation ul--item {
+  background-color: var(--_na-item-bg);
+  color: var(--_na-item-fc);
+  font: unset;
+  font-size: var(--_na-item-fs);
+  padding: var(--_na-item-p);
+  white-space: var(--_na-item-ws);
+  align-items: center;
+  border: none;
+  border-radius: var(--br-md);
+  box-shadow: none;
+  cursor: pointer;
+  display: flex;
+  position: relative;
+  text-decoration: none;
+  user-select: auto;
+}
+.s-navigation .s-navigation--item.is-selected,
+.s-navigation .s-navigation ul--item.is-selected,
+.s-navigation ul .s-navigation--item.is-selected,
+.s-navigation ul .s-navigation ul--item.is-selected {
+  --_na-item-bg: var(--_na-item-selected-bg);
+  --_na-item-fc: var(--_na-item-selected-fc);
+  --_na-item-fc-hover: var(--_na-item-fc);
+  --_na-item-bg-hover: var(--_na-item-selected-bg-hover);
+  font-weight: bold;
+}
+.s-navigation .s-navigation--item.is-selected:before,
+.s-navigation .s-navigation ul--item.is-selected:before,
+.s-navigation ul .s-navigation--item.is-selected:before,
+.s-navigation ul .s-navigation ul--item.is-selected:before {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: var(--_na-item-selected-h);
+  background-color: var(--_na-item-selected-fc);
+}
+body.theme-highcontrast .s-navigation .s-navigation--item.is-selected,
+body.theme-highcontrast .s-navigation .s-navigation ul--item.is-selected,
+body.theme-highcontrast .s-navigation ul .s-navigation--item.is-selected,
+body.theme-highcontrast .s-navigation ul .s-navigation ul--item.is-selected {
+  --_na-item-fc-hover: var(--white);
+}
+.s-navigation .s-navigation--item__dropdown:after,
+.s-navigation .s-navigation ul--item__dropdown:after,
+.s-navigation ul .s-navigation--item__dropdown:after,
+.s-navigation ul .s-navigation ul--item__dropdown:after {
+  mask-image: var(--_na-after-mask);
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  background-color: var(--_na-after-bg-color);
+  content: "";
+  height: var(--su12);
+  width: var(--su12);
+  margin-left: var(--su8);
+}
+.s-navigation .s-navigation--item:hover,
+.s-navigation .s-navigation ul--item:hover,
+.s-navigation ul .s-navigation--item:hover,
+.s-navigation ul .s-navigation ul--item:hover,
+.s-navigation .s-navigation--item:active,
+.s-navigation .s-navigation ul--item:active,
+.s-navigation ul .s-navigation--item:active,
+.s-navigation ul .s-navigation ul--item:active {
+  background-color: var(--_na-item-bg-hover);
+  color: var(--_na-item-fc-hover);
+}
+body.theme-highcontrast .s-navigation .s-navigation--item:hover,
+body.theme-highcontrast .s-navigation .s-navigation ul--item:hover,
+body.theme-highcontrast .s-navigation ul .s-navigation--item:hover,
+body.theme-highcontrast .s-navigation ul .s-navigation ul--item:hover,
+body.theme-highcontrast .s-navigation .s-navigation--item:active,
+body.theme-highcontrast .s-navigation .s-navigation ul--item:active,
+body.theme-highcontrast .s-navigation ul .s-navigation--item:active,
+body.theme-highcontrast .s-navigation ul .s-navigation ul--item:active {
+  --_na-after-bg-color: var(--white);
+}
+.s-navigation .s-navigation--item:focus-visible,
+.s-navigation .s-navigation ul--item:focus-visible,
+.s-navigation ul .s-navigation--item:focus-visible,
+.s-navigation ul .s-navigation ul--item:focus-visible {
+  box-shadow: inset 0 0 0 var(--su2) var(--focus-theme), inset 0 0 0 var(--su4) var(--focus-neutral);
+  outline: var(--su2) solid transparent !important;
+}
+.s-navigation .s-navigation--item-text,
+.s-navigation .s-navigation ul--item-text,
+.s-navigation ul .s-navigation--item-text,
+.s-navigation ul .s-navigation ul--item-text {
+  display: inline-flex;
+  flex-direction: column;
+  text-align: var(--_na-item-text-ta);
+}
+.s-navigation .s-navigation--item-text:before,
+.s-navigation .s-navigation ul--item-text:before,
+.s-navigation ul .s-navigation--item-text:before,
+.s-navigation ul .s-navigation ul--item-text:before {
+  content: attr(data-text);
+  font-weight: bold;
+  height: 0;
+  pointer-events: none;
+  user-select: none;
+  visibility: hidden;
+}
+.s-navigation .s-navigation--title,
+.s-navigation .s-navigation ul--title,
+.s-navigation ul .s-navigation--title,
+.s-navigation ul .s-navigation ul--title {
+  margin-bottom: 0;
+  font-size: var(--fs-fine);
+  font-weight: normal;
+  color: var(--black-400);
+  padding: calc(var(--su16) + var(--su2)) var(--su8);
+}
+.s-navigation .s-navigation--title .s-btn,
+.s-navigation .s-navigation ul--title .s-btn,
+.s-navigation ul .s-navigation--title .s-btn,
+.s-navigation ul .s-navigation ul--title .s-btn {
+  color: var(--black-400);
+}
+.s-navigation > li ~ li .s-navigation--title,
+.s-navigation ul > li ~ li .s-navigation--title {
+  margin-top: var(--su24);
+}
+.s-navigation .s-navigation--icon,
+.s-navigation .s-navigation ul--icon,
+.s-navigation ul .s-navigation--icon,
+.s-navigation ul .s-navigation ul--icon {
+  color: inherit;
+  margin-right: var(--su4);
+}
+.s-navigation .s-navigation--avatar,
+.s-navigation .s-navigation ul--avatar,
+.s-navigation ul .s-navigation--avatar,
+.s-navigation ul .s-navigation ul--avatar {
+  margin-right: var(--su8);
+  background: transparent;
+}
+/**
+ * Generate color variables with a given color name
+ *
+ * Usage example:
+ * .generate-variant-variables(purple, important);
+ *
+ * @colorName - The name of the color to use to construct variables values
+ * @modifier - Modifier name to determine variable values for that modifier
+ */
+/**
+ * Generate styles for a notice-based component
+ *
+ * Usage examples:
+ * .construct-notice-component(s-banner);
+ * .construct-notice-component(s-notice);
+ *
+ * @baseClass - The base class name for the notice component
+ */
+.s-notice {
+  --_no-bg: var(--black-150);
+  --_no-icon-bg: var(--black-200);
+  --_no-fc: var(--black-600);
+  --_no-code-bc: var(--black-300);
+  --_no-code-bg: var(--black-200);
+  --_no-code-fc: var(--_no-fc);
+  background: var(--_no-bg);
+  color: var(--_no-fc);
+  display: flex;
+  align-items: center;
+  --_no-pd: var(--su8);
+  padding: var(--_no-pd) var(--su12) var(--_no-pd) 0;
+}
+body.theme-highcontrast .s-notice:not(body.theme-highcontrast .s-notice__important) {
+  --_no-icon-bc: var(--_no-code-bc);
+}
+.s-notice__important {
+  --_no-bg: var(--black-400);
+  --_no-icon-bg: var(--black-500);
+  --_no-fc: var(--white);
+  --_no-code-bc: var(--black-300);
+  --_no-code-bg: var(--black-500);
+}
+.s-notice__danger:not(.s-notice__important) {
+  --_no-bg: var(--red-100);
+  --_no-icon-bg: var(--red-200);
+  --_no-code-bc: var(--red-300);
+  --_no-code-bg: var(--red-200);
+}
+.s-notice__danger.s-notice__important {
+  --_no-bg: var(--red-400);
+  --_no-icon-bg: var(--red-500);
+  --_no-fc: var(--white);
+  --_no-code-bc: var(--red-300);
+  --_no-code-bg: var(--red-500);
+}
+.s-notice__info:not(.s-notice__important) {
+  --_no-bg: var(--blue-100);
+  --_no-icon-bg: var(--blue-200);
+  --_no-code-bc: var(--blue-300);
+  --_no-code-bg: var(--blue-200);
+}
+.s-notice__info.s-notice__important {
+  --_no-bg: var(--blue-400);
+  --_no-icon-bg: var(--blue-500);
+  --_no-fc: var(--white);
+  --_no-code-bc: var(--blue-300);
+  --_no-code-bg: var(--blue-500);
+}
+.s-notice__success:not(.s-notice__important) {
+  --_no-bg: var(--green-100);
+  --_no-icon-bg: var(--green-200);
+  --_no-code-bc: var(--green-300);
+  --_no-code-bg: var(--green-200);
+}
+.s-notice__success.s-notice__important {
+  --_no-bg: var(--green-400);
+  --_no-icon-bg: var(--green-500);
+  --_no-fc: var(--white);
+  --_no-code-bc: var(--green-300);
+  --_no-code-bg: var(--green-500);
+}
+.s-notice__featured:not(.s-notice__important) {
+  --_no-bg: var(--purple-100);
+  --_no-icon-bg: var(--purple-200);
+  --_no-code-bc: var(--purple-300);
+  --_no-code-bg: var(--purple-200);
+}
+.s-notice__featured.s-notice__important {
+  --_no-bg: var(--purple-400);
+  --_no-icon-bg: var(--purple-500);
+  --_no-fc: var(--white);
+  --_no-code-bc: var(--purple-300);
+  --_no-code-bg: var(--purple-500);
+}
+.s-notice__activity:not(.s-notice__important) {
+  --_no-bg: var(--pink-100);
+  --_no-icon-bg: var(--pink-200);
+  --_no-code-bc: var(--pink-300);
+  --_no-code-bg: var(--pink-200);
+}
+.s-notice__activity.s-notice__important {
+  --_no-bg: var(--pink-400);
+  --_no-icon-bg: var(--pink-500);
+  --_no-fc: var(--white);
+  --_no-code-bc: var(--pink-300);
+  --_no-code-bg: var(--pink-500);
+}
+.s-notice__warning:not(.s-notice__important) {
+  --_no-bg: var(--yellow-100);
+  --_no-icon-bg: var(--yellow-200);
+  --_no-code-bc: var(--yellow-300);
+  --_no-code-bg: var(--yellow-200);
+}
+.s-notice__warning.s-notice__important {
+  --_no-bg: var(--yellow-300);
+  --_no-icon-bg: var(--yellow-400);
+  --_no-fc: var(--black);
+  --_no-code-bc: var(--yellow-400);
+  --_no-code-bg: var(--yellow-200);
+}
+.s-notice__warning.s-notice__important .s-notice--icon {
+  color: var(--white);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-system .s-notice__warning.s-notice__important {
+    --_no-fc: var(--white);
+    --_no-code-bc: var(--yellow-300);
+    --_no-code-bg: var(--yellow-500);
+    --_no-bg: var(--yellow-400);
+    --_no-icon-bg: var(--yellow-500);
+  }
+}
+body.theme-dark .s-notice__warning.s-notice__important,
+.theme-dark__forced .s-notice__warning.s-notice__important,
+body.theme-system .theme-dark__forced .s-notice__warning.s-notice__important {
+  --_no-fc: var(--white);
+  --_no-code-bc: var(--yellow-300);
+  --_no-code-bg: var(--yellow-500);
+  --_no-bg: var(--yellow-400);
+  --_no-icon-bg: var(--yellow-500);
+}
+body.theme-highcontrast .s-notice__warning.s-notice__important {
+  --_no-bg: var(--yellow-400);
+  --_no-icon-bg: var(--yellow-500);
+  --_no-code-bc: var(--yellow-300);
+  --_no-code-bg: var(--yellow-500);
+  --_no-fc: var(--white);
+}
+.s-notice code {
+  background-color: var(--_no-code-bg);
+  color: var(--_no-code-fc);
+  outline: var(--su1) solid var(--_no-code-bc);
+  padding-left: var(--su2);
+  padding-right: var(--su2);
+  white-space: nowrap;
+}
+button.s-notice--dismiss {
+  color: var(--_no-fc);
+}
+button.s-notice--dismiss:active {
+  background-color: var(--_no-fc);
+  color: var(--_no-bg);
+}
+button.s-notice--dismiss:focus-visible,
+button.s-notice--dismiss:hover,
+button.s-notice--dismiss.focus-inset-bordered {
+  background-color: var(--_no-fc);
+  color: var(--_no-bg);
+}
+.s-notice--actions {
+  display: flex;
+  margin-left: auto;
+  align-self: flex-start;
+  padding-left: var(--su24);
+  color: var(--_no-fc);
+  gap: calc(var(--su24) - var(--su2));
+  overflow-wrap: initial !important;
+}
+.s-notice--actions > .s-link:not(.s-notice--dismiss) {
+  color: var(--_no-fc);
+}
+.s-notice--icon {
+  background: var(--_no-icon-bg);
+  border: var(--su1) solid var(--_no-icon-bc, var(--_no-icon-bg));
+  padding: var(--_no-pd);
+  margin-right: var(--su12);
+  align-self: stretch;
+  margin-top: calc(var(--_no-pd) * -1);
+  margin-bottom: calc(var(--_no-pd) * -1);
+}
+.s-pagination ul,
+ul.s-pagination {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.s-pagination .s-pagination--item {
+  --_pa-item-bg: unset;
+  --_pa-item-br: unset;
+  --_pa-item-fc: var(--black-400);
+  --_pa-item-p: var(--su4);
+  background-color: var(--_pa-item-bg);
+  border-radius: var(--_pa-item-br);
+  color: var(--_pa-item-fc);
+  padding: var(--_pa-item-p);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: var(--su1);
+  position: relative;
+  text-decoration: none;
+}
+body.theme-highcontrast .s-pagination .s-pagination--item[href] {
+  text-decoration: underline;
+}
+.s-pagination .s-pagination--item.is-selected {
+  --_pa-item-fc: var(--black-600);
+}
+.s-pagination .s-pagination--item.is-selected:not(:hover):not(:focus-visible):before {
+  background-color: var(--black-600);
+  content: "";
+  height: var(--su2);
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 100%;
+}
+.s-pagination .s-pagination--item.s-pagination--item__nav {
+  --_pa-item-bg: var(--black-150);
+  --_pa-item-br: var(--br-circle);
+  --_pa-item-fc: var(--black-600);
+  --_pa-item-p: var(--su6);
+  aspect-ratio: 1 / 1;
+}
+.s-pagination .s-pagination--item.s-pagination--item__nav:hover {
+  --_pa-item-bg: var(--black-200);
+}
+.s-pagination .s-pagination--item[href]:hover:not(.s-pagination .s-pagination--item__nav) {
+  --_pa-item-bg: var(--black-150);
+  --_pa-item-br: var(--br-pill);
+  --_pa-item-fc: var(--black-600);
+}
+.s-pagination .s-pagination--item:focus-visible {
+  --_pa-item-bg: var(--black-150);
+  --_pa-item-fc: var(--black-600);
+  border-color: var(--focus-neutral) !important;
+  box-shadow: 0 0 0 var(--su1) var(--focus-neutral), 0 0 0 var(--su3) var(--focus-theme);
+  outline: var(--su2) solid transparent !important;
+}
+.s-pagination .s-pagination--item:focus-visible:not(.s-pagination .s-pagination--item__nav),
+.s-pagination .s-pagination--item.focus-inset-bordered {
+  --_pa-item-br: var(--br-md);
+}
+.s-pagination,
+.s-pagination ul {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--su2);
+}
+.s-popover {
+  --_po-bg: var(--white);
+  --_po-bc: var(--bc-medium);
+  --_po-bs: var(--bs-md);
+  --_po-d: none;
+  --_po-wmn: 10.5rem;
+  --_po-w: 100%;
+  --_po-topbar-height: var(--theme-topbar-height, calc(var(--su48) + var(--su8)));
+  --_po-content-mxh: calc(100vh - var(--_po-topbar-height) - var(--su48));
+  background-color: var(--_po-bg);
+  border: var(--su1) solid var(--_po-bc);
+  box-shadow: var(--_po-bs);
+  display: var(--_po-d);
+  min-width: var(--_po-wmn);
+  width: var(--_po-w);
+  border-radius: var(--br-md);
+  color: var(--fc-dark);
+  font-size: var(--fs-body1);
+  max-width: 21rem;
+  padding: var(--su12);
+  position: absolute;
+  white-space: normal;
+  z-index: var(--zi-popovers);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-system .s-popover {
+    --_po-bg: var(--black-100);
+  }
+}
+body.theme-dark .s-popover,
+.theme-dark__forced .s-popover,
+body.theme-system .theme-dark__forced .s-popover {
+  --_po-bg: var(--black-100);
+}
+.s-popover.is-visible {
+  --_po-d: block;
+}
+.s-popover.s-popover__tooltip {
+  --_po-wmn: unset;
+  --_po-w: auto;
+}
+.s-popover .s-popover--close {
+  float: right;
+  top: var(--sun8);
+  right: var(--sun8);
+  padding: var(--su6) !important;
+}
+.s-popover .s-popover--content {
+  max-height: var(--_po-content-mxh);
+  overflow-y: auto;
+  margin: var(--sun12);
+  padding: var(--su12);
+}
+.s-post-summary {
+  --_ps-answer-icon-fc: unset;
+  --_ps-content-type-bc: var(--black-200);
+  --_ps-content-type-bg: var(--black-050);
+  --_ps-content-type-fc: var(--black-600);
+  --_ps-stats-answers-bg: unset;
+  --_ps-stats-answers-fc: var(--black-400);
+  --_ps-stats-answers-fw: unset;
+  --_ps-stats-answers-icon-fc: unset;
+  --_ps-title-link-fc: var(--theme-secondary-600);
+  container-type: inline-size;
+  container-name: post-summary;
+  color: var(--black-500);
+  display: flex;
+  gap: var(--su16);
+  position: relative;
+  width: 100%;
+}
+body.theme-highcontrast .s-post-summary a[href] {
+  text-decoration: underline !important;
+}
+body.theme-highcontrast .s-post-summary__deleted * {
+  --_ps-ignored-fc: var(--black-500);
+}
+@container post-summary (width <= 28rem) {
+  .s-post-summary .s-post-summary--sm-hide {
+    display: none !important;
+  }
+  .s-post-summary .s-post-summary--sm-show {
+    display: flex !important;
+  }
+}
+@container post-summary (width > 28rem) {
+  .s-post-summary .s-post-summary--sm-hide {
+    display: flex !important;
+  }
+  .s-post-summary .s-post-summary--sm-show {
+    display: none !important;
+  }
+}
+.s-post-summary.s-post-summary__answered {
+  --_ps-stats-answers-bg: var(--green-400);
+  --_ps-stats-answers-fc: var(--white);
+  --_ps-stats-answers-fw: 600;
+  --_ps-stats-answers-icon-fc: var(--green-400);
+}
+.s-post-summary.s-post-summary__deleted,
+.s-post-summary:has(.s-tag.s-tag__ignored) {
+  --_ps-ignored-bg: var(--black-100);
+  --_ps-ignored-fc: var(--black-400);
+}
+.s-post-summary.s-post-summary__deleted.s-post-summary__answered,
+.s-post-summary:has(.s-tag.s-tag__ignored).s-post-summary__answered {
+  --_ps-stats-answers-bg: var(--_ps-ignored-bg);
+  --_ps-stats-answers-fc: var(--_ps-ignored-fc);
+  --_ps-stats-answers-icon-fc: var(--black-350);
+}
+.s-post-summary.s-post-summary__deleted *,
+.s-post-summary:has(.s-tag.s-tag__ignored) * {
+  color: var(--_ps-ignored-fc) !important;
+}
+.s-post-summary.s-post-summary__deleted .s-avatar,
+.s-post-summary:has(.s-tag.s-tag__ignored) .s-avatar {
+  opacity: 0.5;
+}
+.s-post-summary.s-post-summary__deleted .s-user-card--rep .s-bling:before,
+.s-post-summary:has(.s-tag.s-tag__ignored) .s-user-card--rep .s-bling:before {
+  background-color: var(--_ps-ignored-fc) !important;
+}
+.s-post-summary.s-post-summary__deleted .s-badge,
+.s-post-summary:has(.s-tag.s-tag__ignored) .s-badge,
+.s-post-summary.s-post-summary__deleted .s-tag,
+.s-post-summary:has(.s-tag.s-tag__ignored) .s-tag,
+.s-post-summary.s-post-summary__deleted .s-post-summary--stats-bounty,
+.s-post-summary:has(.s-tag.s-tag__ignored) .s-post-summary--stats-bounty {
+  background-color: var(--_ps-ignored-bg) !important;
+  border-color: var(--_ps-ignored-bg) !important;
+  color: var(--_ps-ignored-fc) !important;
+}
+.s-post-summary.s-post-summary__deleted {
+  background-color: var(--red-100);
+  border: var(--su8) solid var(--red-100);
+}
+.s-post-summary .s-tag.s-tag__watched {
+  --_ta-bc: var(--yellow-200);
+  --_ta-bg: var(--yellow-200);
+  --_ta-fc: var(--yellow-600);
+  --_ta-bc-hover: var(--yellow-200);
+  --_ta-bg-hover: var(--yellow-200);
+}
+.s-post-summary .s-post-summary--answers {
+  display: flex;
+  flex-direction: column;
+  gap: var(--su16);
+  padding-top: calc(var(--su8) + var(--su2));
+}
+.s-post-summary .s-post-summary--answer {
+  border-left: var(--su4) solid var(--black-200);
+  display: flex;
+  flex-direction: column;
+  gap: var(--su6);
+  padding-left: var(--su8);
+}
+.s-post-summary .s-post-summary--answer__accepted {
+  --_ps-answer-icon-fc: var(--green-400);
+}
+.s-post-summary .s-post-summary--answer .s-post-summary--stats-answers--icon {
+  color: var(--_ps-answer-icon-fc);
+}
+.s-post-summary .s-post-summary--content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--su4);
+  width: 100%;
+}
+.s-post-summary .s-post-summary--content-meta {
+  align-items: center;
+  color: var(--black-400);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: var(--fs-caption);
+  gap: var(--su6);
+  margin-bottom: var(--su4);
+}
+.s-post-summary .s-post-summary--content-type {
+  border: var(--su1) solid var(--_ps-content-type-bc);
+  background-color: var(--_ps-content-type-bg);
+  color: var(--_ps-content-type-fc);
+  display: flex;
+  align-items: center;
+  gap: var(--su4);
+  padding: 0 var(--su4);
+  font-size: var(--fs-caption);
+}
+.s-post-summary .s-post-summary--content-type:focus-visible {
+  box-shadow: 0 0 0 var(--su2) var(--focus-neutral), 0 0 0 var(--su4) var(--focus-theme);
+  outline: var(--su2) solid transparent !important;
+}
+.s-post-summary .s-post-summary--content-type:hover {
+  --_ps-content-type-bc: var(--black-150);
+  --_ps-content-type-bg: var(--black-100);
+  --_ps-content-type-fc: var(--black-600);
+}
+.s-post-summary .s-post-summary--excerpt {
+  line-height: 1.25rem;
+  margin-bottom: 0;
+}
+.s-post-summary .s-post-summary--stats {
+  display: flex;
+  gap: var(--su6);
+  font-size: var(--fs-caption);
+}
+.s-post-summary .s-post-summary--stats.s-post-summary--sm-hide {
+  flex-direction: column;
+}
+.s-post-summary .s-post-summary--stats.s-post-summary--sm-hide .s-post-summary--stats-answers {
+  background-color: var(--_ps-stats-answers-bg);
+  color: var(--_ps-stats-answers-fc);
+  font-weight: var(--_ps-stats-answers-fw);
+  align-items: center;
+  display: flex;
+  gap: var(--su4);
+  justify-content: center;
+  padding: var(--su4);
+}
+.s-post-summary .s-post-summary--stats.s-post-summary--sm-hide .s-post-summary--stats-bounty {
+  align-items: center;
+  background-color: var(--blue-400);
+  color: var(--white);
+  display: flex;
+  gap: var(--su2);
+  font-weight: 600;
+  justify-content: center;
+  padding: var(--su4);
+}
+.s-post-summary .s-post-summary--stats.s-post-summary--sm-hide .s-post-summary--stats-votes {
+  align-items: center;
+  aspect-ratio: 1/1;
+  border: var(--su1) solid var(--black-200);
+  display: flex;
+  justify-content: center;
+  font-size: var(--fs-body2);
+  font-weight: 600;
+  margin-bottom: var(--su2);
+  padding: var(--su4);
+  width: calc(var(--su48) + var(--su8));
+}
+.s-post-summary .s-post-summary--stats.s-post-summary--sm-show {
+  align-items: center;
+  justify-content: center;
+  padding: var(--su4);
+}
+.s-post-summary .s-post-summary--stats.s-post-summary--sm-show .s-post-summary--stats-answers--icon {
+  color: var(--_ps-stats-answers-icon-fc);
+}
+.s-post-summary .s-post-summary--stats .s-post-summary--stats-bounty {
+  align-items: center;
+  justify-content: center;
+  background-color: var(--blue-400);
+  color: var(--white);
+  display: flex;
+  gap: var(--su1);
+  padding: 0 calc(var(--su4) - var(--su1));
+}
+.s-post-summary .s-post-summary--stats-item {
+  align-items: center;
+  display: flex;
+  gap: var(--su6);
+}
+.s-post-summary .s-post-summary--stats-item:before {
+  aspect-ratio: 1/1;
+  background-color: var(--black-300);
+  content: "";
+  display: block;
+  height: var(--su4);
+}
+.s-post-summary .s-post-summary--tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--su8);
+  margin-top: var(--su6);
+}
+.s-post-summary .s-post-summary--title {
+  display: flex;
+  gap: var(--su6);
+  line-height: 1.563rem;
+  overflow-wrap: break-word;
+  hyphens: auto;
+}
+.s-post-summary .s-post-summary--title-link {
+  color: var(--_ps-title-link-fc);
+  display: flex;
+  font-size: var(--fs-body3);
+  font-weight: 600;
+  gap: var(--su4);
+  margin-top: var(--su2);
+  text-decoration: none;
+}
+.s-post-summary .s-post-summary--title-link:hover {
+  --_ps-title-link-fc: var(--theme-secondary-500);
+}
+.s-post-summary .s-post-summary--title-link:hover:visited {
+  color: var(--theme-secondary-600);
+}
+.s-post-summary .s-post-summary--title-link:visited {
+  color: var(--theme-secondary-400);
+}
+.s-post-summary .s-post-summary--title-icon {
+  flex-shrink: 0;
+}
+.s-prose {
+  --_pr-fs: unset;
+  --_pr-lh: 1.5;
+  --_pr-blockquote-ml: 1em;
+  --_pr-blockquote-mt: 0;
+  --_pr-blockquote-before-bg: var(--black-250);
+  --_pr-code-fs: var(--fs-body1);
+  --_pr-h1-fs: var(--fs-headline1);
+  --_pr-h2-fs: var(--fs-title);
+  --_pr-h3-fs: var(--fs-subheading);
+  --_pr-h4-fs: var(--fs-body3);
+  --_pr-h5-fs: var(--fs-body2);
+  --_pr-h6-fs: var(--fs-body1);
+  --_pr-hr-bg: var(--black-225);
+  --_pr-img-mb: 1.1em;
+  --_pr-kbd-bc: var(--black-300);
+  --_pr-kbd-bs: 0 var(--su1) var(--su1) hsla(210, 8%, 5%, 0.15), inset 0 1px 0 0 var(--_white-static);
+  --_pr-spoiler-cursor: pointer;
+  --_pr-spoiler-after-t: 1em;
+  --_pr-soiler-after-o: unset;
+  --_pr-soiler-child-o: 0;
+  --_pr-soiler-child-visibility: hidden;
+  --s-prose-spacing: 1.1em;
+  --s-prose-spacing-condensed: calc(1.1em / 2);
+  font-size: var(--_pr-fs);
+  line-height: var(--_pr-lh);
+  overflow-wrap: break-word;
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-system .s-prose {
+    --_pr-kbd-bc: transparent;
+    --_pr-kbd-btc: var(--black-400);
+    --_pr-kbd-bs: 0 var(--su1) var(--su1) hsla(210, 8%, 5%, 0.8);
+  }
+}
+body.theme-dark .s-prose,
+.theme-dark__forced .s-prose,
+body.theme-system .theme-dark__forced .s-prose {
+  --_pr-kbd-bc: transparent;
+  --_pr-kbd-btc: var(--black-400);
+  --_pr-kbd-bs: 0 var(--su1) var(--su1) hsla(210, 8%, 5%, 0.8);
+}
+body.theme-highcontrast .s-prose {
+  --_pr-blockquote-before-bg: var(--black-500);
+  --_pr-hr-bg: var(--black-400);
+}
+@media (max-width: 48.75rem) {
+  .s-prose {
+    --_pr-spoiler-after-t: calc(var(--su8) + var(--su1));
+  }
+}
+.s-prose.s-prose__sm {
+  --_pr-h1-fs: 1.75em;
+  --_pr-h2-fs: 1.375em;
+  --_pr-h3-fs: 1.25em;
+  --_pr-h4-fs: 1.125em;
+  --_pr-h5-fs: 1em;
+  --_pr-fs: var(--fs-caption);
+  --_pr-lh: var(--lh-md);
+  --_pr-code-fs: var(--fs-caption);
+}
+.s-prose *:not(.s-code-block) > a code {
+  color: var(--theme-link-color, var(--theme-secondary-400));
+}
+.s-prose *:not(.s-code-block) > code {
+  background-color: var(--black-200);
+  color: var(--black-600);
+  font-size: 0.875em;
+  padding: 0.1875em 0.375em;
+}
+.s-prose blockquote:last-child,
+.s-prose dl:last-child,
+.s-prose h1:last-child,
+.s-prose h2:last-child,
+.s-prose h3:last-child,
+.s-prose h4:last-child,
+.s-prose h5:last-child,
+.s-prose h6:last-child,
+.s-prose hr:last-child,
+.s-prose img:last-child,
+.s-prose ol:last-child,
+.s-prose p:last-child,
+.s-prose pre:last-child,
+.s-prose table:last-child,
+.s-prose ul:last-child,
+.s-prose .s-link-preview:last-child,
+.s-prose .s-table-container:last-child,
+.s-prose blockquote:only-child,
+.s-prose dl:only-child,
+.s-prose h1:only-child,
+.s-prose h2:only-child,
+.s-prose h3:only-child,
+.s-prose h4:only-child,
+.s-prose h5:only-child,
+.s-prose h6:only-child,
+.s-prose hr:only-child,
+.s-prose img:only-child,
+.s-prose ol:only-child,
+.s-prose p:only-child,
+.s-prose pre:only-child,
+.s-prose table:only-child,
+.s-prose ul:only-child,
+.s-prose .s-link-preview:only-child,
+.s-prose .s-table-container:only-child {
+  margin-bottom: 0;
+}
+.s-prose blockquote + h1,
+.s-prose dd + h1,
+.s-prose dl + h1,
+.s-prose img + h1,
+.s-prose ol + h1,
+.s-prose p + h1,
+.s-prose pre + h1,
+.s-prose table + h1,
+.s-prose ul + h1,
+.s-prose .s-link-preview + h1,
+.s-prose .s-table-container + h1 {
+  margin-top: 1.5667em;
+}
+.s-prose blockquote + h2,
+.s-prose dd + h2,
+.s-prose dl + h2,
+.s-prose img + h2,
+.s-prose ol + h2,
+.s-prose p + h2,
+.s-prose pre + h2,
+.s-prose table + h2,
+.s-prose ul + h2,
+.s-prose .s-link-preview + h2,
+.s-prose .s-table-container + h2 {
+  margin-top: 1.667em;
+}
+.s-prose blockquote + h3,
+.s-prose dd + h3,
+.s-prose dl + h3,
+.s-prose img + h3,
+.s-prose ol + h3,
+.s-prose p + h3,
+.s-prose pre + h3,
+.s-prose table + h3,
+.s-prose ul + h3,
+.s-prose .s-link-preview + h3,
+.s-prose .s-table-container + h3 {
+  margin-top: 1.4667em;
+}
+.s-prose blockquote + h4,
+.s-prose dd + h4,
+.s-prose dl + h4,
+.s-prose img + h4,
+.s-prose ol + h4,
+.s-prose p + h4,
+.s-prose pre + h4,
+.s-prose table + h4,
+.s-prose ul + h4,
+.s-prose .s-link-preview + h4,
+.s-prose .s-table-container + h4,
+.s-prose blockquote + h5,
+.s-prose dd + h5,
+.s-prose dl + h5,
+.s-prose img + h5,
+.s-prose ol + h5,
+.s-prose p + h5,
+.s-prose pre + h5,
+.s-prose table + h5,
+.s-prose ul + h5,
+.s-prose .s-link-preview + h5,
+.s-prose .s-table-container + h5,
+.s-prose blockquote + h6,
+.s-prose dd + h6,
+.s-prose dl + h6,
+.s-prose img + h6,
+.s-prose ol + h6,
+.s-prose p + h6,
+.s-prose pre + h6,
+.s-prose table + h6,
+.s-prose ul + h6,
+.s-prose .s-link-preview + h6,
+.s-prose .s-table-container + h6 {
+  margin-top: 1.6667em;
+}
+.s-prose h1,
+.s-prose h2,
+.s-prose h3,
+.s-prose h4,
+.s-prose h5,
+.s-prose h6 {
+  --_pr-code-fs: 0.9em;
+  font-weight: bold !important;
+  margin-bottom: 0.5em;
+}
+.s-prose h1 {
+  font-size: var(--_pr-h1-fs);
+  margin-bottom: 0.6em;
+}
+.s-prose h2 {
+  font-size: var(--_pr-h2-fs);
+  margin-bottom: 0.7em;
+}
+.s-prose h3 {
+  font-size: var(--_pr-h3-fs);
+  margin-bottom: 0.74em;
+}
+.s-prose h4 {
+  font-size: var(--_pr-h4-fs);
+  margin-bottom: 1em;
+}
+.s-prose h5 {
+  font-size: var(--_pr-h5-fs);
+}
+.s-prose h6 {
+  font-size: var(--_pr-h6-fs);
+}
+.s-prose a:not([class]) {
+  color: var(--theme-link-color, var(--black-600));
+  cursor: pointer;
+  user-select: auto;
+}
+.s-prose a:not([class]):active,
+.s-prose a:not([class]):hover {
+  color: var(--theme-link-color-hover, var(--blue-400));
+  text-decoration: underline !important;
+}
+.s-prose a:not([class]):visited {
+  color: var(--theme-link-color-visited, var(--black-400));
+}
+.s-prose a:not([class]):hover:visited {
+  color: var(--theme-link-color-hover, var(--blue-400));
+  text-decoration: underline !important;
+}
+.s-prose blockquote,
+.s-prose q {
+  quotes: none;
+}
+.s-prose dd,
+.s-prose dl,
+.s-prose .s-table-container,
+.s-prose .s-link-preview {
+  margin-bottom: 1.1em;
+}
+.s-prose ol,
+.s-prose ul {
+  margin-bottom: 1.1em;
+  margin-top: 0;
+}
+.s-prose ol blockquote:last-child,
+.s-prose ul blockquote:last-child,
+.s-prose ol dl:last-child,
+.s-prose ul dl:last-child,
+.s-prose ol hr:last-child,
+.s-prose ul hr:last-child,
+.s-prose ol ol:last-child,
+.s-prose ul ol:last-child,
+.s-prose ol p:last-child,
+.s-prose ul p:last-child,
+.s-prose ol table:last-child,
+.s-prose ul table:last-child,
+.s-prose ol ul:last-child,
+.s-prose ul ul:last-child,
+.s-prose ol blockquote:only-child,
+.s-prose ul blockquote:only-child,
+.s-prose ol dl:only-child,
+.s-prose ul dl:only-child,
+.s-prose ol hr:only-child,
+.s-prose ul hr:only-child,
+.s-prose ol ol:only-child,
+.s-prose ul ol:only-child,
+.s-prose ol p:only-child,
+.s-prose ul p:only-child,
+.s-prose ol table:only-child,
+.s-prose ul table:only-child,
+.s-prose ol ul:only-child,
+.s-prose ul ul:only-child {
+  margin-bottom: 0;
+}
+.s-prose ol blockquote,
+.s-prose ul blockquote,
+.s-prose ol dd,
+.s-prose ul dd,
+.s-prose ol dl,
+.s-prose ul dl,
+.s-prose ol hr,
+.s-prose ul hr,
+.s-prose ol li,
+.s-prose ul li,
+.s-prose ol ol,
+.s-prose ul ol,
+.s-prose ol p,
+.s-prose ul p,
+.s-prose ol table,
+.s-prose ul table,
+.s-prose ol ul,
+.s-prose ul ul {
+  margin-bottom: calc(1.1em / 2);
+}
+.s-prose ol li:last-child,
+.s-prose ul li:last-child {
+  margin-bottom: 0;
+}
+.s-prose ol li ol,
+.s-prose ul li ol,
+.s-prose ol li ul,
+.s-prose ul li ul {
+  margin-top: calc(1.1em / 2);
+}
+.s-prose ol pre,
+.s-prose ul pre {
+  margin-bottom: calc(calc(1.1em / 2) + 0.1em);
+}
+.s-prose sub,
+.s-prose sup {
+  --_pr-code-fs: 90%;
+}
+.s-prose blockquote {
+  --_pr-img-mb: 0;
+  color: var(--black-500);
+  margin: var(--_pr-blockquote-mt) 1em 1.1em var(--_pr-blockquote-ml);
+  padding: 0.8em 0.8em 0.8em 1em;
+  position: relative;
+}
+.s-prose blockquote:before {
+  background: var(--_pr-blockquote-before-bg);
+  border-radius: var(--su8);
+  bottom: 0;
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: var(--su4);
+}
+.s-prose blockquote *:last-child {
+  margin-bottom: 0;
+}
+.s-prose blockquote blockquote {
+  --_pr-blockquote-ml: 0;
+}
+.s-prose code {
+  font-size: var(--_pr-code-fs);
+  font-family: var(--ff-mono);
+}
+.s-prose dd {
+  margin: 0;
+  padding: 0;
+}
+.s-prose dd:last-child {
+  margin-bottom: 0;
+}
+.s-prose dl {
+  margin-top: 0;
+}
+.s-prose dt {
+  font-weight: bold;
+}
+.s-prose hr {
+  background-color: var(--_pr-hr-bg);
+  color: var(--_pr-hr-bg);
+  border: 0;
+  height: var(--su1);
+  margin-bottom: 1.1em;
+}
+.s-prose img {
+  margin-bottom: var(--_pr-img-mb);
+  max-width: 100%;
+  vertical-align: bottom;
+}
+.s-prose kbd {
+  border: var(--su1) solid var(--_pr-kbd-bc);
+  border-top-color: var(--_pr-kbd-btc, var(--_pr-kbd-bc));
+  box-shadow: var(--_pr-kbd-bs);
+  background-color: var(--black-200);
+  border-radius: var(--br-md);
+  color: var(--black-600);
+  display: inline-block;
+  font-family: var(--ff-sans);
+  font-size: var(--fs-fine);
+  line-height: var(--_pr-lh);
+  margin: 0 0.1em;
+  overflow-wrap: break-word;
+  padding: 0.1em 0.6em;
+  text-shadow: 0 var(--su1) 0 var(--white);
+}
+.s-prose li {
+  --_pr-blockquote-mt: calc(1.1em / 2);
+  --_pr-img-mb: 0;
+  overflow-wrap: break-word;
+}
+.s-prose li pre {
+  overflow-wrap: normal;
+}
+.s-prose p {
+  --_pr-img-mb: 0;
+  margin-bottom: 1.1em;
+}
+.s-prose p a:not([class]) {
+  text-decoration: underline;
+}
+.s-prose pre {
+  margin-top: 0;
+  margin-bottom: calc(1.1em + 0.4em);
+  overflow-wrap: normal;
+}
+.s-prose pre:not(.s-code-block) {
+  scrollbar-color: var(--scrollbar) transparent;
+  background-color: var(--highlight-bg);
+  border-radius: var(--br-md);
+  color: var(--highlight-color);
+  font-size: var(--fs-body1);
+  line-height: var(--lh-md);
+  max-height: 600px;
+  overflow: auto;
+  padding: var(--su12);
+  width: auto;
+}
+.s-prose pre:not(.s-code-block) code {
+  background-color: transparent;
+  border-radius: 0;
+  padding: 0;
+}
+.s-prose pre:not(.s-code-block)::-webkit-scrollbar {
+  width: calc(var(--su12) - var(--su2));
+  height: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.s-prose pre:not(.s-code-block)::-webkit-scrollbar-track {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.s-prose pre:not(.s-code-block)::-webkit-scrollbar-thumb {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: var(--scrollbar);
+}
+.s-prose pre:not(.s-code-block)::-webkit-scrollbar-corner {
+  background-color: transparent;
+  border-color: transparent;
+}
+.s-prose .soundcloud-embed iframe {
+  height: 116px;
+  max-width: 640px;
+  width: 100%;
+}
+.s-prose .spoiler {
+  cursor: var(--_pr-spoiler-cursor);
+  background: var(--black-150);
+  border-radius: var(--br-md);
+  color: var(--black-600);
+  min-height: var(--su48);
+}
+.s-prose .spoiler:after {
+  opacity: var(--_pr-soiler-after-o);
+  top: var(--_pr-spoiler-after-t);
+  transition: opacity 0.1s ease-in-out;
+  background-image: url("data:image/svg+xml;,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='rgb(132, 141, 149)' width='18' height='18' viewBox='0 0 18 18'%3E%3Cpath d='M9 17A8 8 0 119 1a8 8 0 010 16zM8 4v6h2V4H8zm0 8v2h2v-2H8z'%3E%3C/path%3E%3C/svg%3E");
+  background-position: center right;
+  background-repeat: no-repeat;
+  color: var(--black-400);
+  content: attr(data-spoiler) " ";
+  font-size: var(--fs-body1);
+  padding-right: calc(var(--su24) - var(--su2));
+  pointer-events: none;
+  position: absolute;
+  right: 1em;
+}
+.s-prose .spoiler.is-visible {
+  --_pr-spoiler-cursor: auto;
+  --_pr-soiler-after-o: 0;
+  --_pr-soiler-child-o: 1;
+  --_pr-soiler-child-visibility: visible;
+}
+.s-prose .spoiler > * {
+  opacity: var(--_pr-soiler-child-o);
+  transition: var(--_pr-spoiler-transition);
+  visibility: var(--_pr-soiler-child-visibility);
+}
+.s-prose .youtube-embed {
+  max-width: 640px;
+  position: relative;
+  width: 100%;
+}
+.s-prose .youtube-embed > div {
+  height: 35px;
+  padding-bottom: 56.25%;
+  position: relative;
+  width: 100%;
+}
+.s-prose .youtube-embed > div iframe {
+  height: 100%;
+  position: absolute;
+  width: 100%;
+}
+.s-select {
+  --_se-arrow-fc: currentColor;
+  --_se-select-bc: var(--bc-darker);
+  --_se-select-bg: var(--white);
+  --_se-select-br: var(--br-md);
+  --_se-select-fc: var(--black);
+  --_se-select-px: 0.7em;
+  --_se-select-py: var(--su8);
+  --_se-select-fs: var(--fs-body1);
+  --_se-select-lh: var(--lh-base);
+  color: var(--fc-dark);
+  position: relative;
+}
+@supports (-webkit-overflow-scrolling: touch) {
+  .s-select {
+    --_se-select-fs: var(--su16);
+    --_se-select-px: 0.55em;
+    --_se-select-py: 0.4em;
+  }
+}
+.is-disabled .s-select,
+.is-readonly .s-select,
+.has-success .s-select,
+.has-error .s-select,
+.has-warning .s-select {
+  position: relative;
+}
+.has-error .s-select,
+.has-success .s-select,
+.has-warning .s-select {
+  --_se-select-bc-focus: var(--_se-select-bc);
+}
+.has-error .s-select {
+  --_se-select-bc: var(--red-400);
+}
+.has-success .s-select {
+  --_se-select-bc: var(--green-400);
+}
+.has-warning .s-select {
+  --_se-select-bc: var(--yellow-500);
+}
+.s-select.s-select__sm {
+  --_se-select-fs: var(--fs-caption);
+  --_se-select-lh: var(--lh-sm);
+  --_se-select-py: calc(var(--su6) - var(--su1) / 2);
+}
+.s-select.s-select__lg {
+  --_se-select-fs: var(--fs-body3);
+  --_se-select-lh: var(--lh-lg);
+}
+select.s-select:-webkit-autofill,
+.s-select > select:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 1000px var(--theme-secondary-200) inset;
+  -webkit-text-fill-color: var(--black);
+  border-color: var(--blue-400);
+  transition: background-color 0s 50000s;
+}
+select.s-select:-webkit-autofill:focus,
+.s-select > select:-webkit-autofill:focus {
+  border-color: var(--blue-400);
+  -webkit-box-shadow: 0 0 0 1000px var(--blue-200) inset, 0 0 0 var(--su4) var(--focus-ring);
+}
+select.s-select::-webkit-contacts-auto-fill-button,
+.s-select > select::-webkit-contacts-auto-fill-button {
+  background-color: var(--black);
+}
+.s-select:after {
+  background-color: currentColor;
+  content: "";
+  height: var(--su16);
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpath d='M13.06 10 8 15.06 2.94 10 4 8.94l.53.53L8 12.94l3.47-3.47.53-.53zm0-4L12 7.06l-.53-.53L8 3.06 4.53 6.53 4 7.06 2.94 6 8 .94z'/%3E%3C/svg%3E");
+  mask-repeat: no-repeat;
+  mask-position: center;
+  mask-size: contain;
+  pointer-events: none;
+  position: absolute;
+  right: calc(var(--su32) - var(--su24));
+  top: 50%;
+  transform: translateY(-50%);
+  width: var(--su16);
+  z-index: var(--zi-selected);
+}
+.is-disabled .s-select {
+  --_se-arrow-fc: var(--bc-dark);
+}
+.is-disabled .s-select:after {
+  background-color: var(--_se-arrow-fc);
+}
+.s-select > select {
+  background-color: var(--_se-select-bg);
+  border: var(--su1) solid var(--_se-select-bc);
+  border-radius: var(--_se-select-br);
+  color: var(--_se-select-fc);
+  font-size: var(--_se-select-fs);
+  padding: var(--_se-select-py) var(--_se-select-px);
+  appearance: none;
+  font-family: inherit;
+  height: 100%;
+  line-height: var(--_se-select-lh);
+  outline: 0;
+  padding-right: var(--su32);
+  position: relative;
+  width: 100%;
+}
+fieldset[disabled] .s-select > select,
+.s-select > select[disabled] {
+  cursor: not-allowed;
+  --_se-select-fc: var(--black-300);
+  --_se-select-bg: var(--black-100);
+}
+.s-select > select[readonly],
+.is-readonly .s-select > select {
+  --_se-select-bc: var(--bc-light);
+  --_se-select-bg: var(--black-150);
+  --_se-select-fc: var(--black-300);
+  cursor: not-allowed;
+}
+body.theme-highcontrast .s-select > select[readonly],
+body.theme-highcontrast .is-readonly .s-select > select {
+  --_se-select-fc: var(--fc-light);
+}
+.s-select > select:focus {
+  box-shadow: 0 0 0 var(--su2) var(--focus-neutral), 0 0 0 var(--su4) var(--focus-theme);
+  outline: var(--su2) solid transparent !important;
+}
+.s-select > select:focus,
+.s-select > select.focus {
+  color: var(--black);
+}
+.s-select .s-input-icon {
+  right: var(--su32);
+}
+.s-sidebarwidget {
+  font-size: var(--fs-body1);
+}
+.s-sidebarwidget .s-sidebarwidget--content {
+  display: flex;
+  padding: var(--su12) 0 var(--su16) 0;
+  font-size: var(--fs-body2);
+}
+.s-sidebarwidget .s-sidebarwidget--content .s-sidebarwidget--action {
+  font-size: var(--fs-fine);
+  margin-left: var(--su16);
+  align-self: flex-start;
+}
+.s-sidebarwidget .s-sidebarwidget--header {
+  align-items: center;
+  display: flex;
+  padding: var(--su4) 0;
+}
+.s-sidebarwidget .s-sidebarwidget--header > h1,
+.s-sidebarwidget .s-sidebarwidget--header h2,
+.s-sidebarwidget .s-sidebarwidget--header h3,
+.s-sidebarwidget .s-sidebarwidget--header h4,
+.s-sidebarwidget .s-sidebarwidget--header h5,
+.s-sidebarwidget .s-sidebarwidget--header h6 {
+  margin: 0;
+  padding-right: var(--su6);
+  font-size: var(--fs-body1);
+  font-weight: 500;
+}
+.s-sidebarwidget .s-sidebarwidget--header .s-sidebarwidget--action {
+  margin-left: auto;
+}
+.s-sidebarwidget .s-sidebarwidget--footer {
+  display: flex;
+  font-size: var(--fs-body2);
+}
+.s-sidebarwidget .s-sidebarwidget--footer .s-sidebarwidget--action {
+  flex: 1;
+}
+.s-sidebarwidget .s-sidebarwidget--action:is(a, button) {
+  white-space: nowrap;
+}
+.s-table {
+  --_ta-tbody-tbody-bc: var(--bc-medium);
+  --_ta-tbody-tbody-bw: var(--su2);
+  --_ta-tbody-tr-even-bg: unset;
+  --_ta-td-bbw: 0;
+  --_ta-td-bc: var(--bc-medium);
+  --_ta-td-fs: unset;
+  --_ta-td-fw: unset;
+  --_ta-td-p: var(--su8);
+  --_ta-td-ta: left;
+  --_ta-td-va: middle;
+  --_ta-td-w: unset;
+  --_ta-thead-th-bg: var(--black-100);
+  --_ta-th-bbw: 0;
+  --_ta-th-bc: var(--bc-medium);
+  --_ta-th-fs: unset;
+  --_ta-th-p: var(--su8);
+  --_ta-th-ta: left;
+  --_ta-th-va: middle;
+  --_ta-th-w: unset;
+  border-collapse: collapse;
+  border-spacing: 0;
+  display: table;
+  font-size: var(--fs-body1);
+  max-width: 100%;
+  width: 100%;
+}
+body.theme-highcontrast .s-table a[href] {
+  text-decoration: underline;
+}
+.s-table.s-table__stripes {
+  --_ta-tbody-tr-even-bg: var(--black-100);
+  --_ta-thead-th-bg: var(--black-150);
+}
+.s-table.ta-center {
+  --_ta-td-ta: center;
+  --_ta-th-ta: center;
+}
+.s-table.ta-left {
+  --_ta-td-ta: left;
+  --_ta-th-ta: left;
+}
+.s-table.ta-justify {
+  --_ta-td-ta: justify;
+  --_ta-th-ta: justify;
+}
+.s-table.ta-right {
+  --_ta-td-ta: right;
+  --_ta-th-ta: right;
+}
+.s-table.va-bottom {
+  --_ta-td-va: bottom;
+  --_ta-th-va: bottom;
+}
+.s-table.va-middle {
+  --_ta-td-va: middle;
+  --_ta-th-va: middle;
+}
+.s-table.va-top {
+  --_ta-td-va: top;
+  --_ta-th-va: top;
+}
+.s-table.s-table__b0 {
+  --_ta-td-bc: transparent;
+  --_ta-th-bc: transparent;
+  --_ta-tbody-tbody-bc: transparent;
+  --_ta-tbody-tbody-bw: var(--su12);
+  --_ta-thead-th-bg: transparent;
+}
+.s-table.s-table__b0 thead th {
+  font-size: inherit;
+  text-transform: initial;
+  letter-spacing: initial;
+}
+.s-table.s-table__bx tr > *:not(:first-child) {
+  border-left-color: transparent;
+}
+.s-table.s-table__bx tr > *:not(:last-child) {
+  border-right-color: transparent;
+}
+.s-table.s-table__bx-simple {
+  --_ta-thead-th-bg: transparent;
+  --_ta-foot-td-bc: transparent;
+  --_ta-foot-th-bc: transparent;
+}
+.s-table.s-table__bx-simple td,
+.s-table.s-table__bx-simple th {
+  border-left-color: transparent;
+  border-right-color: transparent;
+}
+.s-table.s-table__bx-simple tbody tr:first-of-type th,
+.s-table.s-table__bx-simple tbody tr:first-of-type td {
+  border-top-color: transparent;
+}
+.s-table.s-table__bx-simple tbody tr:last-of-type th,
+.s-table.s-table__bx-simple tbody tr:last-of-type td {
+  border-bottom-color: transparent;
+}
+.s-table.s-table__bx-simple thead th {
+  border-top-color: transparent;
+  border-bottom-color: var(--bc-dark);
+  font-size: inherit;
+  text-transform: initial;
+  letter-spacing: initial;
+}
+.s-table.s-table__sortable thead th {
+  color: var(--fc-light);
+  cursor: pointer;
+}
+.s-table.s-table__sortable thead th a,
+.s-table.s-table__sortable thead th button {
+  color: inherit !important;
+}
+.s-table.s-table__sortable thead th button {
+  appearance: none;
+  background-color: transparent;
+  border: 0;
+  cursor: pointer;
+  display: flex;
+  gap: var(--su4);
+  font-weight: inherit;
+  margin: calc(var(--_ta-th-p) * -1);
+  padding: var(--_ta-th-p);
+  text-align: left;
+  width: calc(100% + calc(var(--_ta-th-p) * 2));
+}
+.s-table.s-table__sortable thead th.is-sorted {
+  color: var(--black-600);
+}
+.s-table.s-table__sm {
+  --_ta-td-p: var(--su4);
+  --_ta-th-p: var(--su4);
+}
+.s-table.s-table__lg {
+  --_ta-td-p: var(--su12);
+  --_ta-th-p: var(--su12);
+}
+.s-table td,
+.s-table tr {
+  color: var(--theme-link-color, var(--black-600));
+  text-decoration: none;
+  cursor: pointer;
+}
+.s-table td a:not([class]):active,
+.s-table tr a:not([class]):active,
+.s-table td a:not([class]):hover,
+.s-table tr a:not([class]):hover {
+  color: var(--theme-link-color-hover, var(--blue-400));
+  text-decoration: underline;
+}
+.s-table td a:not([class]):visited,
+.s-table tr a:not([class]):visited {
+  color: var(--theme-link-color-visited, var(--black-400));
+}
+.s-table td a:not([class]):hover:visited,
+.s-table tr a:not([class]):hover:visited {
+  color: var(--theme-link-color-hover, var(--blue-400));
+}
+.s-table .s-table--cell1 {
+  --_ta-td-w: 8.33333333%;
+  --_ta-th-w: 8.33333333%;
+}
+.s-table .s-table--cell2 {
+  --_ta-td-w: 16.66666667%;
+  --_ta-th-w: 16.66666667%;
+}
+.s-table .s-table--cell3 {
+  --_ta-td-w: 25%;
+  --_ta-th-w: 25%;
+}
+.s-table .s-table--cell4 {
+  --_ta-td-w: 33.33333333%;
+  --_ta-th-w: 33.33333333%;
+}
+.s-table .s-table--cell5 {
+  --_ta-td-w: 41.66666667%;
+  --_ta-th-w: 41.66666667%;
+}
+.s-table .s-table--cell6 {
+  --_ta-td-w: 50%;
+  --_ta-th-w: 50%;
+}
+.s-table .s-table--cell7 {
+  --_ta-td-w: 58.33333333%;
+  --_ta-th-w: 58.33333333%;
+}
+.s-table .s-table--cell8 {
+  --_ta-td-w: 66.66666667%;
+  --_ta-th-w: 66.66666667%;
+}
+.s-table .s-table--cell9 {
+  --_ta-td-w: 75%;
+  --_ta-th-w: 75%;
+}
+.s-table .s-table--cell10 {
+  --_ta-td-w: 83.33333333%;
+  --_ta-th-w: 83.33333333%;
+}
+.s-table .s-table--cell11 {
+  --_ta-td-w: 91.66666667%;
+  --_ta-th-w: 91.66666667%;
+}
+.s-table .s-table--cell12 {
+  --_ta-td-w: 100%;
+  --_ta-th-w: 100%;
+}
+.s-table .s-table--totals {
+  --_ta-td-fs: var(--fs-subheading);
+  --_ta-td-pt: var(--su12);
+  --_ta-td-fw: bold;
+  --_ta-th-fs: var(--fs-subheading);
+  --_ta-th-pt: var(--su12);
+}
+.s-table tbody + tbody {
+  border-top: var(--_ta-tbody-tbody-bw) solid var(--_ta-tbody-tbody-bc);
+}
+.s-table tbody th {
+  font-weight: normal;
+}
+.s-table tbody tr:nth-child(2n) {
+  background-color: var(--_ta-tbody-tr-even-bg);
+}
+.s-table td {
+  border: var(--su1) solid var(--_ta-td-bc);
+  border-bottom-width: var(--_ta-td-bbw, var(--su1));
+  border-left-width: var(--_ta-td-blw, var(--su1));
+  border-right-width: var(--_ta-td-brw, var(--su1));
+  border-top-width: var(--_ta-td-btw, var(--su1));
+  font-size: var(--_ta-td-fs);
+  font-weight: var(--_ta-td-fw);
+  padding: var(--_ta-td-p);
+  padding-left: var(--_ta-td-pl, var(--_ta-td-p));
+  padding-top: var(--_ta-td-pt, var(--_ta-td-p));
+  text-align: var(--_ta-td-ta);
+  vertical-align: var(--_ta-td-va);
+  width: var(--_ta-td-w);
+  color: var(--fc-medium);
+}
+.s-table td.s-table--bulk {
+  --_ta-td-w: calc(var(--su32) - var(--su2));
+}
+.s-table td.s-table--progress {
+  --_ta-td-ta: right;
+  --_ta-td-brw: 0;
+}
+.s-table td.s-table--progress-bar {
+  --_ta-td-blw: 0;
+  --_ta-td-pl: 0;
+  --_ta-td-w: calc(var(--su12) * 10);
+}
+.s-table tfoot td {
+  border-bottom-color: var(--_ta-foot-td-bc, var(--_ta-td-bc));
+}
+.s-table tfoot th {
+  border-bottom-color: var(--_ta-foot-th-bc, var(--_ta-td-bc));
+}
+.s-table th {
+  border: var(--su1) solid var(--_ta-th-bc);
+  border-width: var(--su1) var(--su1) var(--_ta-th-bbw);
+  font-size: var(--_ta-th-fs);
+  padding: var(--_ta-th-p);
+  padding-top: var(--_ta-th-pt, var(--_ta-th-p));
+  text-align: var(--_ta-th-ta);
+  vertical-align: var(--_ta-th-va);
+  width: var(--_ta-th-w);
+  color: var(--fc-dark);
+  font-weight: bold;
+}
+.s-table th.s-table--bulk {
+  --_ta-th-w: calc(var(--su32) - var(--su2));
+}
+.s-table thead th {
+  background-color: var(--_ta-thead-th-bg);
+  line-height: var(--lh-sm);
+  vertical-align: bottom;
+  white-space: nowrap;
+}
+.s-table tr:last-of-type {
+  --_ta-td-bbw: var(--su1);
+  --_ta-th-bbw: var(--su1);
+}
+.s-table tr.is-disabled {
+  background-color: var(--black-100);
+  --_ta-tbody-tr-even-bg: var(--black-100);
+}
+.s-table tr.is-disabled th:not(.is-enabled),
+.s-table tr.is-disabled td:not(.is-enabled) {
+  opacity: calc(var(--_o-disabled) * 0.6);
+}
+.tl-fixed {
+  table-layout: fixed !important;
+}
+.tl-auto {
+  table-layout: auto !important;
+}
+.s-table-container {
+  overflow-x: auto;
+  scrollbar-color: var(--scrollbar) transparent;
+}
+.s-table-container::-webkit-scrollbar {
+  width: calc(var(--su12) - var(--su2));
+  height: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.s-table-container::-webkit-scrollbar-track {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: transparent;
+}
+.s-table-container::-webkit-scrollbar-thumb {
+  border-radius: calc(var(--su12) - var(--su2));
+  background-color: var(--scrollbar);
+}
+.s-table-container::-webkit-scrollbar-corner {
+  background-color: transparent;
+  border-color: transparent;
+}
+.s-tag {
+  --_ta-bc: var(--theme-tag-border-color, var(--_ta-bg));
+  --_ta-bg: var(--theme-tag-background-color, var(--black-150));
+  --_ta-fc: var(--theme-tag-color, var(--black-600));
+  --_ta-bc-hover: var(--theme-tag-hover-border-color, var(--_ta-bg-hover));
+  --_ta-bg-hover: var(--theme-tag-hover-background-color, var(--black-200));
+  --_ta-fc-hover: var(--theme-tag-hover-color, var(--black-600));
+  --_ta-fs: var(--fs-caption);
+  --_ta-pb: calc(var(--_ta-pt) + var(--su1));
+  --_ta-pl: var(--su8);
+  --_ta-pr: var(--su8);
+  --_ta-pt: var(--su4);
+  background-color: var(--_ta-bg);
+  border: var(--su1) solid var(--_ta-bc);
+  color: var(--_ta-fc);
+  font-size: var(--_ta-fs);
+  padding: var(--_ta-pt) var(--_ta-pr) var(--_ta-pb) var(--_ta-pl);
+  align-items: center;
+  display: inline-flex;
+  gap: var(--su4);
+  justify-content: center;
+  line-height: var(--lh-xs);
+  text-decoration: none;
+  white-space: nowrap;
+}
+body.theme-highcontrast .s-tag:is(a),
+body.theme-highcontrast .s-tag a[href] {
+  text-decoration: underline;
+}
+body.theme-highcontrast .s-tag:not(body.theme-highcontrast .s-tag__moderator):not(body.theme-highcontrast .s-tag__required) {
+  --_ta-bc: var(--theme-tag-border-color, var(--black-300));
+  --_ta-bc-hover: var(--theme-tag-hover-border-color, var(--black-300));
+}
+body.theme-highcontrast .s-tag:not(body.theme-highcontrast .s-tag__moderator):not(body.theme-highcontrast .s-tag__required).s-tag__ignored {
+  --_ta-fc: var(--black-500);
+}
+.s-tag.s-tag__sm {
+  --_ta-pl: var(--su4);
+  --_ta-pr: var(--su4);
+  --_ta-pt: var(--su1);
+}
+.s-tag.s-tag__lg {
+  --_ta-fs: var(--fs-body1);
+  --_ta-pt: var(--su4);
+}
+.s-tag.s-tag__ignored:before,
+.s-tag.s-tag__watched:before {
+  -webkit-mask: var(--_ta-before-icon) no-repeat center;
+  mask: var(--_ta-before-icon) no-repeat center;
+  background-color: currentColor;
+  content: "";
+  display: block;
+  height: calc(var(--su16) - var(--su2));
+  -webkit-mask-size: contain;
+  mask-size: contain;
+  width: calc(var(--su16) - var(--su2));
+}
+.s-tag.s-tag__deleted,
+.s-tag.s-tag__ignored,
+.s-tag.s-tag__deleted.s-tag__required:not(.s-tag.s-tag__deleted__moderator),
+.s-tag.s-tag__ignored.s-tag__required:not(.s-tag.s-tag__deleted__moderator),
+.s-tag.s-tag__deleted.s-tag__required:not(.s-tag.s-tag__ignored__moderator),
+.s-tag.s-tag__ignored.s-tag__required:not(.s-tag.s-tag__ignored__moderator),
+.s-tag.s-tag__deleted.s-tag__moderator,
+.s-tag.s-tag__ignored.s-tag__moderator {
+  --_ta-bc-hover: var(--_ta-bc);
+  --_ta-bg-hover: var(--_ta-bg);
+  --_ta-fc-hover: var(--_ta-fc);
+}
+.s-tag.s-tag__deleted {
+  --_ta-fc: var(--black-500);
+}
+.s-tag.s-tag__deleted.s-tag__required:not(.s-tag.s-tag__deleted__moderator) {
+  --_ta-bc: var(--black-300);
+  --_ta-fc: var(--black-400);
+}
+.s-tag.s-tag__ignored {
+  --_ta-bg-hover: var(--_ta-bg);
+  --_ta-before-icon: url("data:image/svg+xml;,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14'%3E%3Cpath d='M3.52 7.38 1.58 9.26A12.38 12.38 0 0 1 0 7s2.63-5.14 7.05-5.14c.66 0 1.28.12 1.86.32L7.44 3.6a3.48 3.48 0 0 0-3.92 3.78ZM5.3 9.99c.5.28 1.1.44 1.71.44 1.94 0 3.5-1.53 3.5-3.43 0-.62-.17-1.21-.47-1.72L8.7 6.6a1.73 1.73 0 0 1-2.08 2.07L5.29 10Zm6.23-6.19A12.7 12.7 0 0 1 14 7s-2.63 5.14-6.95 5.14A6.1 6.1 0 0 1 4 11.3L2.27 13l-1.4-1.36L11.9 1l1.23 1.2-1.6 1.6Z'/%3E%3C/svg%3E");
+  --_ta-fc: var(--black-400);
+  --_ta-fc-hover: var(--black-400);
+}
+.s-tag.s-tag__moderator {
+  --_ta-bc: var(--orange-300);
+  --_ta-bg: var(--orange-100);
+  --_ta-fc: var(--orange-500);
+  --_ta-bc-hover: var(--orange-300);
+  --_ta-bg-hover: var(--orange-200);
+  --_ta-fc-hover: var(--orange-600);
+}
+.s-tag.s-tag__required:not(.s-tag__moderator) {
+  --_ta-bc: var(--theme-tag-required-border-color, var(--theme-tag-border-color, var(--black-500)));
+  --_ta-bc-hover: var(--theme-tag-required-hover-border-color, var(--theme-tag-hover-border-color, var(--black-600)));
+}
+.s-tag.s-tag__watched {
+  --_ta-before-icon: url("data:image/svg+xml;,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='12' viewBox='0 0 14 12'%3E%3Cpath d='M7.05 1C2.63 1 0 6.5 0 6.5S2.63 12 7.05 12C11.38 12 14 6.5 14 6.5S11.37 1 7.05 1ZM7 10.17A3.59 3.59 0 0 1 3.5 6.5 3.6 3.6 0 0 1 7 2.83c1.94 0 3.5 1.65 3.5 3.67A3.57 3.57 0 0 1 7 10.17Zm0-1.84c.97 0 1.75-.81 1.75-1.83S7.97 4.67 7 4.67s-1.75.81-1.75 1.83S6.03 8.33 7 8.33Z'/%3E%3C/svg%3E");
+}
+.s-tag a {
+  color: var(--_ta-fc) !important;
+  margin: calc(var(--_ta-pt) * -1) calc(var(--_ta-pr) * -1) calc(var(--_ta-pb) * -1) calc(var(--_ta-pl) * -1);
+  padding: var(--_ta-pt) var(--_ta-pr) var(--_ta-pb) var(--_ta-pl);
+}
+.s-tag a:focus-visible {
+  box-shadow: 0 0 0 var(--su2) var(--focus-neutral), 0 0 0 var(--su4) var(--focus-theme);
+  outline: var(--su2) solid transparent !important;
+}
+.s-tag:has( > .s-tag--dismiss) {
+  --_ta-pr: var(--su2);
+}
+.s-tag .s-tag--dismiss {
+  all: unset;
+  align-items: center;
+  background-color: transparent;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  margin: calc(var(--_ta-pt) * -1) 0 calc(var(--_ta-pb) * -1);
+  padding: var(--su2);
+}
+.s-tag .s-tag--dismiss:focus-visible {
+  box-shadow: 0 0 0 var(--su2) var(--focus-neutral), 0 0 0 var(--su4) var(--focus-theme);
+  outline: var(--su2) solid transparent !important;
+}
+.s-tag .s-tag--dismiss:hover {
+  background-color: var(--_ta-fc);
+  color: var(--_ta-bg);
+}
+.s-tag:has( > .s-tag--sponsor) {
+  --_ta-pl: var(--su2);
+}
+.s-tag .s-tag--sponsor {
+  max-width: calc(var(--su16) + var(--su2));
+  margin: calc(var(--_ta-pt) * -1) 0 calc(var(--_ta-pb) * -1) 0;
+}
+.s-tag .s-tag--sponsor img,
+.s-tag .s-tag--sponsor .svg-icon {
+  width: 100%;
+  height: 100%;
+}
+.s-tag:has([href]),
+.s-tag a {
+  text-decoration: none;
+}
+.s-tag a:not([class]):hover,
+.s-tag a:not([class]):active {
+  background-color: var(--_ta-bg-hover);
+  border-color: var(--_ta-bc-hover);
+  color: var(--_ta-fc-hover);
+}
+.s-tag:focus-visible {
+  border-color: var(--focus-neutral) !important;
+  box-shadow: 0 0 0 var(--su1) var(--focus-neutral), 0 0 0 var(--su3) var(--focus-theme);
+  outline: var(--su2) solid transparent !important;
+}
+.s-toast {
+  display: flex;
+  justify-content: center;
+  left: var(--su8);
+  opacity: 0;
+  pointer-events: none;
+  position: fixed;
+  right: var(--su8);
+  top: var(--su16);
+  transform: translate3d(0, -66px, 0);
+  transition: transform 100ms var(--te-smooth-slow) 0s, opacity 60ms var(--te-smooth-slow) 0ms, visibility 0s 150ms;
+  visibility: hidden;
+  z-index: calc(var(--zi-modals) + 1);
+}
+@media (prefers-reduced-motion) {
+  .s-toast {
+    transform: none !important;
+  }
+}
+.s-toast[aria-hidden="false"] {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+  transition: visibility 0s 0s, opacity 100ms var(--te-smooth) 0s, transform 100ms var(--te-smooth) 0s;
+  visibility: visible;
+}
+.s-toast .s-notice {
+  box-shadow: var(--bs-sm);
+  max-width: 38.5rem;
+  padding-bottom: var(--su8);
+  padding-top: var(--su8);
+  pointer-events: all;
+  display: flex;
+  align-items: center;
+  min-width: var(--su448);
+}
+.s-toggle-switch {
+  --_ts-bg: var(--black-300);
+  --_ts-bg-image: url("data:image/svg+xml;,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23ffffff'/%3e%3c/svg%3e");
+  --_ts-bg-ps: left center;
+  --_ts-multiple-bg: unset;
+  --_ts-multiple-fc: var(--black-400);
+}
+@media (prefers-color-scheme: dark) {
+  body.theme-system .s-toggle-switch {
+    --_ts-bg-image: url("data:image/svg+xml;,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23141414'/%3e%3c/svg%3e");
+  }
+}
+body.theme-dark .s-toggle-switch,
+.theme-dark__forced .s-toggle-switch,
+body.theme-system .theme-dark__forced .s-toggle-switch {
+  --_ts-bg-image: url("data:image/svg+xml;,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23141414'/%3e%3c/svg%3e");
+}
+fieldset[disabled] .s-toggle-switch,
+.s-toggle-switch[disabled],
+fieldset[disabled] .s-toggle-switch label,
+.s-toggle-switch[disabled] label {
+  cursor: not-allowed;
+  opacity: var(--_o-disabled-static);
+}
+.s-toggle-switch.s-toggle-switch__multiple {
+  align-items: stretch;
+  display: flex;
+  border: var(--su2) solid var(--black-150);
+  border-radius: var(--br-pill);
+  background-color: var(--black-150);
+}
+.s-toggle-switch.s-toggle-switch__multiple input[type="radio"] {
+  left: -999em;
+  margin: 0;
+  opacity: 0;
+  position: absolute;
+}
+.s-toggle-switch.s-toggle-switch__multiple input[type="radio"]:checked + label {
+  --_ts-multiple-bg: var(--black-050);
+  --_ts-multiple-fc: var(--black);
+}
+.s-toggle-switch.s-toggle-switch__multiple input[type="radio"]:not(:checked) + label {
+  --_ts-multiple-fc: var(--black-400);
+}
+.s-toggle-switch.s-toggle-switch__multiple input[type="radio"]:focus-visible + label {
+  box-shadow: inset 0 0 0 var(--su2) var(--focus-theme), inset 0 0 0 var(--su4) var(--focus-neutral);
+  outline: var(--su2) solid transparent !important;
+}
+.s-toggle-switch.s-toggle-switch__multiple label {
+  background-color: var(--_ts-multiple-bg);
+  color: var(--_ts-multiple-fc);
+  border-radius: var(--br-pill);
+  cursor: pointer;
+  font-size: var(--fs-body1);
+  font-weight: 400;
+  line-height: 1;
+  margin: 0;
+  padding: calc(var(--su4) + var(--su1)) calc(var(--su8) + var(--su2));
+  text-align: center;
+  white-space: nowrap;
+  width: 100%;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+input[type="checkbox"].s-toggle-switch {
+  background-color: var(--_ts-bg);
+  background-position: var(--_ts-bg-ps);
+  appearance: none;
+  background-image: var(--_ts-bg-image);
+  background-size: contain;
+  background-repeat: no-repeat;
+  border-radius: 1000px;
+  cursor: pointer;
+  flex-shrink: 0;
+  height: var(--su24);
+  margin: 0;
+  transition: background-position 0.2s ease;
+  vertical-align: top;
+  width: calc(var(--su48) - var(--su4));
+}
+input[type="checkbox"].s-toggle-switch:checked {
+  --_ts-bg: var(--green-400);
+  --_ts-bg-ps: right center;
+}
+input[type="checkbox"].s-toggle-switch:focus-visible {
+  box-shadow: 0 0 0 var(--su2) var(--focus-neutral), 0 0 0 var(--su4) var(--focus-theme);
+  outline: var(--su2) solid transparent !important;
+}
+input[type="checkbox"].s-toggle-switch[disabled] {
+  cursor: default;
+}
+.s-user-card {
+  --_uc-ai: center;
+  --_uc-fd: unset;
+  --_uc-column-gap: var(--su6);
+  --_uc-group-gap: var(--su4);
+  --_uc-row-gap: var(--su6);
+  --_uc-username-fs: unset;
+  --_uc-username-p: unset;
+  --_uc-username-bl: unset;
+  --_uc-username-bg: unset;
+  --_uc-username-fc: var(--black-600);
+  --_uc-username-d: unset;
+  --_uc-username-ai: unset;
+  align-items: var(--_uc-ai);
+  color: var(--black-500);
+  display: flex;
+  flex-direction: var(--_uc-fd);
+  flex-wrap: wrap;
+  font-size: var(--fs-caption);
+  gap: var(--su6);
+}
+body.theme-highcontrast .s-user-card a[href] {
+  text-decoration: underline;
+}
+.s-user-card.s-user-card__lg {
+  --_uc-ai: flex-start;
+  --_uc-fd: column;
+  --_uc-username-fs: var(--fs-body3);
+}
+.s-user-card.s-user-card__lg .s-avatar {
+  margin-right: var(--su6);
+}
+.s-user-card.s-user-card__lg .s-user-card--username {
+  margin-right: var(--su2);
+}
+.s-user-card.s-user-card__lg .s-user-card--group:has(> .s-user-card--rep) {
+  margin-top: var(--sun2);
+}
+.s-user-card.s-user-card__deleted {
+  --_uc-username-fc: var(--black-400);
+}
+.s-user-card a {
+  text-decoration: none;
+}
+.s-user-card .s-user-card--bio {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  color: var(--black-400);
+}
+.s-user-card .s-user-card--recognition {
+  --_uc-row-gap: var(--su4);
+}
+.s-user-card .s-user-card--recognition,
+.s-user-card .s-user-card--recognition a {
+  color: var(--theme-primary);
+}
+.s-user-card .s-user-card--recognition-additional-bling,
+.s-user-card .s-user-card--recognition-additional-bling a {
+  color: var(--theme-primary);
+}
+.s-user-card .s-user-card--rep {
+  color: var(--black-600);
+  font-weight: 600;
+}
+.s-user-card .s-user-card--time {
+  color: var(--black-400);
+}
+.s-user-card .s-user-card--username {
+  align-items: var(--_uc-username-ai);
+  background-color: var(--_uc-username-bg);
+  border-left: var(--_uc-username-bl);
+  color: var(--_uc-username-fc);
+  display: var(--_uc-username-d);
+  font-size: var(--_uc-username-fs);
+  font-weight: 500;
+  min-width: 0;
+  overflow-wrap: break-word;
+  padding: var(--_uc-username-p);
+  word-break: break-all;
+}
+.s-user-card--username__op {
+  --_uc-username-p: var(--su3) var(--su4) var(--su3) var(--su4);
+  --_uc-username-bg: var(--blue-100);
+  --_uc-username-bl: var(--su4) solid var(--blue-300);
+  --_uc-username-d: flex;
+  --_uc-username-ai: center;
+}
+.s-user-card__sm .s-user-card--username__op {
+  --_uc-username-p: 0 var(--su4);
+}
+.s-user-card .s-user-card--column {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: var(--_uc-column-gap);
+}
+.s-user-card .s-user-card--group {
+  align-items: center;
+  display: flex;
+  gap: var(--_uc-group-gap);
+}
+.s-user-card .s-user-card--group:has(> .s-avatar) {
+  --_uc-group-gap: var(--su6);
+}
+.s-user-card .s-user-card--group:has(+ .s-user-card--time) {
+  margin-right: var(--su2);
+}
+.s-user-card ul.s-user-card--group {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.s-user-card ul.s-user-card--group.s-user-card--group__split li:not(:last-child):after {
+  background-color: var(--black-350);
+  content: "";
+  display: block;
+  margin-left: var(--su4);
+  width: var(--su4);
+  height: var(--su4);
+}
+.s-user-card ul.s-user-card--group li {
+  align-items: center;
+  display: inline-flex;
+  gap: var(--su2);
+}
+.s-user-card .s-user-card--row {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: var(--_uc-row-gap);
+}
+.s-vote {
+  --_vo-fd: column;
+  --_vo-child-bg: var(--black-150);
+  --_vo-child-br: unset;
+  --_vo-child-fd: var(--_vo-fd);
+  --_vo-child-g: calc(var(--su8) + var(--su2));
+  --_vo-child-h: unset;
+  --_vo-child-w: calc(var(--su48) + var(--su2));
+  --_vo-child-p: unset;
+  flex-direction: var(--_vo-fd);
+  display: flex;
+}
+.s-vote:not(.s-vote__horizontal) :first-child {
+  --_vo-child-p: calc(var(--su12) + var(--su2)) 0 calc(var(--su12) - var(--su2));
+  --_vo-child-br: var(--br-pill) var(--br-pill) 0 0;
+}
+.s-vote:not(.s-vote__horizontal) :last-child {
+  --_vo-child-p: calc(var(--su12) - var(--su2)) 0 calc(var(--su12) + var(--su2));
+  --_vo-child-br: 0 0 var(--br-pill) var(--br-pill);
+}
+.s-vote:not(.s-vote__horizontal) :only-child {
+  --_vo-child-br: var(--br-pill);
+  --_vo-child-g: calc(var(--su16) + var(--su4));
+  --_vo-child-p: calc(var(--su12) + var(--su2)) 0;
+}
+.s-vote.s-vote__expanded {
+  --_vo-child-g: var(--su2);
+  --_vo-child-p: 0;
+}
+.s-vote.s-vote__expanded .s-vote--total {
+  display: none;
+}
+.s-vote.s-vote__expanded .s-vote--upvotes,
+.s-vote.s-vote__expanded .s-vote--downvotes {
+  display: block;
+}
+.s-vote.s-vote__horizontal {
+  --_vo-fd: row;
+  --_vo-child-h: var(--su32);
+  --_vo-child-p: 0 var(--su4);
+  --_vo-child-w: unset;
+}
+.s-vote.s-vote__horizontal :first-child {
+  --_vo-child-p: 0 var(--su6) 0 calc(var(--su8) + var(--su2));
+  --_vo-child-br: var(--br-pill) 0 0 var(--br-pill);
+}
+.s-vote.s-vote__horizontal :last-child {
+  --_vo-child-p: 0 calc(var(--su8) + var(--su2)) 0 var(--su6);
+  --_vo-child-br: 0 var(--br-pill) var(--br-pill) 0;
+}
+.s-vote.s-vote__horizontal .s-vote--votes:last-child:not(:only-child) {
+  --_vo-child-p: 0 calc(var(--su12) + var(--su2)) 0 var(--su4);
+}
+.s-vote.s-vote__horizontal :only-child {
+  --_vo-child-br: var(--br-pill);
+  --_vo-child-g: calc(var(--su8) + var(--su2));
+  --_vo-child-p: 0 calc(var(--su12) + var(--su2)) 0 calc(var(--su8) + var(--su2));
+}
+.s-vote > button {
+  appearance: none;
+  -webkit-appearance: none;
+  background: none;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  margin: 0;
+  padding: 0;
+}
+.s-vote .s-vote--btn,
+.s-vote > .s-vote--votes {
+  background-color: var(--_vo-child-bg);
+  border-radius: var(--_vo-child-br);
+  flex-direction: var(--_vo-child-fd);
+  gap: var(--_vo-child-g);
+  height: var(--_vo-child-h);
+  padding: var(--_vo-child-p);
+  width: var(--_vo-child-w);
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  overflow: hidden;
+  font-weight: 600;
+  text-align: center;
+  white-space: nowrap;
+}
+.s-vote .s-vote--upvotes,
+.s-vote .s-vote--downvotes {
+  display: none;
+}
+.s-vote .s-vote--upvotes {
+  color: var(--green-500);
+}
+.s-vote .s-vote--downvotes {
+  color: var(--red-500);
+}
+.s-vote > button:focus-visible,
+.s-vote .s-vote--btn:focus-visible {
+  box-shadow: inset 0 0 0 var(--su2) var(--focus-theme), inset 0 0 0 var(--su4) var(--focus-neutral);
+  outline: var(--su2) solid transparent !important;
+}
+.s-vote > button:hover,
+.s-vote .s-vote--btn:hover {
+  --_vo-child-bg: var(--black-200);
+}
+/* stylelint-disable */
+@media (max-width: 92.25rem) {
+  .lg\\:ta-left {
+    text-align: left !important;
+  }
+  .lg\\:ta-center {
+    text-align: center !important;
+  }
+  .lg\\:ta-right {
+    text-align: right !important;
+  }
+  .lg\\:ba {
+    border-style: solid !important;
+    border-width: var(--su1) !important;
+  }
+  .lg\\:bt {
+    border-top-style: solid !important;
+    border-top-width: var(--su1) !important;
+  }
+  .lg\\:br {
+    border-right-style: solid !important;
+    border-right-width: var(--su1) !important;
+  }
+  .lg\\:bb {
+    border-bottom-style: solid !important;
+    border-bottom-width: var(--su1) !important;
+  }
+  .lg\\:bl {
+    border-left-style: solid !important;
+    border-left-width: var(--su1) !important;
+  }
+  .lg\\:baw0 {
+    border-width: 0 !important;
+  }
+  .lg\\:btw0 {
+    border-top-width: 0 !important;
+  }
+  .lg\\:brw0 {
+    border-right-width: 0 !important;
+  }
+  .lg\\:bbw0 {
+    border-bottom-width: 0 !important;
+  }
+  .lg\\:blw0 {
+    border-left-width: 0 !important;
+  }
+  .lg\\:bar0 {
+    border-radius: 0 !important;
+  }
+  .lg\\:bs-none {
+    box-shadow: none !important;
+  }
+  .lg\\:d-block {
+    display: block !important;
+  }
+  .lg\\:d-flex {
+    display: flex !important;
+  }
+  .lg\\:d-inline-flex {
+    display: inline-flex !important;
+  }
+  .lg\\:d-grid {
+    display: grid !important;
+  }
+  .lg\\:d-inline-grid {
+    display: inline-grid !important;
+  }
+  .lg\\:d-inline {
+    display: inline !important;
+  }
+  .lg\\:d-inline-block {
+    display: inline-block !important;
+  }
+  .lg\\:d-none {
+    display: none !important;
+  }
+  .lg\\:fd-row {
+    flex-direction: row !important;
+  }
+  .lg\\:fd-row-reverse {
+    flex-direction: row-reverse !important;
+  }
+  .lg\\:fd-column {
+    flex-direction: column !important;
+  }
+  .lg\\:fd-column-reverse {
+    flex-direction: column-reverse !important;
+  }
+  .lg\\:fw-wrap {
+    flex-wrap: wrap !important;
+  }
+  .lg\\:fw-reverse {
+    flex-wrap: wrap-reverse !important;
+  }
+  .lg\\:fw-nowrap {
+    flex-wrap: nowrap !important;
+  }
+  .lg\\:jc-center {
+    justify-content: center !important;
+  }
+  .lg\\:jc-end {
+    justify-content: flex-end !important;
+  }
+  .lg\\:jc-space-around {
+    justify-content: space-around !important;
+  }
+  .lg\\:jc-space-between {
+    justify-content: space-between !important;
+  }
+  .lg\\:jc-space-evenly {
+    justify-content: space-evenly !important;
+  }
+  .lg\\:jc-start {
+    justify-content: flex-start !important;
+  }
+  .lg\\:ai-baseline {
+    align-items: baseline !important;
+  }
+  .lg\\:ai-center {
+    align-items: center !important;
+  }
+  .lg\\:ai-end {
+    align-items: flex-end !important;
+  }
+  .lg\\:ai-start {
+    align-items: flex-start !important;
+  }
+  .lg\\:ai-stretch {
+    align-items: stretch !important;
+  }
+  .lg\\:fl-grow1 {
+    flex-grow: 1 !important;
+  }
+  .lg\\:fl-grow0 {
+    flex-grow: 0 !important;
+  }
+  .lg\\:fl-shrink1 {
+    flex-shrink: 1 !important;
+  }
+  .lg\\:fl-shrink0 {
+    flex-shrink: 0 !important;
+  }
+  .lg\\:fl-none {
+    flex: none !important;
+  }
+  .lg\\:fl-initial {
+    flex: 0 1 auto !important;
+  }
+  .lg\\:fl-auto {
+    flex: 1 1 auto !important;
+  }
+  .lg\\:fl-equal {
+    flex: 1 1 0% !important;
+  }
+  .lg\\:order-first {
+    order: -1 !important;
+  }
+  .lg\\:order-last {
+    order: 1 !important;
+  }
+  .lg\\:fl0 {
+    flex: 0 auto !important;
+  }
+  .lg\\:fl1 {
+    flex: 1 auto !important;
+  }
+  .lg\\:g0 {
+    --_gap-y: 0;
+    --_gap-x: 0;
+  }
+  .lg\\:g1 {
+    --_gap-y: var(--su1);
+    --_gap-x: var(--su1);
+  }
+  .lg\\:g2 {
+    --_gap-y: var(--su2);
+    --_gap-x: var(--su2);
+  }
+  .lg\\:g4 {
+    --_gap-y: var(--su4);
+    --_gap-x: var(--su4);
+  }
+  .lg\\:g6 {
+    --_gap-y: var(--su6);
+    --_gap-x: var(--su6);
+  }
+  .lg\\:g8 {
+    --_gap-y: var(--su8);
+    --_gap-x: var(--su8);
+  }
+  .lg\\:g12 {
+    --_gap-y: var(--su12);
+    --_gap-x: var(--su12);
+  }
+  .lg\\:g16 {
+    --_gap-y: var(--su16);
+    --_gap-x: var(--su16);
+  }
+  .lg\\:g24 {
+    --_gap-y: var(--su24);
+    --_gap-x: var(--su24);
+  }
+  .lg\\:g32 {
+    --_gap-y: var(--su32);
+    --_gap-x: var(--su32);
+  }
+  .lg\\:g48 {
+    --_gap-y: var(--su48);
+    --_gap-x: var(--su48);
+  }
+  .lg\\:g64 {
+    --_gap-y: var(--su64);
+    --_gap-x: var(--su64);
+  }
+  .lg\\:gx0 {
+    --_gap-x: 0;
+  }
+  .lg\\:gx1 {
+    --_gap-x: var(--su1);
+  }
+  .lg\\:gx2 {
+    --_gap-x: var(--su2);
+  }
+  .lg\\:gx4 {
+    --_gap-x: var(--su4);
+  }
+  .lg\\:gx6 {
+    --_gap-x: var(--su6);
+  }
+  .lg\\:gx8 {
+    --_gap-x: var(--su8);
+  }
+  .lg\\:gx12 {
+    --_gap-x: var(--su12);
+  }
+  .lg\\:gx16 {
+    --_gap-x: var(--su16);
+  }
+  .lg\\:gx24 {
+    --_gap-x: var(--su24);
+  }
+  .lg\\:gx32 {
+    --_gap-x: var(--su32);
+  }
+  .lg\\:gx48 {
+    --_gap-x: var(--su48);
+  }
+  .lg\\:gx64 {
+    --_gap-x: var(--su64);
+  }
+  .lg\\:gy0 {
+    --_gap-y: 0;
+  }
+  .lg\\:gy1 {
+    --_gap-y: var(--su1);
+  }
+  .lg\\:gy2 {
+    --_gap-y: var(--su2);
+  }
+  .lg\\:gy4 {
+    --_gap-y: var(--su4);
+  }
+  .lg\\:gy6 {
+    --_gap-y: var(--su6);
+  }
+  .lg\\:gy8 {
+    --_gap-y: var(--su8);
+  }
+  .lg\\:gy12 {
+    --_gap-y: var(--su12);
+  }
+  .lg\\:gy16 {
+    --_gap-y: var(--su16);
+  }
+  .lg\\:gy24 {
+    --_gap-y: var(--su24);
+  }
+  .lg\\:gy32 {
+    --_gap-y: var(--su32);
+  }
+  .lg\\:gy48 {
+    --_gap-y: var(--su48);
+  }
+  .lg\\:gy64 {
+    --_gap-y: var(--su64);
+  }
+  .lg\\:g-af-dense {
+    grid-auto-flow: dense;
+  }
+  .lg\\:g-af-row {
+    grid-auto-flow: row;
+  }
+  .lg\\:g-af-column {
+    grid-auto-flow: column;
+  }
+  .lg\\:grid__1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+  .lg\\:grid__2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .lg\\:grid__3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .lg\\:grid__4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+  .lg\\:grid__5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+  .lg\\:grid__6 {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+  .lg\\:grid__7 {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+  .lg\\:grid__8 {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+  }
+  .lg\\:grid__9 {
+    grid-template-columns: repeat(9, minmax(0, 1fr));
+  }
+  .lg\\:grid__10 {
+    grid-template-columns: repeat(10, minmax(0, 1fr));
+  }
+  .lg\\:grid__11 {
+    grid-template-columns: repeat(11, minmax(0, 1fr));
+  }
+  .lg\\:grid__12 {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+  }
+  .lg\\:grid__auto {
+    grid-template-columns: auto 1fr;
+  }
+  .lg\\:grid--col-all {
+    grid-column: 1 / -1;
+  }
+  .lg\\:grid--row-all {
+    grid-row: 1 / -1;
+  }
+  .lg\\:grid--col1 {
+    grid-column: span 1;
+  }
+  .lg\\:grid--col2 {
+    grid-column: span 2;
+  }
+  .lg\\:grid--col3 {
+    grid-column: span 3;
+  }
+  .lg\\:grid--col4 {
+    grid-column: span 4;
+  }
+  .lg\\:grid--col5 {
+    grid-column: span 5;
+  }
+  .lg\\:grid--col6 {
+    grid-column: span 6;
+  }
+  .lg\\:grid--col7 {
+    grid-column: span 7;
+  }
+  .lg\\:grid--col8 {
+    grid-column: span 8;
+  }
+  .lg\\:grid--col9 {
+    grid-column: span 9;
+  }
+  .lg\\:grid--col10 {
+    grid-column: span 10;
+  }
+  .lg\\:grid--col11 {
+    grid-column: span 11;
+  }
+  .lg\\:grid--col12 {
+    grid-column: span 12;
+  }
+  .lg\\:grid--row1 {
+    grid-row: span 1;
+  }
+  .lg\\:grid--row2 {
+    grid-row: span 2;
+  }
+  .lg\\:grid--row3 {
+    grid-row: span 3;
+  }
+  .lg\\:grid--row4 {
+    grid-row: span 4;
+  }
+  .lg\\:grid--row5 {
+    grid-row: span 5;
+  }
+  .lg\\:grid--row6 {
+    grid-row: span 6;
+  }
+  .lg\\:grid--row7 {
+    grid-row: span 7;
+  }
+  .lg\\:grid--row8 {
+    grid-row: span 8;
+  }
+  .lg\\:grid--row9 {
+    grid-row: span 9;
+  }
+  .lg\\:grid--row10 {
+    grid-row: span 10;
+  }
+  .lg\\:grid--row11 {
+    grid-row: span 11;
+  }
+  .lg\\:grid--row12 {
+    grid-row: span 12;
+  }
+  .lg\\:grid--col-start1 {
+    grid-column-start: 1;
+  }
+  .lg\\:grid--col-start2 {
+    grid-column-start: 2;
+  }
+  .lg\\:grid--col-start3 {
+    grid-column-start: 3;
+  }
+  .lg\\:grid--col-start4 {
+    grid-column-start: 4;
+  }
+  .lg\\:grid--col-start5 {
+    grid-column-start: 5;
+  }
+  .lg\\:grid--col-start6 {
+    grid-column-start: 6;
+  }
+  .lg\\:grid--col-start7 {
+    grid-column-start: 7;
+  }
+  .lg\\:grid--col-start8 {
+    grid-column-start: 8;
+  }
+  .lg\\:grid--col-start9 {
+    grid-column-start: 9;
+  }
+  .lg\\:grid--col-start10 {
+    grid-column-start: 10;
+  }
+  .lg\\:grid--col-start11 {
+    grid-column-start: 11;
+  }
+  .lg\\:grid--col-start12 {
+    grid-column-start: 12;
+  }
+  .lg\\:grid--col-end2 {
+    grid-column-end: 2;
+  }
+  .lg\\:grid--col-end3 {
+    grid-column-end: 3;
+  }
+  .lg\\:grid--col-end4 {
+    grid-column-end: 4;
+  }
+  .lg\\:grid--col-end5 {
+    grid-column-end: 5;
+  }
+  .lg\\:grid--col-end6 {
+    grid-column-end: 6;
+  }
+  .lg\\:grid--col-end7 {
+    grid-column-end: 7;
+  }
+  .lg\\:grid--col-end8 {
+    grid-column-end: 8;
+  }
+  .lg\\:grid--col-end9 {
+    grid-column-end: 9;
+  }
+  .lg\\:grid--col-end10 {
+    grid-column-end: 10;
+  }
+  .lg\\:grid--col-end11 {
+    grid-column-end: 11;
+  }
+  .lg\\:grid--col-end12 {
+    grid-column-end: 12;
+  }
+  .lg\\:grid--col-end13 {
+    grid-column-end: 13;
+  }
+  .lg\\:grid--row-start1 {
+    grid-row-start: 1;
+  }
+  .lg\\:grid--row-start2 {
+    grid-row-start: 2;
+  }
+  .lg\\:grid--row-start3 {
+    grid-row-start: 3;
+  }
+  .lg\\:grid--row-start4 {
+    grid-row-start: 4;
+  }
+  .lg\\:grid--row-start5 {
+    grid-row-start: 5;
+  }
+  .lg\\:grid--row-start6 {
+    grid-row-start: 6;
+  }
+  .lg\\:grid--row-start7 {
+    grid-row-start: 7;
+  }
+  .lg\\:grid--row-start8 {
+    grid-row-start: 8;
+  }
+  .lg\\:grid--row-start9 {
+    grid-row-start: 9;
+  }
+  .lg\\:grid--row-start10 {
+    grid-row-start: 10;
+  }
+  .lg\\:grid--row-start11 {
+    grid-row-start: 11;
+  }
+  .lg\\:grid--row-start12 {
+    grid-row-start: 12;
+  }
+  .lg\\:grid--row-end2 {
+    grid-row-end: 2;
+  }
+  .lg\\:grid--row-end3 {
+    grid-row-end: 3;
+  }
+  .lg\\:grid--row-end4 {
+    grid-row-end: 4;
+  }
+  .lg\\:grid--row-end5 {
+    grid-row-end: 5;
+  }
+  .lg\\:grid--row-end6 {
+    grid-row-end: 6;
+  }
+  .lg\\:grid--row-end7 {
+    grid-row-end: 7;
+  }
+  .lg\\:grid--row-end8 {
+    grid-row-end: 8;
+  }
+  .lg\\:grid--row-end9 {
+    grid-row-end: 9;
+  }
+  .lg\\:grid--row-end10 {
+    grid-row-end: 10;
+  }
+  .lg\\:grid--row-end11 {
+    grid-row-end: 11;
+  }
+  .lg\\:grid--row-end12 {
+    grid-row-end: 12;
+  }
+  .lg\\:grid--row-end13 {
+    grid-row-end: 13;
+  }
+  .lg\\:ji-auto {
+    justify-items: auto !important;
+  }
+  .lg\\:ji-center {
+    justify-items: center !important;
+  }
+  .lg\\:ji-start {
+    justify-items: start !important;
+  }
+  .lg\\:ji-end {
+    justify-items: end !important;
+  }
+  .lg\\:ji-stretch {
+    justify-items: stretch !important;
+  }
+  .lg\\:ji-unset {
+    justify-items: unset !important;
+  }
+  .lg\\:js-auto {
+    justify-self: auto !important;
+  }
+  .lg\\:js-center {
+    justify-self: center !important;
+  }
+  .lg\\:js-start {
+    justify-self: start !important;
+  }
+  .lg\\:js-end {
+    justify-self: end !important;
+  }
+  .lg\\:js-stretch {
+    justify-self: stretch !important;
+  }
+  .lg\\:js-unset {
+    justify-self: unset !important;
+  }
+  .lg\\:h100 {
+    height: 100% !important;
+  }
+  .lg\\:h-auto {
+    height: auto !important;
+  }
+  .lg\\:h-screen {
+    height: 100vh !important;
+  }
+  .lg\\:hmn100 {
+    min-height: 100% !important;
+  }
+  .lg\\:hmn-initial {
+    min-height: initial !important;
+  }
+  .lg\\:hmn-screen {
+    min-height: 100vh !important;
+  }
+  .lg\\:hmx100 {
+    max-height: 100% !important;
+  }
+  .lg\\:hmx-initial {
+    max-height: initial !important;
+  }
+  .lg\\:hmx-screen {
+    max-height: 100vh !important;
+  }
+  .lg\\:m0 {
+    margin: var(--su0) !important;
+  }
+  .lg\\:m1 {
+    margin: var(--su1) !important;
+  }
+  .lg\\:m2 {
+    margin: var(--su2) !important;
+  }
+  .lg\\:m4 {
+    margin: var(--su4) !important;
+  }
+  .lg\\:m6 {
+    margin: var(--su6) !important;
+  }
+  .lg\\:m8 {
+    margin: var(--su8) !important;
+  }
+  .lg\\:m12 {
+    margin: var(--su12) !important;
+  }
+  .lg\\:m16 {
+    margin: var(--su16) !important;
+  }
+  .lg\\:m24 {
+    margin: var(--su24) !important;
+  }
+  .lg\\:m32 {
+    margin: var(--su32) !important;
+  }
+  .lg\\:m48 {
+    margin: var(--su48) !important;
+  }
+  .lg\\:m64 {
+    margin: var(--su64) !important;
+  }
+  .lg\\:m96 {
+    margin: var(--su96) !important;
+  }
+  .lg\\:m128 {
+    margin: var(--su128) !important;
+  }
+  .lg\\:mn1 {
+    margin: var(--sun1) !important;
+  }
+  .lg\\:mn2 {
+    margin: var(--sun2) !important;
+  }
+  .lg\\:mn4 {
+    margin: var(--sun4) !important;
+  }
+  .lg\\:mn6 {
+    margin: var(--sun6) !important;
+  }
+  .lg\\:mn8 {
+    margin: var(--sun8) !important;
+  }
+  .lg\\:mn12 {
+    margin: var(--sun12) !important;
+  }
+  .lg\\:mn16 {
+    margin: var(--sun16) !important;
+  }
+  .lg\\:mn24 {
+    margin: var(--sun24) !important;
+  }
+  .lg\\:mn32 {
+    margin: var(--sun32) !important;
+  }
+  .lg\\:mn48 {
+    margin: var(--sun48) !important;
+  }
+  .lg\\:mn64 {
+    margin: var(--sun64) !important;
+  }
+  .lg\\:mn96 {
+    margin: var(--sun96) !important;
+  }
+  .lg\\:mn128 {
+    margin: var(--sun128) !important;
+  }
+  .lg\\:m50 {
+    margin: 50% !important;
+  }
+  .lg\\:m100 {
+    margin: 100% !important;
+  }
+  .lg\\:mn50 {
+    margin: -50% !important;
+  }
+  .lg\\:mn100 {
+    margin: -100% !important;
+  }
+  .lg\\:mt0 {
+    margin-top: var(--su0) !important;
+  }
+  .lg\\:mt1 {
+    margin-top: var(--su1) !important;
+  }
+  .lg\\:mt2 {
+    margin-top: var(--su2) !important;
+  }
+  .lg\\:mt4 {
+    margin-top: var(--su4) !important;
+  }
+  .lg\\:mt6 {
+    margin-top: var(--su6) !important;
+  }
+  .lg\\:mt8 {
+    margin-top: var(--su8) !important;
+  }
+  .lg\\:mt12 {
+    margin-top: var(--su12) !important;
+  }
+  .lg\\:mt16 {
+    margin-top: var(--su16) !important;
+  }
+  .lg\\:mt24 {
+    margin-top: var(--su24) !important;
+  }
+  .lg\\:mt32 {
+    margin-top: var(--su32) !important;
+  }
+  .lg\\:mt48 {
+    margin-top: var(--su48) !important;
+  }
+  .lg\\:mt64 {
+    margin-top: var(--su64) !important;
+  }
+  .lg\\:mt96 {
+    margin-top: var(--su96) !important;
+  }
+  .lg\\:mt128 {
+    margin-top: var(--su128) !important;
+  }
+  .lg\\:mtn1 {
+    margin-top: var(--sun1) !important;
+  }
+  .lg\\:mtn2 {
+    margin-top: var(--sun2) !important;
+  }
+  .lg\\:mtn4 {
+    margin-top: var(--sun4) !important;
+  }
+  .lg\\:mtn6 {
+    margin-top: var(--sun6) !important;
+  }
+  .lg\\:mtn8 {
+    margin-top: var(--sun8) !important;
+  }
+  .lg\\:mtn12 {
+    margin-top: var(--sun12) !important;
+  }
+  .lg\\:mtn16 {
+    margin-top: var(--sun16) !important;
+  }
+  .lg\\:mtn24 {
+    margin-top: var(--sun24) !important;
+  }
+  .lg\\:mtn32 {
+    margin-top: var(--sun32) !important;
+  }
+  .lg\\:mtn48 {
+    margin-top: var(--sun48) !important;
+  }
+  .lg\\:mtn64 {
+    margin-top: var(--sun64) !important;
+  }
+  .lg\\:mtn96 {
+    margin-top: var(--sun96) !important;
+  }
+  .lg\\:mtn128 {
+    margin-top: var(--sun128) !important;
+  }
+  .lg\\:mt50 {
+    margin-top: 50% !important;
+  }
+  .lg\\:mt100 {
+    margin-top: 100% !important;
+  }
+  .lg\\:mtn50 {
+    margin-top: -50% !important;
+  }
+  .lg\\:mtn100 {
+    margin-top: -100% !important;
+  }
+  .lg\\:mr0 {
+    margin-right: var(--su0) !important;
+  }
+  .lg\\:mr1 {
+    margin-right: var(--su1) !important;
+  }
+  .lg\\:mr2 {
+    margin-right: var(--su2) !important;
+  }
+  .lg\\:mr4 {
+    margin-right: var(--su4) !important;
+  }
+  .lg\\:mr6 {
+    margin-right: var(--su6) !important;
+  }
+  .lg\\:mr8 {
+    margin-right: var(--su8) !important;
+  }
+  .lg\\:mr12 {
+    margin-right: var(--su12) !important;
+  }
+  .lg\\:mr16 {
+    margin-right: var(--su16) !important;
+  }
+  .lg\\:mr24 {
+    margin-right: var(--su24) !important;
+  }
+  .lg\\:mr32 {
+    margin-right: var(--su32) !important;
+  }
+  .lg\\:mr48 {
+    margin-right: var(--su48) !important;
+  }
+  .lg\\:mr64 {
+    margin-right: var(--su64) !important;
+  }
+  .lg\\:mr96 {
+    margin-right: var(--su96) !important;
+  }
+  .lg\\:mr128 {
+    margin-right: var(--su128) !important;
+  }
+  .lg\\:mrn1 {
+    margin-right: var(--sun1) !important;
+  }
+  .lg\\:mrn2 {
+    margin-right: var(--sun2) !important;
+  }
+  .lg\\:mrn4 {
+    margin-right: var(--sun4) !important;
+  }
+  .lg\\:mrn6 {
+    margin-right: var(--sun6) !important;
+  }
+  .lg\\:mrn8 {
+    margin-right: var(--sun8) !important;
+  }
+  .lg\\:mrn12 {
+    margin-right: var(--sun12) !important;
+  }
+  .lg\\:mrn16 {
+    margin-right: var(--sun16) !important;
+  }
+  .lg\\:mrn24 {
+    margin-right: var(--sun24) !important;
+  }
+  .lg\\:mrn32 {
+    margin-right: var(--sun32) !important;
+  }
+  .lg\\:mrn48 {
+    margin-right: var(--sun48) !important;
+  }
+  .lg\\:mrn64 {
+    margin-right: var(--sun64) !important;
+  }
+  .lg\\:mrn96 {
+    margin-right: var(--sun96) !important;
+  }
+  .lg\\:mrn128 {
+    margin-right: var(--sun128) !important;
+  }
+  .lg\\:mr50 {
+    margin-right: 50% !important;
+  }
+  .lg\\:mr100 {
+    margin-right: 100% !important;
+  }
+  .lg\\:mrn50 {
+    margin-right: -50% !important;
+  }
+  .lg\\:mrn100 {
+    margin-right: -100% !important;
+  }
+  .lg\\:mb0 {
+    margin-bottom: var(--su0) !important;
+  }
+  .lg\\:mb1 {
+    margin-bottom: var(--su1) !important;
+  }
+  .lg\\:mb2 {
+    margin-bottom: var(--su2) !important;
+  }
+  .lg\\:mb4 {
+    margin-bottom: var(--su4) !important;
+  }
+  .lg\\:mb6 {
+    margin-bottom: var(--su6) !important;
+  }
+  .lg\\:mb8 {
+    margin-bottom: var(--su8) !important;
+  }
+  .lg\\:mb12 {
+    margin-bottom: var(--su12) !important;
+  }
+  .lg\\:mb16 {
+    margin-bottom: var(--su16) !important;
+  }
+  .lg\\:mb24 {
+    margin-bottom: var(--su24) !important;
+  }
+  .lg\\:mb32 {
+    margin-bottom: var(--su32) !important;
+  }
+  .lg\\:mb48 {
+    margin-bottom: var(--su48) !important;
+  }
+  .lg\\:mb64 {
+    margin-bottom: var(--su64) !important;
+  }
+  .lg\\:mb96 {
+    margin-bottom: var(--su96) !important;
+  }
+  .lg\\:mb128 {
+    margin-bottom: var(--su128) !important;
+  }
+  .lg\\:mbn1 {
+    margin-bottom: var(--sun1) !important;
+  }
+  .lg\\:mbn2 {
+    margin-bottom: var(--sun2) !important;
+  }
+  .lg\\:mbn4 {
+    margin-bottom: var(--sun4) !important;
+  }
+  .lg\\:mbn6 {
+    margin-bottom: var(--sun6) !important;
+  }
+  .lg\\:mbn8 {
+    margin-bottom: var(--sun8) !important;
+  }
+  .lg\\:mbn12 {
+    margin-bottom: var(--sun12) !important;
+  }
+  .lg\\:mbn16 {
+    margin-bottom: var(--sun16) !important;
+  }
+  .lg\\:mbn24 {
+    margin-bottom: var(--sun24) !important;
+  }
+  .lg\\:mbn32 {
+    margin-bottom: var(--sun32) !important;
+  }
+  .lg\\:mbn48 {
+    margin-bottom: var(--sun48) !important;
+  }
+  .lg\\:mbn64 {
+    margin-bottom: var(--sun64) !important;
+  }
+  .lg\\:mbn96 {
+    margin-bottom: var(--sun96) !important;
+  }
+  .lg\\:mbn128 {
+    margin-bottom: var(--sun128) !important;
+  }
+  .lg\\:mb50 {
+    margin-bottom: 50% !important;
+  }
+  .lg\\:mb100 {
+    margin-bottom: 100% !important;
+  }
+  .lg\\:mbn50 {
+    margin-bottom: -50% !important;
+  }
+  .lg\\:mbn100 {
+    margin-bottom: -100% !important;
+  }
+  .lg\\:ml0 {
+    margin-left: var(--su0) !important;
+  }
+  .lg\\:ml1 {
+    margin-left: var(--su1) !important;
+  }
+  .lg\\:ml2 {
+    margin-left: var(--su2) !important;
+  }
+  .lg\\:ml4 {
+    margin-left: var(--su4) !important;
+  }
+  .lg\\:ml6 {
+    margin-left: var(--su6) !important;
+  }
+  .lg\\:ml8 {
+    margin-left: var(--su8) !important;
+  }
+  .lg\\:ml12 {
+    margin-left: var(--su12) !important;
+  }
+  .lg\\:ml16 {
+    margin-left: var(--su16) !important;
+  }
+  .lg\\:ml24 {
+    margin-left: var(--su24) !important;
+  }
+  .lg\\:ml32 {
+    margin-left: var(--su32) !important;
+  }
+  .lg\\:ml48 {
+    margin-left: var(--su48) !important;
+  }
+  .lg\\:ml64 {
+    margin-left: var(--su64) !important;
+  }
+  .lg\\:ml96 {
+    margin-left: var(--su96) !important;
+  }
+  .lg\\:ml128 {
+    margin-left: var(--su128) !important;
+  }
+  .lg\\:mln1 {
+    margin-left: var(--sun1) !important;
+  }
+  .lg\\:mln2 {
+    margin-left: var(--sun2) !important;
+  }
+  .lg\\:mln4 {
+    margin-left: var(--sun4) !important;
+  }
+  .lg\\:mln6 {
+    margin-left: var(--sun6) !important;
+  }
+  .lg\\:mln8 {
+    margin-left: var(--sun8) !important;
+  }
+  .lg\\:mln12 {
+    margin-left: var(--sun12) !important;
+  }
+  .lg\\:mln16 {
+    margin-left: var(--sun16) !important;
+  }
+  .lg\\:mln24 {
+    margin-left: var(--sun24) !important;
+  }
+  .lg\\:mln32 {
+    margin-left: var(--sun32) !important;
+  }
+  .lg\\:mln48 {
+    margin-left: var(--sun48) !important;
+  }
+  .lg\\:mln64 {
+    margin-left: var(--sun64) !important;
+  }
+  .lg\\:mln96 {
+    margin-left: var(--sun96) !important;
+  }
+  .lg\\:mln128 {
+    margin-left: var(--sun128) !important;
+  }
+  .lg\\:ml50 {
+    margin-left: 50% !important;
+  }
+  .lg\\:ml100 {
+    margin-left: 100% !important;
+  }
+  .lg\\:mln50 {
+    margin-left: -50% !important;
+  }
+  .lg\\:mln100 {
+    margin-left: -100% !important;
+  }
+  .lg\\:mx0 {
+    margin-left: var(--su0) !important;
+    margin-right: var(--su0) !important;
+  }
+  .lg\\:mx1 {
+    margin-left: var(--su1) !important;
+    margin-right: var(--su1) !important;
+  }
+  .lg\\:mx2 {
+    margin-left: var(--su2) !important;
+    margin-right: var(--su2) !important;
+  }
+  .lg\\:mx4 {
+    margin-left: var(--su4) !important;
+    margin-right: var(--su4) !important;
+  }
+  .lg\\:mx6 {
+    margin-left: var(--su6) !important;
+    margin-right: var(--su6) !important;
+  }
+  .lg\\:mx8 {
+    margin-left: var(--su8) !important;
+    margin-right: var(--su8) !important;
+  }
+  .lg\\:mx12 {
+    margin-left: var(--su12) !important;
+    margin-right: var(--su12) !important;
+  }
+  .lg\\:mx16 {
+    margin-left: var(--su16) !important;
+    margin-right: var(--su16) !important;
+  }
+  .lg\\:mx24 {
+    margin-left: var(--su24) !important;
+    margin-right: var(--su24) !important;
+  }
+  .lg\\:mx32 {
+    margin-left: var(--su32) !important;
+    margin-right: var(--su32) !important;
+  }
+  .lg\\:mx48 {
+    margin-left: var(--su48) !important;
+    margin-right: var(--su48) !important;
+  }
+  .lg\\:mx64 {
+    margin-left: var(--su64) !important;
+    margin-right: var(--su64) !important;
+  }
+  .lg\\:mx96 {
+    margin-left: var(--su96) !important;
+    margin-right: var(--su96) !important;
+  }
+  .lg\\:mx128 {
+    margin-left: var(--su128) !important;
+    margin-right: var(--su128) !important;
+  }
+  .lg\\:mxn1 {
+    margin-left: var(--sun1) !important;
+    margin-right: var(--sun1) !important;
+  }
+  .lg\\:mxn2 {
+    margin-left: var(--sun2) !important;
+    margin-right: var(--sun2) !important;
+  }
+  .lg\\:mxn4 {
+    margin-left: var(--sun4) !important;
+    margin-right: var(--sun4) !important;
+  }
+  .lg\\:mxn6 {
+    margin-left: var(--sun6) !important;
+    margin-right: var(--sun6) !important;
+  }
+  .lg\\:mxn8 {
+    margin-left: var(--sun8) !important;
+    margin-right: var(--sun8) !important;
+  }
+  .lg\\:mxn12 {
+    margin-left: var(--sun12) !important;
+    margin-right: var(--sun12) !important;
+  }
+  .lg\\:mxn16 {
+    margin-left: var(--sun16) !important;
+    margin-right: var(--sun16) !important;
+  }
+  .lg\\:mxn24 {
+    margin-left: var(--sun24) !important;
+    margin-right: var(--sun24) !important;
+  }
+  .lg\\:mxn32 {
+    margin-left: var(--sun32) !important;
+    margin-right: var(--sun32) !important;
+  }
+  .lg\\:mxn48 {
+    margin-left: var(--sun48) !important;
+    margin-right: var(--sun48) !important;
+  }
+  .lg\\:mxn64 {
+    margin-left: var(--sun64) !important;
+    margin-right: var(--sun64) !important;
+  }
+  .lg\\:mxn96 {
+    margin-left: var(--sun96) !important;
+    margin-right: var(--sun96) !important;
+  }
+  .lg\\:mxn128 {
+    margin-left: var(--sun128) !important;
+    margin-right: var(--sun128) !important;
+  }
+  .lg\\:my0 {
+    margin-top: var(--su0) !important;
+    margin-bottom: var(--su0) !important;
+  }
+  .lg\\:my1 {
+    margin-top: var(--su1) !important;
+    margin-bottom: var(--su1) !important;
+  }
+  .lg\\:my2 {
+    margin-top: var(--su2) !important;
+    margin-bottom: var(--su2) !important;
+  }
+  .lg\\:my4 {
+    margin-top: var(--su4) !important;
+    margin-bottom: var(--su4) !important;
+  }
+  .lg\\:my6 {
+    margin-top: var(--su6) !important;
+    margin-bottom: var(--su6) !important;
+  }
+  .lg\\:my8 {
+    margin-top: var(--su8) !important;
+    margin-bottom: var(--su8) !important;
+  }
+  .lg\\:my12 {
+    margin-top: var(--su12) !important;
+    margin-bottom: var(--su12) !important;
+  }
+  .lg\\:my16 {
+    margin-top: var(--su16) !important;
+    margin-bottom: var(--su16) !important;
+  }
+  .lg\\:my24 {
+    margin-top: var(--su24) !important;
+    margin-bottom: var(--su24) !important;
+  }
+  .lg\\:my32 {
+    margin-top: var(--su32) !important;
+    margin-bottom: var(--su32) !important;
+  }
+  .lg\\:my48 {
+    margin-top: var(--su48) !important;
+    margin-bottom: var(--su48) !important;
+  }
+  .lg\\:my64 {
+    margin-top: var(--su64) !important;
+    margin-bottom: var(--su64) !important;
+  }
+  .lg\\:my96 {
+    margin-top: var(--su96) !important;
+    margin-bottom: var(--su96) !important;
+  }
+  .lg\\:my128 {
+    margin-top: var(--su128) !important;
+    margin-bottom: var(--su128) !important;
+  }
+  .lg\\:myn1 {
+    margin-top: var(--sun1) !important;
+    margin-bottom: var(--sun1) !important;
+  }
+  .lg\\:myn2 {
+    margin-top: var(--sun2) !important;
+    margin-bottom: var(--sun2) !important;
+  }
+  .lg\\:myn4 {
+    margin-top: var(--sun4) !important;
+    margin-bottom: var(--sun4) !important;
+  }
+  .lg\\:myn6 {
+    margin-top: var(--sun6) !important;
+    margin-bottom: var(--sun6) !important;
+  }
+  .lg\\:myn8 {
+    margin-top: var(--sun8) !important;
+    margin-bottom: var(--sun8) !important;
+  }
+  .lg\\:myn12 {
+    margin-top: var(--sun12) !important;
+    margin-bottom: var(--sun12) !important;
+  }
+  .lg\\:myn16 {
+    margin-top: var(--sun16) !important;
+    margin-bottom: var(--sun16) !important;
+  }
+  .lg\\:myn24 {
+    margin-top: var(--sun24) !important;
+    margin-bottom: var(--sun24) !important;
+  }
+  .lg\\:myn32 {
+    margin-top: var(--sun32) !important;
+    margin-bottom: var(--sun32) !important;
+  }
+  .lg\\:myn48 {
+    margin-top: var(--sun48) !important;
+    margin-bottom: var(--sun48) !important;
+  }
+  .lg\\:myn64 {
+    margin-top: var(--sun64) !important;
+    margin-bottom: var(--sun64) !important;
+  }
+  .lg\\:myn96 {
+    margin-top: var(--sun96) !important;
+    margin-bottom: var(--sun96) !important;
+  }
+  .lg\\:myn128 {
+    margin-top: var(--sun128) !important;
+    margin-bottom: var(--sun128) !important;
+  }
+  .lg\\:p0 {
+    padding: var(--su0) !important;
+  }
+  .lg\\:p1 {
+    padding: var(--su1) !important;
+  }
+  .lg\\:p2 {
+    padding: var(--su2) !important;
+  }
+  .lg\\:p4 {
+    padding: var(--su4) !important;
+  }
+  .lg\\:p6 {
+    padding: var(--su6) !important;
+  }
+  .lg\\:p8 {
+    padding: var(--su8) !important;
+  }
+  .lg\\:p12 {
+    padding: var(--su12) !important;
+  }
+  .lg\\:p16 {
+    padding: var(--su16) !important;
+  }
+  .lg\\:p24 {
+    padding: var(--su24) !important;
+  }
+  .lg\\:p32 {
+    padding: var(--su32) !important;
+  }
+  .lg\\:p48 {
+    padding: var(--su48) !important;
+  }
+  .lg\\:p64 {
+    padding: var(--su64) !important;
+  }
+  .lg\\:p96 {
+    padding: var(--su96) !important;
+  }
+  .lg\\:p128 {
+    padding: var(--su128) !important;
+  }
+  .lg\\:pt0 {
+    padding-top: var(--su0) !important;
+  }
+  .lg\\:pt1 {
+    padding-top: var(--su1) !important;
+  }
+  .lg\\:pt2 {
+    padding-top: var(--su2) !important;
+  }
+  .lg\\:pt4 {
+    padding-top: var(--su4) !important;
+  }
+  .lg\\:pt6 {
+    padding-top: var(--su6) !important;
+  }
+  .lg\\:pt8 {
+    padding-top: var(--su8) !important;
+  }
+  .lg\\:pt12 {
+    padding-top: var(--su12) !important;
+  }
+  .lg\\:pt16 {
+    padding-top: var(--su16) !important;
+  }
+  .lg\\:pt24 {
+    padding-top: var(--su24) !important;
+  }
+  .lg\\:pt32 {
+    padding-top: var(--su32) !important;
+  }
+  .lg\\:pt48 {
+    padding-top: var(--su48) !important;
+  }
+  .lg\\:pt64 {
+    padding-top: var(--su64) !important;
+  }
+  .lg\\:pt96 {
+    padding-top: var(--su96) !important;
+  }
+  .lg\\:pt128 {
+    padding-top: var(--su128) !important;
+  }
+  .lg\\:pr0 {
+    padding-right: var(--su0) !important;
+  }
+  .lg\\:pr1 {
+    padding-right: var(--su1) !important;
+  }
+  .lg\\:pr2 {
+    padding-right: var(--su2) !important;
+  }
+  .lg\\:pr4 {
+    padding-right: var(--su4) !important;
+  }
+  .lg\\:pr6 {
+    padding-right: var(--su6) !important;
+  }
+  .lg\\:pr8 {
+    padding-right: var(--su8) !important;
+  }
+  .lg\\:pr12 {
+    padding-right: var(--su12) !important;
+  }
+  .lg\\:pr16 {
+    padding-right: var(--su16) !important;
+  }
+  .lg\\:pr24 {
+    padding-right: var(--su24) !important;
+  }
+  .lg\\:pr32 {
+    padding-right: var(--su32) !important;
+  }
+  .lg\\:pr48 {
+    padding-right: var(--su48) !important;
+  }
+  .lg\\:pr64 {
+    padding-right: var(--su64) !important;
+  }
+  .lg\\:pr96 {
+    padding-right: var(--su96) !important;
+  }
+  .lg\\:pr128 {
+    padding-right: var(--su128) !important;
+  }
+  .lg\\:pb0 {
+    padding-bottom: var(--su0) !important;
+  }
+  .lg\\:pb1 {
+    padding-bottom: var(--su1) !important;
+  }
+  .lg\\:pb2 {
+    padding-bottom: var(--su2) !important;
+  }
+  .lg\\:pb4 {
+    padding-bottom: var(--su4) !important;
+  }
+  .lg\\:pb6 {
+    padding-bottom: var(--su6) !important;
+  }
+  .lg\\:pb8 {
+    padding-bottom: var(--su8) !important;
+  }
+  .lg\\:pb12 {
+    padding-bottom: var(--su12) !important;
+  }
+  .lg\\:pb16 {
+    padding-bottom: var(--su16) !important;
+  }
+  .lg\\:pb24 {
+    padding-bottom: var(--su24) !important;
+  }
+  .lg\\:pb32 {
+    padding-bottom: var(--su32) !important;
+  }
+  .lg\\:pb48 {
+    padding-bottom: var(--su48) !important;
+  }
+  .lg\\:pb64 {
+    padding-bottom: var(--su64) !important;
+  }
+  .lg\\:pb96 {
+    padding-bottom: var(--su96) !important;
+  }
+  .lg\\:pb128 {
+    padding-bottom: var(--su128) !important;
+  }
+  .lg\\:pl0 {
+    padding-left: var(--su0) !important;
+  }
+  .lg\\:pl1 {
+    padding-left: var(--su1) !important;
+  }
+  .lg\\:pl2 {
+    padding-left: var(--su2) !important;
+  }
+  .lg\\:pl4 {
+    padding-left: var(--su4) !important;
+  }
+  .lg\\:pl6 {
+    padding-left: var(--su6) !important;
+  }
+  .lg\\:pl8 {
+    padding-left: var(--su8) !important;
+  }
+  .lg\\:pl12 {
+    padding-left: var(--su12) !important;
+  }
+  .lg\\:pl16 {
+    padding-left: var(--su16) !important;
+  }
+  .lg\\:pl24 {
+    padding-left: var(--su24) !important;
+  }
+  .lg\\:pl32 {
+    padding-left: var(--su32) !important;
+  }
+  .lg\\:pl48 {
+    padding-left: var(--su48) !important;
+  }
+  .lg\\:pl64 {
+    padding-left: var(--su64) !important;
+  }
+  .lg\\:pl96 {
+    padding-left: var(--su96) !important;
+  }
+  .lg\\:pl128 {
+    padding-left: var(--su128) !important;
+  }
+  .lg\\:px0 {
+    padding-left: var(--su0) !important;
+    padding-right: var(--su0) !important;
+  }
+  .lg\\:px1 {
+    padding-left: var(--su1) !important;
+    padding-right: var(--su1) !important;
+  }
+  .lg\\:px2 {
+    padding-left: var(--su2) !important;
+    padding-right: var(--su2) !important;
+  }
+  .lg\\:px4 {
+    padding-left: var(--su4) !important;
+    padding-right: var(--su4) !important;
+  }
+  .lg\\:px6 {
+    padding-left: var(--su6) !important;
+    padding-right: var(--su6) !important;
+  }
+  .lg\\:px8 {
+    padding-left: var(--su8) !important;
+    padding-right: var(--su8) !important;
+  }
+  .lg\\:px12 {
+    padding-left: var(--su12) !important;
+    padding-right: var(--su12) !important;
+  }
+  .lg\\:px16 {
+    padding-left: var(--su16) !important;
+    padding-right: var(--su16) !important;
+  }
+  .lg\\:px24 {
+    padding-left: var(--su24) !important;
+    padding-right: var(--su24) !important;
+  }
+  .lg\\:px32 {
+    padding-left: var(--su32) !important;
+    padding-right: var(--su32) !important;
+  }
+  .lg\\:px48 {
+    padding-left: var(--su48) !important;
+    padding-right: var(--su48) !important;
+  }
+  .lg\\:px64 {
+    padding-left: var(--su64) !important;
+    padding-right: var(--su64) !important;
+  }
+  .lg\\:px96 {
+    padding-left: var(--su96) !important;
+    padding-right: var(--su96) !important;
+  }
+  .lg\\:px128 {
+    padding-left: var(--su128) !important;
+    padding-right: var(--su128) !important;
+  }
+  .lg\\:py0 {
+    padding-top: var(--su0) !important;
+    padding-bottom: var(--su0) !important;
+  }
+  .lg\\:py1 {
+    padding-top: var(--su1) !important;
+    padding-bottom: var(--su1) !important;
+  }
+  .lg\\:py2 {
+    padding-top: var(--su2) !important;
+    padding-bottom: var(--su2) !important;
+  }
+  .lg\\:py4 {
+    padding-top: var(--su4) !important;
+    padding-bottom: var(--su4) !important;
+  }
+  .lg\\:py6 {
+    padding-top: var(--su6) !important;
+    padding-bottom: var(--su6) !important;
+  }
+  .lg\\:py8 {
+    padding-top: var(--su8) !important;
+    padding-bottom: var(--su8) !important;
+  }
+  .lg\\:py12 {
+    padding-top: var(--su12) !important;
+    padding-bottom: var(--su12) !important;
+  }
+  .lg\\:py16 {
+    padding-top: var(--su16) !important;
+    padding-bottom: var(--su16) !important;
+  }
+  .lg\\:py24 {
+    padding-top: var(--su24) !important;
+    padding-bottom: var(--su24) !important;
+  }
+  .lg\\:py32 {
+    padding-top: var(--su32) !important;
+    padding-bottom: var(--su32) !important;
+  }
+  .lg\\:py48 {
+    padding-top: var(--su48) !important;
+    padding-bottom: var(--su48) !important;
+  }
+  .lg\\:py64 {
+    padding-top: var(--su64) !important;
+    padding-bottom: var(--su64) !important;
+  }
+  .lg\\:py96 {
+    padding-top: var(--su96) !important;
+    padding-bottom: var(--su96) !important;
+  }
+  .lg\\:py128 {
+    padding-top: var(--su128) !important;
+    padding-bottom: var(--su128) !important;
+  }
+  .lg\\:ps-absolute {
+    position: absolute !important;
+  }
+  .lg\\:ps-fixed {
+    position: fixed !important;
+  }
+  .lg\\:ps-relative {
+    position: relative !important;
+  }
+  .lg\\:ps-static {
+    position: static !important;
+  }
+  .lg\\:ps-sticky {
+    position: sticky !important;
+  }
+  .lg\\:t0 {
+    top: var(--su0) !important;
+  }
+  .lg\\:t1 {
+    top: var(--su1) !important;
+  }
+  .lg\\:t2 {
+    top: var(--su2) !important;
+  }
+  .lg\\:t4 {
+    top: var(--su4) !important;
+  }
+  .lg\\:t6 {
+    top: var(--su6) !important;
+  }
+  .lg\\:t8 {
+    top: var(--su8) !important;
+  }
+  .lg\\:t12 {
+    top: var(--su12) !important;
+  }
+  .lg\\:t16 {
+    top: var(--su16) !important;
+  }
+  .lg\\:t24 {
+    top: var(--su24) !important;
+  }
+  .lg\\:t32 {
+    top: var(--su32) !important;
+  }
+  .lg\\:t48 {
+    top: var(--su48) !important;
+  }
+  .lg\\:t64 {
+    top: var(--su64) !important;
+  }
+  .lg\\:t96 {
+    top: var(--su96) !important;
+  }
+  .lg\\:t128 {
+    top: var(--su128) !important;
+  }
+  .lg\\:tn1 {
+    top: var(--sun1) !important;
+  }
+  .lg\\:tn2 {
+    top: var(--sun2) !important;
+  }
+  .lg\\:tn4 {
+    top: var(--sun4) !important;
+  }
+  .lg\\:tn6 {
+    top: var(--sun6) !important;
+  }
+  .lg\\:tn8 {
+    top: var(--sun8) !important;
+  }
+  .lg\\:tn12 {
+    top: var(--sun12) !important;
+  }
+  .lg\\:tn16 {
+    top: var(--sun16) !important;
+  }
+  .lg\\:tn24 {
+    top: var(--sun24) !important;
+  }
+  .lg\\:tn32 {
+    top: var(--sun32) !important;
+  }
+  .lg\\:tn48 {
+    top: var(--sun48) !important;
+  }
+  .lg\\:tn64 {
+    top: var(--sun64) !important;
+  }
+  .lg\\:tn96 {
+    top: var(--sun96) !important;
+  }
+  .lg\\:tn128 {
+    top: var(--sun128) !important;
+  }
+  .lg\\:t50 {
+    top: 50% !important;
+  }
+  .lg\\:t100 {
+    top: 100% !important;
+  }
+  .lg\\:tn50 {
+    top: -50% !important;
+  }
+  .lg\\:tn100 {
+    top: -100% !important;
+  }
+  .lg\\:r0 {
+    right: var(--su0) !important;
+  }
+  .lg\\:r1 {
+    right: var(--su1) !important;
+  }
+  .lg\\:r2 {
+    right: var(--su2) !important;
+  }
+  .lg\\:r4 {
+    right: var(--su4) !important;
+  }
+  .lg\\:r6 {
+    right: var(--su6) !important;
+  }
+  .lg\\:r8 {
+    right: var(--su8) !important;
+  }
+  .lg\\:r12 {
+    right: var(--su12) !important;
+  }
+  .lg\\:r16 {
+    right: var(--su16) !important;
+  }
+  .lg\\:r24 {
+    right: var(--su24) !important;
+  }
+  .lg\\:r32 {
+    right: var(--su32) !important;
+  }
+  .lg\\:r48 {
+    right: var(--su48) !important;
+  }
+  .lg\\:r64 {
+    right: var(--su64) !important;
+  }
+  .lg\\:r96 {
+    right: var(--su96) !important;
+  }
+  .lg\\:r128 {
+    right: var(--su128) !important;
+  }
+  .lg\\:rn1 {
+    right: var(--sun1) !important;
+  }
+  .lg\\:rn2 {
+    right: var(--sun2) !important;
+  }
+  .lg\\:rn4 {
+    right: var(--sun4) !important;
+  }
+  .lg\\:rn6 {
+    right: var(--sun6) !important;
+  }
+  .lg\\:rn8 {
+    right: var(--sun8) !important;
+  }
+  .lg\\:rn12 {
+    right: var(--sun12) !important;
+  }
+  .lg\\:rn16 {
+    right: var(--sun16) !important;
+  }
+  .lg\\:rn24 {
+    right: var(--sun24) !important;
+  }
+  .lg\\:rn32 {
+    right: var(--sun32) !important;
+  }
+  .lg\\:rn48 {
+    right: var(--sun48) !important;
+  }
+  .lg\\:rn64 {
+    right: var(--sun64) !important;
+  }
+  .lg\\:rn96 {
+    right: var(--sun96) !important;
+  }
+  .lg\\:rn128 {
+    right: var(--sun128) !important;
+  }
+  .lg\\:r50 {
+    right: 50% !important;
+  }
+  .lg\\:r100 {
+    right: 100% !important;
+  }
+  .lg\\:rn50 {
+    right: -50% !important;
+  }
+  .lg\\:rn100 {
+    right: -100% !important;
+  }
+  .lg\\:b0 {
+    bottom: var(--su0) !important;
+  }
+  .lg\\:b1 {
+    bottom: var(--su1) !important;
+  }
+  .lg\\:b2 {
+    bottom: var(--su2) !important;
+  }
+  .lg\\:b4 {
+    bottom: var(--su4) !important;
+  }
+  .lg\\:b6 {
+    bottom: var(--su6) !important;
+  }
+  .lg\\:b8 {
+    bottom: var(--su8) !important;
+  }
+  .lg\\:b12 {
+    bottom: var(--su12) !important;
+  }
+  .lg\\:b16 {
+    bottom: var(--su16) !important;
+  }
+  .lg\\:b24 {
+    bottom: var(--su24) !important;
+  }
+  .lg\\:b32 {
+    bottom: var(--su32) !important;
+  }
+  .lg\\:b48 {
+    bottom: var(--su48) !important;
+  }
+  .lg\\:b64 {
+    bottom: var(--su64) !important;
+  }
+  .lg\\:b96 {
+    bottom: var(--su96) !important;
+  }
+  .lg\\:b128 {
+    bottom: var(--su128) !important;
+  }
+  .lg\\:bn1 {
+    bottom: var(--sun1) !important;
+  }
+  .lg\\:bn2 {
+    bottom: var(--sun2) !important;
+  }
+  .lg\\:bn4 {
+    bottom: var(--sun4) !important;
+  }
+  .lg\\:bn6 {
+    bottom: var(--sun6) !important;
+  }
+  .lg\\:bn8 {
+    bottom: var(--sun8) !important;
+  }
+  .lg\\:bn12 {
+    bottom: var(--sun12) !important;
+  }
+  .lg\\:bn16 {
+    bottom: var(--sun16) !important;
+  }
+  .lg\\:bn24 {
+    bottom: var(--sun24) !important;
+  }
+  .lg\\:bn32 {
+    bottom: var(--sun32) !important;
+  }
+  .lg\\:bn48 {
+    bottom: var(--sun48) !important;
+  }
+  .lg\\:bn64 {
+    bottom: var(--sun64) !important;
+  }
+  .lg\\:bn96 {
+    bottom: var(--sun96) !important;
+  }
+  .lg\\:bn128 {
+    bottom: var(--sun128) !important;
+  }
+  .lg\\:b50 {
+    bottom: 50% !important;
+  }
+  .lg\\:b100 {
+    bottom: 100% !important;
+  }
+  .lg\\:bn50 {
+    bottom: -50% !important;
+  }
+  .lg\\:bn100 {
+    bottom: -100% !important;
+  }
+  .lg\\:l0 {
+    left: var(--su0) !important;
+  }
+  .lg\\:l1 {
+    left: var(--su1) !important;
+  }
+  .lg\\:l2 {
+    left: var(--su2) !important;
+  }
+  .lg\\:l4 {
+    left: var(--su4) !important;
+  }
+  .lg\\:l6 {
+    left: var(--su6) !important;
+  }
+  .lg\\:l8 {
+    left: var(--su8) !important;
+  }
+  .lg\\:l12 {
+    left: var(--su12) !important;
+  }
+  .lg\\:l16 {
+    left: var(--su16) !important;
+  }
+  .lg\\:l24 {
+    left: var(--su24) !important;
+  }
+  .lg\\:l32 {
+    left: var(--su32) !important;
+  }
+  .lg\\:l48 {
+    left: var(--su48) !important;
+  }
+  .lg\\:l64 {
+    left: var(--su64) !important;
+  }
+  .lg\\:l96 {
+    left: var(--su96) !important;
+  }
+  .lg\\:l128 {
+    left: var(--su128) !important;
+  }
+  .lg\\:ln1 {
+    left: var(--sun1) !important;
+  }
+  .lg\\:ln2 {
+    left: var(--sun2) !important;
+  }
+  .lg\\:ln4 {
+    left: var(--sun4) !important;
+  }
+  .lg\\:ln6 {
+    left: var(--sun6) !important;
+  }
+  .lg\\:ln8 {
+    left: var(--sun8) !important;
+  }
+  .lg\\:ln12 {
+    left: var(--sun12) !important;
+  }
+  .lg\\:ln16 {
+    left: var(--sun16) !important;
+  }
+  .lg\\:ln24 {
+    left: var(--sun24) !important;
+  }
+  .lg\\:ln32 {
+    left: var(--sun32) !important;
+  }
+  .lg\\:ln48 {
+    left: var(--sun48) !important;
+  }
+  .lg\\:ln64 {
+    left: var(--sun64) !important;
+  }
+  .lg\\:ln96 {
+    left: var(--sun96) !important;
+  }
+  .lg\\:ln128 {
+    left: var(--sun128) !important;
+  }
+  .lg\\:l50 {
+    left: 50% !important;
+  }
+  .lg\\:l100 {
+    left: 100% !important;
+  }
+  .lg\\:ln50 {
+    left: -50% !important;
+  }
+  .lg\\:ln100 {
+    left: -100% !important;
+  }
+  .lg\\:w25 {
+    width: 25% !important;
+  }
+  .lg\\:w50 {
+    width: 50% !important;
+  }
+  .lg\\:w75 {
+    width: 75% !important;
+  }
+  .lg\\:w100 {
+    width: 100% !important;
+  }
+  .lg\\:w33 {
+    width: calc(100% / 3) !important;
+  }
+  .lg\\:w66 {
+    width: calc(100% / 3 * 2) !important;
+  }
+  .lg\\:w-auto {
+    width: auto !important;
+  }
+  .lg\\:w-screen {
+    width: 100vw !important;
+  }
+  .lg\\:wmn100 {
+    min-width: 100% !important;
+  }
+  .lg\\:wmn-initial {
+    min-width: initial !important;
+  }
+  .lg\\:wmn-screen {
+    min-width: 100vw !important;
+  }
+  .lg\\:wmx100 {
+    max-width: 100% !important;
+  }
+  .lg\\:wmx-initial {
+    max-width: initial !important;
+  }
+  .lg\\:wmx-screen {
+    max-width: 100vw !important;
+  }
+}
+@media (max-width: 71.875rem) {
+  .md\\:ta-left {
+    text-align: left !important;
+  }
+  .md\\:ta-center {
+    text-align: center !important;
+  }
+  .md\\:ta-right {
+    text-align: right !important;
+  }
+  .md\\:ba {
+    border-style: solid !important;
+    border-width: var(--su1) !important;
+  }
+  .md\\:bt {
+    border-top-style: solid !important;
+    border-top-width: var(--su1) !important;
+  }
+  .md\\:br {
+    border-right-style: solid !important;
+    border-right-width: var(--su1) !important;
+  }
+  .md\\:bb {
+    border-bottom-style: solid !important;
+    border-bottom-width: var(--su1) !important;
+  }
+  .md\\:bl {
+    border-left-style: solid !important;
+    border-left-width: var(--su1) !important;
+  }
+  .md\\:baw0 {
+    border-width: 0 !important;
+  }
+  .md\\:btw0 {
+    border-top-width: 0 !important;
+  }
+  .md\\:brw0 {
+    border-right-width: 0 !important;
+  }
+  .md\\:bbw0 {
+    border-bottom-width: 0 !important;
+  }
+  .md\\:blw0 {
+    border-left-width: 0 !important;
+  }
+  .md\\:bar0 {
+    border-radius: 0 !important;
+  }
+  .md\\:bs-none {
+    box-shadow: none !important;
+  }
+  .md\\:d-block {
+    display: block !important;
+  }
+  .md\\:d-flex {
+    display: flex !important;
+  }
+  .md\\:d-inline-flex {
+    display: inline-flex !important;
+  }
+  .md\\:d-grid {
+    display: grid !important;
+  }
+  .md\\:d-inline-grid {
+    display: inline-grid !important;
+  }
+  .md\\:d-inline {
+    display: inline !important;
+  }
+  .md\\:d-inline-block {
+    display: inline-block !important;
+  }
+  .md\\:d-none {
+    display: none !important;
+  }
+  .md\\:fd-row {
+    flex-direction: row !important;
+  }
+  .md\\:fd-row-reverse {
+    flex-direction: row-reverse !important;
+  }
+  .md\\:fd-column {
+    flex-direction: column !important;
+  }
+  .md\\:fd-column-reverse {
+    flex-direction: column-reverse !important;
+  }
+  .md\\:fw-wrap {
+    flex-wrap: wrap !important;
+  }
+  .md\\:fw-reverse {
+    flex-wrap: wrap-reverse !important;
+  }
+  .md\\:fw-nowrap {
+    flex-wrap: nowrap !important;
+  }
+  .md\\:jc-center {
+    justify-content: center !important;
+  }
+  .md\\:jc-end {
+    justify-content: flex-end !important;
+  }
+  .md\\:jc-space-around {
+    justify-content: space-around !important;
+  }
+  .md\\:jc-space-between {
+    justify-content: space-between !important;
+  }
+  .md\\:jc-space-evenly {
+    justify-content: space-evenly !important;
+  }
+  .md\\:jc-start {
+    justify-content: flex-start !important;
+  }
+  .md\\:ai-baseline {
+    align-items: baseline !important;
+  }
+  .md\\:ai-center {
+    align-items: center !important;
+  }
+  .md\\:ai-end {
+    align-items: flex-end !important;
+  }
+  .md\\:ai-start {
+    align-items: flex-start !important;
+  }
+  .md\\:ai-stretch {
+    align-items: stretch !important;
+  }
+  .md\\:fl-grow1 {
+    flex-grow: 1 !important;
+  }
+  .md\\:fl-grow0 {
+    flex-grow: 0 !important;
+  }
+  .md\\:fl-shrink1 {
+    flex-shrink: 1 !important;
+  }
+  .md\\:fl-shrink0 {
+    flex-shrink: 0 !important;
+  }
+  .md\\:fl-none {
+    flex: none !important;
+  }
+  .md\\:fl-initial {
+    flex: 0 1 auto !important;
+  }
+  .md\\:fl-auto {
+    flex: 1 1 auto !important;
+  }
+  .md\\:fl-equal {
+    flex: 1 1 0% !important;
+  }
+  .md\\:order-first {
+    order: -1 !important;
+  }
+  .md\\:order-last {
+    order: 1 !important;
+  }
+  .md\\:fl0 {
+    flex: 0 auto !important;
+  }
+  .md\\:fl1 {
+    flex: 1 auto !important;
+  }
+  .md\\:g0 {
+    --_gap-y: 0;
+    --_gap-x: 0;
+  }
+  .md\\:g1 {
+    --_gap-y: var(--su1);
+    --_gap-x: var(--su1);
+  }
+  .md\\:g2 {
+    --_gap-y: var(--su2);
+    --_gap-x: var(--su2);
+  }
+  .md\\:g4 {
+    --_gap-y: var(--su4);
+    --_gap-x: var(--su4);
+  }
+  .md\\:g6 {
+    --_gap-y: var(--su6);
+    --_gap-x: var(--su6);
+  }
+  .md\\:g8 {
+    --_gap-y: var(--su8);
+    --_gap-x: var(--su8);
+  }
+  .md\\:g12 {
+    --_gap-y: var(--su12);
+    --_gap-x: var(--su12);
+  }
+  .md\\:g16 {
+    --_gap-y: var(--su16);
+    --_gap-x: var(--su16);
+  }
+  .md\\:g24 {
+    --_gap-y: var(--su24);
+    --_gap-x: var(--su24);
+  }
+  .md\\:g32 {
+    --_gap-y: var(--su32);
+    --_gap-x: var(--su32);
+  }
+  .md\\:g48 {
+    --_gap-y: var(--su48);
+    --_gap-x: var(--su48);
+  }
+  .md\\:g64 {
+    --_gap-y: var(--su64);
+    --_gap-x: var(--su64);
+  }
+  .md\\:gx0 {
+    --_gap-x: 0;
+  }
+  .md\\:gx1 {
+    --_gap-x: var(--su1);
+  }
+  .md\\:gx2 {
+    --_gap-x: var(--su2);
+  }
+  .md\\:gx4 {
+    --_gap-x: var(--su4);
+  }
+  .md\\:gx6 {
+    --_gap-x: var(--su6);
+  }
+  .md\\:gx8 {
+    --_gap-x: var(--su8);
+  }
+  .md\\:gx12 {
+    --_gap-x: var(--su12);
+  }
+  .md\\:gx16 {
+    --_gap-x: var(--su16);
+  }
+  .md\\:gx24 {
+    --_gap-x: var(--su24);
+  }
+  .md\\:gx32 {
+    --_gap-x: var(--su32);
+  }
+  .md\\:gx48 {
+    --_gap-x: var(--su48);
+  }
+  .md\\:gx64 {
+    --_gap-x: var(--su64);
+  }
+  .md\\:gy0 {
+    --_gap-y: 0;
+  }
+  .md\\:gy1 {
+    --_gap-y: var(--su1);
+  }
+  .md\\:gy2 {
+    --_gap-y: var(--su2);
+  }
+  .md\\:gy4 {
+    --_gap-y: var(--su4);
+  }
+  .md\\:gy6 {
+    --_gap-y: var(--su6);
+  }
+  .md\\:gy8 {
+    --_gap-y: var(--su8);
+  }
+  .md\\:gy12 {
+    --_gap-y: var(--su12);
+  }
+  .md\\:gy16 {
+    --_gap-y: var(--su16);
+  }
+  .md\\:gy24 {
+    --_gap-y: var(--su24);
+  }
+  .md\\:gy32 {
+    --_gap-y: var(--su32);
+  }
+  .md\\:gy48 {
+    --_gap-y: var(--su48);
+  }
+  .md\\:gy64 {
+    --_gap-y: var(--su64);
+  }
+  .md\\:g-af-dense {
+    grid-auto-flow: dense;
+  }
+  .md\\:g-af-row {
+    grid-auto-flow: row;
+  }
+  .md\\:g-af-column {
+    grid-auto-flow: column;
+  }
+  .md\\:grid__1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+  .md\\:grid__2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .md\\:grid__3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .md\\:grid__4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+  .md\\:grid__5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+  .md\\:grid__6 {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+  .md\\:grid__7 {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+  .md\\:grid__8 {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+  }
+  .md\\:grid__9 {
+    grid-template-columns: repeat(9, minmax(0, 1fr));
+  }
+  .md\\:grid__10 {
+    grid-template-columns: repeat(10, minmax(0, 1fr));
+  }
+  .md\\:grid__11 {
+    grid-template-columns: repeat(11, minmax(0, 1fr));
+  }
+  .md\\:grid__12 {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+  }
+  .md\\:grid__auto {
+    grid-template-columns: auto 1fr;
+  }
+  .md\\:grid--col-all {
+    grid-column: 1 / -1;
+  }
+  .md\\:grid--row-all {
+    grid-row: 1 / -1;
+  }
+  .md\\:grid--col1 {
+    grid-column: span 1;
+  }
+  .md\\:grid--col2 {
+    grid-column: span 2;
+  }
+  .md\\:grid--col3 {
+    grid-column: span 3;
+  }
+  .md\\:grid--col4 {
+    grid-column: span 4;
+  }
+  .md\\:grid--col5 {
+    grid-column: span 5;
+  }
+  .md\\:grid--col6 {
+    grid-column: span 6;
+  }
+  .md\\:grid--col7 {
+    grid-column: span 7;
+  }
+  .md\\:grid--col8 {
+    grid-column: span 8;
+  }
+  .md\\:grid--col9 {
+    grid-column: span 9;
+  }
+  .md\\:grid--col10 {
+    grid-column: span 10;
+  }
+  .md\\:grid--col11 {
+    grid-column: span 11;
+  }
+  .md\\:grid--col12 {
+    grid-column: span 12;
+  }
+  .md\\:grid--row1 {
+    grid-row: span 1;
+  }
+  .md\\:grid--row2 {
+    grid-row: span 2;
+  }
+  .md\\:grid--row3 {
+    grid-row: span 3;
+  }
+  .md\\:grid--row4 {
+    grid-row: span 4;
+  }
+  .md\\:grid--row5 {
+    grid-row: span 5;
+  }
+  .md\\:grid--row6 {
+    grid-row: span 6;
+  }
+  .md\\:grid--row7 {
+    grid-row: span 7;
+  }
+  .md\\:grid--row8 {
+    grid-row: span 8;
+  }
+  .md\\:grid--row9 {
+    grid-row: span 9;
+  }
+  .md\\:grid--row10 {
+    grid-row: span 10;
+  }
+  .md\\:grid--row11 {
+    grid-row: span 11;
+  }
+  .md\\:grid--row12 {
+    grid-row: span 12;
+  }
+  .md\\:grid--col-start1 {
+    grid-column-start: 1;
+  }
+  .md\\:grid--col-start2 {
+    grid-column-start: 2;
+  }
+  .md\\:grid--col-start3 {
+    grid-column-start: 3;
+  }
+  .md\\:grid--col-start4 {
+    grid-column-start: 4;
+  }
+  .md\\:grid--col-start5 {
+    grid-column-start: 5;
+  }
+  .md\\:grid--col-start6 {
+    grid-column-start: 6;
+  }
+  .md\\:grid--col-start7 {
+    grid-column-start: 7;
+  }
+  .md\\:grid--col-start8 {
+    grid-column-start: 8;
+  }
+  .md\\:grid--col-start9 {
+    grid-column-start: 9;
+  }
+  .md\\:grid--col-start10 {
+    grid-column-start: 10;
+  }
+  .md\\:grid--col-start11 {
+    grid-column-start: 11;
+  }
+  .md\\:grid--col-start12 {
+    grid-column-start: 12;
+  }
+  .md\\:grid--col-end2 {
+    grid-column-end: 2;
+  }
+  .md\\:grid--col-end3 {
+    grid-column-end: 3;
+  }
+  .md\\:grid--col-end4 {
+    grid-column-end: 4;
+  }
+  .md\\:grid--col-end5 {
+    grid-column-end: 5;
+  }
+  .md\\:grid--col-end6 {
+    grid-column-end: 6;
+  }
+  .md\\:grid--col-end7 {
+    grid-column-end: 7;
+  }
+  .md\\:grid--col-end8 {
+    grid-column-end: 8;
+  }
+  .md\\:grid--col-end9 {
+    grid-column-end: 9;
+  }
+  .md\\:grid--col-end10 {
+    grid-column-end: 10;
+  }
+  .md\\:grid--col-end11 {
+    grid-column-end: 11;
+  }
+  .md\\:grid--col-end12 {
+    grid-column-end: 12;
+  }
+  .md\\:grid--col-end13 {
+    grid-column-end: 13;
+  }
+  .md\\:grid--row-start1 {
+    grid-row-start: 1;
+  }
+  .md\\:grid--row-start2 {
+    grid-row-start: 2;
+  }
+  .md\\:grid--row-start3 {
+    grid-row-start: 3;
+  }
+  .md\\:grid--row-start4 {
+    grid-row-start: 4;
+  }
+  .md\\:grid--row-start5 {
+    grid-row-start: 5;
+  }
+  .md\\:grid--row-start6 {
+    grid-row-start: 6;
+  }
+  .md\\:grid--row-start7 {
+    grid-row-start: 7;
+  }
+  .md\\:grid--row-start8 {
+    grid-row-start: 8;
+  }
+  .md\\:grid--row-start9 {
+    grid-row-start: 9;
+  }
+  .md\\:grid--row-start10 {
+    grid-row-start: 10;
+  }
+  .md\\:grid--row-start11 {
+    grid-row-start: 11;
+  }
+  .md\\:grid--row-start12 {
+    grid-row-start: 12;
+  }
+  .md\\:grid--row-end2 {
+    grid-row-end: 2;
+  }
+  .md\\:grid--row-end3 {
+    grid-row-end: 3;
+  }
+  .md\\:grid--row-end4 {
+    grid-row-end: 4;
+  }
+  .md\\:grid--row-end5 {
+    grid-row-end: 5;
+  }
+  .md\\:grid--row-end6 {
+    grid-row-end: 6;
+  }
+  .md\\:grid--row-end7 {
+    grid-row-end: 7;
+  }
+  .md\\:grid--row-end8 {
+    grid-row-end: 8;
+  }
+  .md\\:grid--row-end9 {
+    grid-row-end: 9;
+  }
+  .md\\:grid--row-end10 {
+    grid-row-end: 10;
+  }
+  .md\\:grid--row-end11 {
+    grid-row-end: 11;
+  }
+  .md\\:grid--row-end12 {
+    grid-row-end: 12;
+  }
+  .md\\:grid--row-end13 {
+    grid-row-end: 13;
+  }
+  .md\\:ji-auto {
+    justify-items: auto !important;
+  }
+  .md\\:ji-center {
+    justify-items: center !important;
+  }
+  .md\\:ji-start {
+    justify-items: start !important;
+  }
+  .md\\:ji-end {
+    justify-items: end !important;
+  }
+  .md\\:ji-stretch {
+    justify-items: stretch !important;
+  }
+  .md\\:ji-unset {
+    justify-items: unset !important;
+  }
+  .md\\:js-auto {
+    justify-self: auto !important;
+  }
+  .md\\:js-center {
+    justify-self: center !important;
+  }
+  .md\\:js-start {
+    justify-self: start !important;
+  }
+  .md\\:js-end {
+    justify-self: end !important;
+  }
+  .md\\:js-stretch {
+    justify-self: stretch !important;
+  }
+  .md\\:js-unset {
+    justify-self: unset !important;
+  }
+  .md\\:h100 {
+    height: 100% !important;
+  }
+  .md\\:h-auto {
+    height: auto !important;
+  }
+  .md\\:h-screen {
+    height: 100vh !important;
+  }
+  .md\\:hmn100 {
+    min-height: 100% !important;
+  }
+  .md\\:hmn-initial {
+    min-height: initial !important;
+  }
+  .md\\:hmn-screen {
+    min-height: 100vh !important;
+  }
+  .md\\:hmx100 {
+    max-height: 100% !important;
+  }
+  .md\\:hmx-initial {
+    max-height: initial !important;
+  }
+  .md\\:hmx-screen {
+    max-height: 100vh !important;
+  }
+  .md\\:m0 {
+    margin: var(--su0) !important;
+  }
+  .md\\:m1 {
+    margin: var(--su1) !important;
+  }
+  .md\\:m2 {
+    margin: var(--su2) !important;
+  }
+  .md\\:m4 {
+    margin: var(--su4) !important;
+  }
+  .md\\:m6 {
+    margin: var(--su6) !important;
+  }
+  .md\\:m8 {
+    margin: var(--su8) !important;
+  }
+  .md\\:m12 {
+    margin: var(--su12) !important;
+  }
+  .md\\:m16 {
+    margin: var(--su16) !important;
+  }
+  .md\\:m24 {
+    margin: var(--su24) !important;
+  }
+  .md\\:m32 {
+    margin: var(--su32) !important;
+  }
+  .md\\:m48 {
+    margin: var(--su48) !important;
+  }
+  .md\\:m64 {
+    margin: var(--su64) !important;
+  }
+  .md\\:m96 {
+    margin: var(--su96) !important;
+  }
+  .md\\:m128 {
+    margin: var(--su128) !important;
+  }
+  .md\\:mn1 {
+    margin: var(--sun1) !important;
+  }
+  .md\\:mn2 {
+    margin: var(--sun2) !important;
+  }
+  .md\\:mn4 {
+    margin: var(--sun4) !important;
+  }
+  .md\\:mn6 {
+    margin: var(--sun6) !important;
+  }
+  .md\\:mn8 {
+    margin: var(--sun8) !important;
+  }
+  .md\\:mn12 {
+    margin: var(--sun12) !important;
+  }
+  .md\\:mn16 {
+    margin: var(--sun16) !important;
+  }
+  .md\\:mn24 {
+    margin: var(--sun24) !important;
+  }
+  .md\\:mn32 {
+    margin: var(--sun32) !important;
+  }
+  .md\\:mn48 {
+    margin: var(--sun48) !important;
+  }
+  .md\\:mn64 {
+    margin: var(--sun64) !important;
+  }
+  .md\\:mn96 {
+    margin: var(--sun96) !important;
+  }
+  .md\\:mn128 {
+    margin: var(--sun128) !important;
+  }
+  .md\\:m50 {
+    margin: 50% !important;
+  }
+  .md\\:m100 {
+    margin: 100% !important;
+  }
+  .md\\:mn50 {
+    margin: -50% !important;
+  }
+  .md\\:mn100 {
+    margin: -100% !important;
+  }
+  .md\\:mt0 {
+    margin-top: var(--su0) !important;
+  }
+  .md\\:mt1 {
+    margin-top: var(--su1) !important;
+  }
+  .md\\:mt2 {
+    margin-top: var(--su2) !important;
+  }
+  .md\\:mt4 {
+    margin-top: var(--su4) !important;
+  }
+  .md\\:mt6 {
+    margin-top: var(--su6) !important;
+  }
+  .md\\:mt8 {
+    margin-top: var(--su8) !important;
+  }
+  .md\\:mt12 {
+    margin-top: var(--su12) !important;
+  }
+  .md\\:mt16 {
+    margin-top: var(--su16) !important;
+  }
+  .md\\:mt24 {
+    margin-top: var(--su24) !important;
+  }
+  .md\\:mt32 {
+    margin-top: var(--su32) !important;
+  }
+  .md\\:mt48 {
+    margin-top: var(--su48) !important;
+  }
+  .md\\:mt64 {
+    margin-top: var(--su64) !important;
+  }
+  .md\\:mt96 {
+    margin-top: var(--su96) !important;
+  }
+  .md\\:mt128 {
+    margin-top: var(--su128) !important;
+  }
+  .md\\:mtn1 {
+    margin-top: var(--sun1) !important;
+  }
+  .md\\:mtn2 {
+    margin-top: var(--sun2) !important;
+  }
+  .md\\:mtn4 {
+    margin-top: var(--sun4) !important;
+  }
+  .md\\:mtn6 {
+    margin-top: var(--sun6) !important;
+  }
+  .md\\:mtn8 {
+    margin-top: var(--sun8) !important;
+  }
+  .md\\:mtn12 {
+    margin-top: var(--sun12) !important;
+  }
+  .md\\:mtn16 {
+    margin-top: var(--sun16) !important;
+  }
+  .md\\:mtn24 {
+    margin-top: var(--sun24) !important;
+  }
+  .md\\:mtn32 {
+    margin-top: var(--sun32) !important;
+  }
+  .md\\:mtn48 {
+    margin-top: var(--sun48) !important;
+  }
+  .md\\:mtn64 {
+    margin-top: var(--sun64) !important;
+  }
+  .md\\:mtn96 {
+    margin-top: var(--sun96) !important;
+  }
+  .md\\:mtn128 {
+    margin-top: var(--sun128) !important;
+  }
+  .md\\:mt50 {
+    margin-top: 50% !important;
+  }
+  .md\\:mt100 {
+    margin-top: 100% !important;
+  }
+  .md\\:mtn50 {
+    margin-top: -50% !important;
+  }
+  .md\\:mtn100 {
+    margin-top: -100% !important;
+  }
+  .md\\:mr0 {
+    margin-right: var(--su0) !important;
+  }
+  .md\\:mr1 {
+    margin-right: var(--su1) !important;
+  }
+  .md\\:mr2 {
+    margin-right: var(--su2) !important;
+  }
+  .md\\:mr4 {
+    margin-right: var(--su4) !important;
+  }
+  .md\\:mr6 {
+    margin-right: var(--su6) !important;
+  }
+  .md\\:mr8 {
+    margin-right: var(--su8) !important;
+  }
+  .md\\:mr12 {
+    margin-right: var(--su12) !important;
+  }
+  .md\\:mr16 {
+    margin-right: var(--su16) !important;
+  }
+  .md\\:mr24 {
+    margin-right: var(--su24) !important;
+  }
+  .md\\:mr32 {
+    margin-right: var(--su32) !important;
+  }
+  .md\\:mr48 {
+    margin-right: var(--su48) !important;
+  }
+  .md\\:mr64 {
+    margin-right: var(--su64) !important;
+  }
+  .md\\:mr96 {
+    margin-right: var(--su96) !important;
+  }
+  .md\\:mr128 {
+    margin-right: var(--su128) !important;
+  }
+  .md\\:mrn1 {
+    margin-right: var(--sun1) !important;
+  }
+  .md\\:mrn2 {
+    margin-right: var(--sun2) !important;
+  }
+  .md\\:mrn4 {
+    margin-right: var(--sun4) !important;
+  }
+  .md\\:mrn6 {
+    margin-right: var(--sun6) !important;
+  }
+  .md\\:mrn8 {
+    margin-right: var(--sun8) !important;
+  }
+  .md\\:mrn12 {
+    margin-right: var(--sun12) !important;
+  }
+  .md\\:mrn16 {
+    margin-right: var(--sun16) !important;
+  }
+  .md\\:mrn24 {
+    margin-right: var(--sun24) !important;
+  }
+  .md\\:mrn32 {
+    margin-right: var(--sun32) !important;
+  }
+  .md\\:mrn48 {
+    margin-right: var(--sun48) !important;
+  }
+  .md\\:mrn64 {
+    margin-right: var(--sun64) !important;
+  }
+  .md\\:mrn96 {
+    margin-right: var(--sun96) !important;
+  }
+  .md\\:mrn128 {
+    margin-right: var(--sun128) !important;
+  }
+  .md\\:mr50 {
+    margin-right: 50% !important;
+  }
+  .md\\:mr100 {
+    margin-right: 100% !important;
+  }
+  .md\\:mrn50 {
+    margin-right: -50% !important;
+  }
+  .md\\:mrn100 {
+    margin-right: -100% !important;
+  }
+  .md\\:mb0 {
+    margin-bottom: var(--su0) !important;
+  }
+  .md\\:mb1 {
+    margin-bottom: var(--su1) !important;
+  }
+  .md\\:mb2 {
+    margin-bottom: var(--su2) !important;
+  }
+  .md\\:mb4 {
+    margin-bottom: var(--su4) !important;
+  }
+  .md\\:mb6 {
+    margin-bottom: var(--su6) !important;
+  }
+  .md\\:mb8 {
+    margin-bottom: var(--su8) !important;
+  }
+  .md\\:mb12 {
+    margin-bottom: var(--su12) !important;
+  }
+  .md\\:mb16 {
+    margin-bottom: var(--su16) !important;
+  }
+  .md\\:mb24 {
+    margin-bottom: var(--su24) !important;
+  }
+  .md\\:mb32 {
+    margin-bottom: var(--su32) !important;
+  }
+  .md\\:mb48 {
+    margin-bottom: var(--su48) !important;
+  }
+  .md\\:mb64 {
+    margin-bottom: var(--su64) !important;
+  }
+  .md\\:mb96 {
+    margin-bottom: var(--su96) !important;
+  }
+  .md\\:mb128 {
+    margin-bottom: var(--su128) !important;
+  }
+  .md\\:mbn1 {
+    margin-bottom: var(--sun1) !important;
+  }
+  .md\\:mbn2 {
+    margin-bottom: var(--sun2) !important;
+  }
+  .md\\:mbn4 {
+    margin-bottom: var(--sun4) !important;
+  }
+  .md\\:mbn6 {
+    margin-bottom: var(--sun6) !important;
+  }
+  .md\\:mbn8 {
+    margin-bottom: var(--sun8) !important;
+  }
+  .md\\:mbn12 {
+    margin-bottom: var(--sun12) !important;
+  }
+  .md\\:mbn16 {
+    margin-bottom: var(--sun16) !important;
+  }
+  .md\\:mbn24 {
+    margin-bottom: var(--sun24) !important;
+  }
+  .md\\:mbn32 {
+    margin-bottom: var(--sun32) !important;
+  }
+  .md\\:mbn48 {
+    margin-bottom: var(--sun48) !important;
+  }
+  .md\\:mbn64 {
+    margin-bottom: var(--sun64) !important;
+  }
+  .md\\:mbn96 {
+    margin-bottom: var(--sun96) !important;
+  }
+  .md\\:mbn128 {
+    margin-bottom: var(--sun128) !important;
+  }
+  .md\\:mb50 {
+    margin-bottom: 50% !important;
+  }
+  .md\\:mb100 {
+    margin-bottom: 100% !important;
+  }
+  .md\\:mbn50 {
+    margin-bottom: -50% !important;
+  }
+  .md\\:mbn100 {
+    margin-bottom: -100% !important;
+  }
+  .md\\:ml0 {
+    margin-left: var(--su0) !important;
+  }
+  .md\\:ml1 {
+    margin-left: var(--su1) !important;
+  }
+  .md\\:ml2 {
+    margin-left: var(--su2) !important;
+  }
+  .md\\:ml4 {
+    margin-left: var(--su4) !important;
+  }
+  .md\\:ml6 {
+    margin-left: var(--su6) !important;
+  }
+  .md\\:ml8 {
+    margin-left: var(--su8) !important;
+  }
+  .md\\:ml12 {
+    margin-left: var(--su12) !important;
+  }
+  .md\\:ml16 {
+    margin-left: var(--su16) !important;
+  }
+  .md\\:ml24 {
+    margin-left: var(--su24) !important;
+  }
+  .md\\:ml32 {
+    margin-left: var(--su32) !important;
+  }
+  .md\\:ml48 {
+    margin-left: var(--su48) !important;
+  }
+  .md\\:ml64 {
+    margin-left: var(--su64) !important;
+  }
+  .md\\:ml96 {
+    margin-left: var(--su96) !important;
+  }
+  .md\\:ml128 {
+    margin-left: var(--su128) !important;
+  }
+  .md\\:mln1 {
+    margin-left: var(--sun1) !important;
+  }
+  .md\\:mln2 {
+    margin-left: var(--sun2) !important;
+  }
+  .md\\:mln4 {
+    margin-left: var(--sun4) !important;
+  }
+  .md\\:mln6 {
+    margin-left: var(--sun6) !important;
+  }
+  .md\\:mln8 {
+    margin-left: var(--sun8) !important;
+  }
+  .md\\:mln12 {
+    margin-left: var(--sun12) !important;
+  }
+  .md\\:mln16 {
+    margin-left: var(--sun16) !important;
+  }
+  .md\\:mln24 {
+    margin-left: var(--sun24) !important;
+  }
+  .md\\:mln32 {
+    margin-left: var(--sun32) !important;
+  }
+  .md\\:mln48 {
+    margin-left: var(--sun48) !important;
+  }
+  .md\\:mln64 {
+    margin-left: var(--sun64) !important;
+  }
+  .md\\:mln96 {
+    margin-left: var(--sun96) !important;
+  }
+  .md\\:mln128 {
+    margin-left: var(--sun128) !important;
+  }
+  .md\\:ml50 {
+    margin-left: 50% !important;
+  }
+  .md\\:ml100 {
+    margin-left: 100% !important;
+  }
+  .md\\:mln50 {
+    margin-left: -50% !important;
+  }
+  .md\\:mln100 {
+    margin-left: -100% !important;
+  }
+  .md\\:mx0 {
+    margin-left: var(--su0) !important;
+    margin-right: var(--su0) !important;
+  }
+  .md\\:mx1 {
+    margin-left: var(--su1) !important;
+    margin-right: var(--su1) !important;
+  }
+  .md\\:mx2 {
+    margin-left: var(--su2) !important;
+    margin-right: var(--su2) !important;
+  }
+  .md\\:mx4 {
+    margin-left: var(--su4) !important;
+    margin-right: var(--su4) !important;
+  }
+  .md\\:mx6 {
+    margin-left: var(--su6) !important;
+    margin-right: var(--su6) !important;
+  }
+  .md\\:mx8 {
+    margin-left: var(--su8) !important;
+    margin-right: var(--su8) !important;
+  }
+  .md\\:mx12 {
+    margin-left: var(--su12) !important;
+    margin-right: var(--su12) !important;
+  }
+  .md\\:mx16 {
+    margin-left: var(--su16) !important;
+    margin-right: var(--su16) !important;
+  }
+  .md\\:mx24 {
+    margin-left: var(--su24) !important;
+    margin-right: var(--su24) !important;
+  }
+  .md\\:mx32 {
+    margin-left: var(--su32) !important;
+    margin-right: var(--su32) !important;
+  }
+  .md\\:mx48 {
+    margin-left: var(--su48) !important;
+    margin-right: var(--su48) !important;
+  }
+  .md\\:mx64 {
+    margin-left: var(--su64) !important;
+    margin-right: var(--su64) !important;
+  }
+  .md\\:mx96 {
+    margin-left: var(--su96) !important;
+    margin-right: var(--su96) !important;
+  }
+  .md\\:mx128 {
+    margin-left: var(--su128) !important;
+    margin-right: var(--su128) !important;
+  }
+  .md\\:mxn1 {
+    margin-left: var(--sun1) !important;
+    margin-right: var(--sun1) !important;
+  }
+  .md\\:mxn2 {
+    margin-left: var(--sun2) !important;
+    margin-right: var(--sun2) !important;
+  }
+  .md\\:mxn4 {
+    margin-left: var(--sun4) !important;
+    margin-right: var(--sun4) !important;
+  }
+  .md\\:mxn6 {
+    margin-left: var(--sun6) !important;
+    margin-right: var(--sun6) !important;
+  }
+  .md\\:mxn8 {
+    margin-left: var(--sun8) !important;
+    margin-right: var(--sun8) !important;
+  }
+  .md\\:mxn12 {
+    margin-left: var(--sun12) !important;
+    margin-right: var(--sun12) !important;
+  }
+  .md\\:mxn16 {
+    margin-left: var(--sun16) !important;
+    margin-right: var(--sun16) !important;
+  }
+  .md\\:mxn24 {
+    margin-left: var(--sun24) !important;
+    margin-right: var(--sun24) !important;
+  }
+  .md\\:mxn32 {
+    margin-left: var(--sun32) !important;
+    margin-right: var(--sun32) !important;
+  }
+  .md\\:mxn48 {
+    margin-left: var(--sun48) !important;
+    margin-right: var(--sun48) !important;
+  }
+  .md\\:mxn64 {
+    margin-left: var(--sun64) !important;
+    margin-right: var(--sun64) !important;
+  }
+  .md\\:mxn96 {
+    margin-left: var(--sun96) !important;
+    margin-right: var(--sun96) !important;
+  }
+  .md\\:mxn128 {
+    margin-left: var(--sun128) !important;
+    margin-right: var(--sun128) !important;
+  }
+  .md\\:my0 {
+    margin-top: var(--su0) !important;
+    margin-bottom: var(--su0) !important;
+  }
+  .md\\:my1 {
+    margin-top: var(--su1) !important;
+    margin-bottom: var(--su1) !important;
+  }
+  .md\\:my2 {
+    margin-top: var(--su2) !important;
+    margin-bottom: var(--su2) !important;
+  }
+  .md\\:my4 {
+    margin-top: var(--su4) !important;
+    margin-bottom: var(--su4) !important;
+  }
+  .md\\:my6 {
+    margin-top: var(--su6) !important;
+    margin-bottom: var(--su6) !important;
+  }
+  .md\\:my8 {
+    margin-top: var(--su8) !important;
+    margin-bottom: var(--su8) !important;
+  }
+  .md\\:my12 {
+    margin-top: var(--su12) !important;
+    margin-bottom: var(--su12) !important;
+  }
+  .md\\:my16 {
+    margin-top: var(--su16) !important;
+    margin-bottom: var(--su16) !important;
+  }
+  .md\\:my24 {
+    margin-top: var(--su24) !important;
+    margin-bottom: var(--su24) !important;
+  }
+  .md\\:my32 {
+    margin-top: var(--su32) !important;
+    margin-bottom: var(--su32) !important;
+  }
+  .md\\:my48 {
+    margin-top: var(--su48) !important;
+    margin-bottom: var(--su48) !important;
+  }
+  .md\\:my64 {
+    margin-top: var(--su64) !important;
+    margin-bottom: var(--su64) !important;
+  }
+  .md\\:my96 {
+    margin-top: var(--su96) !important;
+    margin-bottom: var(--su96) !important;
+  }
+  .md\\:my128 {
+    margin-top: var(--su128) !important;
+    margin-bottom: var(--su128) !important;
+  }
+  .md\\:myn1 {
+    margin-top: var(--sun1) !important;
+    margin-bottom: var(--sun1) !important;
+  }
+  .md\\:myn2 {
+    margin-top: var(--sun2) !important;
+    margin-bottom: var(--sun2) !important;
+  }
+  .md\\:myn4 {
+    margin-top: var(--sun4) !important;
+    margin-bottom: var(--sun4) !important;
+  }
+  .md\\:myn6 {
+    margin-top: var(--sun6) !important;
+    margin-bottom: var(--sun6) !important;
+  }
+  .md\\:myn8 {
+    margin-top: var(--sun8) !important;
+    margin-bottom: var(--sun8) !important;
+  }
+  .md\\:myn12 {
+    margin-top: var(--sun12) !important;
+    margin-bottom: var(--sun12) !important;
+  }
+  .md\\:myn16 {
+    margin-top: var(--sun16) !important;
+    margin-bottom: var(--sun16) !important;
+  }
+  .md\\:myn24 {
+    margin-top: var(--sun24) !important;
+    margin-bottom: var(--sun24) !important;
+  }
+  .md\\:myn32 {
+    margin-top: var(--sun32) !important;
+    margin-bottom: var(--sun32) !important;
+  }
+  .md\\:myn48 {
+    margin-top: var(--sun48) !important;
+    margin-bottom: var(--sun48) !important;
+  }
+  .md\\:myn64 {
+    margin-top: var(--sun64) !important;
+    margin-bottom: var(--sun64) !important;
+  }
+  .md\\:myn96 {
+    margin-top: var(--sun96) !important;
+    margin-bottom: var(--sun96) !important;
+  }
+  .md\\:myn128 {
+    margin-top: var(--sun128) !important;
+    margin-bottom: var(--sun128) !important;
+  }
+  .md\\:p0 {
+    padding: var(--su0) !important;
+  }
+  .md\\:p1 {
+    padding: var(--su1) !important;
+  }
+  .md\\:p2 {
+    padding: var(--su2) !important;
+  }
+  .md\\:p4 {
+    padding: var(--su4) !important;
+  }
+  .md\\:p6 {
+    padding: var(--su6) !important;
+  }
+  .md\\:p8 {
+    padding: var(--su8) !important;
+  }
+  .md\\:p12 {
+    padding: var(--su12) !important;
+  }
+  .md\\:p16 {
+    padding: var(--su16) !important;
+  }
+  .md\\:p24 {
+    padding: var(--su24) !important;
+  }
+  .md\\:p32 {
+    padding: var(--su32) !important;
+  }
+  .md\\:p48 {
+    padding: var(--su48) !important;
+  }
+  .md\\:p64 {
+    padding: var(--su64) !important;
+  }
+  .md\\:p96 {
+    padding: var(--su96) !important;
+  }
+  .md\\:p128 {
+    padding: var(--su128) !important;
+  }
+  .md\\:pt0 {
+    padding-top: var(--su0) !important;
+  }
+  .md\\:pt1 {
+    padding-top: var(--su1) !important;
+  }
+  .md\\:pt2 {
+    padding-top: var(--su2) !important;
+  }
+  .md\\:pt4 {
+    padding-top: var(--su4) !important;
+  }
+  .md\\:pt6 {
+    padding-top: var(--su6) !important;
+  }
+  .md\\:pt8 {
+    padding-top: var(--su8) !important;
+  }
+  .md\\:pt12 {
+    padding-top: var(--su12) !important;
+  }
+  .md\\:pt16 {
+    padding-top: var(--su16) !important;
+  }
+  .md\\:pt24 {
+    padding-top: var(--su24) !important;
+  }
+  .md\\:pt32 {
+    padding-top: var(--su32) !important;
+  }
+  .md\\:pt48 {
+    padding-top: var(--su48) !important;
+  }
+  .md\\:pt64 {
+    padding-top: var(--su64) !important;
+  }
+  .md\\:pt96 {
+    padding-top: var(--su96) !important;
+  }
+  .md\\:pt128 {
+    padding-top: var(--su128) !important;
+  }
+  .md\\:pr0 {
+    padding-right: var(--su0) !important;
+  }
+  .md\\:pr1 {
+    padding-right: var(--su1) !important;
+  }
+  .md\\:pr2 {
+    padding-right: var(--su2) !important;
+  }
+  .md\\:pr4 {
+    padding-right: var(--su4) !important;
+  }
+  .md\\:pr6 {
+    padding-right: var(--su6) !important;
+  }
+  .md\\:pr8 {
+    padding-right: var(--su8) !important;
+  }
+  .md\\:pr12 {
+    padding-right: var(--su12) !important;
+  }
+  .md\\:pr16 {
+    padding-right: var(--su16) !important;
+  }
+  .md\\:pr24 {
+    padding-right: var(--su24) !important;
+  }
+  .md\\:pr32 {
+    padding-right: var(--su32) !important;
+  }
+  .md\\:pr48 {
+    padding-right: var(--su48) !important;
+  }
+  .md\\:pr64 {
+    padding-right: var(--su64) !important;
+  }
+  .md\\:pr96 {
+    padding-right: var(--su96) !important;
+  }
+  .md\\:pr128 {
+    padding-right: var(--su128) !important;
+  }
+  .md\\:pb0 {
+    padding-bottom: var(--su0) !important;
+  }
+  .md\\:pb1 {
+    padding-bottom: var(--su1) !important;
+  }
+  .md\\:pb2 {
+    padding-bottom: var(--su2) !important;
+  }
+  .md\\:pb4 {
+    padding-bottom: var(--su4) !important;
+  }
+  .md\\:pb6 {
+    padding-bottom: var(--su6) !important;
+  }
+  .md\\:pb8 {
+    padding-bottom: var(--su8) !important;
+  }
+  .md\\:pb12 {
+    padding-bottom: var(--su12) !important;
+  }
+  .md\\:pb16 {
+    padding-bottom: var(--su16) !important;
+  }
+  .md\\:pb24 {
+    padding-bottom: var(--su24) !important;
+  }
+  .md\\:pb32 {
+    padding-bottom: var(--su32) !important;
+  }
+  .md\\:pb48 {
+    padding-bottom: var(--su48) !important;
+  }
+  .md\\:pb64 {
+    padding-bottom: var(--su64) !important;
+  }
+  .md\\:pb96 {
+    padding-bottom: var(--su96) !important;
+  }
+  .md\\:pb128 {
+    padding-bottom: var(--su128) !important;
+  }
+  .md\\:pl0 {
+    padding-left: var(--su0) !important;
+  }
+  .md\\:pl1 {
+    padding-left: var(--su1) !important;
+  }
+  .md\\:pl2 {
+    padding-left: var(--su2) !important;
+  }
+  .md\\:pl4 {
+    padding-left: var(--su4) !important;
+  }
+  .md\\:pl6 {
+    padding-left: var(--su6) !important;
+  }
+  .md\\:pl8 {
+    padding-left: var(--su8) !important;
+  }
+  .md\\:pl12 {
+    padding-left: var(--su12) !important;
+  }
+  .md\\:pl16 {
+    padding-left: var(--su16) !important;
+  }
+  .md\\:pl24 {
+    padding-left: var(--su24) !important;
+  }
+  .md\\:pl32 {
+    padding-left: var(--su32) !important;
+  }
+  .md\\:pl48 {
+    padding-left: var(--su48) !important;
+  }
+  .md\\:pl64 {
+    padding-left: var(--su64) !important;
+  }
+  .md\\:pl96 {
+    padding-left: var(--su96) !important;
+  }
+  .md\\:pl128 {
+    padding-left: var(--su128) !important;
+  }
+  .md\\:px0 {
+    padding-left: var(--su0) !important;
+    padding-right: var(--su0) !important;
+  }
+  .md\\:px1 {
+    padding-left: var(--su1) !important;
+    padding-right: var(--su1) !important;
+  }
+  .md\\:px2 {
+    padding-left: var(--su2) !important;
+    padding-right: var(--su2) !important;
+  }
+  .md\\:px4 {
+    padding-left: var(--su4) !important;
+    padding-right: var(--su4) !important;
+  }
+  .md\\:px6 {
+    padding-left: var(--su6) !important;
+    padding-right: var(--su6) !important;
+  }
+  .md\\:px8 {
+    padding-left: var(--su8) !important;
+    padding-right: var(--su8) !important;
+  }
+  .md\\:px12 {
+    padding-left: var(--su12) !important;
+    padding-right: var(--su12) !important;
+  }
+  .md\\:px16 {
+    padding-left: var(--su16) !important;
+    padding-right: var(--su16) !important;
+  }
+  .md\\:px24 {
+    padding-left: var(--su24) !important;
+    padding-right: var(--su24) !important;
+  }
+  .md\\:px32 {
+    padding-left: var(--su32) !important;
+    padding-right: var(--su32) !important;
+  }
+  .md\\:px48 {
+    padding-left: var(--su48) !important;
+    padding-right: var(--su48) !important;
+  }
+  .md\\:px64 {
+    padding-left: var(--su64) !important;
+    padding-right: var(--su64) !important;
+  }
+  .md\\:px96 {
+    padding-left: var(--su96) !important;
+    padding-right: var(--su96) !important;
+  }
+  .md\\:px128 {
+    padding-left: var(--su128) !important;
+    padding-right: var(--su128) !important;
+  }
+  .md\\:py0 {
+    padding-top: var(--su0) !important;
+    padding-bottom: var(--su0) !important;
+  }
+  .md\\:py1 {
+    padding-top: var(--su1) !important;
+    padding-bottom: var(--su1) !important;
+  }
+  .md\\:py2 {
+    padding-top: var(--su2) !important;
+    padding-bottom: var(--su2) !important;
+  }
+  .md\\:py4 {
+    padding-top: var(--su4) !important;
+    padding-bottom: var(--su4) !important;
+  }
+  .md\\:py6 {
+    padding-top: var(--su6) !important;
+    padding-bottom: var(--su6) !important;
+  }
+  .md\\:py8 {
+    padding-top: var(--su8) !important;
+    padding-bottom: var(--su8) !important;
+  }
+  .md\\:py12 {
+    padding-top: var(--su12) !important;
+    padding-bottom: var(--su12) !important;
+  }
+  .md\\:py16 {
+    padding-top: var(--su16) !important;
+    padding-bottom: var(--su16) !important;
+  }
+  .md\\:py24 {
+    padding-top: var(--su24) !important;
+    padding-bottom: var(--su24) !important;
+  }
+  .md\\:py32 {
+    padding-top: var(--su32) !important;
+    padding-bottom: var(--su32) !important;
+  }
+  .md\\:py48 {
+    padding-top: var(--su48) !important;
+    padding-bottom: var(--su48) !important;
+  }
+  .md\\:py64 {
+    padding-top: var(--su64) !important;
+    padding-bottom: var(--su64) !important;
+  }
+  .md\\:py96 {
+    padding-top: var(--su96) !important;
+    padding-bottom: var(--su96) !important;
+  }
+  .md\\:py128 {
+    padding-top: var(--su128) !important;
+    padding-bottom: var(--su128) !important;
+  }
+  .md\\:ps-absolute {
+    position: absolute !important;
+  }
+  .md\\:ps-fixed {
+    position: fixed !important;
+  }
+  .md\\:ps-relative {
+    position: relative !important;
+  }
+  .md\\:ps-static {
+    position: static !important;
+  }
+  .md\\:ps-sticky {
+    position: sticky !important;
+  }
+  .md\\:t0 {
+    top: var(--su0) !important;
+  }
+  .md\\:t1 {
+    top: var(--su1) !important;
+  }
+  .md\\:t2 {
+    top: var(--su2) !important;
+  }
+  .md\\:t4 {
+    top: var(--su4) !important;
+  }
+  .md\\:t6 {
+    top: var(--su6) !important;
+  }
+  .md\\:t8 {
+    top: var(--su8) !important;
+  }
+  .md\\:t12 {
+    top: var(--su12) !important;
+  }
+  .md\\:t16 {
+    top: var(--su16) !important;
+  }
+  .md\\:t24 {
+    top: var(--su24) !important;
+  }
+  .md\\:t32 {
+    top: var(--su32) !important;
+  }
+  .md\\:t48 {
+    top: var(--su48) !important;
+  }
+  .md\\:t64 {
+    top: var(--su64) !important;
+  }
+  .md\\:t96 {
+    top: var(--su96) !important;
+  }
+  .md\\:t128 {
+    top: var(--su128) !important;
+  }
+  .md\\:tn1 {
+    top: var(--sun1) !important;
+  }
+  .md\\:tn2 {
+    top: var(--sun2) !important;
+  }
+  .md\\:tn4 {
+    top: var(--sun4) !important;
+  }
+  .md\\:tn6 {
+    top: var(--sun6) !important;
+  }
+  .md\\:tn8 {
+    top: var(--sun8) !important;
+  }
+  .md\\:tn12 {
+    top: var(--sun12) !important;
+  }
+  .md\\:tn16 {
+    top: var(--sun16) !important;
+  }
+  .md\\:tn24 {
+    top: var(--sun24) !important;
+  }
+  .md\\:tn32 {
+    top: var(--sun32) !important;
+  }
+  .md\\:tn48 {
+    top: var(--sun48) !important;
+  }
+  .md\\:tn64 {
+    top: var(--sun64) !important;
+  }
+  .md\\:tn96 {
+    top: var(--sun96) !important;
+  }
+  .md\\:tn128 {
+    top: var(--sun128) !important;
+  }
+  .md\\:t50 {
+    top: 50% !important;
+  }
+  .md\\:t100 {
+    top: 100% !important;
+  }
+  .md\\:tn50 {
+    top: -50% !important;
+  }
+  .md\\:tn100 {
+    top: -100% !important;
+  }
+  .md\\:r0 {
+    right: var(--su0) !important;
+  }
+  .md\\:r1 {
+    right: var(--su1) !important;
+  }
+  .md\\:r2 {
+    right: var(--su2) !important;
+  }
+  .md\\:r4 {
+    right: var(--su4) !important;
+  }
+  .md\\:r6 {
+    right: var(--su6) !important;
+  }
+  .md\\:r8 {
+    right: var(--su8) !important;
+  }
+  .md\\:r12 {
+    right: var(--su12) !important;
+  }
+  .md\\:r16 {
+    right: var(--su16) !important;
+  }
+  .md\\:r24 {
+    right: var(--su24) !important;
+  }
+  .md\\:r32 {
+    right: var(--su32) !important;
+  }
+  .md\\:r48 {
+    right: var(--su48) !important;
+  }
+  .md\\:r64 {
+    right: var(--su64) !important;
+  }
+  .md\\:r96 {
+    right: var(--su96) !important;
+  }
+  .md\\:r128 {
+    right: var(--su128) !important;
+  }
+  .md\\:rn1 {
+    right: var(--sun1) !important;
+  }
+  .md\\:rn2 {
+    right: var(--sun2) !important;
+  }
+  .md\\:rn4 {
+    right: var(--sun4) !important;
+  }
+  .md\\:rn6 {
+    right: var(--sun6) !important;
+  }
+  .md\\:rn8 {
+    right: var(--sun8) !important;
+  }
+  .md\\:rn12 {
+    right: var(--sun12) !important;
+  }
+  .md\\:rn16 {
+    right: var(--sun16) !important;
+  }
+  .md\\:rn24 {
+    right: var(--sun24) !important;
+  }
+  .md\\:rn32 {
+    right: var(--sun32) !important;
+  }
+  .md\\:rn48 {
+    right: var(--sun48) !important;
+  }
+  .md\\:rn64 {
+    right: var(--sun64) !important;
+  }
+  .md\\:rn96 {
+    right: var(--sun96) !important;
+  }
+  .md\\:rn128 {
+    right: var(--sun128) !important;
+  }
+  .md\\:r50 {
+    right: 50% !important;
+  }
+  .md\\:r100 {
+    right: 100% !important;
+  }
+  .md\\:rn50 {
+    right: -50% !important;
+  }
+  .md\\:rn100 {
+    right: -100% !important;
+  }
+  .md\\:b0 {
+    bottom: var(--su0) !important;
+  }
+  .md\\:b1 {
+    bottom: var(--su1) !important;
+  }
+  .md\\:b2 {
+    bottom: var(--su2) !important;
+  }
+  .md\\:b4 {
+    bottom: var(--su4) !important;
+  }
+  .md\\:b6 {
+    bottom: var(--su6) !important;
+  }
+  .md\\:b8 {
+    bottom: var(--su8) !important;
+  }
+  .md\\:b12 {
+    bottom: var(--su12) !important;
+  }
+  .md\\:b16 {
+    bottom: var(--su16) !important;
+  }
+  .md\\:b24 {
+    bottom: var(--su24) !important;
+  }
+  .md\\:b32 {
+    bottom: var(--su32) !important;
+  }
+  .md\\:b48 {
+    bottom: var(--su48) !important;
+  }
+  .md\\:b64 {
+    bottom: var(--su64) !important;
+  }
+  .md\\:b96 {
+    bottom: var(--su96) !important;
+  }
+  .md\\:b128 {
+    bottom: var(--su128) !important;
+  }
+  .md\\:bn1 {
+    bottom: var(--sun1) !important;
+  }
+  .md\\:bn2 {
+    bottom: var(--sun2) !important;
+  }
+  .md\\:bn4 {
+    bottom: var(--sun4) !important;
+  }
+  .md\\:bn6 {
+    bottom: var(--sun6) !important;
+  }
+  .md\\:bn8 {
+    bottom: var(--sun8) !important;
+  }
+  .md\\:bn12 {
+    bottom: var(--sun12) !important;
+  }
+  .md\\:bn16 {
+    bottom: var(--sun16) !important;
+  }
+  .md\\:bn24 {
+    bottom: var(--sun24) !important;
+  }
+  .md\\:bn32 {
+    bottom: var(--sun32) !important;
+  }
+  .md\\:bn48 {
+    bottom: var(--sun48) !important;
+  }
+  .md\\:bn64 {
+    bottom: var(--sun64) !important;
+  }
+  .md\\:bn96 {
+    bottom: var(--sun96) !important;
+  }
+  .md\\:bn128 {
+    bottom: var(--sun128) !important;
+  }
+  .md\\:b50 {
+    bottom: 50% !important;
+  }
+  .md\\:b100 {
+    bottom: 100% !important;
+  }
+  .md\\:bn50 {
+    bottom: -50% !important;
+  }
+  .md\\:bn100 {
+    bottom: -100% !important;
+  }
+  .md\\:l0 {
+    left: var(--su0) !important;
+  }
+  .md\\:l1 {
+    left: var(--su1) !important;
+  }
+  .md\\:l2 {
+    left: var(--su2) !important;
+  }
+  .md\\:l4 {
+    left: var(--su4) !important;
+  }
+  .md\\:l6 {
+    left: var(--su6) !important;
+  }
+  .md\\:l8 {
+    left: var(--su8) !important;
+  }
+  .md\\:l12 {
+    left: var(--su12) !important;
+  }
+  .md\\:l16 {
+    left: var(--su16) !important;
+  }
+  .md\\:l24 {
+    left: var(--su24) !important;
+  }
+  .md\\:l32 {
+    left: var(--su32) !important;
+  }
+  .md\\:l48 {
+    left: var(--su48) !important;
+  }
+  .md\\:l64 {
+    left: var(--su64) !important;
+  }
+  .md\\:l96 {
+    left: var(--su96) !important;
+  }
+  .md\\:l128 {
+    left: var(--su128) !important;
+  }
+  .md\\:ln1 {
+    left: var(--sun1) !important;
+  }
+  .md\\:ln2 {
+    left: var(--sun2) !important;
+  }
+  .md\\:ln4 {
+    left: var(--sun4) !important;
+  }
+  .md\\:ln6 {
+    left: var(--sun6) !important;
+  }
+  .md\\:ln8 {
+    left: var(--sun8) !important;
+  }
+  .md\\:ln12 {
+    left: var(--sun12) !important;
+  }
+  .md\\:ln16 {
+    left: var(--sun16) !important;
+  }
+  .md\\:ln24 {
+    left: var(--sun24) !important;
+  }
+  .md\\:ln32 {
+    left: var(--sun32) !important;
+  }
+  .md\\:ln48 {
+    left: var(--sun48) !important;
+  }
+  .md\\:ln64 {
+    left: var(--sun64) !important;
+  }
+  .md\\:ln96 {
+    left: var(--sun96) !important;
+  }
+  .md\\:ln128 {
+    left: var(--sun128) !important;
+  }
+  .md\\:l50 {
+    left: 50% !important;
+  }
+  .md\\:l100 {
+    left: 100% !important;
+  }
+  .md\\:ln50 {
+    left: -50% !important;
+  }
+  .md\\:ln100 {
+    left: -100% !important;
+  }
+  .md\\:w25 {
+    width: 25% !important;
+  }
+  .md\\:w50 {
+    width: 50% !important;
+  }
+  .md\\:w75 {
+    width: 75% !important;
+  }
+  .md\\:w100 {
+    width: 100% !important;
+  }
+  .md\\:w33 {
+    width: calc(100% / 3) !important;
+  }
+  .md\\:w66 {
+    width: calc(100% / 3 * 2) !important;
+  }
+  .md\\:w-auto {
+    width: auto !important;
+  }
+  .md\\:w-screen {
+    width: 100vw !important;
+  }
+  .md\\:wmn100 {
+    min-width: 100% !important;
+  }
+  .md\\:wmn-initial {
+    min-width: initial !important;
+  }
+  .md\\:wmn-screen {
+    min-width: 100vw !important;
+  }
+  .md\\:wmx100 {
+    max-width: 100% !important;
+  }
+  .md\\:wmx-initial {
+    max-width: initial !important;
+  }
+  .md\\:wmx-screen {
+    max-width: 100vw !important;
+  }
+}
+@media (max-width: 48.75rem) {
+  .sm\\:ta-left {
+    text-align: left !important;
+  }
+  .sm\\:ta-center {
+    text-align: center !important;
+  }
+  .sm\\:ta-right {
+    text-align: right !important;
+  }
+  .sm\\:ba {
+    border-style: solid !important;
+    border-width: var(--su1) !important;
+  }
+  .sm\\:bt {
+    border-top-style: solid !important;
+    border-top-width: var(--su1) !important;
+  }
+  .sm\\:br {
+    border-right-style: solid !important;
+    border-right-width: var(--su1) !important;
+  }
+  .sm\\:bb {
+    border-bottom-style: solid !important;
+    border-bottom-width: var(--su1) !important;
+  }
+  .sm\\:bl {
+    border-left-style: solid !important;
+    border-left-width: var(--su1) !important;
+  }
+  .sm\\:baw0 {
+    border-width: 0 !important;
+  }
+  .sm\\:btw0 {
+    border-top-width: 0 !important;
+  }
+  .sm\\:brw0 {
+    border-right-width: 0 !important;
+  }
+  .sm\\:bbw0 {
+    border-bottom-width: 0 !important;
+  }
+  .sm\\:blw0 {
+    border-left-width: 0 !important;
+  }
+  .sm\\:bar0 {
+    border-radius: 0 !important;
+  }
+  .sm\\:bs-none {
+    box-shadow: none !important;
+  }
+  .sm\\:d-block {
+    display: block !important;
+  }
+  .sm\\:d-flex {
+    display: flex !important;
+  }
+  .sm\\:d-inline-flex {
+    display: inline-flex !important;
+  }
+  .sm\\:d-grid {
+    display: grid !important;
+  }
+  .sm\\:d-inline-grid {
+    display: inline-grid !important;
+  }
+  .sm\\:d-inline {
+    display: inline !important;
+  }
+  .sm\\:d-inline-block {
+    display: inline-block !important;
+  }
+  .sm\\:d-none {
+    display: none !important;
+  }
+  .sm\\:fd-row {
+    flex-direction: row !important;
+  }
+  .sm\\:fd-row-reverse {
+    flex-direction: row-reverse !important;
+  }
+  .sm\\:fd-column {
+    flex-direction: column !important;
+  }
+  .sm\\:fd-column-reverse {
+    flex-direction: column-reverse !important;
+  }
+  .sm\\:fw-wrap {
+    flex-wrap: wrap !important;
+  }
+  .sm\\:fw-reverse {
+    flex-wrap: wrap-reverse !important;
+  }
+  .sm\\:fw-nowrap {
+    flex-wrap: nowrap !important;
+  }
+  .sm\\:jc-center {
+    justify-content: center !important;
+  }
+  .sm\\:jc-end {
+    justify-content: flex-end !important;
+  }
+  .sm\\:jc-space-around {
+    justify-content: space-around !important;
+  }
+  .sm\\:jc-space-between {
+    justify-content: space-between !important;
+  }
+  .sm\\:jc-space-evenly {
+    justify-content: space-evenly !important;
+  }
+  .sm\\:jc-start {
+    justify-content: flex-start !important;
+  }
+  .sm\\:ai-baseline {
+    align-items: baseline !important;
+  }
+  .sm\\:ai-center {
+    align-items: center !important;
+  }
+  .sm\\:ai-end {
+    align-items: flex-end !important;
+  }
+  .sm\\:ai-start {
+    align-items: flex-start !important;
+  }
+  .sm\\:ai-stretch {
+    align-items: stretch !important;
+  }
+  .sm\\:fl-grow1 {
+    flex-grow: 1 !important;
+  }
+  .sm\\:fl-grow0 {
+    flex-grow: 0 !important;
+  }
+  .sm\\:fl-shrink1 {
+    flex-shrink: 1 !important;
+  }
+  .sm\\:fl-shrink0 {
+    flex-shrink: 0 !important;
+  }
+  .sm\\:fl-none {
+    flex: none !important;
+  }
+  .sm\\:fl-initial {
+    flex: 0 1 auto !important;
+  }
+  .sm\\:fl-auto {
+    flex: 1 1 auto !important;
+  }
+  .sm\\:fl-equal {
+    flex: 1 1 0% !important;
+  }
+  .sm\\:order-first {
+    order: -1 !important;
+  }
+  .sm\\:order-last {
+    order: 1 !important;
+  }
+  .sm\\:fl0 {
+    flex: 0 auto !important;
+  }
+  .sm\\:fl1 {
+    flex: 1 auto !important;
+  }
+  .sm\\:g0 {
+    --_gap-y: 0;
+    --_gap-x: 0;
+  }
+  .sm\\:g1 {
+    --_gap-y: var(--su1);
+    --_gap-x: var(--su1);
+  }
+  .sm\\:g2 {
+    --_gap-y: var(--su2);
+    --_gap-x: var(--su2);
+  }
+  .sm\\:g4 {
+    --_gap-y: var(--su4);
+    --_gap-x: var(--su4);
+  }
+  .sm\\:g6 {
+    --_gap-y: var(--su6);
+    --_gap-x: var(--su6);
+  }
+  .sm\\:g8 {
+    --_gap-y: var(--su8);
+    --_gap-x: var(--su8);
+  }
+  .sm\\:g12 {
+    --_gap-y: var(--su12);
+    --_gap-x: var(--su12);
+  }
+  .sm\\:g16 {
+    --_gap-y: var(--su16);
+    --_gap-x: var(--su16);
+  }
+  .sm\\:g24 {
+    --_gap-y: var(--su24);
+    --_gap-x: var(--su24);
+  }
+  .sm\\:g32 {
+    --_gap-y: var(--su32);
+    --_gap-x: var(--su32);
+  }
+  .sm\\:g48 {
+    --_gap-y: var(--su48);
+    --_gap-x: var(--su48);
+  }
+  .sm\\:g64 {
+    --_gap-y: var(--su64);
+    --_gap-x: var(--su64);
+  }
+  .sm\\:gx0 {
+    --_gap-x: 0;
+  }
+  .sm\\:gx1 {
+    --_gap-x: var(--su1);
+  }
+  .sm\\:gx2 {
+    --_gap-x: var(--su2);
+  }
+  .sm\\:gx4 {
+    --_gap-x: var(--su4);
+  }
+  .sm\\:gx6 {
+    --_gap-x: var(--su6);
+  }
+  .sm\\:gx8 {
+    --_gap-x: var(--su8);
+  }
+  .sm\\:gx12 {
+    --_gap-x: var(--su12);
+  }
+  .sm\\:gx16 {
+    --_gap-x: var(--su16);
+  }
+  .sm\\:gx24 {
+    --_gap-x: var(--su24);
+  }
+  .sm\\:gx32 {
+    --_gap-x: var(--su32);
+  }
+  .sm\\:gx48 {
+    --_gap-x: var(--su48);
+  }
+  .sm\\:gx64 {
+    --_gap-x: var(--su64);
+  }
+  .sm\\:gy0 {
+    --_gap-y: 0;
+  }
+  .sm\\:gy1 {
+    --_gap-y: var(--su1);
+  }
+  .sm\\:gy2 {
+    --_gap-y: var(--su2);
+  }
+  .sm\\:gy4 {
+    --_gap-y: var(--su4);
+  }
+  .sm\\:gy6 {
+    --_gap-y: var(--su6);
+  }
+  .sm\\:gy8 {
+    --_gap-y: var(--su8);
+  }
+  .sm\\:gy12 {
+    --_gap-y: var(--su12);
+  }
+  .sm\\:gy16 {
+    --_gap-y: var(--su16);
+  }
+  .sm\\:gy24 {
+    --_gap-y: var(--su24);
+  }
+  .sm\\:gy32 {
+    --_gap-y: var(--su32);
+  }
+  .sm\\:gy48 {
+    --_gap-y: var(--su48);
+  }
+  .sm\\:gy64 {
+    --_gap-y: var(--su64);
+  }
+  .sm\\:g-af-dense {
+    grid-auto-flow: dense;
+  }
+  .sm\\:g-af-row {
+    grid-auto-flow: row;
+  }
+  .sm\\:g-af-column {
+    grid-auto-flow: column;
+  }
+  .sm\\:grid__1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+  .sm\\:grid__2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .sm\\:grid__3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .sm\\:grid__4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+  .sm\\:grid__5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+  .sm\\:grid__6 {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+  .sm\\:grid__7 {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+  .sm\\:grid__8 {
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+  }
+  .sm\\:grid__9 {
+    grid-template-columns: repeat(9, minmax(0, 1fr));
+  }
+  .sm\\:grid__10 {
+    grid-template-columns: repeat(10, minmax(0, 1fr));
+  }
+  .sm\\:grid__11 {
+    grid-template-columns: repeat(11, minmax(0, 1fr));
+  }
+  .sm\\:grid__12 {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+  }
+  .sm\\:grid__auto {
+    grid-template-columns: auto 1fr;
+  }
+  .sm\\:grid--col-all {
+    grid-column: 1 / -1;
+  }
+  .sm\\:grid--row-all {
+    grid-row: 1 / -1;
+  }
+  .sm\\:grid--col1 {
+    grid-column: span 1;
+  }
+  .sm\\:grid--col2 {
+    grid-column: span 2;
+  }
+  .sm\\:grid--col3 {
+    grid-column: span 3;
+  }
+  .sm\\:grid--col4 {
+    grid-column: span 4;
+  }
+  .sm\\:grid--col5 {
+    grid-column: span 5;
+  }
+  .sm\\:grid--col6 {
+    grid-column: span 6;
+  }
+  .sm\\:grid--col7 {
+    grid-column: span 7;
+  }
+  .sm\\:grid--col8 {
+    grid-column: span 8;
+  }
+  .sm\\:grid--col9 {
+    grid-column: span 9;
+  }
+  .sm\\:grid--col10 {
+    grid-column: span 10;
+  }
+  .sm\\:grid--col11 {
+    grid-column: span 11;
+  }
+  .sm\\:grid--col12 {
+    grid-column: span 12;
+  }
+  .sm\\:grid--row1 {
+    grid-row: span 1;
+  }
+  .sm\\:grid--row2 {
+    grid-row: span 2;
+  }
+  .sm\\:grid--row3 {
+    grid-row: span 3;
+  }
+  .sm\\:grid--row4 {
+    grid-row: span 4;
+  }
+  .sm\\:grid--row5 {
+    grid-row: span 5;
+  }
+  .sm\\:grid--row6 {
+    grid-row: span 6;
+  }
+  .sm\\:grid--row7 {
+    grid-row: span 7;
+  }
+  .sm\\:grid--row8 {
+    grid-row: span 8;
+  }
+  .sm\\:grid--row9 {
+    grid-row: span 9;
+  }
+  .sm\\:grid--row10 {
+    grid-row: span 10;
+  }
+  .sm\\:grid--row11 {
+    grid-row: span 11;
+  }
+  .sm\\:grid--row12 {
+    grid-row: span 12;
+  }
+  .sm\\:grid--col-start1 {
+    grid-column-start: 1;
+  }
+  .sm\\:grid--col-start2 {
+    grid-column-start: 2;
+  }
+  .sm\\:grid--col-start3 {
+    grid-column-start: 3;
+  }
+  .sm\\:grid--col-start4 {
+    grid-column-start: 4;
+  }
+  .sm\\:grid--col-start5 {
+    grid-column-start: 5;
+  }
+  .sm\\:grid--col-start6 {
+    grid-column-start: 6;
+  }
+  .sm\\:grid--col-start7 {
+    grid-column-start: 7;
+  }
+  .sm\\:grid--col-start8 {
+    grid-column-start: 8;
+  }
+  .sm\\:grid--col-start9 {
+    grid-column-start: 9;
+  }
+  .sm\\:grid--col-start10 {
+    grid-column-start: 10;
+  }
+  .sm\\:grid--col-start11 {
+    grid-column-start: 11;
+  }
+  .sm\\:grid--col-start12 {
+    grid-column-start: 12;
+  }
+  .sm\\:grid--col-end2 {
+    grid-column-end: 2;
+  }
+  .sm\\:grid--col-end3 {
+    grid-column-end: 3;
+  }
+  .sm\\:grid--col-end4 {
+    grid-column-end: 4;
+  }
+  .sm\\:grid--col-end5 {
+    grid-column-end: 5;
+  }
+  .sm\\:grid--col-end6 {
+    grid-column-end: 6;
+  }
+  .sm\\:grid--col-end7 {
+    grid-column-end: 7;
+  }
+  .sm\\:grid--col-end8 {
+    grid-column-end: 8;
+  }
+  .sm\\:grid--col-end9 {
+    grid-column-end: 9;
+  }
+  .sm\\:grid--col-end10 {
+    grid-column-end: 10;
+  }
+  .sm\\:grid--col-end11 {
+    grid-column-end: 11;
+  }
+  .sm\\:grid--col-end12 {
+    grid-column-end: 12;
+  }
+  .sm\\:grid--col-end13 {
+    grid-column-end: 13;
+  }
+  .sm\\:grid--row-start1 {
+    grid-row-start: 1;
+  }
+  .sm\\:grid--row-start2 {
+    grid-row-start: 2;
+  }
+  .sm\\:grid--row-start3 {
+    grid-row-start: 3;
+  }
+  .sm\\:grid--row-start4 {
+    grid-row-start: 4;
+  }
+  .sm\\:grid--row-start5 {
+    grid-row-start: 5;
+  }
+  .sm\\:grid--row-start6 {
+    grid-row-start: 6;
+  }
+  .sm\\:grid--row-start7 {
+    grid-row-start: 7;
+  }
+  .sm\\:grid--row-start8 {
+    grid-row-start: 8;
+  }
+  .sm\\:grid--row-start9 {
+    grid-row-start: 9;
+  }
+  .sm\\:grid--row-start10 {
+    grid-row-start: 10;
+  }
+  .sm\\:grid--row-start11 {
+    grid-row-start: 11;
+  }
+  .sm\\:grid--row-start12 {
+    grid-row-start: 12;
+  }
+  .sm\\:grid--row-end2 {
+    grid-row-end: 2;
+  }
+  .sm\\:grid--row-end3 {
+    grid-row-end: 3;
+  }
+  .sm\\:grid--row-end4 {
+    grid-row-end: 4;
+  }
+  .sm\\:grid--row-end5 {
+    grid-row-end: 5;
+  }
+  .sm\\:grid--row-end6 {
+    grid-row-end: 6;
+  }
+  .sm\\:grid--row-end7 {
+    grid-row-end: 7;
+  }
+  .sm\\:grid--row-end8 {
+    grid-row-end: 8;
+  }
+  .sm\\:grid--row-end9 {
+    grid-row-end: 9;
+  }
+  .sm\\:grid--row-end10 {
+    grid-row-end: 10;
+  }
+  .sm\\:grid--row-end11 {
+    grid-row-end: 11;
+  }
+  .sm\\:grid--row-end12 {
+    grid-row-end: 12;
+  }
+  .sm\\:grid--row-end13 {
+    grid-row-end: 13;
+  }
+  .sm\\:ji-auto {
+    justify-items: auto !important;
+  }
+  .sm\\:ji-center {
+    justify-items: center !important;
+  }
+  .sm\\:ji-start {
+    justify-items: start !important;
+  }
+  .sm\\:ji-end {
+    justify-items: end !important;
+  }
+  .sm\\:ji-stretch {
+    justify-items: stretch !important;
+  }
+  .sm\\:ji-unset {
+    justify-items: unset !important;
+  }
+  .sm\\:js-auto {
+    justify-self: auto !important;
+  }
+  .sm\\:js-center {
+    justify-self: center !important;
+  }
+  .sm\\:js-start {
+    justify-self: start !important;
+  }
+  .sm\\:js-end {
+    justify-self: end !important;
+  }
+  .sm\\:js-stretch {
+    justify-self: stretch !important;
+  }
+  .sm\\:js-unset {
+    justify-self: unset !important;
+  }
+  .sm\\:h100 {
+    height: 100% !important;
+  }
+  .sm\\:h-auto {
+    height: auto !important;
+  }
+  .sm\\:h-screen {
+    height: 100vh !important;
+  }
+  .sm\\:hmn100 {
+    min-height: 100% !important;
+  }
+  .sm\\:hmn-initial {
+    min-height: initial !important;
+  }
+  .sm\\:hmn-screen {
+    min-height: 100vh !important;
+  }
+  .sm\\:hmx100 {
+    max-height: 100% !important;
+  }
+  .sm\\:hmx-initial {
+    max-height: initial !important;
+  }
+  .sm\\:hmx-screen {
+    max-height: 100vh !important;
+  }
+  .sm\\:m0 {
+    margin: var(--su0) !important;
+  }
+  .sm\\:m1 {
+    margin: var(--su1) !important;
+  }
+  .sm\\:m2 {
+    margin: var(--su2) !important;
+  }
+  .sm\\:m4 {
+    margin: var(--su4) !important;
+  }
+  .sm\\:m6 {
+    margin: var(--su6) !important;
+  }
+  .sm\\:m8 {
+    margin: var(--su8) !important;
+  }
+  .sm\\:m12 {
+    margin: var(--su12) !important;
+  }
+  .sm\\:m16 {
+    margin: var(--su16) !important;
+  }
+  .sm\\:m24 {
+    margin: var(--su24) !important;
+  }
+  .sm\\:m32 {
+    margin: var(--su32) !important;
+  }
+  .sm\\:m48 {
+    margin: var(--su48) !important;
+  }
+  .sm\\:m64 {
+    margin: var(--su64) !important;
+  }
+  .sm\\:m96 {
+    margin: var(--su96) !important;
+  }
+  .sm\\:m128 {
+    margin: var(--su128) !important;
+  }
+  .sm\\:mn1 {
+    margin: var(--sun1) !important;
+  }
+  .sm\\:mn2 {
+    margin: var(--sun2) !important;
+  }
+  .sm\\:mn4 {
+    margin: var(--sun4) !important;
+  }
+  .sm\\:mn6 {
+    margin: var(--sun6) !important;
+  }
+  .sm\\:mn8 {
+    margin: var(--sun8) !important;
+  }
+  .sm\\:mn12 {
+    margin: var(--sun12) !important;
+  }
+  .sm\\:mn16 {
+    margin: var(--sun16) !important;
+  }
+  .sm\\:mn24 {
+    margin: var(--sun24) !important;
+  }
+  .sm\\:mn32 {
+    margin: var(--sun32) !important;
+  }
+  .sm\\:mn48 {
+    margin: var(--sun48) !important;
+  }
+  .sm\\:mn64 {
+    margin: var(--sun64) !important;
+  }
+  .sm\\:mn96 {
+    margin: var(--sun96) !important;
+  }
+  .sm\\:mn128 {
+    margin: var(--sun128) !important;
+  }
+  .sm\\:m50 {
+    margin: 50% !important;
+  }
+  .sm\\:m100 {
+    margin: 100% !important;
+  }
+  .sm\\:mn50 {
+    margin: -50% !important;
+  }
+  .sm\\:mn100 {
+    margin: -100% !important;
+  }
+  .sm\\:mt0 {
+    margin-top: var(--su0) !important;
+  }
+  .sm\\:mt1 {
+    margin-top: var(--su1) !important;
+  }
+  .sm\\:mt2 {
+    margin-top: var(--su2) !important;
+  }
+  .sm\\:mt4 {
+    margin-top: var(--su4) !important;
+  }
+  .sm\\:mt6 {
+    margin-top: var(--su6) !important;
+  }
+  .sm\\:mt8 {
+    margin-top: var(--su8) !important;
+  }
+  .sm\\:mt12 {
+    margin-top: var(--su12) !important;
+  }
+  .sm\\:mt16 {
+    margin-top: var(--su16) !important;
+  }
+  .sm\\:mt24 {
+    margin-top: var(--su24) !important;
+  }
+  .sm\\:mt32 {
+    margin-top: var(--su32) !important;
+  }
+  .sm\\:mt48 {
+    margin-top: var(--su48) !important;
+  }
+  .sm\\:mt64 {
+    margin-top: var(--su64) !important;
+  }
+  .sm\\:mt96 {
+    margin-top: var(--su96) !important;
+  }
+  .sm\\:mt128 {
+    margin-top: var(--su128) !important;
+  }
+  .sm\\:mtn1 {
+    margin-top: var(--sun1) !important;
+  }
+  .sm\\:mtn2 {
+    margin-top: var(--sun2) !important;
+  }
+  .sm\\:mtn4 {
+    margin-top: var(--sun4) !important;
+  }
+  .sm\\:mtn6 {
+    margin-top: var(--sun6) !important;
+  }
+  .sm\\:mtn8 {
+    margin-top: var(--sun8) !important;
+  }
+  .sm\\:mtn12 {
+    margin-top: var(--sun12) !important;
+  }
+  .sm\\:mtn16 {
+    margin-top: var(--sun16) !important;
+  }
+  .sm\\:mtn24 {
+    margin-top: var(--sun24) !important;
+  }
+  .sm\\:mtn32 {
+    margin-top: var(--sun32) !important;
+  }
+  .sm\\:mtn48 {
+    margin-top: var(--sun48) !important;
+  }
+  .sm\\:mtn64 {
+    margin-top: var(--sun64) !important;
+  }
+  .sm\\:mtn96 {
+    margin-top: var(--sun96) !important;
+  }
+  .sm\\:mtn128 {
+    margin-top: var(--sun128) !important;
+  }
+  .sm\\:mt50 {
+    margin-top: 50% !important;
+  }
+  .sm\\:mt100 {
+    margin-top: 100% !important;
+  }
+  .sm\\:mtn50 {
+    margin-top: -50% !important;
+  }
+  .sm\\:mtn100 {
+    margin-top: -100% !important;
+  }
+  .sm\\:mr0 {
+    margin-right: var(--su0) !important;
+  }
+  .sm\\:mr1 {
+    margin-right: var(--su1) !important;
+  }
+  .sm\\:mr2 {
+    margin-right: var(--su2) !important;
+  }
+  .sm\\:mr4 {
+    margin-right: var(--su4) !important;
+  }
+  .sm\\:mr6 {
+    margin-right: var(--su6) !important;
+  }
+  .sm\\:mr8 {
+    margin-right: var(--su8) !important;
+  }
+  .sm\\:mr12 {
+    margin-right: var(--su12) !important;
+  }
+  .sm\\:mr16 {
+    margin-right: var(--su16) !important;
+  }
+  .sm\\:mr24 {
+    margin-right: var(--su24) !important;
+  }
+  .sm\\:mr32 {
+    margin-right: var(--su32) !important;
+  }
+  .sm\\:mr48 {
+    margin-right: var(--su48) !important;
+  }
+  .sm\\:mr64 {
+    margin-right: var(--su64) !important;
+  }
+  .sm\\:mr96 {
+    margin-right: var(--su96) !important;
+  }
+  .sm\\:mr128 {
+    margin-right: var(--su128) !important;
+  }
+  .sm\\:mrn1 {
+    margin-right: var(--sun1) !important;
+  }
+  .sm\\:mrn2 {
+    margin-right: var(--sun2) !important;
+  }
+  .sm\\:mrn4 {
+    margin-right: var(--sun4) !important;
+  }
+  .sm\\:mrn6 {
+    margin-right: var(--sun6) !important;
+  }
+  .sm\\:mrn8 {
+    margin-right: var(--sun8) !important;
+  }
+  .sm\\:mrn12 {
+    margin-right: var(--sun12) !important;
+  }
+  .sm\\:mrn16 {
+    margin-right: var(--sun16) !important;
+  }
+  .sm\\:mrn24 {
+    margin-right: var(--sun24) !important;
+  }
+  .sm\\:mrn32 {
+    margin-right: var(--sun32) !important;
+  }
+  .sm\\:mrn48 {
+    margin-right: var(--sun48) !important;
+  }
+  .sm\\:mrn64 {
+    margin-right: var(--sun64) !important;
+  }
+  .sm\\:mrn96 {
+    margin-right: var(--sun96) !important;
+  }
+  .sm\\:mrn128 {
+    margin-right: var(--sun128) !important;
+  }
+  .sm\\:mr50 {
+    margin-right: 50% !important;
+  }
+  .sm\\:mr100 {
+    margin-right: 100% !important;
+  }
+  .sm\\:mrn50 {
+    margin-right: -50% !important;
+  }
+  .sm\\:mrn100 {
+    margin-right: -100% !important;
+  }
+  .sm\\:mb0 {
+    margin-bottom: var(--su0) !important;
+  }
+  .sm\\:mb1 {
+    margin-bottom: var(--su1) !important;
+  }
+  .sm\\:mb2 {
+    margin-bottom: var(--su2) !important;
+  }
+  .sm\\:mb4 {
+    margin-bottom: var(--su4) !important;
+  }
+  .sm\\:mb6 {
+    margin-bottom: var(--su6) !important;
+  }
+  .sm\\:mb8 {
+    margin-bottom: var(--su8) !important;
+  }
+  .sm\\:mb12 {
+    margin-bottom: var(--su12) !important;
+  }
+  .sm\\:mb16 {
+    margin-bottom: var(--su16) !important;
+  }
+  .sm\\:mb24 {
+    margin-bottom: var(--su24) !important;
+  }
+  .sm\\:mb32 {
+    margin-bottom: var(--su32) !important;
+  }
+  .sm\\:mb48 {
+    margin-bottom: var(--su48) !important;
+  }
+  .sm\\:mb64 {
+    margin-bottom: var(--su64) !important;
+  }
+  .sm\\:mb96 {
+    margin-bottom: var(--su96) !important;
+  }
+  .sm\\:mb128 {
+    margin-bottom: var(--su128) !important;
+  }
+  .sm\\:mbn1 {
+    margin-bottom: var(--sun1) !important;
+  }
+  .sm\\:mbn2 {
+    margin-bottom: var(--sun2) !important;
+  }
+  .sm\\:mbn4 {
+    margin-bottom: var(--sun4) !important;
+  }
+  .sm\\:mbn6 {
+    margin-bottom: var(--sun6) !important;
+  }
+  .sm\\:mbn8 {
+    margin-bottom: var(--sun8) !important;
+  }
+  .sm\\:mbn12 {
+    margin-bottom: var(--sun12) !important;
+  }
+  .sm\\:mbn16 {
+    margin-bottom: var(--sun16) !important;
+  }
+  .sm\\:mbn24 {
+    margin-bottom: var(--sun24) !important;
+  }
+  .sm\\:mbn32 {
+    margin-bottom: var(--sun32) !important;
+  }
+  .sm\\:mbn48 {
+    margin-bottom: var(--sun48) !important;
+  }
+  .sm\\:mbn64 {
+    margin-bottom: var(--sun64) !important;
+  }
+  .sm\\:mbn96 {
+    margin-bottom: var(--sun96) !important;
+  }
+  .sm\\:mbn128 {
+    margin-bottom: var(--sun128) !important;
+  }
+  .sm\\:mb50 {
+    margin-bottom: 50% !important;
+  }
+  .sm\\:mb100 {
+    margin-bottom: 100% !important;
+  }
+  .sm\\:mbn50 {
+    margin-bottom: -50% !important;
+  }
+  .sm\\:mbn100 {
+    margin-bottom: -100% !important;
+  }
+  .sm\\:ml0 {
+    margin-left: var(--su0) !important;
+  }
+  .sm\\:ml1 {
+    margin-left: var(--su1) !important;
+  }
+  .sm\\:ml2 {
+    margin-left: var(--su2) !important;
+  }
+  .sm\\:ml4 {
+    margin-left: var(--su4) !important;
+  }
+  .sm\\:ml6 {
+    margin-left: var(--su6) !important;
+  }
+  .sm\\:ml8 {
+    margin-left: var(--su8) !important;
+  }
+  .sm\\:ml12 {
+    margin-left: var(--su12) !important;
+  }
+  .sm\\:ml16 {
+    margin-left: var(--su16) !important;
+  }
+  .sm\\:ml24 {
+    margin-left: var(--su24) !important;
+  }
+  .sm\\:ml32 {
+    margin-left: var(--su32) !important;
+  }
+  .sm\\:ml48 {
+    margin-left: var(--su48) !important;
+  }
+  .sm\\:ml64 {
+    margin-left: var(--su64) !important;
+  }
+  .sm\\:ml96 {
+    margin-left: var(--su96) !important;
+  }
+  .sm\\:ml128 {
+    margin-left: var(--su128) !important;
+  }
+  .sm\\:mln1 {
+    margin-left: var(--sun1) !important;
+  }
+  .sm\\:mln2 {
+    margin-left: var(--sun2) !important;
+  }
+  .sm\\:mln4 {
+    margin-left: var(--sun4) !important;
+  }
+  .sm\\:mln6 {
+    margin-left: var(--sun6) !important;
+  }
+  .sm\\:mln8 {
+    margin-left: var(--sun8) !important;
+  }
+  .sm\\:mln12 {
+    margin-left: var(--sun12) !important;
+  }
+  .sm\\:mln16 {
+    margin-left: var(--sun16) !important;
+  }
+  .sm\\:mln24 {
+    margin-left: var(--sun24) !important;
+  }
+  .sm\\:mln32 {
+    margin-left: var(--sun32) !important;
+  }
+  .sm\\:mln48 {
+    margin-left: var(--sun48) !important;
+  }
+  .sm\\:mln64 {
+    margin-left: var(--sun64) !important;
+  }
+  .sm\\:mln96 {
+    margin-left: var(--sun96) !important;
+  }
+  .sm\\:mln128 {
+    margin-left: var(--sun128) !important;
+  }
+  .sm\\:ml50 {
+    margin-left: 50% !important;
+  }
+  .sm\\:ml100 {
+    margin-left: 100% !important;
+  }
+  .sm\\:mln50 {
+    margin-left: -50% !important;
+  }
+  .sm\\:mln100 {
+    margin-left: -100% !important;
+  }
+  .sm\\:mx0 {
+    margin-left: var(--su0) !important;
+    margin-right: var(--su0) !important;
+  }
+  .sm\\:mx1 {
+    margin-left: var(--su1) !important;
+    margin-right: var(--su1) !important;
+  }
+  .sm\\:mx2 {
+    margin-left: var(--su2) !important;
+    margin-right: var(--su2) !important;
+  }
+  .sm\\:mx4 {
+    margin-left: var(--su4) !important;
+    margin-right: var(--su4) !important;
+  }
+  .sm\\:mx6 {
+    margin-left: var(--su6) !important;
+    margin-right: var(--su6) !important;
+  }
+  .sm\\:mx8 {
+    margin-left: var(--su8) !important;
+    margin-right: var(--su8) !important;
+  }
+  .sm\\:mx12 {
+    margin-left: var(--su12) !important;
+    margin-right: var(--su12) !important;
+  }
+  .sm\\:mx16 {
+    margin-left: var(--su16) !important;
+    margin-right: var(--su16) !important;
+  }
+  .sm\\:mx24 {
+    margin-left: var(--su24) !important;
+    margin-right: var(--su24) !important;
+  }
+  .sm\\:mx32 {
+    margin-left: var(--su32) !important;
+    margin-right: var(--su32) !important;
+  }
+  .sm\\:mx48 {
+    margin-left: var(--su48) !important;
+    margin-right: var(--su48) !important;
+  }
+  .sm\\:mx64 {
+    margin-left: var(--su64) !important;
+    margin-right: var(--su64) !important;
+  }
+  .sm\\:mx96 {
+    margin-left: var(--su96) !important;
+    margin-right: var(--su96) !important;
+  }
+  .sm\\:mx128 {
+    margin-left: var(--su128) !important;
+    margin-right: var(--su128) !important;
+  }
+  .sm\\:mxn1 {
+    margin-left: var(--sun1) !important;
+    margin-right: var(--sun1) !important;
+  }
+  .sm\\:mxn2 {
+    margin-left: var(--sun2) !important;
+    margin-right: var(--sun2) !important;
+  }
+  .sm\\:mxn4 {
+    margin-left: var(--sun4) !important;
+    margin-right: var(--sun4) !important;
+  }
+  .sm\\:mxn6 {
+    margin-left: var(--sun6) !important;
+    margin-right: var(--sun6) !important;
+  }
+  .sm\\:mxn8 {
+    margin-left: var(--sun8) !important;
+    margin-right: var(--sun8) !important;
+  }
+  .sm\\:mxn12 {
+    margin-left: var(--sun12) !important;
+    margin-right: var(--sun12) !important;
+  }
+  .sm\\:mxn16 {
+    margin-left: var(--sun16) !important;
+    margin-right: var(--sun16) !important;
+  }
+  .sm\\:mxn24 {
+    margin-left: var(--sun24) !important;
+    margin-right: var(--sun24) !important;
+  }
+  .sm\\:mxn32 {
+    margin-left: var(--sun32) !important;
+    margin-right: var(--sun32) !important;
+  }
+  .sm\\:mxn48 {
+    margin-left: var(--sun48) !important;
+    margin-right: var(--sun48) !important;
+  }
+  .sm\\:mxn64 {
+    margin-left: var(--sun64) !important;
+    margin-right: var(--sun64) !important;
+  }
+  .sm\\:mxn96 {
+    margin-left: var(--sun96) !important;
+    margin-right: var(--sun96) !important;
+  }
+  .sm\\:mxn128 {
+    margin-left: var(--sun128) !important;
+    margin-right: var(--sun128) !important;
+  }
+  .sm\\:my0 {
+    margin-top: var(--su0) !important;
+    margin-bottom: var(--su0) !important;
+  }
+  .sm\\:my1 {
+    margin-top: var(--su1) !important;
+    margin-bottom: var(--su1) !important;
+  }
+  .sm\\:my2 {
+    margin-top: var(--su2) !important;
+    margin-bottom: var(--su2) !important;
+  }
+  .sm\\:my4 {
+    margin-top: var(--su4) !important;
+    margin-bottom: var(--su4) !important;
+  }
+  .sm\\:my6 {
+    margin-top: var(--su6) !important;
+    margin-bottom: var(--su6) !important;
+  }
+  .sm\\:my8 {
+    margin-top: var(--su8) !important;
+    margin-bottom: var(--su8) !important;
+  }
+  .sm\\:my12 {
+    margin-top: var(--su12) !important;
+    margin-bottom: var(--su12) !important;
+  }
+  .sm\\:my16 {
+    margin-top: var(--su16) !important;
+    margin-bottom: var(--su16) !important;
+  }
+  .sm\\:my24 {
+    margin-top: var(--su24) !important;
+    margin-bottom: var(--su24) !important;
+  }
+  .sm\\:my32 {
+    margin-top: var(--su32) !important;
+    margin-bottom: var(--su32) !important;
+  }
+  .sm\\:my48 {
+    margin-top: var(--su48) !important;
+    margin-bottom: var(--su48) !important;
+  }
+  .sm\\:my64 {
+    margin-top: var(--su64) !important;
+    margin-bottom: var(--su64) !important;
+  }
+  .sm\\:my96 {
+    margin-top: var(--su96) !important;
+    margin-bottom: var(--su96) !important;
+  }
+  .sm\\:my128 {
+    margin-top: var(--su128) !important;
+    margin-bottom: var(--su128) !important;
+  }
+  .sm\\:myn1 {
+    margin-top: var(--sun1) !important;
+    margin-bottom: var(--sun1) !important;
+  }
+  .sm\\:myn2 {
+    margin-top: var(--sun2) !important;
+    margin-bottom: var(--sun2) !important;
+  }
+  .sm\\:myn4 {
+    margin-top: var(--sun4) !important;
+    margin-bottom: var(--sun4) !important;
+  }
+  .sm\\:myn6 {
+    margin-top: var(--sun6) !important;
+    margin-bottom: var(--sun6) !important;
+  }
+  .sm\\:myn8 {
+    margin-top: var(--sun8) !important;
+    margin-bottom: var(--sun8) !important;
+  }
+  .sm\\:myn12 {
+    margin-top: var(--sun12) !important;
+    margin-bottom: var(--sun12) !important;
+  }
+  .sm\\:myn16 {
+    margin-top: var(--sun16) !important;
+    margin-bottom: var(--sun16) !important;
+  }
+  .sm\\:myn24 {
+    margin-top: var(--sun24) !important;
+    margin-bottom: var(--sun24) !important;
+  }
+  .sm\\:myn32 {
+    margin-top: var(--sun32) !important;
+    margin-bottom: var(--sun32) !important;
+  }
+  .sm\\:myn48 {
+    margin-top: var(--sun48) !important;
+    margin-bottom: var(--sun48) !important;
+  }
+  .sm\\:myn64 {
+    margin-top: var(--sun64) !important;
+    margin-bottom: var(--sun64) !important;
+  }
+  .sm\\:myn96 {
+    margin-top: var(--sun96) !important;
+    margin-bottom: var(--sun96) !important;
+  }
+  .sm\\:myn128 {
+    margin-top: var(--sun128) !important;
+    margin-bottom: var(--sun128) !important;
+  }
+  .sm\\:p0 {
+    padding: var(--su0) !important;
+  }
+  .sm\\:p1 {
+    padding: var(--su1) !important;
+  }
+  .sm\\:p2 {
+    padding: var(--su2) !important;
+  }
+  .sm\\:p4 {
+    padding: var(--su4) !important;
+  }
+  .sm\\:p6 {
+    padding: var(--su6) !important;
+  }
+  .sm\\:p8 {
+    padding: var(--su8) !important;
+  }
+  .sm\\:p12 {
+    padding: var(--su12) !important;
+  }
+  .sm\\:p16 {
+    padding: var(--su16) !important;
+  }
+  .sm\\:p24 {
+    padding: var(--su24) !important;
+  }
+  .sm\\:p32 {
+    padding: var(--su32) !important;
+  }
+  .sm\\:p48 {
+    padding: var(--su48) !important;
+  }
+  .sm\\:p64 {
+    padding: var(--su64) !important;
+  }
+  .sm\\:p96 {
+    padding: var(--su96) !important;
+  }
+  .sm\\:p128 {
+    padding: var(--su128) !important;
+  }
+  .sm\\:pt0 {
+    padding-top: var(--su0) !important;
+  }
+  .sm\\:pt1 {
+    padding-top: var(--su1) !important;
+  }
+  .sm\\:pt2 {
+    padding-top: var(--su2) !important;
+  }
+  .sm\\:pt4 {
+    padding-top: var(--su4) !important;
+  }
+  .sm\\:pt6 {
+    padding-top: var(--su6) !important;
+  }
+  .sm\\:pt8 {
+    padding-top: var(--su8) !important;
+  }
+  .sm\\:pt12 {
+    padding-top: var(--su12) !important;
+  }
+  .sm\\:pt16 {
+    padding-top: var(--su16) !important;
+  }
+  .sm\\:pt24 {
+    padding-top: var(--su24) !important;
+  }
+  .sm\\:pt32 {
+    padding-top: var(--su32) !important;
+  }
+  .sm\\:pt48 {
+    padding-top: var(--su48) !important;
+  }
+  .sm\\:pt64 {
+    padding-top: var(--su64) !important;
+  }
+  .sm\\:pt96 {
+    padding-top: var(--su96) !important;
+  }
+  .sm\\:pt128 {
+    padding-top: var(--su128) !important;
+  }
+  .sm\\:pr0 {
+    padding-right: var(--su0) !important;
+  }
+  .sm\\:pr1 {
+    padding-right: var(--su1) !important;
+  }
+  .sm\\:pr2 {
+    padding-right: var(--su2) !important;
+  }
+  .sm\\:pr4 {
+    padding-right: var(--su4) !important;
+  }
+  .sm\\:pr6 {
+    padding-right: var(--su6) !important;
+  }
+  .sm\\:pr8 {
+    padding-right: var(--su8) !important;
+  }
+  .sm\\:pr12 {
+    padding-right: var(--su12) !important;
+  }
+  .sm\\:pr16 {
+    padding-right: var(--su16) !important;
+  }
+  .sm\\:pr24 {
+    padding-right: var(--su24) !important;
+  }
+  .sm\\:pr32 {
+    padding-right: var(--su32) !important;
+  }
+  .sm\\:pr48 {
+    padding-right: var(--su48) !important;
+  }
+  .sm\\:pr64 {
+    padding-right: var(--su64) !important;
+  }
+  .sm\\:pr96 {
+    padding-right: var(--su96) !important;
+  }
+  .sm\\:pr128 {
+    padding-right: var(--su128) !important;
+  }
+  .sm\\:pb0 {
+    padding-bottom: var(--su0) !important;
+  }
+  .sm\\:pb1 {
+    padding-bottom: var(--su1) !important;
+  }
+  .sm\\:pb2 {
+    padding-bottom: var(--su2) !important;
+  }
+  .sm\\:pb4 {
+    padding-bottom: var(--su4) !important;
+  }
+  .sm\\:pb6 {
+    padding-bottom: var(--su6) !important;
+  }
+  .sm\\:pb8 {
+    padding-bottom: var(--su8) !important;
+  }
+  .sm\\:pb12 {
+    padding-bottom: var(--su12) !important;
+  }
+  .sm\\:pb16 {
+    padding-bottom: var(--su16) !important;
+  }
+  .sm\\:pb24 {
+    padding-bottom: var(--su24) !important;
+  }
+  .sm\\:pb32 {
+    padding-bottom: var(--su32) !important;
+  }
+  .sm\\:pb48 {
+    padding-bottom: var(--su48) !important;
+  }
+  .sm\\:pb64 {
+    padding-bottom: var(--su64) !important;
+  }
+  .sm\\:pb96 {
+    padding-bottom: var(--su96) !important;
+  }
+  .sm\\:pb128 {
+    padding-bottom: var(--su128) !important;
+  }
+  .sm\\:pl0 {
+    padding-left: var(--su0) !important;
+  }
+  .sm\\:pl1 {
+    padding-left: var(--su1) !important;
+  }
+  .sm\\:pl2 {
+    padding-left: var(--su2) !important;
+  }
+  .sm\\:pl4 {
+    padding-left: var(--su4) !important;
+  }
+  .sm\\:pl6 {
+    padding-left: var(--su6) !important;
+  }
+  .sm\\:pl8 {
+    padding-left: var(--su8) !important;
+  }
+  .sm\\:pl12 {
+    padding-left: var(--su12) !important;
+  }
+  .sm\\:pl16 {
+    padding-left: var(--su16) !important;
+  }
+  .sm\\:pl24 {
+    padding-left: var(--su24) !important;
+  }
+  .sm\\:pl32 {
+    padding-left: var(--su32) !important;
+  }
+  .sm\\:pl48 {
+    padding-left: var(--su48) !important;
+  }
+  .sm\\:pl64 {
+    padding-left: var(--su64) !important;
+  }
+  .sm\\:pl96 {
+    padding-left: var(--su96) !important;
+  }
+  .sm\\:pl128 {
+    padding-left: var(--su128) !important;
+  }
+  .sm\\:px0 {
+    padding-left: var(--su0) !important;
+    padding-right: var(--su0) !important;
+  }
+  .sm\\:px1 {
+    padding-left: var(--su1) !important;
+    padding-right: var(--su1) !important;
+  }
+  .sm\\:px2 {
+    padding-left: var(--su2) !important;
+    padding-right: var(--su2) !important;
+  }
+  .sm\\:px4 {
+    padding-left: var(--su4) !important;
+    padding-right: var(--su4) !important;
+  }
+  .sm\\:px6 {
+    padding-left: var(--su6) !important;
+    padding-right: var(--su6) !important;
+  }
+  .sm\\:px8 {
+    padding-left: var(--su8) !important;
+    padding-right: var(--su8) !important;
+  }
+  .sm\\:px12 {
+    padding-left: var(--su12) !important;
+    padding-right: var(--su12) !important;
+  }
+  .sm\\:px16 {
+    padding-left: var(--su16) !important;
+    padding-right: var(--su16) !important;
+  }
+  .sm\\:px24 {
+    padding-left: var(--su24) !important;
+    padding-right: var(--su24) !important;
+  }
+  .sm\\:px32 {
+    padding-left: var(--su32) !important;
+    padding-right: var(--su32) !important;
+  }
+  .sm\\:px48 {
+    padding-left: var(--su48) !important;
+    padding-right: var(--su48) !important;
+  }
+  .sm\\:px64 {
+    padding-left: var(--su64) !important;
+    padding-right: var(--su64) !important;
+  }
+  .sm\\:px96 {
+    padding-left: var(--su96) !important;
+    padding-right: var(--su96) !important;
+  }
+  .sm\\:px128 {
+    padding-left: var(--su128) !important;
+    padding-right: var(--su128) !important;
+  }
+  .sm\\:py0 {
+    padding-top: var(--su0) !important;
+    padding-bottom: var(--su0) !important;
+  }
+  .sm\\:py1 {
+    padding-top: var(--su1) !important;
+    padding-bottom: var(--su1) !important;
+  }
+  .sm\\:py2 {
+    padding-top: var(--su2) !important;
+    padding-bottom: var(--su2) !important;
+  }
+  .sm\\:py4 {
+    padding-top: var(--su4) !important;
+    padding-bottom: var(--su4) !important;
+  }
+  .sm\\:py6 {
+    padding-top: var(--su6) !important;
+    padding-bottom: var(--su6) !important;
+  }
+  .sm\\:py8 {
+    padding-top: var(--su8) !important;
+    padding-bottom: var(--su8) !important;
+  }
+  .sm\\:py12 {
+    padding-top: var(--su12) !important;
+    padding-bottom: var(--su12) !important;
+  }
+  .sm\\:py16 {
+    padding-top: var(--su16) !important;
+    padding-bottom: var(--su16) !important;
+  }
+  .sm\\:py24 {
+    padding-top: var(--su24) !important;
+    padding-bottom: var(--su24) !important;
+  }
+  .sm\\:py32 {
+    padding-top: var(--su32) !important;
+    padding-bottom: var(--su32) !important;
+  }
+  .sm\\:py48 {
+    padding-top: var(--su48) !important;
+    padding-bottom: var(--su48) !important;
+  }
+  .sm\\:py64 {
+    padding-top: var(--su64) !important;
+    padding-bottom: var(--su64) !important;
+  }
+  .sm\\:py96 {
+    padding-top: var(--su96) !important;
+    padding-bottom: var(--su96) !important;
+  }
+  .sm\\:py128 {
+    padding-top: var(--su128) !important;
+    padding-bottom: var(--su128) !important;
+  }
+  .sm\\:ps-absolute {
+    position: absolute !important;
+  }
+  .sm\\:ps-fixed {
+    position: fixed !important;
+  }
+  .sm\\:ps-relative {
+    position: relative !important;
+  }
+  .sm\\:ps-static {
+    position: static !important;
+  }
+  .sm\\:ps-sticky {
+    position: sticky !important;
+  }
+  .sm\\:t0 {
+    top: var(--su0) !important;
+  }
+  .sm\\:t1 {
+    top: var(--su1) !important;
+  }
+  .sm\\:t2 {
+    top: var(--su2) !important;
+  }
+  .sm\\:t4 {
+    top: var(--su4) !important;
+  }
+  .sm\\:t6 {
+    top: var(--su6) !important;
+  }
+  .sm\\:t8 {
+    top: var(--su8) !important;
+  }
+  .sm\\:t12 {
+    top: var(--su12) !important;
+  }
+  .sm\\:t16 {
+    top: var(--su16) !important;
+  }
+  .sm\\:t24 {
+    top: var(--su24) !important;
+  }
+  .sm\\:t32 {
+    top: var(--su32) !important;
+  }
+  .sm\\:t48 {
+    top: var(--su48) !important;
+  }
+  .sm\\:t64 {
+    top: var(--su64) !important;
+  }
+  .sm\\:t96 {
+    top: var(--su96) !important;
+  }
+  .sm\\:t128 {
+    top: var(--su128) !important;
+  }
+  .sm\\:tn1 {
+    top: var(--sun1) !important;
+  }
+  .sm\\:tn2 {
+    top: var(--sun2) !important;
+  }
+  .sm\\:tn4 {
+    top: var(--sun4) !important;
+  }
+  .sm\\:tn6 {
+    top: var(--sun6) !important;
+  }
+  .sm\\:tn8 {
+    top: var(--sun8) !important;
+  }
+  .sm\\:tn12 {
+    top: var(--sun12) !important;
+  }
+  .sm\\:tn16 {
+    top: var(--sun16) !important;
+  }
+  .sm\\:tn24 {
+    top: var(--sun24) !important;
+  }
+  .sm\\:tn32 {
+    top: var(--sun32) !important;
+  }
+  .sm\\:tn48 {
+    top: var(--sun48) !important;
+  }
+  .sm\\:tn64 {
+    top: var(--sun64) !important;
+  }
+  .sm\\:tn96 {
+    top: var(--sun96) !important;
+  }
+  .sm\\:tn128 {
+    top: var(--sun128) !important;
+  }
+  .sm\\:t50 {
+    top: 50% !important;
+  }
+  .sm\\:t100 {
+    top: 100% !important;
+  }
+  .sm\\:tn50 {
+    top: -50% !important;
+  }
+  .sm\\:tn100 {
+    top: -100% !important;
+  }
+  .sm\\:r0 {
+    right: var(--su0) !important;
+  }
+  .sm\\:r1 {
+    right: var(--su1) !important;
+  }
+  .sm\\:r2 {
+    right: var(--su2) !important;
+  }
+  .sm\\:r4 {
+    right: var(--su4) !important;
+  }
+  .sm\\:r6 {
+    right: var(--su6) !important;
+  }
+  .sm\\:r8 {
+    right: var(--su8) !important;
+  }
+  .sm\\:r12 {
+    right: var(--su12) !important;
+  }
+  .sm\\:r16 {
+    right: var(--su16) !important;
+  }
+  .sm\\:r24 {
+    right: var(--su24) !important;
+  }
+  .sm\\:r32 {
+    right: var(--su32) !important;
+  }
+  .sm\\:r48 {
+    right: var(--su48) !important;
+  }
+  .sm\\:r64 {
+    right: var(--su64) !important;
+  }
+  .sm\\:r96 {
+    right: var(--su96) !important;
+  }
+  .sm\\:r128 {
+    right: var(--su128) !important;
+  }
+  .sm\\:rn1 {
+    right: var(--sun1) !important;
+  }
+  .sm\\:rn2 {
+    right: var(--sun2) !important;
+  }
+  .sm\\:rn4 {
+    right: var(--sun4) !important;
+  }
+  .sm\\:rn6 {
+    right: var(--sun6) !important;
+  }
+  .sm\\:rn8 {
+    right: var(--sun8) !important;
+  }
+  .sm\\:rn12 {
+    right: var(--sun12) !important;
+  }
+  .sm\\:rn16 {
+    right: var(--sun16) !important;
+  }
+  .sm\\:rn24 {
+    right: var(--sun24) !important;
+  }
+  .sm\\:rn32 {
+    right: var(--sun32) !important;
+  }
+  .sm\\:rn48 {
+    right: var(--sun48) !important;
+  }
+  .sm\\:rn64 {
+    right: var(--sun64) !important;
+  }
+  .sm\\:rn96 {
+    right: var(--sun96) !important;
+  }
+  .sm\\:rn128 {
+    right: var(--sun128) !important;
+  }
+  .sm\\:r50 {
+    right: 50% !important;
+  }
+  .sm\\:r100 {
+    right: 100% !important;
+  }
+  .sm\\:rn50 {
+    right: -50% !important;
+  }
+  .sm\\:rn100 {
+    right: -100% !important;
+  }
+  .sm\\:b0 {
+    bottom: var(--su0) !important;
+  }
+  .sm\\:b1 {
+    bottom: var(--su1) !important;
+  }
+  .sm\\:b2 {
+    bottom: var(--su2) !important;
+  }
+  .sm\\:b4 {
+    bottom: var(--su4) !important;
+  }
+  .sm\\:b6 {
+    bottom: var(--su6) !important;
+  }
+  .sm\\:b8 {
+    bottom: var(--su8) !important;
+  }
+  .sm\\:b12 {
+    bottom: var(--su12) !important;
+  }
+  .sm\\:b16 {
+    bottom: var(--su16) !important;
+  }
+  .sm\\:b24 {
+    bottom: var(--su24) !important;
+  }
+  .sm\\:b32 {
+    bottom: var(--su32) !important;
+  }
+  .sm\\:b48 {
+    bottom: var(--su48) !important;
+  }
+  .sm\\:b64 {
+    bottom: var(--su64) !important;
+  }
+  .sm\\:b96 {
+    bottom: var(--su96) !important;
+  }
+  .sm\\:b128 {
+    bottom: var(--su128) !important;
+  }
+  .sm\\:bn1 {
+    bottom: var(--sun1) !important;
+  }
+  .sm\\:bn2 {
+    bottom: var(--sun2) !important;
+  }
+  .sm\\:bn4 {
+    bottom: var(--sun4) !important;
+  }
+  .sm\\:bn6 {
+    bottom: var(--sun6) !important;
+  }
+  .sm\\:bn8 {
+    bottom: var(--sun8) !important;
+  }
+  .sm\\:bn12 {
+    bottom: var(--sun12) !important;
+  }
+  .sm\\:bn16 {
+    bottom: var(--sun16) !important;
+  }
+  .sm\\:bn24 {
+    bottom: var(--sun24) !important;
+  }
+  .sm\\:bn32 {
+    bottom: var(--sun32) !important;
+  }
+  .sm\\:bn48 {
+    bottom: var(--sun48) !important;
+  }
+  .sm\\:bn64 {
+    bottom: var(--sun64) !important;
+  }
+  .sm\\:bn96 {
+    bottom: var(--sun96) !important;
+  }
+  .sm\\:bn128 {
+    bottom: var(--sun128) !important;
+  }
+  .sm\\:b50 {
+    bottom: 50% !important;
+  }
+  .sm\\:b100 {
+    bottom: 100% !important;
+  }
+  .sm\\:bn50 {
+    bottom: -50% !important;
+  }
+  .sm\\:bn100 {
+    bottom: -100% !important;
+  }
+  .sm\\:l0 {
+    left: var(--su0) !important;
+  }
+  .sm\\:l1 {
+    left: var(--su1) !important;
+  }
+  .sm\\:l2 {
+    left: var(--su2) !important;
+  }
+  .sm\\:l4 {
+    left: var(--su4) !important;
+  }
+  .sm\\:l6 {
+    left: var(--su6) !important;
+  }
+  .sm\\:l8 {
+    left: var(--su8) !important;
+  }
+  .sm\\:l12 {
+    left: var(--su12) !important;
+  }
+  .sm\\:l16 {
+    left: var(--su16) !important;
+  }
+  .sm\\:l24 {
+    left: var(--su24) !important;
+  }
+  .sm\\:l32 {
+    left: var(--su32) !important;
+  }
+  .sm\\:l48 {
+    left: var(--su48) !important;
+  }
+  .sm\\:l64 {
+    left: var(--su64) !important;
+  }
+  .sm\\:l96 {
+    left: var(--su96) !important;
+  }
+  .sm\\:l128 {
+    left: var(--su128) !important;
+  }
+  .sm\\:ln1 {
+    left: var(--sun1) !important;
+  }
+  .sm\\:ln2 {
+    left: var(--sun2) !important;
+  }
+  .sm\\:ln4 {
+    left: var(--sun4) !important;
+  }
+  .sm\\:ln6 {
+    left: var(--sun6) !important;
+  }
+  .sm\\:ln8 {
+    left: var(--sun8) !important;
+  }
+  .sm\\:ln12 {
+    left: var(--sun12) !important;
+  }
+  .sm\\:ln16 {
+    left: var(--sun16) !important;
+  }
+  .sm\\:ln24 {
+    left: var(--sun24) !important;
+  }
+  .sm\\:ln32 {
+    left: var(--sun32) !important;
+  }
+  .sm\\:ln48 {
+    left: var(--sun48) !important;
+  }
+  .sm\\:ln64 {
+    left: var(--sun64) !important;
+  }
+  .sm\\:ln96 {
+    left: var(--sun96) !important;
+  }
+  .sm\\:ln128 {
+    left: var(--sun128) !important;
+  }
+  .sm\\:l50 {
+    left: 50% !important;
+  }
+  .sm\\:l100 {
+    left: 100% !important;
+  }
+  .sm\\:ln50 {
+    left: -50% !important;
+  }
+  .sm\\:ln100 {
+    left: -100% !important;
+  }
+  .sm\\:w25 {
+    width: 25% !important;
+  }
+  .sm\\:w50 {
+    width: 50% !important;
+  }
+  .sm\\:w75 {
+    width: 75% !important;
+  }
+  .sm\\:w100 {
+    width: 100% !important;
+  }
+  .sm\\:w33 {
+    width: calc(100% / 3) !important;
+  }
+  .sm\\:w66 {
+    width: calc(100% / 3 * 2) !important;
+  }
+  .sm\\:w-auto {
+    width: auto !important;
+  }
+  .sm\\:w-screen {
+    width: 100vw !important;
+  }
+  .sm\\:wmn100 {
+    min-width: 100% !important;
+  }
+  .sm\\:wmn-initial {
+    min-width: initial !important;
+  }
+  .sm\\:wmn-screen {
+    min-width: 100vw !important;
+  }
+  .sm\\:wmx100 {
+    max-width: 100% !important;
+  }
+  .sm\\:wmx-initial {
+    max-width: initial !important;
+  }
+  .sm\\:wmx-screen {
+    max-width: 100vw !important;
+  }
+}
+@media print {
+  .print\\:d-block  {
+    display: block !important;
+  }
+  .print\\:d-none  {
+    display: none !important;
+  }
+}
+/* stylelint-enable */
+/* stylelint-disable */
+html,
+body {
+  color: var(--theme-body-font-color, var(--black-600));
+  font-family: var(--theme-body-font-family);
+  line-height: var(--lh-base);
+}
+body {
+  background-color: var(--theme-background-color, var(--white));
+  box-sizing: border-box;
+  font-size: var(--fs-body1);
+  min-height: 100%;
+}
+body *,
+body *:before,
+body *:after {
+  box-sizing: inherit;
+}
+"
+`;

--- a/packages/stacks-classic/lib/stacks.less.test.ts
+++ b/packages/stacks-classic/lib/stacks.less.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { renderLess } from "./test/less-test-utils";
+
+describe("stacks complete bundle", () => {
+    it("should output all stacks styles", async () => {
+        const css = await renderLess(`
+            @import "./lib/stacks.less";
+        `);
+
+        expect(css).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
## Summary

Adds a complete Less snapshot test for the Stacks classic CSS bundle so missing imports are easier to catch.

## Related Issue

[STACKS-909](https://stackoverflow.atlassian.net/browse/STACKS-909)

## Changes

- Adds `packages/stacks-classic/lib/stacks.less.test.ts`.
- Adds the generated snapshot for `@import "./lib/stacks.less";`.

## Testing

- `npx vitest run lib/stacks.less.test.ts`
- `npm run test:less -w packages/stacks-classic`

## Changeset

None. Test-only change.