### PR TITLE
fix(modal): stop Escape propagation by default

### DIFF
--- a/packages/stacks-svelte/src/components/Modal/Modal.svelte
+++ b/packages/stacks-svelte/src/components/Modal/Modal.svelte
@@ -43,10 +43,6 @@
          */
         hideCloseButton?: boolean;
         /**
-         * Boolean controlling whether Escape key presses handled by the modal should stop propagation.
-         */
-        stopEscapePropagation?: boolean;
-        /**
          * Callback fired when the modal is closed
          */
         onclose?: () => void;
@@ -72,7 +68,6 @@
         i18nCloseButtonLabel = "Close",
         preventCloseOnClickOutside = false,
         hideCloseButton = false,
-        stopEscapePropagation = true,
         onclose,
         header,
         body,
@@ -94,10 +89,7 @@
     const keyPress = (event: KeyboardEvent) => {
         if (event.key === "Escape" && visible) {
             event.preventDefault();
-
-            if (stopEscapePropagation) {
-                event.stopImmediatePropagation();
-            }
+            event.stopImmediatePropagation();
 
             close();
         }

--- a/packages/stacks-svelte/src/components/Modal/Modal.svelte
+++ b/packages/stacks-svelte/src/components/Modal/Modal.svelte
@@ -88,7 +88,6 @@
 
     const keyPress = (event: KeyboardEvent) => {
         if (event.key === "Escape" && visible) {
-            event.preventDefault();
             event.stopImmediatePropagation();
 
             close();

--- a/packages/stacks-svelte/src/components/Modal/Modal.svelte
+++ b/packages/stacks-svelte/src/components/Modal/Modal.svelte
@@ -43,6 +43,10 @@
          */
         hideCloseButton?: boolean;
         /**
+         * Boolean controlling whether Escape key presses handled by the modal should stop propagation.
+         */
+        stopEscapePropagation?: boolean;
+        /**
          * Callback fired when the modal is closed
          */
         onclose?: () => void;
@@ -68,6 +72,7 @@
         i18nCloseButtonLabel = "Close",
         preventCloseOnClickOutside = false,
         hideCloseButton = false,
+        stopEscapePropagation = true,
         onclose,
         header,
         body,
@@ -86,8 +91,14 @@
         }
     };
 
-    const keyPress = (e: KeyboardEvent) => {
-        if (e.key === "Escape") {
+    const keyPress = (event: KeyboardEvent) => {
+        if (event.key === "Escape" && visible) {
+            event.preventDefault();
+
+            if (stopEscapePropagation) {
+                event.stopImmediatePropagation();
+            }
+
             close();
         }
     };

--- a/packages/stacks-svelte/src/components/Modal/Modal.test.ts
+++ b/packages/stacks-svelte/src/components/Modal/Modal.test.ts
@@ -146,6 +146,55 @@ describe("Modal", () => {
             expectModalVisible(false);
         });
 
+        it("should stop esc press propagation when closing a visible modal", async () => {
+            const laterWindowListener = sinon.spy();
+            render(Modal, { id: "test-modal", visible: true });
+            window.addEventListener("keydown", laterWindowListener);
+
+            try {
+                await userEvent.keyboard("{Escape}");
+
+                expectModalVisible(false);
+                expect(laterWindowListener).not.to.have.been.called;
+            } finally {
+                window.removeEventListener("keydown", laterWindowListener);
+            }
+        });
+
+        it("should allow esc press propagation when stopEscapePropagation is false", async () => {
+            const laterWindowListener = sinon.spy();
+            render(Modal, {
+                id: "test-modal",
+                stopEscapePropagation: false,
+                visible: true,
+            });
+            window.addEventListener("keydown", laterWindowListener);
+
+            try {
+                await userEvent.keyboard("{Escape}");
+
+                expectModalVisible(false);
+                expect(laterWindowListener).to.have.been.calledOnce;
+            } finally {
+                window.removeEventListener("keydown", laterWindowListener);
+            }
+        });
+
+        it("should not stop esc press propagation when modal is not visible", async () => {
+            const laterWindowListener = sinon.spy();
+            render(Modal, { id: "test-modal", visible: false });
+            window.addEventListener("keydown", laterWindowListener);
+
+            try {
+                await userEvent.keyboard("{Escape}");
+
+                expectModalVisible(false);
+                expect(laterWindowListener).to.have.been.calledOnce;
+            } finally {
+                window.removeEventListener("keydown", laterWindowListener);
+            }
+        });
+
         it("should emit close event on close when modal is visible", async () => {
             const onClose = sinon.spy();
             render(Modal, {

--- a/packages/stacks-svelte/src/components/Modal/Modal.test.ts
+++ b/packages/stacks-svelte/src/components/Modal/Modal.test.ts
@@ -161,25 +161,6 @@ describe("Modal", () => {
             }
         });
 
-        it("should allow esc press propagation when stopEscapePropagation is false", async () => {
-            const laterWindowListener = sinon.spy();
-            render(Modal, {
-                id: "test-modal",
-                stopEscapePropagation: false,
-                visible: true,
-            });
-            window.addEventListener("keydown", laterWindowListener);
-
-            try {
-                await userEvent.keyboard("{Escape}");
-
-                expectModalVisible(false);
-                expect(laterWindowListener).to.have.been.calledOnce;
-            } finally {
-                window.removeEventListener("keydown", laterWindowListener);
-            }
-        });
-
         it("should not stop esc press propagation when modal is not visible", async () => {
             const laterWindowListener = sinon.spy();
             render(Modal, { id: "test-modal", visible: false });


### PR DESCRIPTION
On NXT-104 story, [Dan found out](https://github.com/StackEng/StackInternal.Chat/pull/118#discussion_r3538085403) that pressing "Esc" keyboard key also closes the Recents Panel. We can code the solution in Chat repo, but I think this logic can fit into the Modal components too as it is a common case.