### PR TITLE
docs(resources): add Stacks GitHub repository link

### DIFF
--- a/packages/stacks-docs/src/structure.yaml
+++ b/packages/stacks-docs/src/structure.yaml
@@ -362,6 +362,11 @@ navigation:
             slug: "fonts"
             image: "/images/heros/typography.svg"
 
+          - title: "GitHub repository"
+            slug: "github"
+            image: "/images/heros/develop.svg"
+            externalUrl: https://github.com/StackExchange/Stacks
+
           - title: "Icons & Spots"
             slug: "icons"
             image: "/images/heros/product.svg"


### PR DESCRIPTION
## Summary

Adds the Stacks GitHub repository to the Resources page.

## Related Issue

[STACKS-878](https://stackoverflow.atlassian.net/browse/STACKS-878)

## Changes

- Added a new Resources page item linking to the Stacks GitHub repository
- Uses the existing development hero thumbnail for the link

## Testing

- mise exec node@22.22.2 -- npm run lint -w packages/stacks-docs
- Result: 0 errors, 5 existing unrelated Svelte warnings

## Changeset

None. This updates the private docs site only.