### PR TITLE
fix(ci): dependabot CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,10 @@ jobs:
 
       - name: 🔑 Setup SSH for private submodule
         run: |
+          if [ -z "$SUBMODULE_SSH_KEY" ]; then
+            echo "Skipping SSH setup; SUBMODULE_SSH_KEY is not available"
+            exit 0
+          fi
           mkdir -p ~/.ssh
           echo -e "${SUBMODULE_SSH_KEY//_/\\n}" > ~/.ssh/id_rsa
           chmod og-rwx ~/.ssh/id_rsa

--- a/packages/stacks-docs/package.json
+++ b/packages/stacks-docs/package.json
@@ -12,7 +12,7 @@
         "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
         "lint": "npm run check && eslint .",
         "format": "prettier --write .",
-        "init-private-content": "if [ -d src/docs/private/.git ]; then git -C src/docs/private pull --ff-only; elif [ -f ~/.ssh/id_rsa ]; then GIT_SSH_COMMAND=\"ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no\" git clone --depth 1 git@github.com:StackEng/StacksDocsPrivate.git src/docs/private; else echo 'Skipping private docs; no SSH key found'; fi"
+        "init-private-content": "if [ -d src/docs/private/.git ]; then git -C src/docs/private pull --ff-only; elif [ -s ~/.ssh/id_rsa ]; then GIT_SSH_COMMAND=\"ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no\" git clone --depth 1 git@github.com:StackEng/StacksDocsPrivate.git src/docs/private; else echo 'Skipping private docs; no SSH key found'; fi"
     },
     "devDependencies": {
         "@eslint/compat": "^2.1.0",


### PR DESCRIPTION
Dependabot-authored workflow runs do not have access to the private docs SSH key. The workflow was still creating an empty key file, which made the docs build try to clone private docs and fail with exit 128.

This skips SSH setup when the secret is unavailable and makes the docs script ignore empty key files.