### PR TITLE
ci(docs): wait for Netlify deploy completion

### DIFF
--- a/.github/scripts/deploy-netlify.sh
+++ b/.github/scripts/deploy-netlify.sh
@@ -26,7 +26,7 @@ fi
 
 printf 'Netlify build %s created for deploy %s.\n' "$build_id" "$deploy_id"
 
-timeout_seconds="${NETLIFY_DEPLOY_TIMEOUT_SECONDS:-1800}"
+timeout_seconds="${NETLIFY_DEPLOY_TIMEOUT_SECONDS:-900}"
 poll_interval_seconds="${NETLIFY_DEPLOY_POLL_INTERVAL_SECONDS:-15}"
 deadline=$((SECONDS + timeout_seconds))
 

--- a/.github/scripts/deploy-netlify.sh
+++ b/.github/scripts/deploy-netlify.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${NETLIFY_API_TOKEN:?NETLIFY_API_TOKEN is required}"
+: "${NETLIFY_SITE_ID:?NETLIFY_SITE_ID is required}"
+: "${NETLIFY_BRANCH:?NETLIFY_BRANCH is required}"
+: "${NETLIFY_DEPLOY_TITLE:?NETLIFY_DEPLOY_TITLE is required}"
+
+api_url="https://api.netlify.com/api/v1"
+encoded_title="$(printf '%s' "$NETLIFY_DEPLOY_TITLE" | jq -sRr @uri)"
+
+build_response="$(curl --fail --silent --show-error --retry 3 --retry-all-errors \
+  --request POST \
+  --header "Authorization: Bearer $NETLIFY_API_TOKEN" \
+  "$api_url/sites/$NETLIFY_SITE_ID/builds?branch=$NETLIFY_BRANCH&title=$encoded_title")"
+
+build_id="$(jq -r '.id // empty' <<<"$build_response")"
+deploy_id="$(jq -r '.deploy_id // empty' <<<"$build_response")"
+build_error="$(jq -r '.error // empty' <<<"$build_response")"
+
+if [[ -n "$build_error" || -z "$build_id" || -z "$deploy_id" ]]; then
+  printf 'Netlify did not schedule the build: %s\n' "${build_error:-unexpected API response}" >&2
+  exit 1
+fi
+
+printf 'Netlify build %s created for deploy %s.\n' "$build_id" "$deploy_id"
+
+timeout_seconds="${NETLIFY_DEPLOY_TIMEOUT_SECONDS:-1800}"
+poll_interval_seconds="${NETLIFY_DEPLOY_POLL_INTERVAL_SECONDS:-15}"
+deadline=$((SECONDS + timeout_seconds))
+
+while (( SECONDS < deadline )); do
+  deploy_response="$(curl --fail --silent --show-error --retry 3 --retry-all-errors \
+    --header "Authorization: Bearer $NETLIFY_API_TOKEN" \
+    "$api_url/deploys/$deploy_id")"
+  state="$(jq -r '.state // empty' <<<"$deploy_response")"
+
+  case "$state" in
+    ready)
+      printf 'Netlify deploy %s succeeded.\n' "$deploy_id"
+      exit 0
+      ;;
+    error)
+      error_message="$(jq -r '.error_message // "unknown Netlify error"' <<<"$deploy_response")"
+      printf 'Netlify deploy %s failed: %s\n' "$deploy_id" "$error_message" >&2
+      exit 1
+      ;;
+    *)
+      printf 'Netlify deploy %s is %s; waiting.\n' "$deploy_id" "${state:-unknown}"
+      sleep "$poll_interval_seconds"
+      ;;
+  esac
+done
+
+printf 'Netlify deploy %s did not finish within %s seconds.\n' "$deploy_id" "$timeout_seconds" >&2
+exit 1

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -10,7 +10,7 @@ jobs:
     name: "Deploy docs (manual)"
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
       - name: Deploy docs site

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -10,14 +10,16 @@ jobs:
     name: "Deploy docs (manual)"
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     steps:
+      - uses: actions/checkout@v5
       - name: Deploy docs site
-        run: |
-          curl --fail --silent --show-error --retry 3 --retry-all-errors \
-            --request POST \
-            "$NETLIFY_DOCS_BUILD_HOOK_URL?trigger_branch=main&trigger_title=Manual+docs+deploy"
+        run: bash .github/scripts/deploy-netlify.sh
         env:
-          NETLIFY_DOCS_BUILD_HOOK_URL: ${{ secrets.NETLIFY_DOCS_BUILD_HOOK_URL }}
+          NETLIFY_API_TOKEN: ${{ secrets.NETLIFY_API_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_BRANCH: main
+          NETLIFY_DEPLOY_TITLE: Manual docs deploy
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [build-and-test]
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 20
     env:
       BETTER_AUTH_SECRET: ${{ secrets.AUTH_SECRET || 'ci-build-placeholder-secret' }}
     outputs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [build-and-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     env:
       BETTER_AUTH_SECRET: ${{ secrets.AUTH_SECRET || 'ci-build-placeholder-secret' }}
     outputs:
@@ -108,12 +109,12 @@ jobs:
             See this GH issue for more details: https://github.com/changesets/action/issues/187
       - name: Deploy docs site
         if: steps.changesets.outputs.published == 'true'
-        run: |
-          curl --fail --silent --show-error --retry 3 --retry-all-errors \
-            --request POST \
-            "$NETLIFY_DOCS_BUILD_HOOK_URL?trigger_branch=main&trigger_title=Release+docs+deploy"
+        run: bash .github/scripts/deploy-netlify.sh
         env:
-          NETLIFY_DOCS_BUILD_HOOK_URL: ${{ secrets.NETLIFY_DOCS_BUILD_HOOK_URL }}
+          NETLIFY_API_TOKEN: ${{ secrets.NETLIFY_API_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_BRANCH: main
+          NETLIFY_DEPLOY_TITLE: Release docs deploy
 
 # cancel the jobs if another workflow is kicked off for the same branch
 concurrency:


### PR DESCRIPTION
## Summary
- Trigger Netlify builds through the API and capture the deploy ID.
- Poll Netlify until the deploy is ready, errors, or times out.
- Apply the same status-aware behavior to release and manual docs deploys.

## Required repository secrets
- `NETLIFY_API_TOKEN`
- `NETLIFY_SITE_ID`

The Netlify API token must be authorized for the SAML-protected team.

## Verification
- Bash syntax validation passed.
- Workflow YAML parsing passed.
- `npm run test -w packages/stacks-docs` passed (5 tests).
- `git diff --check` passed.