### PR TITLE
ci(tests): run visual regressions conditionally

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,48 @@ on:
     branches: [main]
 
 jobs:
+  detect-visual-changes:
+    name: Detect visual changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.filter.outputs.styles == 'true' || steps.filter.outputs.runtime == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.infrastructure == 'true' }}
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+
+      - name: 🔎 Detect visual changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            styles:
+              - 'packages/stacks-classic/lib/**/*.less'
+            runtime:
+              - 'packages/stacks-classic/lib/index.ts'
+              - 'packages/stacks-classic/lib/esm-no-css.ts'
+              - 'packages/stacks-classic/lib/controllers.ts'
+              - 'packages/stacks-classic/lib/stacks.ts'
+              - 'packages/stacks-classic/lib/components/**/!(*.test|*.test.setup|*.fixtures).ts'
+            tests:
+              - 'packages/stacks-classic/lib/**/*.visual.test.ts'
+              - 'packages/stacks-classic/lib/**/*.test.setup.ts'
+              - 'packages/stacks-classic/lib/**/*.fixtures.ts'
+              - 'packages/stacks-classic/lib/test/test-utils.ts'
+              - 'packages/stacks-classic/lib/test/visual-test-utils.ts'
+            infrastructure:
+              - '.gitattributes'
+              - '.github/workflows/main.yml'
+              - '.github/workflows/test.yml'
+              - 'package.json'
+              - 'packages/stacks-classic/package.json'
+              - 'packages/stacks-classic/run-test-visual.ps1'
+              - 'packages/stacks-classic/screenshots/**'
+              - 'packages/stacks-classic/web-test-runner.config.mjs'
+              - 'packages/stacks-classic/web-test-runner.config.ci.mjs'
+
   build-and-test:
     name: ${{ matrix.command_description }}
     uses: ./.github/workflows/test.yml
@@ -34,10 +76,6 @@ jobs:
           command: npm run test:a11y -w packages/stacks-classic -- --config web-test-runner.config.ci.mjs
           needs_lfs: false
           needs_playwright: true
-        - command_description: Visual Regression Tests
-          command: npm run test:visual:ci -w packages/stacks-classic -- --config ./visual-runner/stacks-classic-runner-config/web-test-runner.config.ci.mjs
-          needs_lfs: true
-          needs_playwright: false # we are using playwright docker image to run visual tests
         - command_description: Unit Tests (stacks-svelte)
           command: npm run test -w packages/stacks-svelte
           needs_lfs: false
@@ -61,10 +99,23 @@ jobs:
       needs_lfs: ${{ matrix.needs_lfs }}
     secrets: inherit
 
+  visual-regression-tests:
+    name: Visual Regression Tests
+    needs: detect-visual-changes
+    if: ${{ always() }}
+    uses: ./.github/workflows/test.yml
+    with:
+      command: npm run test:visual:ci -w packages/stacks-classic -- --config ./visual-runner/stacks-classic-runner-config/web-test-runner.config.ci.mjs
+      command_description: Visual Regression Tests
+      needs_lfs: true
+      needs_playwright: false # we are using playwright docker image to run visual tests
+      should_run: ${{ needs.detect-visual-changes.result != 'success' || needs.detect-visual-changes.outputs.should_run == 'true' }}
+    secrets: inherit
+
   release:
     name: "Release (main)"
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [build-and-test]
+    needs: [build-and-test, visual-regression-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,10 @@ on:
         description: 'Whether or not to checkout with LFS'
         type: boolean
         default: false
+      should_run:
+        description: 'Whether or not to execute the command'
+        type: boolean
+        default: true
 
 jobs:
   build-and-test:
@@ -27,24 +31,32 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: ⏭️ Skip ${{ inputs.command_description }}
+        if: inputs.should_run == false
+        run: echo "No relevant changes detected; skipping ${{ inputs.command_description }}."
+
       - name: ⬇️ Checkout
+        if: inputs.should_run
         uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.needs_lfs }}
 
       - name: ⎔ Setup node
+        if: inputs.should_run
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
 
       - name: 🏗 Install Dependencies
+        if: inputs.should_run
         run: npm ci
 
       - name: 🏗 Install Playwright
-        if: inputs.needs_playwright == true
+        if: inputs.should_run && inputs.needs_playwright == true
         run: npx playwright install --with-deps
 
       - name: 🔑 Setup SSH for private submodule
+        if: inputs.should_run
         run: |
           if [ -z "$SUBMODULE_SSH_KEY" ]; then
             echo "Skipping SSH setup; SUBMODULE_SSH_KEY is not available"
@@ -57,13 +69,14 @@ jobs:
           SUBMODULE_SSH_KEY: ${{ secrets.SUBMODULE_SSH_KEY }}
 
       - name: ▶️ ${{ inputs.command_description }}
+        if: inputs.should_run
         run: ${{ inputs.command }}
         env:
           BETTER_AUTH_SECRET: ${{ secrets.AUTH_SECRET || 'ci-build-placeholder-secret' }}
 
       - name: ⬆️ Upload Visual Regression Test Results
         uses: actions/upload-artifact@v4
-        if: ${{ failure() && inputs.command_description == 'Visual Regression Tests' }}
+        if: ${{ failure() && inputs.should_run && inputs.command_description == 'Visual Regression Tests' }}
         with:
           name: visual-regression-test-results
           path: packages/stacks-classic/screenshots

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ npm run test:unit:watch -w packages/stacks-classic
 This [Web Test Runner plugin](https://www.npmjs.com/package/@web/test-runner-visual-regression) is used to run visual regression tests.
 Visual regression tests end with this suffix `*.visual.test.ts`.
 
+In CI, the visual regression suite runs only when a pull request or commit changes Stacks Classic styles, runtime code, visual tests or fixtures, baselines, direct dependency manifests, or visual test infrastructure. The required check still completes successfully without executing the suite for unrelated changes.
+
 Execute the visual regression tests suite by running:
 ```sh
 npm run test:visual -w packages/stacks-classic


### PR DESCRIPTION
## Summary

- detect changes that can affect Stacks Classic visual output
- preserve the required visual regression check while skipping expensive setup and execution for unrelated changes
- default to running visual tests if change detection fails
- document the conditional CI behavior

## Testing

- `actionlint`
- representative path-filter assertions
- `git diff --check`

## Notes

- This PR changes visual-test infrastructure, so its own visual regression suite is expected to run in full.
- Lockfile-only dependency updates remain excluded; direct dependency manifest changes trigger the suite.