### PR TITLE
docs(readme): fix visual diff typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Execute the visual regression tests suite by running:
 npm run test:visual -w packages/stacks-classic
 ```
 After the first run, if there are failing snapshots, they end up overriding the baseline ones in the filesystem (e.g. `/screenshots/<browser>/baseline/<name>.png`).
-We do this for easier comparison of the dif directly in vscode and to make sure only the failing snapshots get regenerated (see [this GH discussion](https://github.com/modernweb-dev/web/discussions/427#discussioncomment-3543771) that inspired the approach).
+We do this for easier comparison of the diff directly in vscode and to make sure only the failing snapshots get regenerated (see [this GH discussion](https://github.com/modernweb-dev/web/discussions/427#discussioncomment-3543771) that inspired the approach).
 
 We also recommend to install [this vscode extension](https://marketplace.visualstudio.com/items?itemName=RayWiis.png-image-diff) for getting better diffs.
 


### PR DESCRIPTION
## Summary

- correct a typo in the visual regression testing documentation
- provide a docs-only change to verify that visual regression CI takes its skip path

## Expected CI behavior

The required visual regression check should complete successfully without checking out LFS files, installing dependencies, building the Docker image, or running visual tests.

## Testing

- `git diff --check`
- confirmed `README.md` does not match any configured visual-test path filter