### PR TITLE
ci(tests): mark omitted visual tests as skipped

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
 
   release:
     name: "Release (main)"
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.build-and-test.result == 'success' && (needs.visual-regression-tests.result == 'success' || needs.visual-regression-tests.result == 'skipped') }}
     needs: [build-and-test, visual-regression-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,35 +28,28 @@ on:
 jobs:
   build-and-test:
     name: ${{ inputs.command_description }}
+    if: inputs.should_run
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: ⏭️ Skip ${{ inputs.command_description }}
-        if: inputs.should_run == false
-        run: echo "No relevant changes detected; skipping ${{ inputs.command_description }}."
-
       - name: ⬇️ Checkout
-        if: inputs.should_run
         uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.needs_lfs }}
 
       - name: ⎔ Setup node
-        if: inputs.should_run
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
 
       - name: 🏗 Install Dependencies
-        if: inputs.should_run
         run: npm ci
 
       - name: 🏗 Install Playwright
-        if: inputs.should_run && inputs.needs_playwright == true
+        if: inputs.needs_playwright == true
         run: npx playwright install --with-deps
 
       - name: 🔑 Setup SSH for private submodule
-        if: inputs.should_run
         run: |
           if [ -z "$SUBMODULE_SSH_KEY" ]; then
             echo "Skipping SSH setup; SUBMODULE_SSH_KEY is not available"
@@ -69,14 +62,13 @@ jobs:
           SUBMODULE_SSH_KEY: ${{ secrets.SUBMODULE_SSH_KEY }}
 
       - name: ▶️ ${{ inputs.command_description }}
-        if: inputs.should_run
         run: ${{ inputs.command }}
         env:
           BETTER_AUTH_SECRET: ${{ secrets.AUTH_SECRET || 'ci-build-placeholder-secret' }}
 
       - name: ⬆️ Upload Visual Regression Test Results
         uses: actions/upload-artifact@v4
-        if: ${{ failure() && inputs.should_run && inputs.command_description == 'Visual Regression Tests' }}
+        if: ${{ failure() && inputs.command_description == 'Visual Regression Tests' }}
         with:
           name: visual-regression-test-results
           path: packages/stacks-classic/screenshots

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ npm run test:unit:watch -w packages/stacks-classic
 This [Web Test Runner plugin](https://www.npmjs.com/package/@web/test-runner-visual-regression) is used to run visual regression tests.
 Visual regression tests end with this suffix `*.visual.test.ts`.
 
-In CI, the visual regression suite runs only when a pull request or commit changes Stacks Classic styles, runtime code, visual tests or fixtures, baselines, direct dependency manifests, or visual test infrastructure. The required check still completes successfully without executing the suite for unrelated changes.
+In CI, the visual regression suite runs only when a pull request or commit changes Stacks Classic styles, runtime code, visual tests or fixtures, baselines, direct dependency manifests, or visual test infrastructure. The required check is marked as skipped for unrelated changes.
 
 Execute the visual regression tests suite by running:
 ```sh


### PR DESCRIPTION
## Summary

- skip the reusable visual regression job at the job level when no relevant files changed
- preserve the required `Visual Regression Tests / Visual Regression Tests` check with a skipped conclusion
- allow releases to proceed after visual tests succeed or are intentionally skipped while still blocking failures
- update the README to describe the skipped check

## Testing

- `actionlint`
- `git diff --check`
- independent workflow review

## Follow-up validation

This PR changes visual-test infrastructure, so its own visual suite should run. After merge, refresh docs-only PR #2354 to verify that the exact required check is shown as skipped and still satisfies branch protection.