### PR TITLE
fix(ci): restore required visual check name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,28 +28,35 @@ on:
 jobs:
   build-and-test:
     name: ${{ inputs.command_description }}
-    if: inputs.should_run
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: ⏭️ Skip ${{ inputs.command_description }}
+        if: inputs.should_run == false
+        run: echo "No relevant changes detected; skipping ${{ inputs.command_description }}."
+
       - name: ⬇️ Checkout
+        if: inputs.should_run
         uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.needs_lfs }}
 
       - name: ⎔ Setup node
+        if: inputs.should_run
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
 
       - name: 🏗 Install Dependencies
+        if: inputs.should_run
         run: npm ci
 
       - name: 🏗 Install Playwright
-        if: inputs.needs_playwright == true
+        if: inputs.should_run && inputs.needs_playwright == true
         run: npx playwright install --with-deps
 
       - name: 🔑 Setup SSH for private submodule
+        if: inputs.should_run
         run: |
           if [ -z "$SUBMODULE_SSH_KEY" ]; then
             echo "Skipping SSH setup; SUBMODULE_SSH_KEY is not available"
@@ -62,13 +69,14 @@ jobs:
           SUBMODULE_SSH_KEY: ${{ secrets.SUBMODULE_SSH_KEY }}
 
       - name: ▶️ ${{ inputs.command_description }}
+        if: inputs.should_run
         run: ${{ inputs.command }}
         env:
           BETTER_AUTH_SECRET: ${{ secrets.AUTH_SECRET || 'ci-build-placeholder-secret' }}
 
       - name: ⬆️ Upload Visual Regression Test Results
         uses: actions/upload-artifact@v4
-        if: ${{ failure() && inputs.command_description == 'Visual Regression Tests' }}
+        if: ${{ failure() && inputs.should_run && inputs.command_description == 'Visual Regression Tests' }}
         with:
           name: visual-regression-test-results
           path: packages/stacks-classic/screenshots

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ npm run test:unit:watch -w packages/stacks-classic
 This [Web Test Runner plugin](https://www.npmjs.com/package/@web/test-runner-visual-regression) is used to run visual regression tests.
 Visual regression tests end with this suffix `*.visual.test.ts`.
 
-In CI, the visual regression suite runs only when a pull request or commit changes Stacks Classic styles, runtime code, visual tests or fixtures, baselines, direct dependency manifests, or visual test infrastructure. The required check is marked as skipped for unrelated changes.
+In CI, the visual regression suite runs only when a pull request or commit changes Stacks Classic styles, runtime code, visual tests or fixtures, baselines, direct dependency manifests, or visual test infrastructure. The required check still completes successfully without executing the suite for unrelated changes.
 
 Execute the visual regression tests suite by running:
 ```sh


### PR DESCRIPTION
## Summary

- restore the previously verified successful no-op behavior for unrelated changes
- preserve the required `Visual Regression Tests / Visual Regression Tests` check identity
- skip checkout, LFS, dependency installation, Docker, and visual execution at the step level
- correct the README description

## Why

Skipping the reusable job at the job level caused GitHub to report `Visual Regression Tests / inputs.command_description`. The required `Visual Regression Tests / Visual Regression Tests` context was never created, leaving eligible PRs blocked indefinitely.

## Testing

- `actionlint`
- `git diff --check`
- verified this workflow is byte-for-byte identical to the implementation exercised successfully in Actions run 30842253081
- independent workflow review