### PR TITLE
fix(utils): harden package for stable release

### DIFF
--- a/.changeset/fix-utils-node-types.md
+++ b/.changeset/fix-utils-node-types.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks-utils": patch
+---
+
+Fix TypeScript declaration resolution for NodeNext consumers and avoid changing the consumer's default Day.js locale.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,10 @@ jobs:
           command: npm run test -w packages/stacks-utils
           needs_lfs: false
           needs_playwright: false
+        - command_description: Package Tests (stacks-utils)
+          command: npm run test:package -w packages/stacks-utils
+          needs_lfs: false
+          needs_playwright: false
         - command_description: Unit Tests (stacks-docs)
           command: npm run test -w packages/stacks-docs
           needs_lfs: false

--- a/packages/stacks-utils/README.md
+++ b/packages/stacks-utils/README.md
@@ -2,6 +2,8 @@
 
 Stack Overflow utility functions for formatting and data manipulation.
 
+This package is ESM-only and formats values using the `en-US` locale.
+
 ## Installation
 
 ```bash
@@ -44,6 +46,8 @@ NumberFormatter.formatCount(42); // "42"
 ### formatTime
 
 Formats UTC time strings into human-readable relative or absolute time formats.
+Inputs should be valid ISO 8601 UTC timestamps representing past dates.
+Absolute dates and times are displayed in the consumer's local timezone.
 
 ```typescript
 import { formatTime } from "@stackoverflow/stacks-utils";

--- a/packages/stacks-utils/package.json
+++ b/packages/stacks-utils/package.json
@@ -18,6 +18,7 @@
     "scripts": {
         "build": "vite build && tsc --emitDeclarationOnly",
         "test": "vitest run",
+        "test:package": "npm run build && node ./scripts/test-package.mjs",
         "test:watch": "vitest watch",
         "format": "prettier --write .",
         "lint": "eslint . && prettier --check .",

--- a/packages/stacks-utils/scripts/test-package.mjs
+++ b/packages/stacks-utils/scripts/test-package.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+    mkdtempSync,
+    mkdirSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { env, execPath } from "node:process";
+import { fileURLToPath } from "node:url";
+
+const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryRoot = resolve(packageDirectory, "../..");
+const temporaryDirectory = mkdtempSync(resolve(tmpdir(), "stacks-utils-"));
+const consumerDirectory = resolve(temporaryDirectory, "consumer");
+
+function run(command, args, options = {}) {
+    return execFileSync(command, args, {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "inherit"],
+        ...options,
+    });
+}
+
+function runNpm(args, options = {}) {
+    assert.ok(env.npm_execpath, "Run this test through npm run test:package");
+    return run(execPath, [env.npm_execpath, ...args], options);
+}
+
+try {
+    const packResult = JSON.parse(
+        runNpm(["pack", "--json", "--pack-destination", temporaryDirectory], {
+            cwd: packageDirectory,
+        })
+    )[0];
+    const packagedFiles = new Set(packResult.files.map(({ path }) => path));
+
+    for (const expectedFile of [
+        "dist/index.js",
+        "dist/index.d.ts",
+        "dist/DateTimeFormatter.js",
+        "dist/NumberFormatter.js",
+        "package.json",
+        "README.md",
+    ]) {
+        assert.ok(
+            packagedFiles.has(expectedFile),
+            `Missing ${expectedFile} from package`
+        );
+    }
+
+    assert.ok(
+        [...packagedFiles].every((path) => !path.endsWith(".test.js")),
+        "Package contains compiled test files"
+    );
+
+    mkdirSync(consumerDirectory);
+    writeFileSync(
+        resolve(consumerDirectory, "package.json"),
+        JSON.stringify({
+            name: "stacks-utils-consumer",
+            private: true,
+            type: "module",
+        })
+    );
+
+    const tarballPath = resolve(temporaryDirectory, packResult.filename);
+    runNpm(
+        [
+            "install",
+            "--ignore-scripts",
+            "--no-audit",
+            "--no-fund",
+            "--no-package-lock",
+            tarballPath,
+        ],
+        { cwd: consumerDirectory }
+    );
+
+    writeFileSync(
+        resolve(consumerDirectory, "consumer.mjs"),
+        `import assert from "node:assert/strict";
+import {
+    DateTimeFormatter,
+    NumberFormatter,
+    formatCount,
+    formatTime,
+} from "@stackoverflow/stacks-utils";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime.js";
+
+assert.equal(formatCount(12_345), "12.3k");
+assert.equal(NumberFormatter.formatCount(-1_234), "-1,234");
+assert.match(formatTime("2020-06-15T12:00:00Z"), /2020/);
+assert.equal(typeof DateTimeFormatter.formatTime, "function");
+dayjs.extend(relativeTime);
+assert.equal(dayjs().subtract(1, "hour").fromNow(), "an hour ago");
+`
+    );
+    run("node", ["consumer.mjs"], { cwd: consumerDirectory });
+
+    writeFileSync(
+        resolve(consumerDirectory, "consumer.ts"),
+        `import {
+    DateTimeFormatter,
+    NumberFormatter,
+    formatCount,
+    formatTime,
+} from "@stackoverflow/stacks-utils";
+
+const count: string = formatCount(12_345);
+const classCount: string = NumberFormatter.formatCount(12_345);
+const time: string = formatTime("2020-06-15T12:00:00Z");
+const classTime: string = DateTimeFormatter.formatTime("2020-06-15T12:00:00Z");
+
+void [count, classCount, time, classTime];
+`
+    );
+    writeFileSync(
+        resolve(consumerDirectory, "tsconfig.json"),
+        JSON.stringify({
+            compilerOptions: {
+                module: "NodeNext",
+                moduleResolution: "NodeNext",
+                noEmit: true,
+                strict: true,
+                target: "ES2022",
+            },
+            include: ["consumer.ts"],
+        })
+    );
+
+    const typescriptBin = resolve(
+        repositoryRoot,
+        "node_modules/typescript/bin/tsc"
+    );
+    assert.ok(readFileSync(typescriptBin), "TypeScript is not installed");
+    run(execPath, [typescriptBin, "--project", "tsconfig.json"], {
+        cwd: consumerDirectory,
+    });
+} finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+}

--- a/packages/stacks-utils/src/DateTimeFormatter.test.ts
+++ b/packages/stacks-utils/src/DateTimeFormatter.test.ts
@@ -1,5 +1,27 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime.js";
 import { DateTimeFormatter, formatTime } from "./DateTimeFormatter";
+
+dayjs.extend(relativeTime);
+
+function formatAbsoluteTime(time: string, includeYear = false): string {
+    const options: Intl.DateTimeFormatOptions = {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+    };
+
+    if (includeYear) {
+        options.year = "numeric";
+    }
+
+    return new Intl.DateTimeFormat("en-US", options)
+        .format(new Date(time))
+        .replace(/,([^,]*)$/, " at$1");
+}
 
 describe("DateTimeFormatter.formatTime", () => {
     beforeEach(() => {
@@ -36,13 +58,27 @@ describe("DateTimeFormatter.formatTime", () => {
             const result = DateTimeFormatter.formatTime(minutesAgo);
             expect(result).toBe("30 minutes ago");
         });
+
+        it("should use relative time at exactly the two-day boundary", () => {
+            const twoDaysAgo = new Date("2026-01-13T12:00:00Z").toISOString();
+            const result = DateTimeFormatter.formatTime(twoDaysAgo);
+            expect(result).toBe("2 days ago");
+        });
     });
 
     describe("same year format (beyond 2 days)", () => {
         it("should format date with time for same year", () => {
             const threeDaysAgo = new Date("2026-01-12T15:45:00Z").toISOString();
             const result = DateTimeFormatter.formatTime(threeDaysAgo);
-            expect(result).toMatch(/Jan 12 at \d{2}:\d{2}/);
+            expect(result).toBe(formatAbsoluteTime(threeDaysAgo));
+        });
+
+        it("should use an absolute date beyond the two-day boundary", () => {
+            const beyondTwoDays = new Date(
+                "2026-01-13T11:59:59Z"
+            ).toISOString();
+            const result = DateTimeFormatter.formatTime(beyondTwoDays);
+            expect(result).toBe(formatAbsoluteTime(beyondTwoDays));
         });
     });
 
@@ -50,7 +86,7 @@ describe("DateTimeFormatter.formatTime", () => {
         it("should format date with year for different year", () => {
             const lastYear = new Date("2025-12-15T15:45:00Z").toISOString();
             const result = DateTimeFormatter.formatTime(lastYear);
-            expect(result).toMatch(/Dec 15, 2025 at \d{2}:\d{2}/);
+            expect(result).toBe(formatAbsoluteTime(lastYear, true));
         });
     });
 
@@ -67,5 +103,9 @@ describe("DateTimeFormatter.formatTime", () => {
             const result2 = DateTimeFormatter.formatTime(testTime);
             expect(result1).toBe(result2);
         });
+    });
+
+    it("should not modify the consumer's default Day.js locale", () => {
+        expect(dayjs().subtract(1, "hour").fromNow()).toBe("an hour ago");
     });
 });

--- a/packages/stacks-utils/src/DateTimeFormatter.ts
+++ b/packages/stacks-utils/src/DateTimeFormatter.ts
@@ -1,36 +1,28 @@
 ﻿import dayjs from "dayjs";
+import en from "dayjs/locale/en.js";
 import relativeTime from "dayjs/plugin/relativeTime.js";
-import updateLocale from "dayjs/plugin/updateLocale.js";
 
 dayjs.extend(relativeTime);
-dayjs.extend(updateLocale);
-const config = {
-    // strict thresholds
-    thresholds: [
-        { l: "s", r: 1 },
-        { l: "m", r: 1 },
-        { l: "mm", r: 59, d: "minute" },
-        { l: "h", r: 1 },
-        { l: "hh", r: 23, d: "hour" },
-        { l: "d", r: 1 },
-        { l: "dd", r: 29, d: "day" },
-    ],
-    relativeTime: {
-        future: "in %s",
-        past: "%s ago",
-        s: "%d seconds ago",
-        ss: "%d seconds ago",
-        m: "1 minute ago",
-        mm: "%d minutes ago",
-        h: "1 hour ago",
-        hh: "%d hours ago",
-        d: "yesterday",
-        dd: "%d days ago",
+const localeName = "stacks-utils";
+dayjs.locale(
+    {
+        ...en,
+        name: localeName,
+        relativeTime: {
+            future: "in %s",
+            past: "%s ago",
+            s: "%d seconds ago",
+            m: "1 minute ago",
+            mm: "%d minutes ago",
+            h: "1 hour ago",
+            hh: "%d hours ago",
+            d: "yesterday",
+            dd: "%d days ago",
+        },
     },
-    rounding: Math.floor,
-};
-
-dayjs.updateLocale("en", config);
+    undefined,
+    true
+);
 
 /**
  * Utility class for formatting date and time values into various formats.
@@ -68,7 +60,7 @@ export class DateTimeFormatter {
             {
                 condition: (diff: number) => diff <= 2 * secondsInDay,
                 format: (theTime: Date) => {
-                    return dayjs(theTime).fromNow(true);
+                    return dayjs(theTime).locale(localeName).fromNow(true);
                 },
             },
             {

--- a/packages/stacks-utils/src/NumberFormatter.test.ts
+++ b/packages/stacks-utils/src/NumberFormatter.test.ts
@@ -60,6 +60,13 @@ describe("NumberFormatter.formatCount", () => {
         });
     });
 
+    describe("custom compact threshold", () => {
+        it("should switch formats at the provided threshold", () => {
+            expect(NumberFormatter.formatCount(999, 1000)).toBe("999");
+            expect(NumberFormatter.formatCount(1000, 1000)).toBe("1k");
+        });
+    });
+
     describe("convenience function export", () => {
         it("should work with the exported formatCount function", () => {
             expect(formatCount(1234)).toBe("1,234");

--- a/packages/stacks-utils/src/index.ts
+++ b/packages/stacks-utils/src/index.ts
@@ -1,2 +1,2 @@
-export { NumberFormatter, formatCount } from "./NumberFormatter";
-export { DateTimeFormatter, formatTime } from "./DateTimeFormatter";
+export { NumberFormatter, formatCount } from "./NumberFormatter.js";
+export { DateTimeFormatter, formatTime } from "./DateTimeFormatter.js";


### PR DESCRIPTION
## Summary

- validate the packed Stacks Utils package through a clean ESM and TypeScript NodeNext consumer
- fix NodeNext declaration resolution and isolate the custom Day.js locale from consumer applications
- document formatting/runtime contracts and add timezone-safe boundary coverage
- run the package smoke test in CI

## Jira

- [STACKS-890](https://stackoverflow.atlassian.net/browse/STACKS-890)

## Validation

- `npm run build -w packages/stacks-utils`
- `npm run test -w packages/stacks-utils` — 22 passed
- `npm run lint -w packages/stacks-utils`
- `npm run test:package -w packages/stacks-utils`
- `npm run build -w packages/stacks-svelte`
- `npm run lint -w packages/stacks-svelte`
- `npm run test -w packages/stacks-svelte` — 577 browser tests and 26 tooling tests passed
- independent Day.js locale-mutation check
- `git diff --check`

## Release notes

- includes a patch changeset for `@stackoverflow/stacks-utils`
- this is release-readiness work; stable publication remains part of the global Changesets prerelease exit after the remaining Stacks packages are ready

## Accessibility

- no UI or accessibility behavior changed