### PR TITLE
test(classic): add release-readiness coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,10 @@ jobs:
           command: npm run test:a11y -w packages/stacks-classic -- --config web-test-runner.config.ci.mjs
           needs_lfs: false
           needs_playwright: true
+        - command_description: Package Tests (stacks-classic)
+          command: npm run test:package -w packages/stacks-classic
+          needs_lfs: false
+          needs_playwright: true
         - command_description: Unit Tests (stacks-svelte)
           command: npm run test -w packages/stacks-svelte
           needs_lfs: false

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,5 +1,30 @@
 # Migrating from Stacks Classic v2 to v3
 
+## Installation and supported entry points
+
+Install Stacks Classic V3 from npm once the stable release is available:
+
+```bash
+npm install @stackoverflow/stacks@^3.0.0
+```
+
+Stacks Classic publishes the following supported entry points:
+
+| Asset | Package entry point |
+| --- | --- |
+| CSS | `@stackoverflow/stacks/dist/css/stacks.css` |
+| Minified CSS | `@stackoverflow/stacks/dist/css/stacks.min.css` |
+| JavaScript (UMD) | `@stackoverflow/stacks/dist/js/stacks.js` |
+| Minified JavaScript (UMD) | `@stackoverflow/stacks/dist/js/stacks.min.js` |
+| Less | `@stackoverflow/stacks/lib/stacks.less` |
+| TypeScript declarations | Resolved automatically from `@stackoverflow/stacks` |
+
+The JavaScript bundle initializes Stacks controllers and requires a browser DOM.
+Stacks Classic does not currently publish a supported ESM JavaScript entry point.
+Use the entry points above rather than relying on other internal package paths.
+
+Projects remaining on Stacks Classic V2 should install `@stackoverflow/stacks@^2.9.0` and refer to the [V2 documentation](https://v2.stackoverflow.design/).
+
 ## Breaking changes
 
 ### Atomic styles

--- a/README.md
+++ b/README.md
@@ -180,8 +180,9 @@ We use [changesets](https://github.com/changesets/changesets) to automatize the 
 
 - Every time you do work that requires a new release to be published, [add a changesets entry](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) by running `npx changeset` and follow the instructions on screen. (changes that do not require a new release - e.g. changing a test file - don't need a changeset).
     - When opening a PR without a corresponding changeset the [changesets-bot](https://github.com/apps/changeset-bot) will remind you to do so. It generally makes sense to have one changeset for PR (if the PR changes do not require a new release to be published the bot message can be safely ignored)
-- The [release github workflow](.github/workflows/main.yml) runs on `main` and `beta`. On `beta`, it creates and updates the `chore(release)` PR as pending changesets are merged. On `main`, it publishes the latest release to NPM and creates GitHub releases.
-- When we are ready to cut a beta release we merge the `chore(release)` PR. The release github workflow publishes the changes to NPM and gives us an opportunity to adjust the automatically generated changelog before release notes are created.
+- After CI succeeds on `main`, the [release GitHub workflow](.github/workflows/main.yml) creates or updates the `chore(new-release)` PR as pending changesets are merged.
+- Prerelease mode and its npm tag are controlled by [`.changeset/pre.json`](.changeset/pre.json), not by a separate release branch.
+- When the `chore(new-release)` PR is merged, the workflow publishes the prepared package versions to npm and creates GitHub releases. Review the generated versions and changelogs before merging it.
 
 _The release github workflow only run if the CI workflow (running linter, formatter and tests) is successful: CI is blocking accidental releases_.
 

--- a/packages/stacks-classic/README.md
+++ b/packages/stacks-classic/README.md
@@ -1,29 +1,35 @@
-# Stacks
+# Stacks Classic
 
 [![ci status][gh-action-badge]][gh-action-url] [![npm version][npm-badge]][npm-url]
 
-Stacks is Stack Overflow’s design system. It includes the resources needed to create consistent, predictable interfaces and workflows that conform to Stack Overflow’s principles, design language, and best practices.
+Stacks Classic is the CSS, Less, and JavaScript foundation of Stack Overflow’s Stacks design system. It includes the resources needed to create consistent, predictable interfaces and workflows that conform to Stack Overflow’s principles, design language, and best practices.
 
 Our documentation is built with Stacks itself, using its [immutable, atomic classes](http://johnpolacek.com/rethinking/) and components.
 
 The [Stacks website](https://stackoverflow.design/) documents:
 
 ## Product
+
 - Semantic and accessible component markup
 - Cross-browser compatible Less / CSS
 - An [icon library](https://github.com/StackExchange/Stacks-Icons)
 
 ## Email
+
 - Email templates & components
 
 # Using Stacks
+
 Using Stacks is outlined in our [usage guidelines](https://stackoverflow.design/product/develop/using-stacks).
 
-## Migrating from v1 to v2
+## Migrating between major versions
 
-To migrate from Stacks v1 to v2, see our [migration guide](/MIGRATION_GUIDE.md).
+See the migration guide for instructions and breaking changes:
+
+- [Stacks Classic V2 to V3](https://github.com/StackExchange/Stacks/blob/main/MIGRATION_GUIDE.md#migrating-from-stacks-classic-v2-to-v3)
+- [Stacks Classic V1 to V2](https://github.com/StackExchange/Stacks/blob/main/MIGRATION_GUIDE.md#migrating-from-stacks-v1-to-v2)
 
 [gh-action-url]: https://github.com/StackExchange/Stacks/actions/workflows/main.yml
-[gh-action-badge]: https://github.com/StackExchange/Stacks/actions/workflows/workflow.yml/badge.svg?branch=develop
+[gh-action-badge]: https://github.com/StackExchange/Stacks/actions/workflows/main.yml/badge.svg?branch=main
 [npm-url]: https://npmjs.org/package/@stackoverflow/stacks
 [npm-badge]: https://img.shields.io/npm/v/@stackoverflow/stacks.svg

--- a/packages/stacks-classic/package.json
+++ b/packages/stacks-classic/package.json
@@ -15,6 +15,7 @@
     "scripts": {
         "build": "webpack --mode=production",
         "test": "npm run test:less && npm run test:unit && npm run test:a11y && npm run test:visual",
+        "test:package": "npm run build && node ./scripts/test-package.mjs",
         "test:a11y": "web-test-runner --group=a11y",
         "test:unit": "web-test-runner --group=unit",
         "test:unit:watch": "web-test-runner --group=unit --watch",

--- a/packages/stacks-classic/scripts/test-package.mjs
+++ b/packages/stacks-classic/scripts/test-package.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+import {
+    existsSync,
+    mkdtempSync,
+    mkdirSync,
+    readFileSync,
+    realpathSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { env, execPath } from "node:process";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const packageDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryRoot = resolve(packageDirectory, "../..");
+const temporaryDirectory = mkdtempSync(resolve(tmpdir(), "stacks-classic-"));
+const consumerDirectory = resolve(temporaryDirectory, "consumer");
+let browser;
+
+function run(command, args, options = {}) {
+    return execFileSync(command, args, {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "inherit"],
+        ...options,
+    });
+}
+
+function runNpm(args, options = {}) {
+    assert.ok(env.npm_execpath, "Run this test through npm run test:package");
+    return run(execPath, [env.npm_execpath, ...args], options);
+}
+
+try {
+    const packResult = JSON.parse(
+        runNpm(["pack", "--json", "--pack-destination", temporaryDirectory], {
+            cwd: packageDirectory,
+        })
+    )[0];
+    const packagedFiles = new Set(packResult.files.map(({ path }) => path));
+    const expectedFiles = [
+        "dist/css/stacks.css",
+        "dist/css/stacks.min.css",
+        "dist/js/stacks.js",
+        "dist/js/stacks.min.js",
+        "dist/index.d.ts",
+        "lib/stacks.less",
+        "package.json",
+        "README.md",
+    ];
+
+    for (const expectedFile of expectedFiles) {
+        assert.ok(
+            packagedFiles.has(expectedFile),
+            `Missing ${expectedFile} from package`
+        );
+    }
+
+    assert.ok(
+        [...packagedFiles].every((path) => !path.includes(".test.")),
+        "Package contains test files"
+    );
+
+    mkdirSync(consumerDirectory);
+    writeFileSync(
+        resolve(consumerDirectory, "package.json"),
+        JSON.stringify({ name: "stacks-classic-consumer", private: true })
+    );
+
+    const tarballPath = resolve(temporaryDirectory, packResult.filename);
+    runNpm(
+        [
+            "install",
+            "--ignore-scripts",
+            "--no-audit",
+            "--no-fund",
+            "--no-package-lock",
+            tarballPath,
+        ],
+        { cwd: consumerDirectory }
+    );
+
+    const installedPackageDirectory = resolve(
+        consumerDirectory,
+        "node_modules/@stackoverflow/stacks"
+    );
+    const manifest = JSON.parse(
+        readFileSync(resolve(installedPackageDirectory, "package.json"), "utf8")
+    );
+    const publicEntries = {
+        main: "./dist/js/stacks.js",
+        types: "./dist/index.d.ts",
+        style: "./dist/css/stacks.css",
+        less: "./lib/stacks.less",
+        unpkg: "dist/css/stacks.min.css",
+    };
+
+    for (const [field, expectedPath] of Object.entries(publicEntries)) {
+        assert.equal(
+            manifest[field],
+            expectedPath,
+            `Unexpected ${field} entry`
+        );
+        assert.ok(
+            existsSync(resolve(installedPackageDirectory, expectedPath)),
+            `${field} entry does not resolve to a packaged file`
+        );
+    }
+
+    const require = createRequire(resolve(consumerDirectory, "package.json"));
+    assert.equal(
+        realpathSync(require.resolve("@stackoverflow/stacks")),
+        realpathSync(resolve(installedPackageDirectory, "dist/js/stacks.js"))
+    );
+
+    for (const assetPath of [
+        "dist/css/stacks.css",
+        "dist/css/stacks.min.css",
+        "dist/js/stacks.js",
+        "dist/js/stacks.min.js",
+    ]) {
+        assert.ok(
+            readFileSync(resolve(installedPackageDirectory, assetPath)).length >
+                1000,
+            `${assetPath} is unexpectedly empty`
+        );
+    }
+
+    browser = await chromium.launch({ headless: true });
+    for (const bundlePath of ["dist/js/stacks.js", "dist/js/stacks.min.js"]) {
+        const page = await browser.newPage();
+        let pageError;
+        page.on("pageerror", (error) => {
+            pageError = error;
+        });
+        await page.setContent("<!doctype html><html><body></body></html>");
+        await page.addScriptTag({
+            path: resolve(installedPackageDirectory, bundlePath),
+        });
+
+        assert.ifError(pageError);
+        const exports = await page.evaluate(() =>
+            Object.keys(window.Stacks ?? {})
+        );
+        assert.ok(
+            exports.includes("application"),
+            `${bundlePath} did not initialize`
+        );
+        assert.ok(
+            exports.includes("showModal"),
+            `${bundlePath} is missing helpers`
+        );
+        await page.close();
+    }
+
+    writeFileSync(
+        resolve(consumerDirectory, "consumer.ts"),
+        `import type {
+    ControllerDefinition,
+    StacksController,
+} from "@stackoverflow/stacks";
+
+declare const controller: ControllerDefinition;
+declare const controllerInstance: StacksController;
+void [controller, controllerInstance];
+`
+    );
+    writeFileSync(
+        resolve(consumerDirectory, "tsconfig.json"),
+        JSON.stringify({
+            compilerOptions: {
+                module: "NodeNext",
+                moduleResolution: "NodeNext",
+                noEmit: true,
+                strict: true,
+                target: "ES2022",
+            },
+            include: ["consumer.ts"],
+        })
+    );
+
+    const typescriptBin = resolve(
+        repositoryRoot,
+        "node_modules/typescript/bin/tsc"
+    );
+    assert.ok(existsSync(typescriptBin), "TypeScript is not installed");
+    run(execPath, [typescriptBin, "--project", "tsconfig.json"], {
+        cwd: consumerDirectory,
+    });
+
+    const lessInput = resolve(consumerDirectory, "consumer.less");
+    const lessOutput = resolve(consumerDirectory, "consumer.css");
+    writeFileSync(
+        lessInput,
+        '@import "node_modules/@stackoverflow/stacks/lib/stacks.less";\n'
+    );
+
+    const lessBin = resolve(repositoryRoot, "node_modules/less/bin/lessc");
+    assert.ok(existsSync(lessBin), "Less is not installed");
+    run(execPath, [lessBin, lessInput, lessOutput], { cwd: consumerDirectory });
+    assert.match(readFileSync(lessOutput, "utf8"), /\.s-btn/);
+} finally {
+    await browser?.close();
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- validate the packed Stacks Classic tarball, metadata, declarations, CSS, Less, and both UMD bundles through a clean consumer
- run the package smoke test in Chromium as a required CI check
- document the supported V3 package entry points and major-version migration paths
- correct the repository release documentation to match the current main-based Changesets workflow

## Jira

- [STACKS-868](https://stackoverflow.atlassian.net/browse/STACKS-868)

## Validation

- `npm run test:package -w packages/stacks-classic`
- `npm run lint -w packages/stacks-classic`
- `npm run test:less -w packages/stacks-classic` — 40 passed
- `npm run test:unit -w packages/stacks-classic -- --config web-test-runner.config.ci.mjs` — 96 passed
- `npm run test:a11y -w packages/stacks-classic -- --config web-test-runner.config.ci.mjs` — 2,589 passed; 155 existing skips
- `npm run test:visual:ci -w packages/stacks-classic -- --config ./visual-runner/stacks-classic-runner-config/web-test-runner.config.ci.mjs` — 8,508 passed
- `git diff --check`

## Release notes

- no changeset: this PR adds tests and documentation without changing the published package behavior
- versioning, prerelease exit, dependency promotion, and publication remain part of the coordinated stable release

## Accessibility

- no UI behavior changed
- the existing Classic accessibility suite passes with 2,589 checks and 155 pre-existing skips