### PR TITLE
chore(release): exit monorepo prerelease mode

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,7 @@
   "commit": false,
   "access": "public",
   "baseBranch": "main",
+  "ignore": ["@stackoverflow/stacks-email"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@stackoverflow/stacks": "2.8.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@rollup/plugin-commonjs": "^29.0.2",
                 "@rollup/plugin-replace": "^6.0.3",
                 "@stackoverflow/prettier-config": "^1.0.0",
-                "@stackoverflow/stacks-icons": "^7.0.0-beta.25",
+                "@stackoverflow/stacks-icons": "^7.0.0",
                 "@stackoverflow/stacks-icons-legacy": "npm:@stackoverflow/stacks-icons@^6.9.0",
                 "@storybook/addon-a11y": "^10.4.0",
                 "@storybook/addon-docs": "^10.5.5",
@@ -2883,9 +2883,9 @@
             "link": true
         },
         "node_modules/@stackoverflow/stacks-icons": {
-            "version": "7.0.0-beta.25",
-            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-7.0.0-beta.25.tgz",
-            "integrity": "sha512-n721TEmpmFleWHRzW1bybNsSPLWKi5/zyWRTq5t38ghA45riXaP2TVXzQuJRAkhEA03Vh/SlvZmhRPTMq7SXVw==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@stackoverflow/stacks-icons/-/stacks-icons-7.0.0.tgz",
+            "integrity": "sha512-oLew4J/YVK7DLAovZxMUK/taoA/s6GsYf9yIq3fnb7hVBLdSNc8MwOjONSPwccrxS/vt3U3Ea2Mwl4dIHznpkg==",
             "license": "Apache-2.0"
         },
         "node_modules/@stackoverflow/stacks-icons-legacy": {
@@ -17985,7 +17985,7 @@
             },
             "devDependencies": {
                 "@stackoverflow/stacks": "3.0.0-beta.33",
-                "@stackoverflow/stacks-icons": "^7.0.0-beta.25",
+                "@stackoverflow/stacks-icons": "^7.0.0",
                 "@stackoverflow/stacks-svelte": "*",
                 "@sveltejs/adapter-auto": "^6.1.0",
                 "@sveltejs/kit": "^2.70.2",
@@ -18076,7 +18076,7 @@
             "version": "1.0.0-beta.34",
             "dependencies": {
                 "@floating-ui/core": "^1.7.3",
-                "@stackoverflow/stacks-icons": "^7.0.0-beta.18",
+                "@stackoverflow/stacks-icons": "^7.0.0",
                 "@stackoverflow/stacks-icons-legacy": "npm:@stackoverflow/stacks-icons@^6.9.0",
                 "@stackoverflow/stacks-utils": "^1.0.0-beta.3",
                 "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@rollup/plugin-commonjs": "^29.0.2",
         "@rollup/plugin-replace": "^6.0.3",
         "@stackoverflow/prettier-config": "^1.0.0",
-        "@stackoverflow/stacks-icons": "^7.0.0-beta.25",
+        "@stackoverflow/stacks-icons": "^7.0.0",
         "@stackoverflow/stacks-icons-legacy": "npm:@stackoverflow/stacks-icons@^6.9.0",
         "@storybook/addon-a11y": "^10.4.0",
         "@storybook/addon-docs": "^10.5.5",

--- a/packages/stacks-email/package.json
+++ b/packages/stacks-email/package.json
@@ -38,7 +38,7 @@
         "@sveltejs/kit": "^2.70.2",
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
         "@stackoverflow/stacks": "3.0.0-beta.33",
-        "@stackoverflow/stacks-icons": "^7.0.0-beta.25",
+        "@stackoverflow/stacks-icons": "^7.0.0",
         "@stackoverflow/stacks-svelte": "*",
         "@types/mjml": "^5.0.0",
         "eslint": "^10.8.0",

--- a/packages/stacks-svelte/package.json
+++ b/packages/stacks-svelte/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "clsx": "^2.1.1",
         "@floating-ui/core": "^1.7.3",
-        "@stackoverflow/stacks-icons": "^7.0.0-beta.18",
+        "@stackoverflow/stacks-icons": "^7.0.0",
         "@stackoverflow/stacks-icons-legacy": "npm:@stackoverflow/stacks-icons@^6.9.0",
         "@stackoverflow/stacks-utils": "^1.0.0-beta.3",
         "svelte-floating-ui": "^1.6.2",


### PR DESCRIPTION
## Summary

- exit the repository-wide Changesets beta prerelease train
- move current-generation Icons dependencies to stable `@stackoverflow/stacks-icons@^7.0.0`
- temporarily exclude experimental Stacks Email from stable versioning while preserving its pending release changeset

After this merges, the Changesets release PR should prepare:

- `@stackoverflow/stacks@3.0.0`
- `@stackoverflow/stacks-svelte@1.0.0`
- `@stackoverflow/stacks-utils@1.0.0`

Stacks Email remains at `1.0.0-beta.0`. The generated release PR still needs review and the Svelte Classic peer dependency finalized to `^3.0.0` before publication.

## Verification

- `npm ci`
- `BETTER_AUTH_SECRET=ci-build-placeholder-secret npm run build`
- `BETTER_AUTH_SECRET=ci-build-placeholder-secret npm run lint`
- `BETTER_AUTH_SECRET=ci-build-placeholder-secret npm test`
- `npm run test:package -w packages/stacks-classic`
- `npm run test:package -w packages/stacks-utils`
- dependency graph resolves current Icons to `7.0.0`

## Jira

- [STACKS-846](https://stackoverflow.atlassian.net/browse/STACKS-846)
- [STACKS-868](https://stackoverflow.atlassian.net/browse/STACKS-868)
- [STACKS-890](https://stackoverflow.atlassian.net/browse/STACKS-890)