### PR TITLE
Use PR title for Dependabot squash commits

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,7 +17,8 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --auto --squash --subject "$PR_TITLE" "$PR_URL"
         env:
+          PR_TITLE: ${{github.event.pull_request.title}}
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
[DEVPLAT-450](https://stackoverflow.atlassian.net/browse/DEVPLAT-450)

Ensures Dependabot squash merges use the Jira-prefixed PR title as the commit subject.

### Changes

- Pass the PR title explicitly to the auto-merge command

### Manual testing

1. Let the next eligible Dependabot patch or minor PR merge through auto-merge.
2. Confirm the resulting squash commit subject matches the PR title