### PR TITLE
fix(svelte): prepare 1.0.1 stable release

### DIFF
--- a/.changeset/tidy-svelte-stable.md
+++ b/.changeset/tidy-svelte-stable.md
@@ -1,0 +1,5 @@
+---
+"@stackoverflow/stacks-svelte": patch
+---
+
+Publish 1.0.1 as the first available stable Svelte release. Version 1.0.0 cannot be reused because it was previously published and unpublished by the V2 release workflow.


### PR DESCRIPTION
## Summary

- add a Svelte-only patch changeset for version 1.0.1
- document why npm version 1.0.0 cannot be reused
- preserve the ignored Email changeset and normal Changesets release flow

## Context

The V2 release workflow accidentally published `@stackoverflow/stacks-svelte@1.0.0` on June 24, 2026. That version was later unpublished, and npm permanently prevents it from being reused.

Classic 3.0.0 and Utils 1.0.0 have published successfully. Svelte must advance to 1.0.1 to complete the stable release train.

Historical workflow: https://github.com/StackExchange/Stacks/actions/runs/28087530420

## Verification

- `npm ci`
- `npx changeset status` — Svelte patch only
- `npm run test:release` — 5 passed
- independent review with no findings

## Jira

[STACKS-846](https://stackoverflow.atlassian.net/browse/STACKS-846)