### PR TITLE
fix(docs): use stable Svelte documentation domain

### DIFF
--- a/packages/stacks-docs/src/docs/public/system/base/box-shadow.md
+++ b/packages/stacks-docs/src/docs/public/system/base/box-shadow.md
@@ -1,6 +1,5 @@
 ---
 title: Box shadow
-figma: https://svelte.stackoverflow.design/figma/box-shadows
 description: Box shadow atomic classes allow you to change an element's box shadow quickly.
 ---
 

--- a/packages/stacks-docs/src/docs/public/system/components/activity-indicator.md
+++ b/packages/stacks-docs/src/docs/public/system/components/activity-indicator.md
@@ -1,7 +1,7 @@
 ---
 title: "Activity indicator"
 description: "Stacks provides a small jewel for indicating new activity."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-activityindicator--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-activityindicator--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=610-18796"
 ---
 

--- a/packages/stacks-docs/src/docs/public/system/components/avatars.md
+++ b/packages/stacks-docs/src/docs/public/system/components/avatars.md
@@ -1,7 +1,7 @@
 ---
 title: "Avatars"
 description: "Avatars are used to quickly identify users or teams."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-avatar--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-avatar--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=610-18797&p=f&t=c9NSyJWdASb80eVC-0"
 ---
 

--- a/packages/stacks-docs/src/docs/public/system/components/badges.md
+++ b/packages/stacks-docs/src/docs/public/system/components/badges.md
@@ -1,7 +1,7 @@
 ---
 title: "Badges"
 description: "Badges are labels used for flags, earned achievements, and number totals."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-badge--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-badge--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=610-18799&p=f&m=dev"
 ---
 

--- a/packages/stacks-docs/src/docs/public/system/components/bling.md
+++ b/packages/stacks-docs/src/docs/public/system/components/bling.md
@@ -1,7 +1,7 @@
 ---
 title: "Bling"
 description: "Bling is used to indicate award type in badges and user cards."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-bling--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-bling--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=610-18798"
 ---
 

--- a/packages/stacks-docs/src/docs/public/system/components/buttons.md
+++ b/packages/stacks-docs/src/docs/public/system/components/buttons.md
@@ -1,6 +1,6 @@
 ---
 title: Buttons
-svelte: https://beta.svelte.stackoverflow.design/?path=/docs/components-button--docs
+svelte: https://svelte.stackoverflow.design/?path=/docs/components-button--docs
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=610-18802"
 description: Buttons are user interface elements which allows users to take actions throughout the project. It is important that they have ample click space and help communicate the importance of their actions.
 ---

--- a/packages/stacks-docs/src/docs/public/system/components/empty-states.md
+++ b/packages/stacks-docs/src/docs/public/system/components/empty-states.md
@@ -1,7 +1,7 @@
 ---
 title: "Empty states"
 description: "Empty states are used when there is no data to show. Ideally they orient the user by providing feedback based on the the user's last interaction or communicate the benefits of a feature. When appropriate, they should explain the next steps the user should take and provide guidance with a clear call-to-action."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-emptystate--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-emptystate--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=610-18807&p=f&m=dev"
 ---
 

--- a/packages/stacks-docs/src/docs/public/system/components/links.md
+++ b/packages/stacks-docs/src/docs/public/system/components/links.md
@@ -1,7 +1,7 @@
 ---
 title: "Links"
 description: "Links are lightly styled via the <code>a</code> element by default. In addition, we provide <code>.s-link</code> and its variations. In rare situations, <code>.s-link</code> can be applied to a <code>button</code> while maintaining the look of an anchor."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-link--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-link--docs"
 ---
 
 <script lang="ts">

--- a/packages/stacks-docs/src/docs/public/system/components/loader.md
+++ b/packages/stacks-docs/src/docs/public/system/components/loader.md
@@ -1,7 +1,7 @@
 ---
 title: "Loader"
 description: "The loader component indicates an active wait state for a page, section, or interactive element."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-loader--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-loader--docs"
 ---
 
 <script lang="ts">

--- a/packages/stacks-docs/src/docs/public/system/components/menus.md
+++ b/packages/stacks-docs/src/docs/public/system/components/menus.md
@@ -1,7 +1,7 @@
 ---
 title: "Menus"
 description: "A menu offers a contextual list of actions or functions."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-menu--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-menu--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=610-18810"
 ---
 

--- a/packages/stacks-docs/src/docs/public/system/components/modals.md
+++ b/packages/stacks-docs/src/docs/public/system/components/modals.md
@@ -1,7 +1,7 @@
 ---
 title: "Modals"
 description: "Modals are dialog overlays that prevent the user from interacting with the rest of the website until an action is taken or the dialog is dismissed. Modals are purposefully disruptive and should be used thoughtfully and sparingly."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-modal--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-modal--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=610-18811&p=f&t=c9NSyJWdASb80eVC-0"
 js: true
 ---

--- a/packages/stacks-docs/src/docs/public/system/components/navigation.md
+++ b/packages/stacks-docs/src/docs/public/system/components/navigation.md
@@ -1,7 +1,7 @@
 ---
 title: "Navigation"
 description: "Our navigation component is a collection of buttons that respond gracefully to various window sizes and parent containers."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-navigation--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-navigation--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=610-18812&t=5ggsDIb9OENEwDl0-1"
 js: true
 ---

--- a/packages/stacks-docs/src/docs/public/system/components/notices.md
+++ b/packages/stacks-docs/src/docs/public/system/components/notices.md
@@ -1,7 +1,7 @@
 ---
 title: "Notices"
 description: "Notices deliver <strong>System</strong> and <strong>Engagement</strong> messaging, informing the user about product or account statuses and related actions."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-notice--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-notice--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=612-18813&p=f&m=dev"
 js: true
 ---

--- a/packages/stacks-docs/src/docs/public/system/components/pagination.md
+++ b/packages/stacks-docs/src/docs/public/system/components/pagination.md
@@ -1,7 +1,7 @@
 ---
 title: "Pagination"
 description: "Pagination splits content into pages, as seen on questions, tags, users, and jobs listings."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-paginationcontroller--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-paginationcontroller--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=1189-2035&t=JFrmhokx3ZOeRP9b-0"
 ---
 

--- a/packages/stacks-docs/src/docs/public/system/components/popovers.md
+++ b/packages/stacks-docs/src/docs/public/system/components/popovers.md
@@ -1,7 +1,7 @@
 ---
 title: "Popovers"
 description: "Popovers are small content containers that provide a contextual overlay. They can be used as in-context feature explanations, dropdowns, or tooltips."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-popover--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-popover--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=1617-27089&t=W4QmlFOpYoEpInDB-0"
 js: true
 ---

--- a/packages/stacks-docs/src/docs/public/system/components/post-summary.md
+++ b/packages/stacks-docs/src/docs/public/system/components/post-summary.md
@@ -1,7 +1,7 @@
 ---
 title: "Post summary"
 description: "The post summary component summarizes various content and associated meta data into a highly configurable component."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-postsummary--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-postsummary--docs"
 ---
 
 <script lang="ts">

--- a/packages/stacks-docs/src/docs/public/system/components/tags.md
+++ b/packages/stacks-docs/src/docs/public/system/components/tags.md
@@ -1,8 +1,7 @@
 ---
 title: "Tags"
 description: "Tags are an interactive, community-generated keyword that allow communities to label, organize, and discover related content. Tags are maintained by their respective communities."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-tag--docs"
-figma: "https://svelte.stackoverflow.design/figma/tags"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-tag--docs"
 ---
 
 <script lang="ts">

--- a/packages/stacks-docs/src/docs/public/system/components/user-cards.md
+++ b/packages/stacks-docs/src/docs/public/system/components/user-cards.md
@@ -1,7 +1,7 @@
 ---
 title: "User cards"
 description: "User cards are a combination of a user and metadata about the user or post"
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-usercard--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-usercard--docs"
 ---
 
 <script lang="ts">

--- a/packages/stacks-docs/src/docs/public/system/components/vote.md
+++ b/packages/stacks-docs/src/docs/public/system/components/vote.md
@@ -1,7 +1,7 @@
 ---
 title: "Vote"
 description: "The vote component allows users to vote on the quality of content by casting an upvote or downvote."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-vote--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-vote--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=617-18830&p=f&t=u4su1MPgebbjmcfI-0"
 ---
 

--- a/packages/stacks-docs/src/docs/public/system/forms/checkbox.md
+++ b/packages/stacks-docs/src/docs/public/system/forms/checkbox.md
@@ -1,7 +1,7 @@
 ---
 title: "Checkbox"
 description: "Checkable inputs that visually allow for multiple options or true/false values."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-checkbox--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-checkbox--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=720-2910&p=f&m=dev"
 ---
 

--- a/packages/stacks-docs/src/docs/public/system/forms/inputs.md
+++ b/packages/stacks-docs/src/docs/public/system/forms/inputs.md
@@ -1,7 +1,7 @@
 ---
 title: "Inputs"
 description: "Input elements are used to gather information from users."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-textinput--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-textinput--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=713-24991&p=f&m=dev"
 ---
 

--- a/packages/stacks-docs/src/docs/public/system/forms/radio.md
+++ b/packages/stacks-docs/src/docs/public/system/forms/radio.md
@@ -1,7 +1,7 @@
 ---
 title: "Radio"
 description: "Checkable inputs that visually allow for single selection from multiple options."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-radiogroup--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-radiogroup--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=720-2910&p=f&m=dev"
 ---
 

--- a/packages/stacks-docs/src/docs/public/system/forms/select.md
+++ b/packages/stacks-docs/src/docs/public/system/forms/select.md
@@ -1,7 +1,7 @@
 ---
 title: "Select"
 description: "A selectable menu list from which a user can make a single selection. Typically they are used when there are more than four possible options. The custom select menu styling is achieved by wrapping the <code>select</code> tag within the <code>.s-select</code> class."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-select--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-select--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=4537-50988"
 ---
 

--- a/packages/stacks-docs/src/docs/public/system/forms/textarea.md
+++ b/packages/stacks-docs/src/docs/public/system/forms/textarea.md
@@ -1,7 +1,7 @@
 ---
 title: "Textarea"
 description: "Multi-line inputs used by users to enter longer text portions."
-svelte: "https://beta.svelte.stackoverflow.design/?path=/docs/components-textarea--docs"
+svelte: "https://svelte.stackoverflow.design/?path=/docs/components-textarea--docs"
 figma: "https://www.figma.com/design/do4Ug0Yws8xCfRjHe9cJfZ/Project-SHINE---Product-UI?node-id=4537-49735&m=dev"
 ---
 

--- a/packages/stacks-docs/src/lib/svelteDocsLinks.test.ts
+++ b/packages/stacks-docs/src/lib/svelteDocsLinks.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, extname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const sourceRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const svelteRoot = resolve(sourceRoot, "../../stacks-svelte");
+const sourceExtensions = new Set([".js", ".md", ".svelte", ".ts"]);
+
+function getSourceFiles(directory: string): string[] {
+    return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+        const path = join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+            return getSourceFiles(path);
+        }
+
+        return sourceExtensions.has(extname(path)) ? [path] : [];
+    });
+}
+
+describe("Svelte documentation links", () => {
+    it("use the canonical stable domain", () => {
+        const sourceFiles = [
+            ...getSourceFiles(resolve(sourceRoot, "docs/public")),
+            ...getSourceFiles(resolve(sourceRoot, "routes")),
+            resolve(svelteRoot, ".storybook/stacks-theme.ts"),
+            resolve(svelteRoot, "tools/storybook-llms-extractor.js"),
+        ];
+        const betaHostname = ["beta", "svelte", "stackoverflow", "design"].join(
+            "."
+        );
+        const removedFigmaPath = ["svelte.stackoverflow.design", "figma"].join(
+            "/"
+        );
+
+        for (const sourceFile of sourceFiles) {
+            const source = readFileSync(sourceFile, "utf8");
+
+            expect(source, sourceFile).not.toContain(betaHostname);
+            expect(source, sourceFile).not.toContain(`${removedFigmaPath}/`);
+        }
+    });
+
+    it("does not label the stable Storybook as beta", () => {
+        const theme = readFileSync(
+            resolve(svelteRoot, ".storybook/stacks-theme.ts"),
+            "utf8"
+        );
+
+        expect(theme).not.toContain(">Beta<");
+    });
+});

--- a/packages/stacks-docs/src/routes/+page.svelte
+++ b/packages/stacks-docs/src/routes/+page.svelte
@@ -72,7 +72,7 @@
 <div class="page p32 sm:p24 w100 wmx12">
   <div class="d-flex g4 ai-center mb-auto">
     <span class="s-badge fc-purple-500 bg-purple-100">v{__APP_VERSION__}</span>
-    <a href="https://beta.svelte.stackoverflow.design/" class="s-badge">
+    <a href="https://svelte.stackoverflow.design/" class="s-badge">
       <Icon src={IconServiceSvelte} class="native" />
       v{__SVELTE_VERSION__}
     </a>

--- a/packages/stacks-svelte/.storybook/stacks-theme.ts
+++ b/packages/stacks-svelte/.storybook/stacks-theme.ts
@@ -10,7 +10,6 @@ export default create({
     brandTitle: `<span class="d-flex">
         ${IconGlyph24}
         <span class="fs-body3 ws-nowrap lh-xs as-end">Stacks Svelte</span>
-        <span class="s-badge s-badge__featured s-badge__sm as-end ml8 mb1">Beta</span>
     </span>`,
     brandTarget: "_self",
 });

--- a/packages/stacks-svelte/tools/storybook-llms-extractor.js
+++ b/packages/stacks-svelte/tools/storybook-llms-extractor.js
@@ -25,13 +25,10 @@ function getCurrentBranch() {
 }
 
 const currentBranch = getCurrentBranch();
-const isBeta = currentBranch === "beta";
 
 const CONFIG = {
     distPath: "../netlify/dist",
-    summaryBaseUrl: isBeta
-        ? "https://beta.svelte.stackoverflow.design"
-        : "https://svelte.stackoverflow.design",
+    summaryBaseUrl: "https://svelte.stackoverflow.design",
     summaryTitle: "Stacks Svelte",
     summaryDescription: "Stacks Svelte Components Documentation",
 };


### PR DESCRIPTION
## Summary

- replace remaining beta Svelte documentation links with `svelte.stackoverflow.design`
- remove the Storybook beta badge and generate LLM documentation with the stable domain
- remove two broken pseudo-Figma links and add regression coverage

## Jira

[STACKS-855](https://stackoverflow.atlassian.net/browse/STACKS-855)

## Accessibility

No semantic or interaction changes. Svelte lint passed with no warnings. Docs lint retained five existing warnings unrelated to this change.

## Changeset

Not required. This updates private documentation and Storybook configuration.

## Follow-up

The `v2.svelte.stackoverflow.design` domain and the `beta.svelte.stackoverflow.design` redirect require separate Netlify/DNS configuration.